### PR TITLE
A1R: add associative ordered route summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,11 @@ Guidance for agents (human or otherwise) working in this repository.
 The geometric causal decoder plan, prior S0–S7 completion plan, and
 graph-compiler implementation plan are retained as historical
 engineering/evidence records; none decides what is built next. Native GitHub
-relationships now mirror the programme: #961 closed with reversible S0 state,
-#952 stopped at `REDESIGN_ORDERED_ROUTE_SUMMARY`, and narrow repair #967 now
-precedes #953–#955 and #962–#965. Terminology lives in
+relationships now mirror the programme: #961 closed with reversible S0 state;
+#952 stopped at `REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 repaired the ordered
+state but terminated `RETAIN_STATE_ONLY`; unassigned #970 owns the A1P
+candidate-relative readout/placement redesign and blocks #969 A1Q; #969 blocks
+#953. #953–#955 and #962–#965 follow. Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
 
@@ -18,11 +20,11 @@ A local, CPU-first **geometric intelligence programme**. Geometry is the route
 and the route is the data location. The active lane uses a pinned lexical codec,
 registered prime atoms, semiprime transitions including `p^2` self-loops,
 ordered n-lets, fixed-zeta R4/S3 state, Hopf observation, torsion, exact
-`Z[phi]` radial shells, and the load-bearing project bridge
+`Z[phi]` radial shells, and the required structural/storage project bridge
 `E8 = H4 x H4`, realized in code and serialization by the golden/Galois-coupled
-icosian pair `H4 ⊕ phi H4`. Recursive attention combines exact route identity
-with trajectory/harmonic summaries across sentence, paragraph, conversation,
-and global state.
+icosian pair `H4 ⊕ phi H4`. Full recursive attention is a target, not an
+established property: #969 must qualify any trajectory, harmonic, Hopf, H4,
+zeta, icosian, or SpiralCore term before it may influence semantic scoring.
 
 The intended destination is frontier-like useful local intelligence without
 transformers, MoE/sparse learned routing, or dense matrix intelligence. That is
@@ -152,12 +154,21 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
 - Follow the reconciled #820 dependency chain. #961 closed GI-1/S0 lexical
   geometry at reversible-state scope. #952's A1.0 gate preserved candidate and
   value reachability but stopped before a scorer because the reusable
-  non-digest summaries erase earlier order. #967 owns only the associative
-  ordered-summary repair and candidate-relative re-probe. #953–#955 remain
-  blocked behind it: #953 owns bounded source-free library/CLI generation,
-  followed by correctness and reasoning. #962 owns durable multi-turn CLI/HTTP
-  chat, persistence, isolation, and hive-memory; #963–#965 then own
-  optimization, formal closure, and release.
+  non-digest summaries erase earlier order. #967's A1R delivery added the exact
+  associative ordered fold and passed the frozen scope, global, fold,
+  incremental, and support contracts. Its full arm produced distinct `ll`/`rr`
+  relative states on 6/6 queries and changed the same-candidate state in 5/6
+  paired comparisons, but the scalar shortest-Cayley-distance readout collapsed
+  both candidates to energy 2 and tied on 6/6. Its terminal verdict is
+  `RETAIN_STATE_ONLY`
+  (report `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`).
+  Unassigned #970 follows protected #967 delivery, owns only the A1P
+  candidate-relative readout/placement redesign, and natively blocks #969 A1Q.
+  #969 blocks #953, so neither the repaired state nor closure of #967 promotes
+  attention or generation. #953 then owns bounded source-free library/CLI
+  generation, followed by #954 correctness and #955 reasoning. #962 owns
+  durable multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory;
+  #963–#965 then own optimization, formal closure, and release.
 - Sequence strictly: lexical/address plumbing → recursive attention →
   source-free grammatical inference/generation → correctness/abstention →
   reasoning → optimization/purity/release.
@@ -166,14 +177,22 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
 - Preserve the project shorthand `E8 = H4 x H4`. Its concrete implementation
   and serialization is the golden/Galois-coupled icosian pair
   `H4 ⊕ phi H4` with fixed basis, glue, forward map, and inverse witness.
-- Exact route keys must be combined with the transported trajectory, session
-  hypersphere vector, winding/window state, window projection energy,
-  shared-prime-factor retrieval, bounded resonance, and accumulated Hopf phase.
-  An exact kappa miss must not collapse unseen global history to a suffix-only
-  default.
-- Geometry must execute before token choice and change admitted support or
-  ordering against equal-budget factor-only, count-only, exact-recall,
-  permuted-geometry, and permuted-pair controls before generation is credited.
+- Keep **required structural/storage representation** distinct from a
+  **qualified semantic scoring term**. Paired-H4/icosian coordinates may remain
+  mandatory for canonical storage, address reconstruction, and inverse
+  witnesses without being valid ranking features. Hopf, H4, zeta, icosian,
+  SpiralCore, trajectory, hypersphere, winding/window, projection-energy,
+  shared-factor, and resonance terms remain storage fields, diagnostics, or
+  controls until A1Q/#969 qualifies them with scope-isolated matched evidence.
+  #953 may consume only the semantic terms that A1Q qualifies.
+- An exact kappa miss must not collapse unseen global history to a suffix-only
+  default, but global ordered-state behavior is tested on an independently
+  frozen global-snapshot permutation rather than by mutating session history.
+- Full geometry must execute before token choice and change admitted support or
+  ordering against the equal-budget current-only, existing-additive-summary,
+  factor/count-only, deterministic-ordered-state-permutation,
+  hierarchy-disabled, and exact-recall-only controls before generation is
+  credited.
 - Teacher output may label or compare only after a source-free report freezes.
   It is never substituted for the product response.
 - Every hierarchy selection emits a global-context coverage witness. Exact
@@ -336,7 +355,7 @@ CIDs before loading teacher weights.
   graph lane
   (`uor-r4-graph-format::ScoreQ` wire newtype; `uor-r4-core::score_q::ScoreQ`
   with compiler-side f32 conversions). Do not add a third or prioritize their
-  consolidation ahead of the active #967 ordered-summary repair.
+  consolidation ahead of the #970 candidate-relative readout/placement redesign.
 
 ## Long-run discipline (process amendment, 2026-08-06)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,20 +94,27 @@ Do not create a new test framework for routine confidence.
 The experiment must be able to change the next programme decision:
 
 - **Follow the GI sequence.** GI-1 makes lexical/address state reversible;
-  GI-2/#952 establishes recursive attention; GI-3/#953 adds source-free
-  grammatical inference/generation; GI-4/#954 tests correctness/abstention;
-  GI-5/#955 adds reasoning. Do not generate before attention passes.
+  #952 found the reusable ordered-state defect; A1R/#967 repaired the fold but
+  terminated `RETAIN_STATE_ONLY` after its scalar readout tied distinct
+  candidate-relative states on 6/6 queries; A1P/#970 now owns the
+  candidate-relative readout/placement; and A1Q/#969 separately qualifies full
+  recursive attention. GI-3/#953 may then add source-free grammatical
+  inference/generation using only A1Q-qualified semantic terms; GI-4/#954 tests
+  correctness/abstention; GI-5/#955 adds reasoning. Do not generate before
+  attention passes.
 - **Exercise the real route path.** Geometry must run before token choice and
   emit its admitted support, energy trace, and global-context coverage witness.
 - **Use the smallest falsifier.** Start with a bounded source-free route
   fixture, hierarchy intervention, or held-out continuation before adding data.
-- **Use non-degenerate anti-recall controls.** Compare exact recall, factor-only,
-  count-only, real geometry, permuted geometry, and permuted paired-H4 state
-  under equal budgets.
-- **Preserve unseen global context.** Exact route identity is combined with the
-  transported trajectory, hypersphere/window summaries, shared-factor
-  retrieval, resonance, and accumulated Hopf phase; exact kappa miss cannot
-  collapse to a suffix-only default.
+- **Use non-degenerate anti-recall controls.** Compare the full-geometry
+  treatment against current-only, the existing additive summary,
+  factor/count-only ordering, deterministic ordered-state permutation,
+  hierarchy-disabled, and exact-recall-only controls under equal budgets.
+- **Preserve unseen global context.** Exact route identity remains separate
+  from transported trajectory, hypersphere/window summaries, shared-factor
+  retrieval, resonance, and accumulated Hopf phase. Those fields are storage,
+  diagnostics, or controls until A1Q qualifies them for semantic scoring; an
+  exact kappa miss still cannot collapse to a suffix-only default.
 - **Keep teachers offline.** Teacher labels/comparisons begin only after a
   source-free report freezes and are never substituted for product output.
 - **Include free-running output only when GI-3 or later is in scope.** Attention

--- a/README.md
+++ b/README.md
@@ -49,7 +49,22 @@ To run the one fixed canonical-ingestion witness:
 cargo run --bin r4 -- lexical-ingestion-witness
 ```
 
-That bounded witness maps two turns of text through the pinned lexical codec,
+To reproduce the bounded A1R associative ordered-summary decision:
+
+```bash
+cargo run --bin r4 -- associative-ordered-summary-a1r-probe
+```
+
+The A1R command uses only the frozen construction/evaluation fixture and exact
+finite tables. Its frozen report kappa is
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+The associative state passed the declared scope, independent-global, fold,
+incremental, and support invariants. The full arm produced distinct `ll`/`rr`
+relative states on all 6 queries, but shortest Cayley distance mapped both to
+energy 2 and tied every query. The terminal verdict is `RETAIN_STATE_ONLY`: it
+does not generate text or establish full attention.
+
+The ingestion witness maps two turns of text through the pinned lexical codec,
 prime/spin route state, canonical hierarchy manifest, strict reload, and exact
 lexical reconstruction. It also exercises the declared fail-closed unknown-unit
 path. It loads no model and establishes reversible state plumbing only—not
@@ -68,16 +83,23 @@ input ceiling is 8 turns, 32 paragraphs, 31 sentences, 128 units per sentence,
 
 Downstream code consumes `CanonicalRouteArtifact::decode_canonical`,
 `attention_consumer_trace`, `attention_consumer_trace_for_cursor`,
+`attention_consumer_trace_with_ordered_h4`,
 `incremental_update_trace`, `incremental_cursor`,
 `lookup_shared_class_trace`, `scope_ceilings`, and `reconstruct_input`. The
 attention handoff is ordered current, previous, last-two, sentence, paragraph,
 conversation, then bounded global; the cursor resolver returns those same seven
 slots and marks not-yet-established boundaries absent. S0 serializes state and
 numeric geometry only: every candidate row ceiling is zero and marked
-`NOT_IMPLEMENTED_S0_STATE_ONLY` until #952 supplies and measures the
-recursive-attention operator.
+`NOT_IMPLEMENTED_S0_STATE_ONLY`. #952 established candidate/value reachability
+but found its reusable summaries order-erasing. #967 landed the exact ordered
+state repair but retained it as state only after the candidate tie. Unassigned
+#970 owns the candidate-relative readout/placement redesign and blocks #969;
+#969 separately owns full recursive-attention qualification and blocks #953
+generation. Stored H4/Hopf/zeta/icosian and related route fields remain
+structural state, diagnostics, or controls until A1Q qualifies a term for
+semantic scoring; #953 may use only the qualified terms.
 
-Both commands exercise the no-model research substrate. `demo` does not start
+These commands exercise the no-model research substrate. `demo` does not start
 the historical artifact-discovery server, and `route` does not claim to answer
 the prompt; it exposes how the current geometry represents it.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,13 +8,14 @@ preserved #948–#958 sequencing record. Measured, refuted, and frozen research
 remains in [docs/RESEARCH.md](docs/RESEARCH.md).
 
 _Last reviewed: 2026-08-27 (#961 reversible S0 landed; #952 A1.0 stopped at
-`REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 is the native repair blocker before
-#953–#955 → #962–#965)._
+`REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 A1R terminated `RETAIN_STATE_ONLY`;
+#970 A1P now precedes #969 A1Q, which blocks #953–#955 → #962–#965)._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
-> prime/n-let routes, fixed-zeta state, R4/S3 transport, the load-bearing
-> project bridge `E8 = H4 x H4` serialized as the golden/Galois-coupled
+> prime/n-let routes, fixed-zeta state, R4/S3 transport, the required
+> structural/storage project bridge `E8 = H4 x H4` serialized as the
+> golden/Galois-coupled
 > `H4 ⊕ phi H4` icosian pair, and recursive sentence/paragraph/conversation/
 > global context choose output. Source weights are offline teachers only. The
 > final serving path contains no transformer, dense matrix intelligence kernel,
@@ -47,27 +48,48 @@ Native GitHub relationships are the source of truth:
    canonical hierarchy serialization, independent attention-artifact identity,
    incremental API-neutral state, and the fixed concrete `H4 ⊕ phi H4`
    realization of the project shorthand `E8 = H4 x H4`. Do not generate.
-3. **GI-2 / #952 → #967 — recursive attention repair:** #952 established that
+3. **GI-2 A1R / #952 → #967 — ordered-state repair (terminal):** #952 established that
    the natural bounded candidate/value path works but every current non-digest
-   hierarchy summary collides when only earlier order changes. #967 must first
-   replace that additive/last-child summary with an associative,
-   noncommutative ordered fold and rerun the frozen anti-recall gate. Only then
-   may GI-2 continue to combine exact route identity with the
-   full transported trajectory, hypersphere/window summaries, shared-factor
-   retrieval, resonance, and Hopf accumulation across sentence, paragraph,
-   conversation, and global route levels. Emit a coverage witness and establish
-   anti-recall causal value before producing text.
-4. **GI-3 / #953 — source-free grammatical inference/generation:** compile
-   grammar and syntax into the attention-qualified route engine and establish
-   bounded source-free generation through the library and CLI. Durable chat,
-   persistence, and HTTP session behavior remain outside this stage.
-5. **GI-4 / #954 — correctness and abstention:** test held-out answer
+   hierarchy summary collides when only earlier order changes. #967 replaced
+   that additive/last-child summary with an associative, noncommutative ordered
+   fold and reran the frozen candidate-relative gate.
+   The frozen histories intentionally keep current, previous, last-two, and the
+   immutable global snapshot equal; sentence, paragraph, and conversation state
+   must differ. Any global-order claim uses a separate construction-independent
+   global-snapshot permutation with lower scopes and support held fixed. A1R
+   repaired representation passed its scope, global, fold, incremental, and
+   support invariants. Its full arm produced distinct `ll`/`rr` relative states
+   on 6/6 queries and changed the same-candidate state in 5/6 paired
+   comparisons, but shortest Cayley distance collapsed the distinct states to
+   energy 2 and tied on 6/6. The report therefore terminated
+   `RETAIN_STATE_ONLY` with kappa
+   `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+   This is state evidence only, not attention.
+4. **GI-2 A1P / #970 — candidate-relative readout/placement redesign:** keep the
+   #967 fold, anchors, relative states, and support fixed while replacing the
+   shortest-Cayley scalar readout that tied both admitted targets. #970 is
+   unassigned, owns the broader readout/placement falsifier, follows protected
+   #967 delivery, and natively blocks #969. Do not implement full A1Q or
+   generation here.
+5. **GI-2 A1Q / #969 — full recursive attention qualification:** after #970,
+   independently qualify sentence, paragraph, conversation, and global causal
+   effects with candidate-relative anti-recall fixtures and equal-budget
+   current-only, additive, factor/count-only, deterministic-permutation,
+   hierarchy-disabled, and exact-recall controls. Only terms that pass this
+   qualification become semantic scoring terms; required storage fields remain
+   storage, diagnostics, or controls otherwise.
+6. **GI-3 / #953 — source-free grammatical inference/generation:** after #969,
+   compile grammar and syntax into the attention-qualified route engine using
+   only GI-2-qualified semantic terms, and establish bounded source-free
+   generation through the library and CLI. Durable chat, persistence, and HTTP
+   session behavior remain outside this stage.
+7. **GI-4 / #954 — correctness and abstention:** test held-out answer
    correctness, relevance, abstention, and causal use of required context.
    Teacher weights may label or compare offline only after the source-free
    report freezes.
-6. **GI-5 / #955 — reasoning:** add bounded goal-directed route composition, branch
+8. **GI-5 / #955 — reasoning:** add bounded goal-directed route composition, branch
    comparison, intermediate constraints, and closure/contradiction controls.
-7. **GI-6 / #962–#965 — product, cost, formal closure, and release:** integrate
+9. **GI-6 / #962–#965 — product, cost, formal closure, and release:** integrate
    durable multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory
    (#962); optimize only the measured route-native bottleneck (#963); freeze
    the serving contract (#964); then explicitly activate only the release QA
@@ -76,9 +98,12 @@ Native GitHub relationships are the source of truth:
 The live issue bodies and native dependencies now mirror this sequence. #961
 is closed. #952's terminal negative evidence is preserved in
 [`docs/recursive_geometric_attention_a1_952.md`](docs/recursive_geometric_attention_a1_952.md).
-#967 is unassigned and blocked only until #952 closes; it remains the native
-blocker of #953 afterward. Every later stage stays unassigned and blocked in
-order. Legacy tracker #949 is closed as superseded; #958 is retained directly
+#967 is at terminal A1R delivery with `RETAIN_STATE_ONLY`. New unassigned #970
+follows protected #967 delivery and is the native blocker of #969; #969 remains
+the native blocker of #953. The immediate chain is therefore #952 closed →
+#967 terminal delivery → #970 A1P → #969 A1Q → #953. Closing #967 cannot
+make A1Q or generation eligible. Every later stage stays unassigned and blocked
+in order. Legacy tracker #949 is closed as superseded; #958 is retained directly
 under programme root #820 as GI-0 foundation.
 
 The old S5–S7 and F0 issues are closed not planned/not triggered. R4G1/TLA,
@@ -93,8 +118,19 @@ historical evidence and comparators.
   non-digest fields, so no scorer was built. The real schema-2 path naturally
   admitted both continuations under ceiling eight, inverted both exact values,
   and reproduced incremental next state. Exact H4 and SpiralCore finite tables
-  closed as controls only. Repair is #967; #953 remains blocked. See the
+  closed as controls only. Repair is #967; full attention qualification is
+  #969; #953 remains blocked by #969. See the
   [qualification](docs/recursive_geometric_attention_a1_952.md).
+
+- [x] **#967 A1R associative ordered-state repair** —
+  *`RETAIN_STATE_ONLY`, 2026-08-27*. The exact H4 fold passed the frozen scope,
+  independent-global, group/fold, incremental, and support invariants. The full
+  arm produced distinct candidate-relative states, but shortest Cayley distance
+  mapped both to energy 2 and tied on 6/6, so no attention or generation claim
+  follows. Report kappa:
+  `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+  #970 owns the candidate-relative readout/placement redesign and blocks #969. See the
+  [A1R record](docs/associative_ordered_route_summaries_a1r_967.md).
 
 - [x] **#961 reversible lexical geometry/state plumbing** —
   *`PASS_REVERSIBLE_STATE_PLUMBING_ONLY`, 2026-08-27*. The pinned codec,

--- a/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
+++ b/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
@@ -37,6 +37,15 @@ pub const ICOSIAN_PROFILE_DOMAIN: &str = "uor-r4.icosian-h4-phi-h4-profile/1";
 pub const H4_BINARY_ICOSAHEDRAL_TABLE_SCHEMA: u32 = 1;
 pub const H4_BINARY_ICOSAHEDRAL_TABLE_DOMAIN: &str =
     "uor-r4.scaled-h4-binary-icosahedral-multiplication/1";
+pub const H4_BINARY_ICOSAHEDRAL_ROOT_TABLE_KAPPA_REFERENCE: &str =
+    "blake3:8d33d62a239fb8001fea2bd14a9a5ec7321d0f07d81c74a5715eaeb3df53aa76";
+pub const H4_BINARY_ICOSAHEDRAL_MULTIPLICATION_TABLE_KAPPA_REFERENCE: &str =
+    "blake3:90ee73a27ee2e8ba5bccd1507d7fb37ed1f044b1640772c86752bc0bb2111759";
+pub const ORDERED_H4_FOLD_SCHEMA: u32 = 1;
+pub const ORDERED_H4_FOLD_DOMAIN: &str = "uor-r4.associative-ordered-h4-fold/1";
+pub const ATTENTION_ORDERED_H4_FOLD_TRACE_SCHEMA: u32 = 1;
+pub const ATTENTION_ORDERED_H4_FOLD_TRACE_DOMAIN: &str =
+    "uor-r4.attention-associative-ordered-h4-fold/1";
 pub const TRAJECTORY_PROFILE_SCHEMA: u32 = 1;
 pub const TRAJECTORY_PROFILE_DOMAIN: &str = "uor-r4.route-trajectory-summary/1";
 pub const PROBE_WITNESS_SCHEMA: u32 = 1;
@@ -1279,6 +1288,114 @@ pub struct LexicalRouteValueView {
 /// Exact multiplication table derived from the concrete scaled 120-root H4
 /// table embedded in S0. Products and inverses are indexes into that fixed
 /// root order; no floating point or approximate nearest-root lookup is used.
+///
+/// This key is only an opaque address into the exact finite table. Its numeric
+/// value and numeric differences between keys have no geometric meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct OpaqueH4TableIndex(u16);
+
+impl OpaqueH4TableIndex {
+    /// Construct one checked lookup key. The offset is an addressing detail,
+    /// not a scalar coordinate or a distance.
+    pub fn from_table_offset(offset: u16, table: &H4BinaryIcosahedralClosure) -> Option<Self> {
+        (usize::from(offset) < table.root_count).then_some(Self(offset))
+    }
+
+    /// Return the row/column offset needed for bounded table lookup only.
+    /// Arithmetic on this value is not an admissible geometric operation.
+    pub const fn table_offset(self) -> u16 {
+        self.0
+    }
+}
+
+/// One exact scaled quaternion in the fixed H4 root order. Each pair is the
+/// `(1, phi)` coefficient and the quaternion basis order is `(1, i, j, k)`;
+/// all coordinates are multiplied by two as bound by the root-table kappa.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct H4RootCoordinate {
+    pub scaled_zphi_quaternion: [[i64; 2]; 4],
+}
+
+/// Smallest exact group element used by the associative ordered fold. Route
+/// counts belong to hierarchy/cursor diagnostics, not to this algebraic value,
+/// so inverse and commutator construction cannot manufacture false counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct OrderedH4FoldState {
+    opaque_table_index: OpaqueH4TableIndex,
+}
+
+impl OrderedH4FoldState {
+    pub(crate) fn from_table_index(
+        index: OpaqueH4TableIndex,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CanonicalLexicalError> {
+        validate_ordered_h4_table_shape(table)?;
+        if usize::from(index.table_offset()) >= table.root_count {
+            return Err(CanonicalLexicalError::Invalid(
+                "ordered H4 state index is outside the bound table".to_owned(),
+            ));
+        }
+        Ok(Self {
+            opaque_table_index: index,
+        })
+    }
+
+    pub(crate) fn identity(
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CanonicalLexicalError> {
+        let index = OpaqueH4TableIndex::from_table_offset(table.identity_index, table).ok_or_else(
+            || {
+                CanonicalLexicalError::Invalid(
+                    "ordered H4 identity is outside the bound table".to_owned(),
+                )
+            },
+        )?;
+        Self::from_table_index(index, table)
+    }
+
+    /// Exact `self * right` in the declared left-to-right operand order.
+    pub(crate) fn compose(
+        self,
+        right: Self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CanonicalLexicalError> {
+        let product = table
+            .product_state_index(self.opaque_table_index, right.opaque_table_index)
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "ordered H4 composition addressed outside the bound table".to_owned(),
+                )
+            })?;
+        Self::from_table_index(product, table)
+    }
+
+    pub(crate) fn inverse(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CanonicalLexicalError> {
+        let inverse = table
+            .inverse_state_index(self.opaque_table_index)
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "ordered H4 inverse addressed outside the bound table".to_owned(),
+                )
+            })?;
+        Self::from_table_index(inverse, table)
+    }
+
+    pub(crate) const fn table_index(self) -> OpaqueH4TableIndex {
+        self.opaque_table_index
+    }
+
+    pub(crate) fn root_coordinate(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<H4RootCoordinate, CanonicalLexicalError> {
+        h4_root_coordinate(self.opaque_table_index, table)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct H4BinaryIcosahedralClosure {
     pub schema: u32,
@@ -1314,10 +1431,79 @@ impl H4BinaryIcosahedralClosure {
             .copied()
     }
 
+    /// Typed counterpart to [`Self::product_index`]. Keys remain opaque table
+    /// addresses and are never interpreted as distances.
+    pub fn product_state_index(
+        &self,
+        left: OpaqueH4TableIndex,
+        right: OpaqueH4TableIndex,
+    ) -> Option<OpaqueH4TableIndex> {
+        self.product_index(left.table_offset(), right.table_offset())
+            .and_then(|offset| OpaqueH4TableIndex::from_table_offset(offset, self))
+    }
+
+    pub fn inverse_state_index(&self, state: OpaqueH4TableIndex) -> Option<OpaqueH4TableIndex> {
+        self.inverse_indices
+            .get(usize::from(state.table_offset()))
+            .copied()
+            .and_then(|offset| OpaqueH4TableIndex::from_table_offset(offset, self))
+    }
+
     /// Reproduce the table identity using the canonical self-cleared seed.
     pub fn reproduce_multiplication_table_kappa(&self) -> Result<String, CanonicalLexicalError> {
         h4_multiplication_table_kappa(self)
     }
+}
+
+/// Map one already-registered lexical address through S0's frozen
+/// `prime mod 120` H4-root assignment. No payload, digest, or table-key
+/// distance participates.
+pub(crate) fn h4_leaf_state_for_address(
+    address: &GeometricAddress,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, CanonicalLexicalError> {
+    h4_leaf_state_for_prime(address.atom.value(), table)
+}
+
+/// One ordered fold state attached to a fixed attention hierarchy level.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AttentionOrderedFoldLevel {
+    pub level: String,
+    pub observed_routes: u32,
+    pub state: OrderedH4FoldState,
+    pub root_coordinate: H4RootCoordinate,
+    /// The complete consumer level with the same ordered algebraic state
+    /// attached directly. This avoids a caller-side join between identity /
+    /// additive fields and the A1R ordered-state overlay.
+    pub consumer_level: AttentionLevelTrace,
+}
+
+/// Versioned non-digest state attached to one [`AttentionLevelTrace`] only by
+/// the A1R overlay. Legacy S0/#952 traces leave this absent, preserving their
+/// canonical bytes and identities.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AttentionOrderedH4StateTrace {
+    pub schema: u32,
+    pub domain: String,
+    pub observed_routes: u32,
+    pub state: OrderedH4FoldState,
+    pub root_coordinate: H4RootCoordinate,
+}
+
+/// Versioned overlay over a frozen S0 artifact. This is intentionally not a
+/// field on [`CanonicalRouteArtifact`] or [`AttentionConsumerTrace`], so their
+/// canonical bytes and identities remain unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AttentionOrderedFoldTrace {
+    pub schema: u32,
+    pub domain: String,
+    pub overlay_kappa: String,
+    pub source_artifact_manifest_kappa: String,
+    pub h4_root_table_kappa: String,
+    pub multiplication_table_kappa: String,
+    pub leaf_assignment: String,
+    pub composition_order: String,
+    pub ordered_levels: Vec<AttentionOrderedFoldLevel>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1356,6 +1542,8 @@ pub struct AttentionConsumerTrace {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AttentionLevelTrace {
     pub level: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ordered_h4: Option<AttentionOrderedH4StateTrace>,
     pub identity_kind: String,
     pub identity_kappa: String,
     pub occurrence: Option<u32>,
@@ -1973,6 +2161,88 @@ fn fixed_h4_root_table() -> Result<H4RootTable, CanonicalLexicalError> {
     seed.table_kappa.clear();
     table.table_kappa = canonical_kappa(&canonical_json(&seed)?)?;
     Ok(table)
+}
+
+fn validate_ordered_h4_table_shape(
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<(), CanonicalLexicalError> {
+    if table.schema != H4_BINARY_ICOSAHEDRAL_TABLE_SCHEMA
+        || table.domain != H4_BINARY_ICOSAHEDRAL_TABLE_DOMAIN
+        || table.root_count != 120
+        || table.product_count != table.root_count * table.root_count
+        || table.multiplication_indices.len() != table.product_count
+        || table.inverse_indices.len() != table.root_count
+        || usize::from(table.identity_index) >= table.root_count
+        || table.h4_root_table_kappa != H4_BINARY_ICOSAHEDRAL_ROOT_TABLE_KAPPA_REFERENCE
+        || table.multiplication_table_kappa
+            != H4_BINARY_ICOSAHEDRAL_MULTIPLICATION_TABLE_KAPPA_REFERENCE
+        || !table.unique_closure_exact
+        || !table.identity_exact
+        || !table.inverses_exact
+        || !table.associativity_exact
+        || !table.integer_only_no_rounding
+    {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 fold requires the validated exact 120-root table".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_ordered_h4_table_exact(
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<(), CanonicalLexicalError> {
+    validate_ordered_h4_table_shape(table)?;
+    if h4_multiplication_table_kappa(table)?
+        != H4_BINARY_ICOSAHEDRAL_MULTIPLICATION_TABLE_KAPPA_REFERENCE
+    {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 fold table bytes do not reproduce the frozen exact table identity"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn h4_root_coordinate(
+    index: OpaqueH4TableIndex,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<H4RootCoordinate, CanonicalLexicalError> {
+    validate_ordered_h4_table_shape(table)?;
+    let roots = fixed_h4_root_table()?;
+    if roots.table_kappa != table.h4_root_table_kappa {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 fold table does not bind the canonical root order".to_owned(),
+        ));
+    }
+    let root = roots
+        .roots
+        .get(usize::from(index.table_offset()))
+        .ok_or_else(|| {
+            CanonicalLexicalError::Invalid(
+                "ordered H4 root coordinate index is out of range".to_owned(),
+            )
+        })?;
+    Ok(H4RootCoordinate {
+        scaled_zphi_quaternion: root.map(|coordinate| [coordinate.a, coordinate.b]),
+    })
+}
+
+fn h4_leaf_state_for_prime(
+    prime: u32,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, CanonicalLexicalError> {
+    validate_ordered_h4_table_shape(table)?;
+    let root_count =
+        u32::try_from(table.root_count).map_err(|_| CanonicalLexicalError::ArithmeticOverflow)?;
+    let offset =
+        u16::try_from(prime % root_count).map_err(|_| CanonicalLexicalError::ArithmeticOverflow)?;
+    let index = OpaqueH4TableIndex::from_table_offset(offset, table).ok_or_else(|| {
+        CanonicalLexicalError::Invalid(
+            "ordered H4 leaf assignment addressed outside the bound table".to_owned(),
+        )
+    })?;
+    OrderedH4FoldState::from_table_index(index, table)
 }
 
 fn zphi_checked_neg(value: ZPhi) -> Result<ZPhi, CanonicalLexicalError> {
@@ -2661,6 +2931,7 @@ fn attention_level_from_summary(
 ) -> AttentionLevelTrace {
     AttentionLevelTrace {
         level: level.to_owned(),
+        ordered_h4: None,
         identity_kind: identity_kind.to_owned(),
         identity_kappa: identity_kappa.to_owned(),
         occurrence: route.map(|record| record.body.occurrence),
@@ -3088,6 +3359,208 @@ fn build_global_snapshot(
         ordered_units,
         summary,
         summary_kappa,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OrderedH4FoldAggregate {
+    state: OrderedH4FoldState,
+    observed_routes: u32,
+}
+
+impl OrderedH4FoldAggregate {
+    fn identity(table: &H4BinaryIcosahedralClosure) -> Result<Self, CanonicalLexicalError> {
+        Ok(Self {
+            state: OrderedH4FoldState::identity(table)?,
+            observed_routes: 0,
+        })
+    }
+
+    fn compose(
+        self,
+        right: Self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CanonicalLexicalError> {
+        Ok(Self {
+            state: self.state.compose(right.state, table)?,
+            observed_routes: self
+                .observed_routes
+                .checked_add(right.observed_routes)
+                .ok_or(CanonicalLexicalError::ArithmeticOverflow)?,
+        })
+    }
+}
+
+fn ordered_h4_route_aggregate(
+    record: &RouteRecord,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldAggregate, CanonicalLexicalError> {
+    let state = h4_leaf_state_for_prime(record.body.prime, table)?;
+    if state.table_index().table_offset() != record.body.icosian.selected_h4_root_index {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 leaf does not reproduce the S0 icosian root assignment".to_owned(),
+        ));
+    }
+    Ok(OrderedH4FoldAggregate {
+        state,
+        observed_routes: 1,
+    })
+}
+
+fn ordered_h4_global_aggregate(
+    global: &GlobalSnapshotBinding,
+    lexical_addresses: &[LexicalRouteAddressBinding],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldAggregate, CanonicalLexicalError> {
+    let mut aggregate = OrderedH4FoldAggregate::identity(table)?;
+    for unit in &global.ordered_units {
+        let address = lexical_addresses
+            .get(usize::from(unit.address_index))
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "ordered H4 global unit address index is out of range".to_owned(),
+                )
+            })?;
+        if address.lexical_unit_id != unit.lexical_unit_id
+            || address.address_kappa != unit.address_kappa
+        {
+            return Err(CanonicalLexicalError::Invalid(
+                "ordered H4 global unit does not reproduce its lexical address".to_owned(),
+            ));
+        }
+        aggregate = aggregate.compose(
+            OrderedH4FoldAggregate {
+                state: h4_leaf_state_for_prime(address.prime, table)?,
+                observed_routes: 1,
+            },
+            table,
+        )?;
+    }
+    if aggregate.observed_routes != global.summary.observed_children {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 global route count disagrees with the S0 summary".to_owned(),
+        ));
+    }
+    Ok(aggregate)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ordered_h4_node_aggregate(
+    node_kappa: &str,
+    table: &H4BinaryIcosahedralClosure,
+    node_by_kappa: &BTreeMap<&str, &HierarchyNode>,
+    route_by_kappa: &BTreeMap<&str, &RouteRecord>,
+    global: &GlobalSnapshotBinding,
+    lexical_addresses: &[LexicalRouteAddressBinding],
+    memo: &mut BTreeMap<String, OrderedH4FoldAggregate>,
+    visiting: &mut BTreeSet<String>,
+) -> Result<OrderedH4FoldAggregate, CanonicalLexicalError> {
+    if let Some(aggregate) = memo.get(node_kappa) {
+        return Ok(*aggregate);
+    }
+    if !visiting.insert(node_kappa.to_owned()) {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 hierarchy links contain a cycle".to_owned(),
+        ));
+    }
+    let node = node_by_kappa.get(node_kappa).copied().ok_or_else(|| {
+        CanonicalLexicalError::Invalid(
+            "ordered H4 hierarchy link references an absent node".to_owned(),
+        )
+    })?;
+    let previous = node
+        .body
+        .previous_chain_kappa
+        .as_deref()
+        .map(|previous| {
+            ordered_h4_node_aggregate(
+                previous,
+                table,
+                node_by_kappa,
+                route_by_kappa,
+                global,
+                lexical_addresses,
+                memo,
+                visiting,
+            )
+        })
+        .transpose()?
+        .unwrap_or(OrderedH4FoldAggregate::identity(table)?);
+    let child = match node.body.ordered_child_kind.as_str() {
+        "route" => {
+            let route = route_by_kappa
+                .get(node.body.ordered_child_kappa.as_str())
+                .copied()
+                .ok_or_else(|| {
+                    CanonicalLexicalError::Invalid(
+                        "ordered H4 hierarchy route child is absent".to_owned(),
+                    )
+                })?;
+            ordered_h4_route_aggregate(route, table)?
+        }
+        "sentence-node" | "paragraph-node" => ordered_h4_node_aggregate(
+            &node.body.ordered_child_kappa,
+            table,
+            node_by_kappa,
+            route_by_kappa,
+            global,
+            lexical_addresses,
+            memo,
+            visiting,
+        )?,
+        "global-snapshot" => {
+            if node.body.ordered_child_kappa != global.snapshot_kappa {
+                return Err(CanonicalLexicalError::Invalid(
+                    "ordered H4 global hierarchy link names a different snapshot".to_owned(),
+                ));
+            }
+            ordered_h4_global_aggregate(global, lexical_addresses, table)?
+        }
+        other => {
+            return Err(CanonicalLexicalError::Invalid(format!(
+                "ordered H4 hierarchy has unsupported child kind {other}"
+            )));
+        }
+    };
+    let aggregate = previous.compose(child, table)?;
+    if aggregate.observed_routes != node.body.summary.observed_children {
+        return Err(CanonicalLexicalError::Invalid(
+            "ordered H4 hierarchy route count disagrees with the S0 summary".to_owned(),
+        ));
+    }
+    visiting.remove(node_kappa);
+    memo.insert(node_kappa.to_owned(), aggregate);
+    Ok(aggregate)
+}
+
+fn ordered_h4_trace_level(
+    level: &str,
+    aggregate: OrderedH4FoldAggregate,
+    mut consumer_level: AttentionLevelTrace,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<AttentionOrderedFoldLevel, CanonicalLexicalError> {
+    if consumer_level.level != level
+        || consumer_level.observed_descendant_routes != aggregate.observed_routes
+        || consumer_level.ordered_h4.is_some()
+    {
+        return Err(CanonicalLexicalError::Invalid(format!(
+            "ordered H4 {level} state does not align with its attention consumer level"
+        )));
+    }
+    let root_coordinate = aggregate.state.root_coordinate(table)?;
+    consumer_level.ordered_h4 = Some(AttentionOrderedH4StateTrace {
+        schema: ORDERED_H4_FOLD_SCHEMA,
+        domain: ORDERED_H4_FOLD_DOMAIN.to_owned(),
+        observed_routes: aggregate.observed_routes,
+        state: aggregate.state,
+        root_coordinate,
+    });
+    Ok(AttentionOrderedFoldLevel {
+        level: level.to_owned(),
+        observed_routes: aggregate.observed_routes,
+        state: aggregate.state,
+        root_coordinate,
+        consumer_level,
     })
 }
 
@@ -3719,6 +4192,16 @@ impl CanonicalRouteArtifact {
         self.lexical_route_address_unvalidated(lexical_unit_id)
     }
 
+    /// Internal fixed-probe lookup after the immutable artifact has already
+    /// crossed `validate_transitive`. This prevents one bounded candidate
+    /// query from revalidating the complete artifact for every registry row.
+    pub(crate) fn lexical_route_address_from_validated_artifact(
+        &self,
+        lexical_unit_id: u32,
+    ) -> Result<Option<GeometricAddress>, CanonicalLexicalError> {
+        self.lexical_route_address_unvalidated(lexical_unit_id)
+    }
+
     /// Decode the exact schema-2 child used by the real bounded I1/I2/IS,
     /// divisor, and adjacent-spin candidate path.
     pub fn embedded_spin_manifest(&self) -> Result<CompiledSpinManifest, CanonicalLexicalError> {
@@ -3757,6 +4240,16 @@ impl CanonicalRouteArtifact {
         address: &GeometricAddress,
     ) -> Result<Option<LexicalRouteValueView>, CanonicalLexicalError> {
         self.validate_transitive()?;
+        self.lexical_route_value_for_address_from_validated_artifact(address)
+    }
+
+    /// Internal fixed-probe inverse after the immutable artifact has already
+    /// crossed `validate_transitive`. Public callers retain the fail-closed
+    /// validating entrypoint above.
+    pub(crate) fn lexical_route_value_for_address_from_validated_artifact(
+        &self,
+        address: &GeometricAddress,
+    ) -> Result<Option<LexicalRouteValueView>, CanonicalLexicalError> {
         let address_kappa = address.canonical_kappa()?;
         let Some(stored) = self
             .body
@@ -4022,6 +4515,156 @@ impl CanonicalRouteArtifact {
             conversation: self.body.hierarchy_roots.conversation.clone(),
             global: self.body.hierarchy_roots.global.clone(),
         }
+    }
+
+    /// Derive a versioned associative, noncommutative H4 fold overlay from
+    /// the frozen route and hierarchy links. The S0 artifact and the legacy
+    /// attention trace are not reserialized or assigned a new identity.
+    pub fn attention_consumer_trace_with_ordered_h4(
+        &self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<AttentionOrderedFoldTrace, CanonicalLexicalError> {
+        validate_ordered_h4_table_exact(table)?;
+        if self.body.icosian_profile.h4_root_table.table_kappa != table.h4_root_table_kappa {
+            return Err(CanonicalLexicalError::Invalid(
+                "ordered H4 overlay table is not the source artifact's root table".to_owned(),
+            ));
+        }
+        let base_trace = self.attention_consumer_trace()?;
+
+        let views = self.attention_hierarchy_view();
+        let route_by_kappa = self
+            .body
+            .route_records
+            .iter()
+            .map(|record| (record.route_kappa.as_str(), record))
+            .collect::<BTreeMap<_, _>>();
+        let node_by_kappa = self
+            .body
+            .hierarchy_nodes
+            .iter()
+            .map(|node| (node.node_kappa.as_str(), node))
+            .collect::<BTreeMap<_, _>>();
+        let current = route_by_kappa
+            .get(views.current.as_str())
+            .copied()
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid("ordered H4 current-route root is absent".to_owned())
+            })?;
+        let previous = route_by_kappa
+            .get(views.previous.as_str())
+            .copied()
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "ordered H4 previous-route root is absent".to_owned(),
+                )
+            })?;
+        let expected_levels = [
+            "current",
+            "previous",
+            "last-two",
+            "sentence",
+            "paragraph",
+            "conversation",
+            "global",
+        ];
+        if base_trace.ordered_levels.len() != expected_levels.len()
+            || base_trace
+                .ordered_levels
+                .iter()
+                .zip(expected_levels)
+                .any(|(level, expected)| level.level != expected)
+        {
+            return Err(CanonicalLexicalError::Invalid(
+                "ordered H4 overlay requires the fixed seven-level attention order".to_owned(),
+            ));
+        }
+        let mut base_levels = base_trace.ordered_levels.into_iter();
+        let mut memo = BTreeMap::new();
+        let mut visiting = BTreeSet::new();
+        let mut ordered_levels = vec![
+            ordered_h4_trace_level(
+                "current",
+                ordered_h4_route_aggregate(current, table)?,
+                base_levels.next().ok_or_else(|| {
+                    CanonicalLexicalError::Invalid(
+                        "ordered H4 current consumer level is absent".to_owned(),
+                    )
+                })?,
+                table,
+            )?,
+            ordered_h4_trace_level(
+                "previous",
+                ordered_h4_route_aggregate(previous, table)?,
+                base_levels.next().ok_or_else(|| {
+                    CanonicalLexicalError::Invalid(
+                        "ordered H4 previous consumer level is absent".to_owned(),
+                    )
+                })?,
+                table,
+            )?,
+        ];
+        for (level, expected_scope, kappa) in [
+            ("last-two", "local", views.last_two.as_str()),
+            ("sentence", "sentence", views.sentence.as_str()),
+            ("paragraph", "paragraph", views.paragraph.as_str()),
+            ("conversation", "conversation", views.conversation.as_str()),
+            ("global", "global", views.global.as_str()),
+        ] {
+            let node = node_by_kappa.get(kappa).copied().ok_or_else(|| {
+                CanonicalLexicalError::Invalid(format!(
+                    "ordered H4 {level} hierarchy root is absent"
+                ))
+            })?;
+            if node.body.scope != expected_scope {
+                return Err(CanonicalLexicalError::Invalid(format!(
+                    "ordered H4 {level} hierarchy root has scope {}",
+                    node.body.scope
+                )));
+            }
+            let aggregate = ordered_h4_node_aggregate(
+                kappa,
+                table,
+                &node_by_kappa,
+                &route_by_kappa,
+                &self.body.global_snapshot,
+                &self.body.lexical_route_addresses,
+                &mut memo,
+                &mut visiting,
+            )?;
+            let consumer_level = base_levels.next().ok_or_else(|| {
+                CanonicalLexicalError::Invalid(format!(
+                    "ordered H4 {level} consumer level is absent"
+                ))
+            })?;
+            ordered_levels.push(ordered_h4_trace_level(
+                level,
+                aggregate,
+                consumer_level,
+                table,
+            )?);
+        }
+        if base_levels.next().is_some() {
+            return Err(CanonicalLexicalError::Invalid(
+                "ordered H4 overlay found an unexpected attention consumer level".to_owned(),
+            ));
+        }
+
+        let mut trace = AttentionOrderedFoldTrace {
+            schema: ATTENTION_ORDERED_H4_FOLD_TRACE_SCHEMA,
+            domain: ATTENTION_ORDERED_H4_FOLD_TRACE_DOMAIN.to_owned(),
+            overlay_kappa: String::new(),
+            source_artifact_manifest_kappa: self.manifest_kappa.clone(),
+            h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+            multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+            leaf_assignment: "S(route) = H4[prime mod 120] in the canonical root order".to_owned(),
+            composition_order: "left-to-right S(A || B) = S(A) * S(B)".to_owned(),
+            ordered_levels,
+        };
+        let mut seed = trace.clone();
+        seed.overlay_kappa.clear();
+        trace.overlay_kappa = canonical_kappa(&canonical_json(&seed)?)?;
+        Ok(trace)
     }
 
     /// Return the fixed current -> global consumer order and every geometric

--- a/crates/uor-r4-core/src/prime_route_geometric_attention.rs
+++ b/crates/uor-r4-core/src/prime_route_geometric_attention.rs
@@ -9,6 +9,10 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU16;
 
+use crate::canonical_lexical_ingestion::{
+    h4_leaf_state_for_address, validate_ordered_h4_table_exact, CanonicalLexicalError,
+    H4BinaryIcosahedralClosure, H4RootCoordinate, OrderedH4FoldState,
+};
 use crate::prime_route_attention::{
     zeta_phase_delta, CandidateRow, CompiledSpinManifest, GeometricAddress, OrderedRouteKappa,
     OrderedSentenceRouteState, PhaseQ29, PrimeAtom, PrimeRouteError, RouteIndexes,
@@ -274,6 +278,99 @@ pub struct CausalAttentionState {
     sentence: OrderedSentenceRouteState,
 }
 
+/// API-neutral ordered history accumulator. It carries no candidate rows and
+/// is deliberately separate from [`CausalAttentionState`], so introducing the
+/// associative fold cannot alter the existing query or admission path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CausalOrderedH4State {
+    manifest_kappa: String,
+    h4_root_table_kappa: String,
+    multiplication_table_kappa: String,
+    fold_state: OrderedH4FoldState,
+    observed_routes: u32,
+}
+
+impl CausalOrderedH4State {
+    fn from_first(
+        manifest_kappa: String,
+        first_observation: &GeometricAddress,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, GeometricAttentionError> {
+        Ok(Self {
+            manifest_kappa,
+            h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+            multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+            fold_state: h4_leaf_state_for_address(first_observation, table)
+                .map_err(ordered_h4_error)?,
+            observed_routes: 1,
+        })
+    }
+
+    /// Append one already-observed route in causal left-to-right order.
+    fn observe(
+        &mut self,
+        observed_route: &GeometricAddress,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<(), GeometricAttentionError> {
+        let leaf = h4_leaf_state_for_address(observed_route, table).map_err(ordered_h4_error)?;
+        let next_fold_state = self
+            .fold_state
+            .compose(leaf, table)
+            .map_err(ordered_h4_error)?;
+        let next_observed_routes = self
+            .observed_routes
+            .checked_add(1)
+            .ok_or(GeometricAttentionError::ArithmeticOverflow)?;
+        self.fold_state = next_fold_state;
+        self.observed_routes = next_observed_routes;
+        Ok(())
+    }
+
+    pub const fn fold_state(&self) -> OrderedH4FoldState {
+        self.fold_state
+    }
+
+    pub const fn observed_routes(&self) -> u32 {
+        self.observed_routes
+    }
+
+    pub fn manifest_kappa(&self) -> &str {
+        &self.manifest_kappa
+    }
+
+    pub fn h4_root_table_kappa(&self) -> &str {
+        &self.h4_root_table_kappa
+    }
+
+    pub fn multiplication_table_kappa(&self) -> &str {
+        &self.multiplication_table_kappa
+    }
+
+    /// Resolve the opaque fold state to its exact scaled `Z[phi]` quaternion.
+    /// The numeric table key remains an addressing detail and is never exposed
+    /// as a scalar coordinate or distance.
+    pub fn root_coordinate(
+        &self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<H4RootCoordinate, GeometricAttentionError> {
+        validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+        if self.h4_root_table_kappa != table.h4_root_table_kappa
+            || self.multiplication_table_kappa != table.multiplication_table_kappa
+        {
+            return Err(GeometricAttentionError::Invalid(
+                "causal ordered H4 state is bound to a different exact table".to_owned(),
+            ));
+        }
+        self.fold_state
+            .root_coordinate(table)
+            .map_err(ordered_h4_error)
+    }
+}
+
+fn ordered_h4_error(error: CanonicalLexicalError) -> GeometricAttentionError {
+    GeometricAttentionError::Invalid(format!("ordered H4 state: {error}"))
+}
+
 impl CausalAttentionState {
     fn new(
         manifest_kappa: String,
@@ -478,6 +575,54 @@ impl GeometricAttentionArtifact {
             self.observe(&mut state, observation.clone())?;
         }
         Ok(state)
+    }
+
+    /// Fold the same already-observed address history into the independent H4
+    /// ordered-state overlay. Candidate support, admission, and ranking are not
+    /// consulted by this helper.
+    pub fn causal_ordered_state_from_history(
+        &self,
+        history: &[GeometricAddress],
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<CausalOrderedH4State, GeometricAttentionError> {
+        validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+        let first = history.first().ok_or_else(|| {
+            GeometricAttentionError::Invalid(
+                "causal ordered H4 state requires at least one observed route".to_owned(),
+            )
+        })?;
+        self.validate_observed_address(first)?;
+        let mut state =
+            CausalOrderedH4State::from_first(self.manifest_kappa.clone(), first, table)?;
+        for observation in &history[1..] {
+            self.validate_observed_address(observation)?;
+            state.observe(observation, table)?;
+        }
+        Ok(state)
+    }
+
+    /// Append one observed route to the independent ordered-state overlay.
+    pub fn observe_ordered(
+        &self,
+        state: &mut CausalOrderedH4State,
+        observed_route: &GeometricAddress,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<(), GeometricAttentionError> {
+        validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+        if state.manifest_kappa != self.manifest_kappa {
+            return Err(GeometricAttentionError::Invalid(
+                "causal ordered H4 state is bound to a different manifest".to_owned(),
+            ));
+        }
+        if state.h4_root_table_kappa != table.h4_root_table_kappa
+            || state.multiplication_table_kappa != table.multiplication_table_kappa
+        {
+            return Err(GeometricAttentionError::Invalid(
+                "causal ordered H4 state is bound to a different exact table".to_owned(),
+            ));
+        }
+        self.validate_observed_address(observed_route)?;
+        state.observe(observed_route, table)
     }
 
     pub fn observe(

--- a/crates/uor-r4-core/src/recursive_geometric_attention.rs
+++ b/crates/uor-r4-core/src/recursive_geometric_attention.rs
@@ -1,18 +1,21 @@
 //! A1.0 ordered-state and value-reachability probe for recursive attention.
 //!
-//! This module intentionally stops before implementing an attention scorer.
-//! It freezes a registration-only vocabulary, a construction partition, and
-//! three evaluation contrasts before compiling any route rows or hierarchy
-//! summaries. The evaluation contrasts differ only in earlier order. Candidate
-//! support comes from the existing bounded [`GeometricAttentionArtifact`]
-//! child-manifest path; no target is injected into a query.
+//! A1.0 intentionally stops before scoring when reusable state erases order.
+//! A1R adds only a bounded candidate-relative falsifier after repairing that
+//! representation; it does not qualify recursive attention. Both probes freeze
+//! a registration-only vocabulary, construction partition, and three earlier-
+//! order contrasts before compiling route rows or hierarchy summaries.
+//! Candidate support comes from the existing bounded
+//! [`GeometricAttentionArtifact`] child-manifest path; no target is injected.
 
 use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::canonical_lexical_ingestion::{
-    canonical_global_epoch, validate_h4_binary_icosahedral_closure, AttentionLevelTrace,
-    CanonicalLexicalCodec, CanonicalLexicalError, CanonicalRouteArtifact, ConversationInput,
-    ParagraphInput, TurnInput,
+    canonical_global_epoch, h4_leaf_state_for_address, validate_h4_binary_icosahedral_closure,
+    AttentionLevelTrace, AttentionOrderedFoldTrace, CanonicalLexicalCodec, CanonicalLexicalError,
+    CanonicalRouteArtifact, ConversationInput, H4BinaryIcosahedralClosure, H4RootCoordinate,
+    OrderedH4FoldState, ParagraphInput, TurnInput,
 };
 use crate::prime_route_attention::{GeometricAddress, PrimeRouteError};
 use crate::prime_route_geometric_attention::{
@@ -26,6 +29,14 @@ pub const A1_0_ORDERED_STATE_PROBE_SCHEMA: u32 = 1;
 pub const A1_0_ORDERED_STATE_PROBE_DOMAIN: &str =
     "uor-r4.a1-ordered-state-value-reachability-probe/1";
 pub const REDESIGN_ORDERED_ROUTE_SUMMARY: &str = "REDESIGN_ORDERED_ROUTE_SUMMARY";
+pub const A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_SCHEMA: u32 = 1;
+pub const A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_DOMAIN: &str =
+    "uor-r4.a1r-associative-ordered-summary-probe/1";
+
+pub const REDESIGN_ROUTE_PLACEMENT: &str = "REDESIGN_ROUTE_PLACEMENT";
+pub const RETAIN_STATE_ONLY: &str = "RETAIN_STATE_ONLY";
+pub const REVISE_A1R: &str = "REVISE_A1R";
+pub const PROMOTE_TO_A1Q: &str = "PROMOTE_TO_A1Q";
 
 const ISSUE_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/952";
 const S0_CONSUMER_CONTRACT_URL: &str =
@@ -36,8 +47,32 @@ const A1_FROZEN_FIXTURE_URL: &str =
     "https://github.com/UOR-Foundation/uor-r4/issues/952#issuecomment-5434478600";
 const FROZEN_S0_ARTIFACT_KAPPA: &str =
     "blake3:3f2043e15a32f6ef799c0073d0c714e3140449591b7d8a18069e39c5182662bd";
+const A1R_ISSUE_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/967";
+const A1R_SUCCESSOR_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/969";
+const A1R_DECISION_CONTRACT_URL: &str =
+    "https://github.com/UOR-Foundation/uor-r4/issues/967#issuecomment-5434971151";
+const FROZEN_A1_PARTITION_KAPPA: &str =
+    "blake3:d008b82eda9b16b102cf4c7ffa4a47a40ad514b30f0763ed3f46c0ebae3e277b";
+const FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA: &str =
+    "blake3:2b70588d654c8e8bb2d8ab063f41853d45a21487d742ff7567f93a42cfb9011b";
+const FROZEN_A1_ATTENTION_MANIFEST_KAPPA: &str =
+    "blake3:1c77c4103732964af6776f1dfcabc8b2a9191eea875a8ba205c36ebbf5618a99";
+const FROZEN_A1_REPORT_KAPPA: &str =
+    "blake3:23e07a17e897abb701c09354d35a3113a1b075ba1d60ee634067fa3ed3fd1904";
 
 const CANDIDATE_CEILING: usize = 8;
+const ROWS_PER_QUERY_CEILING: usize = 7;
+const CONTROL_ARMS_PER_QUERY: usize = 8;
+const A1R_REQUIRED_CONTROLS: [&str; 8] = [
+    "full-ordered-hierarchy",
+    "current-only",
+    "existing-additive-summary",
+    "factor-count",
+    "deterministic-conjugation",
+    "hierarchy-disabled",
+    "exact-recall-only",
+    "inverse-h4-intervention",
+];
 const GLOBAL_TOKEN: &str = "gg";
 const REQUIRED_LEVELS: [&str; 7] = [
     "current",
@@ -771,6 +806,2103 @@ pub fn run_a1_0_probe() -> Result<A10OrderedStateProbeReport, RecursiveGeometric
     run_a1_0_ordered_state_probe()
 }
 
+/// Canonical A1R evidence envelope. This consumer-side report is versioned
+/// independently from the frozen S0 and A1.0 artifacts it cites.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RAssociativeOrderedSummaryProbeReport {
+    pub schema: u32,
+    pub domain: String,
+    pub report_kappa: String,
+    pub body: A1RAssociativeOrderedSummaryProbeBody,
+}
+
+impl A1RAssociativeOrderedSummaryProbeReport {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RecursiveGeometricAttentionError> {
+        if self.schema != A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_SCHEMA
+            || self.domain != A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_DOMAIN
+        {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                "A1R report schema/domain is unsupported".to_owned(),
+            ));
+        }
+        if a1r_report_identity_kappa(&self.body)? != self.report_kappa {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                "A1R report kappa does not reproduce".to_owned(),
+            ));
+        }
+        canonical_json(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RAssociativeOrderedSummaryProbeBody {
+    pub probe_status: String,
+    pub terminal_verdict: String,
+    pub successor_effect: String,
+    pub provenance: A1RProvenance,
+    pub work_contract: A1RWorkContract,
+    pub fold_contract: A1RFoldContract,
+    pub collision_census: A1RPermutationCollisionCensus,
+    pub scope_contrasts: Vec<A1RScopeContrast>,
+    pub global_order_fixture: A1RGlobalOrderFixture,
+    pub fold_laws: A1RFoldLawEvidence,
+    pub incremental_checks: Vec<A1RIncrementalCheck>,
+    pub candidate_queries: Vec<A1RCandidateQuery>,
+    pub support_pair_checks: Vec<A1RSupportPairCheck>,
+    pub transition_readout_summary: A1RTransitionReadoutSummary,
+    pub scoring_summary: A1RScoringSummary,
+    pub support_invariants_exact: bool,
+    pub excluded_digest_fields: Vec<String>,
+    pub serving_boundary: A10ServingBoundary,
+    pub claim_boundary: A1RClaimBoundary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RProvenance {
+    pub issue_url: String,
+    pub decision_contract_url: String,
+    pub successor_a1q_url: String,
+    pub frozen_s0_artifact_kappa: String,
+    pub frozen_partition_kappa: String,
+    pub frozen_partition_kappa_reproduces: bool,
+    pub frozen_construction_artifact_kappa: String,
+    pub construction_artifact_kappa_reproduces: bool,
+    pub frozen_attention_manifest_kappa: String,
+    pub attention_manifest_kappa_reproduces: bool,
+    pub frozen_a1_0_report_kappa: String,
+    pub frozen_inputs_modified: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RWorkContract {
+    pub expected_contrasts: usize,
+    pub exercised_contrasts: usize,
+    pub expected_candidate_queries: usize,
+    pub exercised_candidate_queries: usize,
+    pub expected_candidate_payload_inversions: usize,
+    pub exercised_candidate_payload_inversions: usize,
+    pub exact_candidate_payload_inversions: usize,
+    pub expected_incremental_checks: usize,
+    pub exercised_incremental_checks: usize,
+    pub exact_incremental_checks: usize,
+    pub rows_per_query_ceiling: usize,
+    pub expected_row_reads: usize,
+    pub exercised_row_reads: usize,
+    pub candidate_entry_ceiling_per_query: usize,
+    pub candidate_ceiling: usize,
+    pub maximum_admitted_candidates_observed: usize,
+    pub control_arms_per_query: usize,
+    pub expected_permutation_census: usize,
+    pub exercised_permutation_census: usize,
+    pub expected_associativity_checks: usize,
+    pub exercised_associativity_checks: usize,
+    pub external_corpus_population_scan_performed: bool,
+    pub source_model_or_teacher_run_performed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RFoldContract {
+    pub semantic_status: String,
+    pub leaf_assignment: String,
+    pub composition_order: String,
+    pub opaque_index_distance_forbidden: bool,
+    pub h4_root_table_kappa: String,
+    pub multiplication_table_kappa: String,
+    pub root_count: usize,
+    pub identity: A1RStateWitness,
+    pub construction_leaf_states: Vec<A1RNamedStateWitness>,
+    pub symmetric_generators: Vec<A1RStateWitness>,
+    pub cayley_metric_kappa: String,
+    pub cayley_distances: Vec<A1RDistanceEntry>,
+    pub all_states_reachable: bool,
+    pub deterministic_conjugator: A1RStateWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RStateWitness {
+    pub opaque_table_offset: u16,
+    pub root_coordinate: H4RootCoordinate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RNamedStateWitness {
+    pub token: String,
+    pub state: A1RStateWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RDistanceEntry {
+    pub state: A1RStateWitness,
+    pub distance_to_identity: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RPermutationCollisionCensus {
+    pub population: Vec<String>,
+    pub expected_permutations: usize,
+    pub examined_permutations: usize,
+    pub unique_states: usize,
+    pub collision_free: bool,
+    pub largest_collision_bucket_size: usize,
+    pub outcomes: Vec<A1RPermutationOutcome>,
+    pub collision_buckets: Vec<A1RCollisionBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RPermutationOutcome {
+    pub ordered_tokens: Vec<String>,
+    pub fold_state: A1RStateWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RCollisionBucket {
+    pub fold_state: A1RStateWitness,
+    pub ordered_token_sequences: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RScopeContrast {
+    pub contrast_id: String,
+    pub left_overlay_kappa: String,
+    pub right_overlay_kappa: String,
+    pub levels: Vec<A1RScopeLevelComparison>,
+    pub scope_mask_exact: bool,
+    pub legacy_non_digest_summary_equal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RScopeLevelComparison {
+    pub level: String,
+    pub expected_equal: bool,
+    pub observed_equal: bool,
+    pub left_observed_routes: u32,
+    pub right_observed_routes: u32,
+    pub left_state: A1RStateWitness,
+    pub right_state: A1RStateWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RGlobalOrderFixture {
+    pub declaration: String,
+    pub left_global_snapshot_units: Vec<String>,
+    pub right_global_snapshot_units: Vec<String>,
+    pub left_global_epoch: String,
+    pub right_global_epoch: String,
+    pub global_epoch_is_derived_identity: bool,
+    pub lower_scope_inputs_equal: bool,
+    pub candidate_rows_equal: bool,
+    pub candidate_support_equal: bool,
+    pub candidate_work_budget_equal: bool,
+    pub left_support_denominator_kappa: String,
+    pub right_support_denominator_kappa: String,
+    pub levels: Vec<A1RScopeLevelComparison>,
+    pub only_global_state_differs: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RFoldLawEvidence {
+    pub exact_table_identity: bool,
+    pub exact_table_inverses: bool,
+    pub exact_table_associativity: bool,
+    pub exact_table_closure: bool,
+    pub identity_checks: usize,
+    pub inverse_checks: usize,
+    pub associativity_checks: usize,
+    pub grouping_checks: Vec<A1RGroupingCheck>,
+    pub recursive_hierarchy_fixture: A1RRecursiveHierarchyFixture,
+    pub all_grouping_checks_exact: bool,
+    pub all_laws_exact: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RGroupingCheck {
+    pub contrast_id: String,
+    pub side: String,
+    pub flat_state: A1RStateWitness,
+    pub regrouped_state: A1RStateWitness,
+    pub current_matches_leaf: bool,
+    pub previous_matches_leaf: bool,
+    pub last_two_matches_direct_fold: bool,
+    pub sentence_matches_flat_fold: bool,
+    pub paragraph_matches_sentence: bool,
+    pub conversation_matches_paragraph: bool,
+    pub regrouping_exact: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RRecursiveHierarchyFixture {
+    pub declaration: String,
+    pub turn_count: usize,
+    pub paragraph_count: usize,
+    pub sentence_count: usize,
+    pub lexical_unit_count: usize,
+    pub flat_state: A1RStateWitness,
+    pub sentence_regrouped_state: A1RStateWitness,
+    pub paragraph_regrouped_state: A1RStateWitness,
+    pub conversation_state: A1RStateWitness,
+    pub flat_equals_sentence_regrouped: bool,
+    pub flat_equals_paragraph_regrouped: bool,
+    pub flat_equals_recursive_conversation: bool,
+    pub all_regroupings_exact: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RIncrementalCheck {
+    pub contrast_id: String,
+    pub side: String,
+    pub intended_target: String,
+    pub prefix_state: A1RStateWitness,
+    pub incremental_state: A1RStateWitness,
+    pub rebuilt_state: A1RStateWitness,
+    pub incremental_observed_routes: u32,
+    pub rebuilt_observed_routes: u32,
+    pub prefix_clone_unchanged: bool,
+    pub exact_reproduction: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RCandidateQuery {
+    pub contrast_id: String,
+    pub side: String,
+    pub intended_target: String,
+    pub history: Vec<String>,
+    pub candidate_entries_examined: usize,
+    pub candidate_entry_ceiling: usize,
+    pub unique_candidates_before_admission: usize,
+    pub unique_candidates_after_admission: usize,
+    pub retained_candidate_ceiling: usize,
+    pub full_pre_admission_union_observed: bool,
+    pub anchored_candidates_after_admission: usize,
+    pub required_anchored_candidates: usize,
+    pub admission_truncated_union: bool,
+    pub exact_direct_rows_miss: bool,
+    pub divisor_rows_miss: bool,
+    pub adjacent_spin_only_support: bool,
+    pub target_injected: bool,
+    pub future_events_visible: bool,
+    pub support_denominator_kappa: String,
+    pub rows: Vec<A10RowOrigin>,
+    pub candidate_support: Vec<A1RCandidateSupport>,
+    pub exact_candidate_payload_inversions: usize,
+    pub excluded_candidates: Vec<A1RExcludedCandidate>,
+    pub controls: Vec<A1RControlResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RCandidateSupport {
+    pub token: String,
+    pub address_kappa: String,
+    pub payload_cid: String,
+    pub payload_bytes: Vec<u8>,
+    pub exact_payload_inversion: bool,
+    pub source_counts: A10SourceCounts,
+    pub contributing_sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RSupportPairCheck {
+    pub contrast_id: String,
+    pub left_support_denominator_kappa: String,
+    pub right_support_denominator_kappa: String,
+    pub natural_candidate_union_equal: bool,
+    pub candidate_source_counts_equal: bool,
+    pub candidate_origins_equal: bool,
+    pub row_source_outcomes_equal: bool,
+    pub row_and_candidate_budgets_equal: bool,
+    pub both_competing_targets_in_each_union: bool,
+    pub exact_direct_rows_miss_both_sides: bool,
+    pub legacy_additive_summary_equal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RExcludedCandidate {
+    pub address_kappa: String,
+    pub payload_cid: String,
+    pub payload_bytes: Vec<u8>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RControlResult {
+    pub control: String,
+    pub status: String,
+    pub exercised: bool,
+    pub energy_kind: String,
+    pub hierarchy_state: Option<A1RStateWitness>,
+    pub legacy_additive_state: Option<A10AttentionLevelNonDigest>,
+    pub candidates: Vec<A1RCandidateInteraction>,
+    pub minimum_energy: Option<u32>,
+    pub minimum_energy_candidates: Vec<String>,
+    pub canonical_address_tiebreak_rule: String,
+    pub canonical_address_tiebreak_token: Option<String>,
+    pub selected_token: Option<String>,
+    pub tie: bool,
+    pub abstained: bool,
+    pub intended_target_selected: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RCandidateInteraction {
+    pub token: String,
+    pub address_kappa: String,
+    pub payload_cid: String,
+    pub source_counts: A10SourceCounts,
+    pub candidate_state: A1RStateWitness,
+    pub predecessor_token: String,
+    pub predecessor_state: A1RStateWitness,
+    pub interaction_state: Option<A1RStateWitness>,
+    pub predecessor_interaction_state: Option<A1RStateWitness>,
+    pub relative_state: Option<A1RStateWitness>,
+    pub energy: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RScoringSummary {
+    pub status: String,
+    pub required_queries: usize,
+    pub exercised_queries: usize,
+    pub full_strict_correct: usize,
+    pub full_ties: usize,
+    pub control_strict_correct: Vec<A1RControlAggregate>,
+    pub all_required_controls_present: bool,
+    pub all_required_controls_exercised: bool,
+    pub any_exercised_control_not_weaker: bool,
+    pub every_control_weaker: bool,
+    pub positive_contract_satisfied: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RTransitionReadoutSummary {
+    pub interaction: String,
+    pub scalar_readout: String,
+    pub exercised_queries: usize,
+    pub queries_with_distinct_candidate_relative_states: usize,
+    pub queries_with_distinct_relative_states_but_equal_energy: usize,
+    pub paired_same_candidate_comparisons: usize,
+    pub paired_same_candidate_relative_state_differences: usize,
+    pub scalar_readout_degeneracy_observed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RControlAggregate {
+    pub control: String,
+    pub exercised_queries: usize,
+    pub strict_correct: usize,
+    pub ties: usize,
+    pub abstentions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1RClaimBoundary {
+    pub representation_repair_only: bool,
+    pub full_recursive_attention_qualified: bool,
+    pub generation_unblocked: bool,
+    pub correctness_established: bool,
+    pub reasoning_established: bool,
+    pub digest_distance_used_as_geometry: bool,
+    pub all_identity_and_provenance_bits_excluded_from_geometry: bool,
+    pub candidate_support_or_admission_modified: bool,
+}
+
+/// Execute the frozen #967 A1R representation and candidate-relative probe.
+///
+/// This function never changes the frozen #961/#952 artifact bytes, candidate
+/// indexes, or admission rules. A positive report can activate A1Q/#969 only;
+/// it cannot qualify attention or unblock generation.
+pub fn run_a1r_associative_ordered_summary_probe(
+) -> Result<A1RAssociativeOrderedSummaryProbeReport, RecursiveGeometricAttentionError> {
+    let fixed_partition = frozen_partition();
+    validate_frozen_partition(&fixed_partition)?;
+    let partition_kappa = frozen_partition_kappa(&fixed_partition)?;
+    let registry_input = registration_input(&fixed_partition)?;
+    let codec = CanonicalLexicalCodec::compile(&registry_input)?;
+    let construction_input = construction_input(&fixed_partition)?;
+    let construction_artifact = CanonicalRouteArtifact::ingest(&codec, &construction_input)?;
+    let embedded_manifest = construction_artifact.embedded_spin_manifest()?;
+    let attention =
+        GeometricAttentionArtifact::compile_from_manifest_witnesses(&embedded_manifest)?;
+    let table = validate_h4_binary_icosahedral_closure()?;
+
+    let frozen_partition_reproduces = partition_kappa == FROZEN_A1_PARTITION_KAPPA;
+    let frozen_construction_reproduces =
+        construction_artifact.manifest_kappa() == FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA;
+    let frozen_attention_reproduces =
+        attention.manifest_kappa() == FROZEN_A1_ATTENTION_MANIFEST_KAPPA;
+    if !frozen_partition_reproduces
+        || !frozen_construction_reproduces
+        || !frozen_attention_reproduces
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "the frozen #952 partition or construction identity drifted before A1R".to_owned(),
+        ));
+    }
+
+    let predecessors = a1r_candidate_predecessors(&fixed_partition)?;
+    let metric = a1r_cayley_metric(
+        &codec,
+        &construction_artifact,
+        &embedded_manifest.addresses,
+        &table,
+    )?;
+    let permutation_collision_census =
+        a1r_permutation_collision_census(&codec, &construction_artifact, &table)?;
+
+    let mut scope_contrasts = Vec::new();
+    let mut grouping_checks = Vec::new();
+    let mut incremental_checks = Vec::new();
+    let mut prepared_candidate_queries = Vec::new();
+    let mut support_pair_checks = Vec::new();
+    let mut paired_support_exact = true;
+    for contract in &fixed_partition.evaluation_contrasts {
+        let left_artifact = CanonicalRouteArtifact::ingest(
+            &codec,
+            &evaluation_input(&contract.contrast_id, &contract.left_history)?,
+        )?;
+        let right_artifact = CanonicalRouteArtifact::ingest(
+            &codec,
+            &evaluation_input(&contract.contrast_id, &contract.right_history)?,
+        )?;
+        let left_trace = left_artifact.attention_consumer_trace_with_ordered_h4(&table)?;
+        let right_trace = right_artifact.attention_consumer_trace_with_ordered_h4(&table)?;
+        let legacy_left = left_artifact.attention_consumer_trace()?;
+        let legacy_right = right_artifact.attention_consumer_trace()?;
+        let legacy_collision = collision_census(
+            &legacy_left.ordered_levels,
+            &legacy_right.ordered_levels,
+            legacy_left.artifact_manifest_kappa != legacy_right.artifact_manifest_kappa,
+        )?;
+        scope_contrasts.push(a1r_scope_contrast(
+            contract,
+            &left_trace,
+            &right_trace,
+            legacy_collision.all_non_digest_fields_collide,
+            &table,
+        )?);
+
+        let left_history =
+            a1r_history_addresses(&codec, &construction_artifact, &contract.left_history)?;
+        let right_history =
+            a1r_history_addresses(&codec, &construction_artifact, &contract.right_history)?;
+        grouping_checks.push(a1r_grouping_check(
+            &contract.contrast_id,
+            "left",
+            &left_history,
+            &left_trace,
+            &table,
+        )?);
+        grouping_checks.push(a1r_grouping_check(
+            &contract.contrast_id,
+            "right",
+            &right_history,
+            &right_trace,
+            &table,
+        )?);
+
+        let left_path = candidate_path(
+            &codec,
+            &construction_artifact,
+            &attention,
+            &embedded_manifest.addresses,
+            &contract.left_history,
+            &contract.left_target,
+        )?;
+        let right_path = candidate_path(
+            &codec,
+            &construction_artifact,
+            &attention,
+            &embedded_manifest.addresses,
+            &contract.right_history,
+            &contract.right_target,
+        )?;
+        paired_support_exact &=
+            candidate_support_signature(&left_path) == candidate_support_signature(&right_path);
+        let both_competing_targets_in_each_union = [
+            (&left_path, &contract.left_target),
+            (&left_path, &contract.right_target),
+            (&right_path, &contract.left_target),
+            (&right_path, &contract.right_target),
+        ]
+        .into_iter()
+        .all(|(path, target)| a1r_path_contains_token(path, target));
+        support_pair_checks.push(A1RSupportPairCheck {
+            contrast_id: contract.contrast_id.clone(),
+            left_support_denominator_kappa: a1r_support_denominator_kappa(&left_path)?,
+            right_support_denominator_kappa: a1r_support_denominator_kappa(&right_path)?,
+            natural_candidate_union_equal: candidate_support_signature(&left_path)
+                .iter()
+                .map(|(address, _)| address)
+                .eq(candidate_support_signature(&right_path)
+                    .iter()
+                    .map(|(address, _)| address)),
+            candidate_source_counts_equal: candidate_support_signature(&left_path)
+                == candidate_support_signature(&right_path),
+            candidate_origins_equal: a1r_candidate_origin_signature(&left_path)
+                == a1r_candidate_origin_signature(&right_path),
+            row_source_outcomes_equal: a1r_row_source_outcome_signature(&left_path)
+                == a1r_row_source_outcome_signature(&right_path),
+            row_and_candidate_budgets_equal: a1r_path_budget_signature(&left_path)
+                == a1r_path_budget_signature(&right_path),
+            both_competing_targets_in_each_union,
+            exact_direct_rows_miss_both_sides: left_path.exact_direct_rows_miss
+                && right_path.exact_direct_rows_miss,
+            legacy_additive_summary_equal: legacy_collision.all_non_digest_fields_collide,
+        });
+        incremental_checks.push(a1r_incremental_check(
+            &contract.contrast_id,
+            "left",
+            &contract.left_target,
+            &left_history,
+            &attention,
+            &codec,
+            &construction_artifact,
+            &table,
+        )?);
+        incremental_checks.push(a1r_incremental_check(
+            &contract.contrast_id,
+            "right",
+            &contract.right_target,
+            &right_history,
+            &attention,
+            &codec,
+            &construction_artifact,
+            &table,
+        )?);
+        prepared_candidate_queries.push(A1RPreparedCandidateQuery {
+            contract: contract.clone(),
+            side: "left",
+            history: contract.left_history.clone(),
+            path: left_path,
+            trace: left_trace,
+        });
+        prepared_candidate_queries.push(A1RPreparedCandidateQuery {
+            contract: contract.clone(),
+            side: "right",
+            history: contract.right_history.clone(),
+            path: right_path,
+            trace: right_trace,
+        });
+    }
+
+    let global_order_fixture = a1r_global_order_fixture(
+        &codec,
+        &construction_artifact,
+        &attention,
+        &embedded_manifest.addresses,
+        &table,
+    )?;
+    let recursive_hierarchy_fixture =
+        a1r_recursive_hierarchy_fixture(&codec, &construction_artifact, &table)?;
+    let all_grouping_checks_exact = grouping_checks.iter().all(|check| {
+        check.current_matches_leaf
+            && check.previous_matches_leaf
+            && check.last_two_matches_direct_fold
+            && check.sentence_matches_flat_fold
+            && check.paragraph_matches_sentence
+            && check.conversation_matches_paragraph
+            && check.regrouping_exact
+    }) && recursive_hierarchy_fixture.all_regroupings_exact;
+    let fold_laws = A1RFoldLawEvidence {
+        exact_table_identity: table.identity_exact,
+        exact_table_inverses: table.inverses_exact,
+        exact_table_associativity: table.associativity_exact,
+        exact_table_closure: table.unique_closure_exact,
+        identity_checks: table.root_count.saturating_mul(2),
+        inverse_checks: table.root_count.saturating_mul(2),
+        associativity_checks: table.root_count.pow(3),
+        grouping_checks,
+        recursive_hierarchy_fixture,
+        all_grouping_checks_exact,
+        all_laws_exact: table.identity_exact
+            && table.inverses_exact
+            && table.associativity_exact
+            && table.unique_closure_exact
+            && all_grouping_checks_exact,
+    };
+    let frozen_equal_scope_exact = scope_contrasts.iter().all(|contrast| {
+        contrast.levels.iter().all(|level| {
+            !matches!(
+                level.level.as_str(),
+                "current" | "previous" | "last-two" | "global"
+            ) || level.observed_equal
+        })
+    });
+    let required_order_scopes_distinct = scope_contrasts.iter().all(|contrast| {
+        contrast.levels.iter().all(|level| {
+            !matches!(
+                level.level.as_str(),
+                "sentence" | "paragraph" | "conversation"
+            ) || !level.observed_equal
+        })
+    });
+    let incremental_exact = incremental_checks
+        .iter()
+        .all(|check| check.exact_reproduction && check.prefix_clone_unchanged);
+    let support_invariants_exact = paired_support_exact
+        && support_pair_checks.iter().all(|check| {
+            check.left_support_denominator_kappa == check.right_support_denominator_kappa
+                && check.natural_candidate_union_equal
+                && check.candidate_source_counts_equal
+                && check.candidate_origins_equal
+                && check.row_source_outcomes_equal
+                && check.row_and_candidate_budgets_equal
+                && check.both_competing_targets_in_each_union
+                && check.exact_direct_rows_miss_both_sides
+                && check.legacy_additive_summary_equal
+        })
+        && prepared_candidate_queries
+            .iter()
+            .all(|prepared| a1r_candidate_path_contract_exact(&prepared.path));
+    let census_complete = permutation_collision_census.examined_permutations
+        == permutation_collision_census.expected_permutations;
+    let structural_gate_exact = fold_laws.all_laws_exact
+        && incremental_exact
+        && frozen_equal_scope_exact
+        && required_order_scopes_distinct
+        && global_order_fixture.only_global_state_differs
+        && global_order_fixture.candidate_rows_equal
+        && global_order_fixture.candidate_support_equal
+        && global_order_fixture.candidate_work_budget_equal
+        && census_complete;
+    let score_controls =
+        structural_gate_exact && support_invariants_exact && metric.all_states_reachable;
+    let candidate_queries = prepared_candidate_queries
+        .iter()
+        .map(|prepared| {
+            a1r_candidate_query(
+                &prepared.contract,
+                prepared.side,
+                &prepared.history,
+                &prepared.path,
+                &prepared.trace,
+                &codec,
+                &construction_artifact,
+                &predecessors,
+                &metric,
+                &table,
+                score_controls,
+            )
+        })
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let support_invariants_exact = support_invariants_exact
+        && candidate_queries.iter().all(|query| {
+            query.exact_candidate_payload_inversions == query.candidate_support.len()
+                && query.anchored_candidates_after_admission == query.required_anchored_candidates
+        });
+    let scoring_summary = a1r_scoring_summary(&candidate_queries, score_controls);
+    let transition_readout_summary = a1r_transition_readout_summary(&candidate_queries);
+    let mechanics_exact =
+        structural_gate_exact && metric.all_states_reachable && support_invariants_exact;
+    let terminal_verdict = if !fold_laws.all_laws_exact
+        || !incremental_exact
+        || !frozen_equal_scope_exact
+        || !global_order_fixture.only_global_state_differs
+        || !census_complete
+    {
+        REVISE_A1R
+    } else if !required_order_scopes_distinct {
+        REDESIGN_ORDERED_ROUTE_SUMMARY
+    } else if !support_invariants_exact || !metric.all_states_reachable {
+        REVISE_A1R
+    } else if scoring_summary.positive_contract_satisfied {
+        PROMOTE_TO_A1Q
+    } else if scoring_summary.full_ties == scoring_summary.exercised_queries
+        || scoring_summary.any_exercised_control_not_weaker
+    {
+        RETAIN_STATE_ONLY
+    } else {
+        REDESIGN_ROUTE_PLACEMENT
+    };
+
+    let fold_contract = A1RFoldContract {
+        semantic_status: "EXACT_FINITE_STATE_REPRESENTATION_NO_ATTENTION_CLAIM".to_owned(),
+        leaf_assignment: "S(route) = H4[prime mod 120] in the canonical root order".to_owned(),
+        composition_order: "left-to-right S(A || B) = S(A) * S(B)".to_owned(),
+        opaque_index_distance_forbidden: true,
+        h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+        multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+        root_count: table.root_count,
+        identity: a1r_state_witness(OrderedH4FoldState::identity(&table)?, &table)?,
+        construction_leaf_states: metric.construction_leaf_states.clone(),
+        symmetric_generators: metric.generators.clone(),
+        cayley_metric_kappa: metric.metric_kappa.clone(),
+        cayley_distances: metric.distances.clone(),
+        all_states_reachable: metric.all_states_reachable,
+        deterministic_conjugator: a1r_state_witness(metric.conjugator, &table)?,
+    };
+    let body = A1RAssociativeOrderedSummaryProbeBody {
+        probe_status: if mechanics_exact && scoring_summary.all_required_controls_exercised {
+            "EXERCISED_FIXED_A1R_GATE_ALL_CONTROLS"
+        } else if mechanics_exact && scoring_summary.all_required_controls_present {
+            "EXERCISED_FIXED_A1R_NEGATIVE_WITH_UNAVAILABLE_MATCHED_CONTROL"
+        } else {
+            "EXERCISED_A1R_WITH_LOCALIZED_MECHANICS_DEFECT"
+        }
+        .to_owned(),
+        terminal_verdict: terminal_verdict.to_owned(),
+        successor_effect: if terminal_verdict == PROMOTE_TO_A1Q {
+            "A1Q_969_MAY_BECOME_ELIGIBLE_GENERATION_953_REMAINS_BLOCKED"
+        } else {
+            "A1Q_969_MUST_REMAIN_BLOCKED_BY_AN_EXACT_A1R_SUCCESSOR"
+        }
+        .to_owned(),
+        provenance: A1RProvenance {
+            issue_url: A1R_ISSUE_URL.to_owned(),
+            decision_contract_url: A1R_DECISION_CONTRACT_URL.to_owned(),
+            successor_a1q_url: A1R_SUCCESSOR_URL.to_owned(),
+            frozen_s0_artifact_kappa: FROZEN_S0_ARTIFACT_KAPPA.to_owned(),
+            frozen_partition_kappa: partition_kappa,
+            frozen_partition_kappa_reproduces: frozen_partition_reproduces,
+            frozen_construction_artifact_kappa: construction_artifact.manifest_kappa().to_owned(),
+            construction_artifact_kappa_reproduces: frozen_construction_reproduces,
+            frozen_attention_manifest_kappa: attention.manifest_kappa().to_owned(),
+            attention_manifest_kappa_reproduces: frozen_attention_reproduces,
+            frozen_a1_0_report_kappa: FROZEN_A1_REPORT_KAPPA.to_owned(),
+            frozen_inputs_modified: false,
+        },
+        work_contract: A1RWorkContract {
+            expected_contrasts: FIXED_CONTRASTS.len(),
+            exercised_contrasts: scope_contrasts.len(),
+            expected_candidate_queries: FIXED_CONTRASTS.len().saturating_mul(2),
+            exercised_candidate_queries: candidate_queries.len(),
+            expected_candidate_payload_inversions: FIXED_CONTRASTS.len().saturating_mul(4),
+            exercised_candidate_payload_inversions: candidate_queries
+                .iter()
+                .map(|query| query.candidate_support.len())
+                .sum(),
+            exact_candidate_payload_inversions: candidate_queries
+                .iter()
+                .map(|query| query.exact_candidate_payload_inversions)
+                .sum(),
+            expected_incremental_checks: FIXED_CONTRASTS.len().saturating_mul(2),
+            exercised_incremental_checks: incremental_checks.len(),
+            exact_incremental_checks: incremental_checks
+                .iter()
+                .filter(|check| check.exact_reproduction && check.prefix_clone_unchanged)
+                .count(),
+            rows_per_query_ceiling: ROWS_PER_QUERY_CEILING,
+            expected_row_reads: FIXED_CONTRASTS
+                .len()
+                .saturating_mul(2)
+                .saturating_mul(ROWS_PER_QUERY_CEILING),
+            exercised_row_reads: candidate_queries.iter().map(|query| query.rows.len()).sum(),
+            candidate_entry_ceiling_per_query: ROWS_PER_QUERY_CEILING
+                .saturating_mul(CANDIDATE_CEILING),
+            candidate_ceiling: CANDIDATE_CEILING,
+            maximum_admitted_candidates_observed: candidate_queries
+                .iter()
+                .map(|query| query.unique_candidates_after_admission)
+                .max()
+                .unwrap_or(0),
+            control_arms_per_query: CONTROL_ARMS_PER_QUERY,
+            expected_permutation_census: 120,
+            exercised_permutation_census: permutation_collision_census.examined_permutations,
+            expected_associativity_checks: table.root_count.pow(3),
+            exercised_associativity_checks: table.root_count.pow(3),
+            external_corpus_population_scan_performed: false,
+            source_model_or_teacher_run_performed: false,
+        },
+        fold_contract,
+        collision_census: permutation_collision_census,
+        scope_contrasts,
+        global_order_fixture,
+        fold_laws,
+        incremental_checks,
+        candidate_queries,
+        support_pair_checks,
+        transition_readout_summary,
+        scoring_summary,
+        support_invariants_exact,
+        excluded_digest_fields: EXCLUDED_DIGEST_IDENTITY_FIELDS
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        serving_boundary: A10ServingBoundary {
+            source_model_weights_opened: false,
+            teacher_forwards: 0,
+            transformer_calls: 0,
+            moe_calls: 0,
+            learned_router_calls: 0,
+            dense_intelligence_matrix_calls: 0,
+            ollama_calls: 0,
+            hosted_provider_calls: 0,
+        },
+        claim_boundary: A1RClaimBoundary {
+            representation_repair_only: true,
+            full_recursive_attention_qualified: false,
+            generation_unblocked: false,
+            correctness_established: false,
+            reasoning_established: false,
+            digest_distance_used_as_geometry: false,
+            all_identity_and_provenance_bits_excluded_from_geometry: true,
+            candidate_support_or_admission_modified: false,
+        },
+    };
+    let report_kappa = a1r_report_identity_kappa(&body)?;
+    let report = A1RAssociativeOrderedSummaryProbeReport {
+        schema: A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_SCHEMA,
+        domain: A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_DOMAIN.to_owned(),
+        report_kappa,
+        body,
+    };
+    report.canonical_bytes()?;
+    Ok(report)
+}
+
+#[derive(Debug, Clone)]
+struct A1RPreparedCandidateQuery {
+    contract: A10EvaluationContract,
+    side: &'static str,
+    history: Vec<String>,
+    path: A10CandidatePath,
+    trace: AttentionOrderedFoldTrace,
+}
+
+#[derive(Debug, Clone)]
+struct A1RCayleyMetric {
+    construction_leaf_states: Vec<A1RNamedStateWitness>,
+    generators: Vec<A1RStateWitness>,
+    distances: Vec<A1RDistanceEntry>,
+    distance_by_index: Vec<Option<u16>>,
+    all_states_reachable: bool,
+    metric_kappa: String,
+    conjugator: OrderedH4FoldState,
+}
+
+#[derive(Serialize)]
+struct A1RCayleyMetricIdentityWire<'a> {
+    schema: u32,
+    domain: &'static str,
+    h4_root_table_kappa: &'a str,
+    multiplication_table_kappa: &'a str,
+    generators: &'a [A1RStateWitness],
+    distances: &'a [A1RDistanceEntry],
+}
+
+fn a1r_cayley_metric(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    child_manifest_addresses: &[GeometricAddress],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RCayleyMetric, RecursiveGeometricAttentionError> {
+    let child_address_set = child_manifest_addresses.iter().collect::<BTreeSet<_>>();
+    let mut construction_leaf_states = Vec::new();
+    let mut generator_offsets = BTreeSet::new();
+    for token in REGISTERED_TOKENS {
+        let address = lexical_address(codec, construction_artifact, token)?;
+        if !child_address_set.contains(&address) {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                "construction token {token:?} is absent from the frozen child manifest"
+            )));
+        }
+        let state = h4_leaf_state_for_address(&address, table)?;
+        construction_leaf_states.push(A1RNamedStateWitness {
+            token: token.to_owned(),
+            state: a1r_state_witness(state, table)?,
+        });
+        if state.table_index().table_offset() != table.identity_index {
+            generator_offsets.insert(state.table_index().table_offset());
+            generator_offsets.insert(state.inverse(table)?.table_index().table_offset());
+        }
+    }
+    let generator_states = generator_offsets
+        .iter()
+        .map(|offset| a1r_state_from_offset(*offset, table))
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let generators = generator_states
+        .iter()
+        .copied()
+        .map(|state| a1r_state_witness(state, table))
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    if generator_states.is_empty() {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "construction produced no nonidentity Cayley generator".to_owned(),
+        ));
+    }
+
+    let mut distance_by_index: Vec<Option<u16>> = vec![None; table.root_count];
+    let identity_offset = usize::from(table.identity_index);
+    distance_by_index[identity_offset] = Some(0);
+    let mut queue = VecDeque::from([table.identity_index]);
+    while let Some(current_offset) = queue.pop_front() {
+        let current_distance = distance_by_index[usize::from(current_offset)].ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "Cayley traversal dequeued an unvisited state".to_owned(),
+            )
+        })?;
+        for generator in &generator_states {
+            let next = table
+                .product_index(current_offset, generator.table_index().table_offset())
+                .ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(
+                        "Cayley traversal addressed outside the H4 table".to_owned(),
+                    )
+                })?;
+            let entry = &mut distance_by_index[usize::from(next)];
+            if entry.is_none() {
+                *entry = Some(current_distance.checked_add(1).ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(
+                        "Cayley distance overflowed u16".to_owned(),
+                    )
+                })?);
+                queue.push_back(next);
+            }
+        }
+    }
+    let mut distances = Vec::with_capacity(table.root_count);
+    for offset in 0..table.root_count {
+        let offset = u16::try_from(offset).map_err(|_| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "H4 root count exceeds the opaque u16 table key".to_owned(),
+            )
+        })?;
+        distances.push(A1RDistanceEntry {
+            state: a1r_state_witness(a1r_state_from_offset(offset, table)?, table)?,
+            distance_to_identity: distance_by_index[usize::from(offset)],
+        });
+    }
+    let conjugator = (0..table.root_count)
+        .filter_map(|offset| u16::try_from(offset).ok())
+        .map(|offset| a1r_state_from_offset(offset, table))
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?
+        .into_iter()
+        .find(|candidate| {
+            (0..table.root_count).any(|offset| {
+                let Ok(offset) = u16::try_from(offset) else {
+                    return false;
+                };
+                table.product_index(candidate.table_index().table_offset(), offset)
+                    != table.product_index(offset, candidate.table_index().table_offset())
+            })
+        })
+        .ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "the canonical H4 root order has no noncentral conjugator".to_owned(),
+            )
+        })?;
+    let metric_kappa = canonical_kappa(&canonical_json(&A1RCayleyMetricIdentityWire {
+        schema: 1,
+        domain: "uor-r4.a1r-symmetric-construction-cayley-metric/1",
+        h4_root_table_kappa: &table.h4_root_table_kappa,
+        multiplication_table_kappa: &table.multiplication_table_kappa,
+        generators: &generators,
+        distances: &distances,
+    })?)?;
+    Ok(A1RCayleyMetric {
+        construction_leaf_states,
+        generators,
+        distances,
+        all_states_reachable: distance_by_index.iter().all(Option::is_some),
+        distance_by_index,
+        metric_kappa,
+        conjugator,
+    })
+}
+
+fn a1r_state_from_offset(
+    offset: u16,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, RecursiveGeometricAttentionError> {
+    let index =
+        crate::canonical_lexical_ingestion::OpaqueH4TableIndex::from_table_offset(offset, table)
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "H4 table offset {offset} is outside the frozen table"
+                ))
+            })?;
+    Ok(OrderedH4FoldState::from_table_index(index, table)?)
+}
+
+fn a1r_state_witness(
+    state: OrderedH4FoldState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RStateWitness, RecursiveGeometricAttentionError> {
+    Ok(A1RStateWitness {
+        opaque_table_offset: state.table_index().table_offset(),
+        root_coordinate: state.root_coordinate(table)?,
+    })
+}
+
+fn a1r_fold_states(
+    states: &[OrderedH4FoldState],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, RecursiveGeometricAttentionError> {
+    let mut fold = OrderedH4FoldState::identity(table)?;
+    for state in states {
+        fold = fold.compose(*state, table)?;
+    }
+    Ok(fold)
+}
+
+fn a1r_fold_addresses(
+    addresses: &[GeometricAddress],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, RecursiveGeometricAttentionError> {
+    let states = addresses
+        .iter()
+        .map(|address| h4_leaf_state_for_address(address, table))
+        .collect::<Result<Vec<_>, CanonicalLexicalError>>()?;
+    a1r_fold_states(&states, table)
+}
+
+fn a1r_history_addresses(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    history: &[String],
+) -> Result<Vec<GeometricAddress>, RecursiveGeometricAttentionError> {
+    history
+        .iter()
+        .map(|token| lexical_address(codec, construction_artifact, token))
+        .collect()
+}
+
+fn a1r_permutation_collision_census(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RPermutationCollisionCensus, RecursiveGeometricAttentionError> {
+    const POPULATION: [&str; 5] = ["aa", "bb", "cc", "dd", "qq"];
+    let mut permutations = Vec::with_capacity(120);
+    a1r_permute_tokens(
+        &POPULATION,
+        &mut Vec::new(),
+        &mut [false; 5],
+        &mut permutations,
+    );
+    if permutations.len() != 120 {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+            "five-token collision census produced {} rather than 120 permutations",
+            permutations.len()
+        )));
+    }
+    let mut outcomes = Vec::with_capacity(permutations.len());
+    let mut buckets = BTreeMap::<u16, Vec<Vec<String>>>::new();
+    for permutation in permutations {
+        let addresses = permutation
+            .iter()
+            .map(|token| lexical_address(codec, construction_artifact, token))
+            .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+        let state = a1r_fold_addresses(&addresses, table)?;
+        let ordered_tokens: Vec<String> = permutation
+            .iter()
+            .map(|token| (*token).to_owned())
+            .collect();
+        buckets
+            .entry(state.table_index().table_offset())
+            .or_default()
+            .push(ordered_tokens.clone());
+        outcomes.push(A1RPermutationOutcome {
+            ordered_tokens,
+            fold_state: a1r_state_witness(state, table)?,
+        });
+    }
+    let collision_buckets = buckets
+        .iter()
+        .filter(|(_, sequences)| sequences.len() > 1)
+        .map(|(offset, sequences)| {
+            Ok(A1RCollisionBucket {
+                fold_state: a1r_state_witness(a1r_state_from_offset(*offset, table)?, table)?,
+                ordered_token_sequences: sequences.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let largest_collision_bucket_size = buckets.values().map(Vec::len).max().unwrap_or(0);
+    Ok(A1RPermutationCollisionCensus {
+        population: POPULATION.into_iter().map(str::to_owned).collect(),
+        expected_permutations: 120,
+        examined_permutations: outcomes.len(),
+        unique_states: buckets.len(),
+        collision_free: buckets.len() == outcomes.len(),
+        largest_collision_bucket_size,
+        outcomes,
+        collision_buckets,
+    })
+}
+
+fn a1r_permute_tokens<'a>(
+    population: &'a [&'a str; 5],
+    prefix: &mut Vec<&'a str>,
+    used: &mut [bool; 5],
+    permutations: &mut Vec<Vec<&'a str>>,
+) {
+    if prefix.len() == population.len() {
+        permutations.push(prefix.clone());
+        return;
+    }
+    for index in 0..population.len() {
+        if used[index] {
+            continue;
+        }
+        used[index] = true;
+        prefix.push(population[index]);
+        a1r_permute_tokens(population, prefix, used, permutations);
+        prefix.pop();
+        used[index] = false;
+    }
+}
+
+fn a1r_scope_contrast(
+    contract: &A10EvaluationContract,
+    left: &AttentionOrderedFoldTrace,
+    right: &AttentionOrderedFoldTrace,
+    legacy_non_digest_summary_equal: bool,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RScopeContrast, RecursiveGeometricAttentionError> {
+    let expected = [true, true, true, false, false, false, true];
+    let levels = a1r_compare_scope_levels(left, right, &expected, table)?;
+    Ok(A1RScopeContrast {
+        contrast_id: contract.contrast_id.clone(),
+        left_overlay_kappa: left.overlay_kappa.clone(),
+        right_overlay_kappa: right.overlay_kappa.clone(),
+        scope_mask_exact: levels
+            .iter()
+            .all(|level| level.expected_equal == level.observed_equal),
+        legacy_non_digest_summary_equal,
+        levels,
+    })
+}
+
+fn a1r_compare_scope_levels(
+    left: &AttentionOrderedFoldTrace,
+    right: &AttentionOrderedFoldTrace,
+    expected_equal: &[bool; 7],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<Vec<A1RScopeLevelComparison>, RecursiveGeometricAttentionError> {
+    if left.ordered_levels.len() != REQUIRED_LEVELS.len()
+        || right.ordered_levels.len() != REQUIRED_LEVELS.len()
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "ordered H4 overlay did not expose seven required levels".to_owned(),
+        ));
+    }
+    left.ordered_levels
+        .iter()
+        .zip(&right.ordered_levels)
+        .zip(REQUIRED_LEVELS.into_iter().zip(expected_equal))
+        .map(|((left, right), (required, expected_equal))| {
+            if left.level != required || right.level != required {
+                return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "ordered H4 overlay level order diverged at {required}"
+                )));
+            }
+            Ok(A1RScopeLevelComparison {
+                level: required.to_owned(),
+                expected_equal: *expected_equal,
+                observed_equal: left.state == right.state,
+                left_observed_routes: left.observed_routes,
+                right_observed_routes: right.observed_routes,
+                left_state: a1r_state_witness(left.state, table)?,
+                right_state: a1r_state_witness(right.state, table)?,
+            })
+        })
+        .collect()
+}
+
+fn a1r_ordered_level_state(
+    trace: &AttentionOrderedFoldTrace,
+    level: &str,
+) -> Result<OrderedH4FoldState, RecursiveGeometricAttentionError> {
+    trace
+        .ordered_levels
+        .iter()
+        .find(|candidate| candidate.level == level)
+        .map(|candidate| candidate.state)
+        .ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(format!(
+                "ordered H4 overlay is missing {level}"
+            ))
+        })
+}
+
+fn a1r_grouping_check(
+    contrast_id: &str,
+    side: &str,
+    history: &[GeometricAddress],
+    trace: &AttentionOrderedFoldTrace,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RGroupingCheck, RecursiveGeometricAttentionError> {
+    if history.len() < 2 {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "A1R grouping check requires at least two observed routes".to_owned(),
+        ));
+    }
+    let flat = a1r_fold_addresses(history, table)?;
+    let split = 2.min(history.len());
+    let regrouped = a1r_fold_addresses(&history[..split], table)?
+        .compose(a1r_fold_addresses(&history[split..], table)?, table)?;
+    let current = a1r_ordered_level_state(trace, "current")?;
+    let previous = a1r_ordered_level_state(trace, "previous")?;
+    let last_two = a1r_ordered_level_state(trace, "last-two")?;
+    let sentence = a1r_ordered_level_state(trace, "sentence")?;
+    let paragraph = a1r_ordered_level_state(trace, "paragraph")?;
+    let conversation = a1r_ordered_level_state(trace, "conversation")?;
+    Ok(A1RGroupingCheck {
+        contrast_id: contrast_id.to_owned(),
+        side: side.to_owned(),
+        flat_state: a1r_state_witness(flat, table)?,
+        regrouped_state: a1r_state_witness(regrouped, table)?,
+        current_matches_leaf: current
+            == h4_leaf_state_for_address(
+                history.last().ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(
+                        "A1R history unexpectedly became empty".to_owned(),
+                    )
+                })?,
+                table,
+            )?,
+        previous_matches_leaf: previous
+            == h4_leaf_state_for_address(&history[history.len() - 2], table)?,
+        last_two_matches_direct_fold: last_two
+            == a1r_fold_addresses(&history[history.len() - 2..], table)?,
+        sentence_matches_flat_fold: sentence == flat,
+        paragraph_matches_sentence: paragraph == sentence,
+        conversation_matches_paragraph: conversation == paragraph,
+        regrouping_exact: regrouped == flat,
+    })
+}
+
+fn a1r_recursive_hierarchy_fixture(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RRecursiveHierarchyFixture, RecursiveGeometricAttentionError> {
+    let turns = vec![
+        vec![vec![vec!["aa", "bb"], vec!["dd"]], vec![vec!["cc", "qq"]]],
+        vec![vec![vec!["bb", "aa"], vec!["dd", "cc"]]],
+    ];
+    let global_snapshot_units = vec![GLOBAL_TOKEN.as_bytes().to_vec()];
+    let input = ConversationInput {
+        identity_scope: "issue-967/a1r-recursive-hierarchy-fixture".to_owned(),
+        global_epoch: canonical_global_epoch(&global_snapshot_units)?,
+        global_snapshot_units,
+        turns: turns
+            .iter()
+            .enumerate()
+            .map(|(turn_index, paragraphs)| TurnInput {
+                turn_id: format!("turn-{turn_index:04}"),
+                paragraphs: paragraphs
+                    .iter()
+                    .map(|sentences| ParagraphInput {
+                        sentences: sentences
+                            .iter()
+                            .map(|tokens| tokens.join(" ").into_bytes())
+                            .collect(),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    };
+    let trace = CanonicalRouteArtifact::ingest(codec, &input)?
+        .attention_consumer_trace_with_ordered_h4(table)?;
+
+    let mut flat_addresses = Vec::new();
+    let mut sentence_states = Vec::new();
+    let mut paragraph_states = Vec::new();
+    let mut paragraph_count = 0usize;
+    let mut sentence_count = 0usize;
+    for paragraphs in &turns {
+        for sentences in paragraphs {
+            paragraph_count = paragraph_count.saturating_add(1);
+            let mut states_in_paragraph = Vec::new();
+            for tokens in sentences {
+                sentence_count = sentence_count.saturating_add(1);
+                let addresses = tokens
+                    .iter()
+                    .map(|token| lexical_address(codec, construction_artifact, token))
+                    .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+                flat_addresses.extend(addresses.iter().cloned());
+                let sentence_state = a1r_fold_addresses(&addresses, table)?;
+                sentence_states.push(sentence_state);
+                states_in_paragraph.push(sentence_state);
+            }
+            paragraph_states.push(a1r_fold_states(&states_in_paragraph, table)?);
+        }
+    }
+    let flat = a1r_fold_addresses(&flat_addresses, table)?;
+    let sentence_regrouped = a1r_fold_states(&sentence_states, table)?;
+    let paragraph_regrouped = a1r_fold_states(&paragraph_states, table)?;
+    let conversation = a1r_ordered_level_state(&trace, "conversation")?;
+    let flat_equals_sentence_regrouped = flat == sentence_regrouped;
+    let flat_equals_paragraph_regrouped = flat == paragraph_regrouped;
+    let flat_equals_recursive_conversation = flat == conversation;
+    Ok(A1RRecursiveHierarchyFixture {
+        declaration: "two turns, three paragraphs, and five sentences independently regrouped from the same nine lexical units".to_owned(),
+        turn_count: turns.len(),
+        paragraph_count,
+        sentence_count,
+        lexical_unit_count: flat_addresses.len(),
+        flat_state: a1r_state_witness(flat, table)?,
+        sentence_regrouped_state: a1r_state_witness(sentence_regrouped, table)?,
+        paragraph_regrouped_state: a1r_state_witness(paragraph_regrouped, table)?,
+        conversation_state: a1r_state_witness(conversation, table)?,
+        flat_equals_sentence_regrouped,
+        flat_equals_paragraph_regrouped,
+        flat_equals_recursive_conversation,
+        all_regroupings_exact: flat_equals_sentence_regrouped
+            && flat_equals_paragraph_regrouped
+            && flat_equals_recursive_conversation,
+    })
+}
+
+fn a1r_global_order_fixture(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    attention: &GeometricAttentionArtifact,
+    child_manifest_addresses: &[GeometricAddress],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RGlobalOrderFixture, RecursiveGeometricAttentionError> {
+    let history = vec!["aa".to_owned(), "bb".to_owned(), "cc".to_owned()];
+    let left_units = vec![b"aa".to_vec(), b"bb".to_vec(), b"dd".to_vec()];
+    let right_units = vec![b"bb".to_vec(), b"aa".to_vec(), b"dd".to_vec()];
+    let left_input = a1r_global_fixture_input(&history, left_units.clone())?;
+    let right_input = a1r_global_fixture_input(&history, right_units.clone())?;
+    let left_epoch = left_input.global_epoch.clone();
+    let right_epoch = right_input.global_epoch.clone();
+    let left = CanonicalRouteArtifact::ingest(codec, &left_input)?
+        .attention_consumer_trace_with_ordered_h4(table)?;
+    let right = CanonicalRouteArtifact::ingest(codec, &right_input)?
+        .attention_consumer_trace_with_ordered_h4(table)?;
+    let left_path = candidate_path(
+        codec,
+        construction_artifact,
+        attention,
+        child_manifest_addresses,
+        &history,
+        "ll",
+    )?;
+    let right_path = candidate_path(
+        codec,
+        construction_artifact,
+        attention,
+        child_manifest_addresses,
+        &history,
+        "ll",
+    )?;
+    let expected = [true, true, true, true, true, true, false];
+    let levels = a1r_compare_scope_levels(&left, &right, &expected, table)?;
+    let candidate_rows_equal = a1r_row_source_outcome_signature(&left_path)
+        == a1r_row_source_outcome_signature(&right_path);
+    let candidate_support_equal =
+        a1r_candidate_origin_signature(&left_path) == a1r_candidate_origin_signature(&right_path);
+    let candidate_work_budget_equal =
+        a1r_path_budget_signature(&left_path) == a1r_path_budget_signature(&right_path);
+    let lower_scope_inputs_equal = left_input.identity_scope == right_input.identity_scope
+        && left_input.turns == right_input.turns;
+    Ok(A1RGlobalOrderFixture {
+        declaration: "only construction-independent global snapshot order differs".to_owned(),
+        left_global_snapshot_units: left_units.iter().map(hex::encode).collect(),
+        right_global_snapshot_units: right_units.iter().map(hex::encode).collect(),
+        left_global_epoch: left_epoch,
+        right_global_epoch: right_epoch,
+        global_epoch_is_derived_identity: true,
+        lower_scope_inputs_equal,
+        candidate_rows_equal,
+        candidate_support_equal,
+        candidate_work_budget_equal,
+        left_support_denominator_kappa: a1r_support_denominator_kappa(&left_path)?,
+        right_support_denominator_kappa: a1r_support_denominator_kappa(&right_path)?,
+        only_global_state_differs: levels
+            .iter()
+            .all(|level| level.expected_equal == level.observed_equal)
+            && lower_scope_inputs_equal
+            && candidate_rows_equal
+            && candidate_support_equal
+            && candidate_work_budget_equal,
+        levels,
+    })
+}
+
+fn a1r_global_fixture_input(
+    history: &[String],
+    global_snapshot_units: Vec<Vec<u8>>,
+) -> Result<ConversationInput, RecursiveGeometricAttentionError> {
+    Ok(ConversationInput {
+        identity_scope: "issue-967/a1r-global-order-fixture".to_owned(),
+        global_epoch: canonical_global_epoch(&global_snapshot_units)?,
+        global_snapshot_units,
+        turns: vec![TurnInput {
+            turn_id: "turn-0001".to_owned(),
+            paragraphs: vec![ParagraphInput {
+                sentences: vec![history.join(" ").into_bytes()],
+            }],
+        }],
+    })
+}
+
+fn a1r_candidate_predecessors(
+    partition: &A10FrozenPartition,
+) -> Result<BTreeMap<String, String>, RecursiveGeometricAttentionError> {
+    let mut predecessors = BTreeMap::new();
+    for sentence in &partition.construction_sentences {
+        if let [predecessor, candidate] = sentence.as_slice() {
+            if let Some(existing) = predecessors.insert(candidate.clone(), predecessor.clone()) {
+                if existing != *predecessor {
+                    return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                        "candidate {candidate:?} has multiple construction predecessors"
+                    )));
+                }
+            }
+        }
+    }
+    if predecessors.get("ll").map(String::as_str) != Some("uu")
+        || predecessors.get("rr").map(String::as_str) != Some("vv")
+        || predecessors.len() != 2
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "frozen construction predecessor map is not ll<-uu and rr<-vv".to_owned(),
+        ));
+    }
+    Ok(predecessors)
+}
+
+fn a1r_incremental_check(
+    contrast_id: &str,
+    side: &str,
+    intended_target: &str,
+    history: &[GeometricAddress],
+    attention: &GeometricAttentionArtifact,
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RIncrementalCheck, RecursiveGeometricAttentionError> {
+    let mut incremental = attention.causal_ordered_state_from_history(history, table)?;
+    let prefix = incremental.clone();
+    let prefix_state = incremental.fold_state();
+    let target = lexical_address(codec, construction_artifact, intended_target)?;
+    attention.observe_ordered(&mut incremental, &target, table)?;
+    let mut extended = history.to_vec();
+    extended.push(target);
+    let rebuilt = attention.causal_ordered_state_from_history(&extended, table)?;
+    Ok(A1RIncrementalCheck {
+        contrast_id: contrast_id.to_owned(),
+        side: side.to_owned(),
+        intended_target: intended_target.to_owned(),
+        prefix_state: a1r_state_witness(prefix_state, table)?,
+        incremental_state: a1r_state_witness(incremental.fold_state(), table)?,
+        rebuilt_state: a1r_state_witness(rebuilt.fold_state(), table)?,
+        incremental_observed_routes: incremental.observed_routes(),
+        rebuilt_observed_routes: rebuilt.observed_routes(),
+        prefix_clone_unchanged: prefix.fold_state() == prefix_state
+            && prefix.observed_routes()
+                == u32::try_from(history.len()).map_err(|_| {
+                    RecursiveGeometricAttentionError::InvalidProbe(
+                        "A1R history length exceeds u32".to_owned(),
+                    )
+                })?,
+        exact_reproduction: incremental == rebuilt,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct A1RAnchoredCandidate {
+    support: A1RCandidateSupport,
+    candidate_state: OrderedH4FoldState,
+    predecessor_token: String,
+    predecessor_state: OrderedH4FoldState,
+}
+
+#[derive(Debug, Clone)]
+enum A1RControlMode {
+    Geometry(OrderedH4FoldState),
+    LegacyAdditive(A10AttentionLevelNonDigest),
+    FactorCount,
+    ExactRecall,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn a1r_candidate_query(
+    contract: &A10EvaluationContract,
+    side: &str,
+    history: &[String],
+    path: &A10CandidatePath,
+    trace: &AttentionOrderedFoldTrace,
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    predecessors: &BTreeMap<String, String>,
+    metric: &A1RCayleyMetric,
+    table: &H4BinaryIcosahedralClosure,
+    score_controls: bool,
+) -> Result<A1RCandidateQuery, RecursiveGeometricAttentionError> {
+    let intended_target = match side {
+        "left" => &contract.left_target,
+        "right" => &contract.right_target,
+        _ => {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                "unsupported A1R query side {side:?}"
+            )))
+        }
+    };
+    if path.intended_target_token != *intended_target {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+            "candidate path target {} disagrees with {side} contract target {intended_target}",
+            path.intended_target_token
+        )));
+    }
+    let mut candidate_support = Vec::with_capacity(path.candidates.len());
+    let mut anchored = Vec::new();
+    let mut excluded_candidates = Vec::new();
+    for candidate in &path.candidates {
+        let token = std::str::from_utf8(&candidate.address_value.payload_bytes)
+            .map_err(|error| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "candidate payload is not a fixed UTF-8 token: {error}"
+                ))
+            })?
+            .to_owned();
+        let candidate_address = lexical_address(codec, construction_artifact, &token)?;
+        let reproduced_value = construction_artifact
+            .lexical_route_value_for_address_from_validated_artifact(&candidate_address)?
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "candidate {token:?} did not invert through the frozen lexical artifact"
+                ))
+            })?;
+        let exact_payload_inversion = candidate_address.canonical_kappa()?
+            == candidate.address_value.address_kappa
+            && reproduced_value.address_kappa == candidate.address_value.address_kappa
+            && reproduced_value.payload_cid == candidate.address_value.payload_cid
+            && reproduced_value.payload_bytes == candidate.address_value.payload_bytes;
+        let support = A1RCandidateSupport {
+            token: token.clone(),
+            address_kappa: candidate.address_value.address_kappa.clone(),
+            payload_cid: candidate.address_value.payload_cid.clone(),
+            payload_bytes: candidate.address_value.payload_bytes.clone(),
+            exact_payload_inversion,
+            source_counts: candidate.source_counts,
+            contributing_sources: candidate.contributing_sources.clone(),
+        };
+        if let Some(predecessor_token) = predecessors.get(&token) {
+            if !exact_payload_inversion {
+                return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "candidate {token:?} address and payload did not reproduce independently"
+                )));
+            }
+            let predecessor_address =
+                lexical_address(codec, construction_artifact, predecessor_token)?;
+            anchored.push(A1RAnchoredCandidate {
+                support: support.clone(),
+                candidate_state: h4_leaf_state_for_address(&candidate_address, table)?,
+                predecessor_token: predecessor_token.clone(),
+                predecessor_state: h4_leaf_state_for_address(&predecessor_address, table)?,
+            });
+        } else {
+            excluded_candidates.push(A1RExcludedCandidate {
+                address_kappa: support.address_kappa.clone(),
+                payload_cid: support.payload_cid.clone(),
+                payload_bytes: support.payload_bytes.clone(),
+                reason: "NO_UNIQUE_FROZEN_CONSTRUCTION_PREDECESSOR".to_owned(),
+            });
+        }
+        candidate_support.push(support);
+    }
+    anchored.sort_by(|left, right| left.support.token.cmp(&right.support.token));
+    excluded_candidates.sort_by(|left, right| left.address_kappa.cmp(&right.address_kappa));
+
+    let full = a1r_ordered_level_state(trace, "sentence")?;
+    let current = a1r_ordered_level_state(trace, "current")?;
+    let legacy_additive = trace
+        .ordered_levels
+        .iter()
+        .find(|level| level.level == "sentence")
+        .map(|level| non_digest_level(&level.consumer_level))
+        .ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "A1R trace is missing the existing additive sentence summary".to_owned(),
+            )
+        })?;
+    let conjugator_inverse = metric.conjugator.inverse(table)?;
+    let conjugated = metric
+        .conjugator
+        .compose(full, table)?
+        .compose(conjugator_inverse, table)?;
+    let identity = OrderedH4FoldState::identity(table)?;
+    let inverse = full.inverse(table)?;
+    let controls = if score_controls {
+        vec![
+            a1r_control_result(
+                "full-ordered-hierarchy",
+                "symmetric-cayley-word-distance-to-identity",
+                A1RControlMode::Geometry(full),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "current-only",
+                "symmetric-cayley-word-distance-to-identity",
+                A1RControlMode::Geometry(current),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "existing-additive-summary",
+                "no-predeclared-candidate-relative-scorer-for-frozen-additive-state",
+                A1RControlMode::LegacyAdditive(legacy_additive),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "factor-count",
+                "inverse-total-frozen-source-count",
+                A1RControlMode::FactorCount,
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "deterministic-conjugation",
+                "symmetric-cayley-word-distance-to-identity",
+                A1RControlMode::Geometry(conjugated),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "hierarchy-disabled",
+                "symmetric-cayley-word-distance-to-identity",
+                A1RControlMode::Geometry(identity),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "exact-recall-only",
+                "exact-row-hit-binary-energy",
+                A1RControlMode::ExactRecall,
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+            a1r_control_result(
+                "inverse-h4-intervention",
+                "symmetric-cayley-word-distance-to-identity",
+                A1RControlMode::Geometry(inverse),
+                &anchored,
+                intended_target,
+                metric,
+                table,
+            )?,
+        ]
+    } else {
+        Vec::new()
+    };
+    Ok(A1RCandidateQuery {
+        contrast_id: contract.contrast_id.clone(),
+        side: side.to_owned(),
+        intended_target: intended_target.clone(),
+        history: history.to_vec(),
+        candidate_entries_examined: path.candidate_entries_examined,
+        candidate_entry_ceiling: path.candidate_entry_ceiling,
+        unique_candidates_before_admission: path.unique_candidates_before_admission,
+        unique_candidates_after_admission: path.unique_candidates_after_admission,
+        retained_candidate_ceiling: path.retained_candidate_ceiling,
+        full_pre_admission_union_observed: path.full_pre_admission_union_observed,
+        anchored_candidates_after_admission: anchored.len(),
+        required_anchored_candidates: predecessors.len(),
+        admission_truncated_union: path.admission_truncated_union,
+        exact_direct_rows_miss: path.exact_direct_rows_miss,
+        divisor_rows_miss: path
+            .rows
+            .iter()
+            .filter(|row| row.source == "divisor")
+            .all(|row| !row.hit),
+        adjacent_spin_only_support: candidate_support.iter().all(|candidate| {
+            candidate.source_counts.last_one == 0
+                && candidate.source_counts.last_two == 0
+                && candidate.source_counts.ordered_sentence == 0
+                && candidate.source_counts.divisor == 0
+                && candidate.source_counts.adjacent_spin > 0
+                && candidate.contributing_sources.len() == 1
+                && candidate.contributing_sources.first().map(String::as_str)
+                    == Some("adjacent-spin")
+        }),
+        target_injected: path.target_injected,
+        future_events_visible: path.future_events_visible,
+        support_denominator_kappa: a1r_support_denominator_kappa(path)?,
+        rows: path.rows.clone(),
+        exact_candidate_payload_inversions: candidate_support
+            .iter()
+            .filter(|candidate| candidate.exact_payload_inversion)
+            .count(),
+        candidate_support,
+        excluded_candidates,
+        controls,
+    })
+}
+
+fn a1r_support_denominator_kappa(
+    path: &A10CandidatePath,
+) -> Result<String, RecursiveGeometricAttentionError> {
+    canonical_kappa(&canonical_json(&candidate_support_signature(path))?)
+}
+
+fn a1r_path_contains_token(path: &A10CandidatePath, token: &str) -> bool {
+    path.candidates
+        .iter()
+        .any(|candidate| candidate.address_value.payload_bytes == token.as_bytes())
+}
+
+fn a1r_commutator(
+    left: OrderedH4FoldState,
+    right: OrderedH4FoldState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, RecursiveGeometricAttentionError> {
+    Ok(left
+        .compose(right, table)?
+        .compose(left.inverse(table)?, table)?
+        .compose(right.inverse(table)?, table)?)
+}
+
+fn a1r_control_result(
+    control: &str,
+    energy_kind: &str,
+    mode: A1RControlMode,
+    candidates: &[A1RAnchoredCandidate],
+    intended_target: &str,
+    metric: &A1RCayleyMetric,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1RControlResult, RecursiveGeometricAttentionError> {
+    let hierarchy_state = match &mode {
+        A1RControlMode::Geometry(state) => Some(a1r_state_witness(*state, table)?),
+        A1RControlMode::LegacyAdditive(_)
+        | A1RControlMode::FactorCount
+        | A1RControlMode::ExactRecall => None,
+    };
+    let legacy_additive_state = match &mode {
+        A1RControlMode::LegacyAdditive(state) => Some(state.clone()),
+        A1RControlMode::Geometry(_) | A1RControlMode::FactorCount | A1RControlMode::ExactRecall => {
+            None
+        }
+    };
+    let mut interactions = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        let (interaction, predecessor_interaction, relative, energy) = match &mode {
+            A1RControlMode::Geometry(hierarchy) => {
+                let interaction = a1r_commutator(*hierarchy, candidate.candidate_state, table)?;
+                let predecessor_interaction = a1r_commutator(
+                    candidate.predecessor_state,
+                    candidate.candidate_state,
+                    table,
+                )?;
+                let relative =
+                    interaction.compose(predecessor_interaction.inverse(table)?, table)?;
+                let distance = metric.distance_by_index
+                    [usize::from(relative.table_index().table_offset())]
+                .map(u32::from)
+                .unwrap_or(u32::MAX);
+                (
+                    Some(a1r_state_witness(interaction, table)?),
+                    Some(a1r_state_witness(predecessor_interaction, table)?),
+                    Some(a1r_state_witness(relative, table)?),
+                    Some(distance),
+                )
+            }
+            A1RControlMode::LegacyAdditive(_) => (None, None, None, None),
+            A1RControlMode::FactorCount => {
+                let counts = candidate.support.source_counts;
+                let total = counts
+                    .last_one
+                    .saturating_add(counts.last_two)
+                    .saturating_add(counts.ordered_sentence)
+                    .saturating_add(counts.divisor)
+                    .saturating_add(counts.adjacent_spin);
+                (None, None, None, Some(u32::MAX.saturating_sub(total)))
+            }
+            A1RControlMode::ExactRecall => {
+                let counts = candidate.support.source_counts;
+                let exact_hit =
+                    counts.last_one > 0 || counts.last_two > 0 || counts.ordered_sentence > 0;
+                (None, None, None, exact_hit.then_some(0))
+            }
+        };
+        interactions.push(A1RCandidateInteraction {
+            token: candidate.support.token.clone(),
+            address_kappa: candidate.support.address_kappa.clone(),
+            payload_cid: candidate.support.payload_cid.clone(),
+            source_counts: candidate.support.source_counts,
+            candidate_state: a1r_state_witness(candidate.candidate_state, table)?,
+            predecessor_token: candidate.predecessor_token.clone(),
+            predecessor_state: a1r_state_witness(candidate.predecessor_state, table)?,
+            interaction_state: interaction,
+            predecessor_interaction_state: predecessor_interaction,
+            relative_state: relative,
+            energy,
+        });
+    }
+    let minimum_energy = interactions
+        .iter()
+        .filter_map(|candidate| candidate.energy)
+        .min();
+    let mut minimum_energy_candidates = minimum_energy.map_or_else(Vec::new, |minimum| {
+        interactions
+            .iter()
+            .filter(|candidate| candidate.energy == Some(minimum))
+            .map(|candidate| candidate.token.clone())
+            .collect::<Vec<_>>()
+    });
+    minimum_energy_candidates.sort();
+    let canonical_address_tiebreak_token = interactions
+        .iter()
+        .filter(|candidate| minimum_energy_candidates.contains(&candidate.token))
+        .min_by(|left, right| left.address_kappa.cmp(&right.address_kappa))
+        .map(|candidate| candidate.token.clone());
+    let exercised = !matches!(&mode, A1RControlMode::LegacyAdditive(_));
+    let tie = exercised && minimum_energy_candidates.len() > 1;
+    let selected_token = (exercised && minimum_energy_candidates.len() == 1)
+        .then(|| minimum_energy_candidates[0].clone());
+    let abstained = selected_token.is_none();
+    let status = if !exercised {
+        "NOT_EXERCISED_NO_PREDECLARED_ADDITIVE_SCORER"
+    } else if minimum_energy_candidates.is_empty() && matches!(&mode, A1RControlMode::ExactRecall) {
+        "EXERCISED_NO_EXACT_HIT_ABSTAIN"
+    } else if minimum_energy_candidates.is_empty() {
+        "EXERCISED_EMPTY_CANDIDATE_ABSTAIN"
+    } else if tie {
+        "EXERCISED_TIE_ABSTAIN"
+    } else {
+        "EXERCISED_STRICT_SELECTION"
+    };
+    let intended_target_selected = selected_token
+        .as_deref()
+        .is_some_and(|token| token == intended_target);
+    Ok(A1RControlResult {
+        control: control.to_owned(),
+        status: status.to_owned(),
+        exercised,
+        energy_kind: energy_kind.to_owned(),
+        hierarchy_state,
+        legacy_additive_state,
+        candidates: interactions,
+        minimum_energy,
+        minimum_energy_candidates,
+        canonical_address_tiebreak_rule: "lexicographically-smallest-address-kappa-diagnostic-only"
+            .to_owned(),
+        canonical_address_tiebreak_token,
+        selected_token,
+        tie,
+        abstained,
+        intended_target_selected,
+    })
+}
+
+fn a1r_scoring_summary(queries: &[A1RCandidateQuery], score_controls: bool) -> A1RScoringSummary {
+    if !score_controls {
+        return A1RScoringSummary {
+            status: "NOT_EXERCISED_STRUCTURAL_OR_SUPPORT_GATE".to_owned(),
+            required_queries: FIXED_CONTRASTS.len().saturating_mul(2),
+            exercised_queries: 0,
+            full_strict_correct: 0,
+            full_ties: 0,
+            control_strict_correct: Vec::new(),
+            all_required_controls_present: false,
+            all_required_controls_exercised: false,
+            any_exercised_control_not_weaker: false,
+            every_control_weaker: false,
+            positive_contract_satisfied: false,
+        };
+    }
+    let mut aggregates = BTreeMap::<String, (usize, usize, usize, usize)>::new();
+    let mut full_strict_correct = 0usize;
+    let mut full_ties = 0usize;
+    let mut full_exercised_queries = 0usize;
+    let required_controls = A1R_REQUIRED_CONTROLS
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    let all_required_controls_present = queries.iter().all(|query| {
+        query.controls.len() == CONTROL_ARMS_PER_QUERY
+            && query
+                .controls
+                .iter()
+                .map(|control| control.control.clone())
+                .collect::<BTreeSet<_>>()
+                == required_controls
+    });
+    for query in queries {
+        for control in &query.controls {
+            let aggregate = aggregates.entry(control.control.clone()).or_default();
+            if control.exercised {
+                aggregate.0 += 1;
+            }
+            if control.intended_target_selected {
+                aggregate.1 += 1;
+            }
+            if control.tie {
+                aggregate.2 += 1;
+            }
+            if control.abstained {
+                aggregate.3 += 1;
+            }
+            if control.control == "full-ordered-hierarchy" {
+                if control.exercised {
+                    full_exercised_queries += 1;
+                }
+                if control.intended_target_selected {
+                    full_strict_correct += 1;
+                }
+                if control.tie {
+                    full_ties += 1;
+                }
+            }
+        }
+    }
+    let control_strict_correct = aggregates
+        .iter()
+        .filter(|(control, _)| control.as_str() != "full-ordered-hierarchy")
+        .map(
+            |(control, (exercised_queries, strict_correct, ties, abstentions))| {
+                A1RControlAggregate {
+                    control: control.clone(),
+                    exercised_queries: *exercised_queries,
+                    strict_correct: *strict_correct,
+                    ties: *ties,
+                    abstentions: *abstentions,
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    let all_required_controls_exercised = all_required_controls_present
+        && aggregates
+            .iter()
+            .all(|(_, (exercised, _, _, _))| *exercised == queries.len());
+    let every_control_weaker = all_required_controls_exercised
+        && control_strict_correct
+            .iter()
+            .all(|control| control.strict_correct < full_strict_correct);
+    let any_exercised_control_not_weaker = control_strict_correct.iter().any(|control| {
+        control.exercised_queries == queries.len() && control.strict_correct >= full_strict_correct
+    });
+    let status = if !all_required_controls_present {
+        "INVALID_REQUIRED_CONTROL_SET"
+    } else if !all_required_controls_exercised {
+        "EXERCISED_WITH_UNAVAILABLE_MATCHED_CONTROL"
+    } else {
+        "EXERCISED_ALL_MATCHED_CONTROLS"
+    };
+    A1RScoringSummary {
+        status: status.to_owned(),
+        required_queries: FIXED_CONTRASTS.len().saturating_mul(2),
+        exercised_queries: full_exercised_queries,
+        full_strict_correct,
+        full_ties,
+        all_required_controls_present,
+        all_required_controls_exercised,
+        any_exercised_control_not_weaker,
+        every_control_weaker,
+        positive_contract_satisfied: all_required_controls_present
+            && all_required_controls_exercised
+            && full_exercised_queries == FIXED_CONTRASTS.len().saturating_mul(2)
+            && full_strict_correct == queries.len()
+            && every_control_weaker,
+        control_strict_correct,
+    }
+}
+
+fn a1r_transition_readout_summary(queries: &[A1RCandidateQuery]) -> A1RTransitionReadoutSummary {
+    let mut exercised_queries = 0usize;
+    let mut distinct_candidate_relative_states = 0usize;
+    let mut distinct_states_equal_energy = 0usize;
+    for query in queries {
+        let Some(control) = a1r_full_control(query) else {
+            continue;
+        };
+        if !control.exercised {
+            continue;
+        }
+        exercised_queries = exercised_queries.saturating_add(1);
+        let relative_states = control
+            .candidates
+            .iter()
+            .filter_map(|candidate| candidate.relative_state.as_ref())
+            .collect::<Vec<_>>();
+        let relative_states_distinct = relative_states.len() == control.candidates.len()
+            && relative_states.iter().enumerate().all(|(index, state)| {
+                relative_states[..index]
+                    .iter()
+                    .all(|prior| *prior != *state)
+            });
+        if relative_states_distinct {
+            distinct_candidate_relative_states =
+                distinct_candidate_relative_states.saturating_add(1);
+        }
+        let energies = control
+            .candidates
+            .iter()
+            .filter_map(|candidate| candidate.energy)
+            .collect::<Vec<_>>();
+        let equal_energy = energies.len() == control.candidates.len()
+            && energies
+                .first()
+                .is_some_and(|first| energies.iter().all(|energy| energy == first));
+        if relative_states_distinct && equal_energy {
+            distinct_states_equal_energy = distinct_states_equal_energy.saturating_add(1);
+        }
+    }
+
+    let mut paired_same_candidate_comparisons = 0usize;
+    let mut paired_same_candidate_relative_state_differences = 0usize;
+    for contrast in &FIXED_CONTRASTS {
+        let left = queries
+            .iter()
+            .find(|query| query.contrast_id == contrast.id && query.side == "left")
+            .and_then(a1r_full_control);
+        let right = queries
+            .iter()
+            .find(|query| query.contrast_id == contrast.id && query.side == "right")
+            .and_then(a1r_full_control);
+        let (Some(left), Some(right)) = (left, right) else {
+            continue;
+        };
+        for token in ["ll", "rr"] {
+            let left_state = left
+                .candidates
+                .iter()
+                .find(|candidate| candidate.token == token)
+                .and_then(|candidate| candidate.relative_state.as_ref());
+            let right_state = right
+                .candidates
+                .iter()
+                .find(|candidate| candidate.token == token)
+                .and_then(|candidate| candidate.relative_state.as_ref());
+            if let (Some(left_state), Some(right_state)) = (left_state, right_state) {
+                paired_same_candidate_comparisons =
+                    paired_same_candidate_comparisons.saturating_add(1);
+                if left_state != right_state {
+                    paired_same_candidate_relative_state_differences =
+                        paired_same_candidate_relative_state_differences.saturating_add(1);
+                }
+            }
+        }
+    }
+    A1RTransitionReadoutSummary {
+        interaction: "D(H,c)=C(H,c)*C(P_c,c)^-1".to_owned(),
+        scalar_readout: "shortest symmetric construction-Cayley word distance to identity"
+            .to_owned(),
+        exercised_queries,
+        queries_with_distinct_candidate_relative_states: distinct_candidate_relative_states,
+        queries_with_distinct_relative_states_but_equal_energy: distinct_states_equal_energy,
+        paired_same_candidate_comparisons,
+        paired_same_candidate_relative_state_differences,
+        scalar_readout_degeneracy_observed: exercised_queries > 0
+            && distinct_states_equal_energy == exercised_queries,
+    }
+}
+
+fn a1r_full_control(query: &A1RCandidateQuery) -> Option<&A1RControlResult> {
+    query
+        .controls
+        .iter()
+        .find(|control| control.control == "full-ordered-hierarchy")
+}
+
 fn frozen_partition() -> A10FrozenPartition {
     A10FrozenPartition {
         declaration: "compile-time fixed before codec, candidate rows, summaries, or statistics"
@@ -1163,7 +3295,7 @@ fn candidate_path(
         .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
     let target_unit = lexical_unit_id(codec, target_token)?;
     let target = construction_artifact
-        .lexical_route_address(target_unit)?
+        .lexical_route_address_from_validated_artifact(target_unit)?
         .ok_or_else(|| {
             RecursiveGeometricAttentionError::InvalidProbe(format!(
                 "target {target_token} has no registered geometric address"
@@ -1276,7 +3408,7 @@ fn lexical_address(
     token: &str,
 ) -> Result<GeometricAddress, RecursiveGeometricAttentionError> {
     artifact
-        .lexical_route_address(lexical_unit_id(codec, token)?)?
+        .lexical_route_address_from_validated_artifact(lexical_unit_id(codec, token)?)?
         .ok_or_else(|| {
             RecursiveGeometricAttentionError::InvalidProbe(format!(
                 "fixed token {token:?} has no registered route address"
@@ -1422,7 +3554,7 @@ fn address_value(
     address: &GeometricAddress,
 ) -> Result<A10AddressValue, RecursiveGeometricAttentionError> {
     let value = artifact
-        .lexical_route_value_for_address(address)?
+        .lexical_route_value_for_address_from_validated_artifact(address)?
         .ok_or_else(|| {
             RecursiveGeometricAttentionError::InvalidProbe(
                 "admitted candidate cannot resolve to an exact lexical value".to_owned(),
@@ -1528,6 +3660,110 @@ fn candidate_support_signature(path: &A10CandidatePath) -> Vec<(String, A10Sourc
     signature
 }
 
+fn a1r_candidate_origin_signature(
+    path: &A10CandidatePath,
+) -> Vec<(String, String, Vec<u8>, A10SourceCounts, Vec<String>)> {
+    let mut signature = path
+        .candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.address_value.address_kappa.clone(),
+                candidate.address_value.payload_cid.clone(),
+                candidate.address_value.payload_bytes.clone(),
+                candidate.source_counts,
+                candidate.contributing_sources.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    signature.sort();
+    signature
+}
+
+fn a1r_row_source_outcome_signature(path: &A10CandidatePath) -> Vec<(String, String, bool, usize)> {
+    path.rows
+        .iter()
+        .map(|row| {
+            (
+                row.source.clone(),
+                row.key_kind.clone(),
+                row.hit,
+                row.candidate_entries_examined,
+            )
+        })
+        .collect()
+}
+
+fn a1r_path_budget_signature(
+    path: &A10CandidatePath,
+) -> (usize, usize, usize, usize, usize, usize, bool, bool) {
+    (
+        path.rows.len(),
+        path.candidate_entries_examined,
+        path.candidate_entry_ceiling,
+        path.unique_candidates_before_admission,
+        path.unique_candidates_after_admission,
+        path.retained_candidate_ceiling,
+        path.admission_truncated_union,
+        path.full_pre_admission_union_observed,
+    )
+}
+
+fn a1r_candidate_path_contract_exact(path: &A10CandidatePath) -> bool {
+    let source_count = |source: &str| path.rows.iter().filter(|row| row.source == source).count();
+    let divisor_rows_miss = path
+        .rows
+        .iter()
+        .filter(|row| row.source == "divisor")
+        .all(|row| !row.hit);
+    let candidates_are_exact_adjacent_spin_pair = path.candidates.len() == 2
+        && path
+            .candidates
+            .iter()
+            .map(|candidate| candidate.address_value.payload_bytes.as_slice())
+            .collect::<BTreeSet<_>>()
+            == BTreeSet::from([b"ll".as_slice(), b"rr".as_slice()])
+        && path.candidates.iter().all(|candidate| {
+            candidate.source_counts.last_one == 0
+                && candidate.source_counts.last_two == 0
+                && candidate.source_counts.ordered_sentence == 0
+                && candidate.source_counts.divisor == 0
+                && candidate.source_counts.adjacent_spin > 0
+                && candidate.contributing_sources.len() == 1
+                && candidate.contributing_sources.first().map(String::as_str)
+                    == Some("adjacent-spin")
+        });
+    path.rows.len() == ROWS_PER_QUERY_CEILING
+        && source_count("last-one") == 1
+        && source_count("last-two") == 1
+        && source_count("ordered-sentence") == 1
+        && source_count("divisor") == 1
+        && source_count("adjacent-spin") == 3
+        && path.candidate_entries_examined == 2
+        && path.candidate_entry_ceiling == ROWS_PER_QUERY_CEILING.saturating_mul(CANDIDATE_CEILING)
+        && path.unique_candidates_before_admission == 2
+        && path.unique_candidates_after_admission == 2
+        && path.retained_candidate_ceiling == CANDIDATE_CEILING
+        && !path.admission_truncated_union
+        && path.full_pre_admission_union_observed
+        && path.intended_target_pre_admission_reachable == Some(true)
+        && path.intended_target_post_admission_reachable
+        && path.intended_target_truncated_before_geometry == Some(false)
+        && path.exact_direct_rows_miss
+        && divisor_rows_miss
+        && candidates_are_exact_adjacent_spin_pair
+        && path.exclusions.iter().all(|exclusion| {
+            exclusion.status.starts_with("EXCLUDED_")
+                && exclusion.candidate_entries_contributed == 0
+        })
+        && !path.target_injected
+        && !path.future_events_visible
+        && path
+            .incremental_next_state
+            .as_ref()
+            .is_some_and(|state| state.exact_reproduction)
+}
+
 fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>, RecursiveGeometricAttentionError> {
     serde_json::to_vec(value)
         .map_err(|error| RecursiveGeometricAttentionError::Serialization(error.to_string()))
@@ -1546,6 +3782,14 @@ struct ReportIdentityWire<'a> {
     domain: &'static str,
     report_kappa: &'static str,
     body: &'a A10OrderedStateProbeBody,
+}
+
+#[derive(Serialize)]
+struct A1RReportIdentityWire<'a> {
+    schema: u32,
+    domain: &'static str,
+    report_kappa: &'static str,
+    body: &'a A1RAssociativeOrderedSummaryProbeBody,
 }
 
 #[derive(Serialize)]
@@ -1571,6 +3815,17 @@ fn report_identity_kappa(
     canonical_kappa(&canonical_json(&ReportIdentityWire {
         schema: A1_0_ORDERED_STATE_PROBE_SCHEMA,
         domain: A1_0_ORDERED_STATE_PROBE_DOMAIN,
+        report_kappa: "",
+        body,
+    })?)
+}
+
+fn a1r_report_identity_kappa(
+    body: &A1RAssociativeOrderedSummaryProbeBody,
+) -> Result<String, RecursiveGeometricAttentionError> {
+    canonical_kappa(&canonical_json(&A1RReportIdentityWire {
+        schema: A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_SCHEMA,
+        domain: A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_DOMAIN,
         report_kappa: "",
         body,
     })?)

--- a/crates/uor-r4-core/tests/recursive_geometric_attention_967.rs
+++ b/crates/uor-r4-core/tests/recursive_geometric_attention_967.rs
@@ -1,0 +1,355 @@
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use uor_r4_core::canonical_lexical_ingestion::{
+    H4_BINARY_ICOSAHEDRAL_MULTIPLICATION_TABLE_KAPPA_REFERENCE,
+    H4_BINARY_ICOSAHEDRAL_ROOT_TABLE_KAPPA_REFERENCE,
+};
+use uor_r4_core::recursive_geometric_attention::{
+    run_a1r_associative_ordered_summary_probe, A1RAssociativeOrderedSummaryProbeReport,
+    RETAIN_STATE_ONLY,
+};
+
+const FROZEN_A1R_REPORT_KAPPA: &str =
+    "blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881";
+
+fn report() -> &'static A1RAssociativeOrderedSummaryProbeReport {
+    static REPORT: OnceLock<A1RAssociativeOrderedSummaryProbeReport> = OnceLock::new();
+    REPORT
+        .get_or_init(|| run_a1r_associative_ordered_summary_probe().expect("fixed #967 A1R probe"))
+}
+
+#[test]
+fn exact_ordered_h4_fold_laws_and_collision_census_are_report_bound() {
+    let report = report();
+    assert_eq!(report.report_kappa, FROZEN_A1R_REPORT_KAPPA);
+    assert!(!report.canonical_bytes().unwrap().is_empty());
+
+    let body = &report.body;
+    assert_eq!(
+        body.fold_contract.h4_root_table_kappa,
+        H4_BINARY_ICOSAHEDRAL_ROOT_TABLE_KAPPA_REFERENCE
+    );
+    assert_eq!(
+        body.fold_contract.multiplication_table_kappa,
+        H4_BINARY_ICOSAHEDRAL_MULTIPLICATION_TABLE_KAPPA_REFERENCE
+    );
+    assert_eq!(body.fold_contract.root_count, 120);
+    assert!(body.fold_contract.opaque_index_distance_forbidden);
+    assert!(body.fold_contract.all_states_reachable);
+    assert_eq!(body.fold_contract.cayley_distances.len(), 120);
+    assert!(body
+        .fold_contract
+        .cayley_distances
+        .iter()
+        .all(|entry| entry.distance_to_identity.is_some()));
+
+    let laws = &body.fold_laws;
+    assert!(laws.exact_table_identity);
+    assert!(laws.exact_table_inverses);
+    assert!(laws.exact_table_associativity);
+    assert!(laws.exact_table_closure);
+    assert_eq!(laws.identity_checks, 240);
+    assert_eq!(laws.inverse_checks, 240);
+    assert_eq!(laws.associativity_checks, 120 * 120 * 120);
+    assert_eq!(laws.grouping_checks.len(), 6);
+    let recursive = &laws.recursive_hierarchy_fixture;
+    assert_eq!(
+        (
+            recursive.turn_count,
+            recursive.paragraph_count,
+            recursive.sentence_count,
+            recursive.lexical_unit_count,
+        ),
+        (2, 3, 5, 9)
+    );
+    assert!(recursive.flat_equals_sentence_regrouped);
+    assert!(recursive.flat_equals_paragraph_regrouped);
+    assert!(recursive.flat_equals_recursive_conversation);
+    assert!(recursive.all_regroupings_exact);
+    assert!(laws.all_grouping_checks_exact);
+    assert!(laws.all_laws_exact);
+    assert!(laws.grouping_checks.iter().all(|check| {
+        check.current_matches_leaf
+            && check.previous_matches_leaf
+            && check.last_two_matches_direct_fold
+            && check.sentence_matches_flat_fold
+            && check.paragraph_matches_sentence
+            && check.conversation_matches_paragraph
+            && check.regrouping_exact
+    }));
+
+    let census = &body.collision_census;
+    assert_eq!(census.expected_permutations, 120);
+    assert_eq!(census.examined_permutations, 120);
+    assert_eq!(census.outcomes.len(), 120);
+    assert_eq!(census.unique_states, 60);
+    assert!(!census.collision_free);
+    assert_eq!(census.collision_buckets.len(), 41);
+    assert_eq!(census.largest_collision_bucket_size, 5);
+    assert!(census
+        .collision_buckets
+        .iter()
+        .all(|bucket| bucket.ordered_token_sequences.len() > 1));
+
+    let work = &body.work_contract;
+    assert_eq!(work.expected_permutation_census, 120);
+    assert_eq!(work.exercised_permutation_census, 120);
+    assert_eq!(work.expected_associativity_checks, 120 * 120 * 120);
+    assert_eq!(work.exercised_associativity_checks, 120 * 120 * 120);
+    assert!(!work.external_corpus_population_scan_performed);
+    assert!(!work.source_model_or_teacher_run_performed);
+}
+
+#[test]
+fn repaired_state_is_distinct_but_candidate_interaction_truthfully_retains_state_only() {
+    let body = &report().body;
+    assert_eq!(
+        body.probe_status,
+        "EXERCISED_FIXED_A1R_NEGATIVE_WITH_UNAVAILABLE_MATCHED_CONTROL"
+    );
+    assert_eq!(body.terminal_verdict, RETAIN_STATE_ONLY);
+    assert_eq!(
+        body.successor_effect,
+        "A1Q_969_MUST_REMAIN_BLOCKED_BY_AN_EXACT_A1R_SUCCESSOR"
+    );
+
+    assert_eq!(body.scope_contrasts.len(), 3);
+    for contrast in &body.scope_contrasts {
+        assert!(contrast.scope_mask_exact);
+        assert!(contrast.legacy_non_digest_summary_equal);
+        assert_eq!(contrast.levels.len(), 7);
+        for level in &contrast.levels {
+            let expected_equal = matches!(
+                level.level.as_str(),
+                "current" | "previous" | "last-two" | "global"
+            );
+            assert_eq!(level.expected_equal, expected_equal);
+            assert_eq!(level.observed_equal, expected_equal);
+        }
+    }
+
+    assert!(body.global_order_fixture.lower_scope_inputs_equal);
+    assert!(body.global_order_fixture.global_epoch_is_derived_identity);
+    assert_ne!(
+        body.global_order_fixture.left_global_epoch,
+        body.global_order_fixture.right_global_epoch
+    );
+    assert!(body.global_order_fixture.candidate_rows_equal);
+    assert!(body.global_order_fixture.candidate_support_equal);
+    assert!(body.global_order_fixture.candidate_work_budget_equal);
+    assert_eq!(
+        body.global_order_fixture.left_support_denominator_kappa,
+        body.global_order_fixture.right_support_denominator_kappa
+    );
+    assert!(body.global_order_fixture.only_global_state_differs);
+    assert_eq!(body.global_order_fixture.levels.len(), 7);
+    assert!(body
+        .global_order_fixture
+        .levels
+        .iter()
+        .all(|level| level.observed_equal == (level.level != "global")));
+
+    assert_eq!(body.incremental_checks.len(), 6);
+    assert!(body
+        .incremental_checks
+        .iter()
+        .all(|check| check.prefix_clone_unchanged && check.exact_reproduction));
+    assert!(body.support_invariants_exact);
+    assert_eq!(body.support_pair_checks.len(), 3);
+    assert!(body.support_pair_checks.iter().all(|pair| {
+        pair.left_support_denominator_kappa == pair.right_support_denominator_kappa
+            && pair.natural_candidate_union_equal
+            && pair.candidate_source_counts_equal
+            && pair.candidate_origins_equal
+            && pair.row_source_outcomes_equal
+            && pair.row_and_candidate_budgets_equal
+            && pair.both_competing_targets_in_each_union
+            && pair.exact_direct_rows_miss_both_sides
+            && pair.legacy_additive_summary_equal
+    }));
+
+    let work = &body.work_contract;
+    assert_eq!((work.exercised_contrasts, work.expected_contrasts), (3, 3));
+    assert_eq!(
+        (
+            work.exercised_candidate_queries,
+            work.expected_candidate_queries
+        ),
+        (6, 6)
+    );
+    assert_eq!(
+        (
+            work.exact_candidate_payload_inversions,
+            work.exercised_candidate_payload_inversions,
+            work.expected_candidate_payload_inversions
+        ),
+        (12, 12, 12)
+    );
+    assert_eq!(
+        (
+            work.exact_incremental_checks,
+            work.exercised_incremental_checks,
+            work.expected_incremental_checks
+        ),
+        (6, 6, 6)
+    );
+    assert_eq!(work.candidate_ceiling, 8);
+    assert_eq!(work.maximum_admitted_candidates_observed, 2);
+    assert_eq!(work.rows_per_query_ceiling, 7);
+    assert_eq!(
+        (work.exercised_row_reads, work.expected_row_reads),
+        (42, 42)
+    );
+    assert_eq!(work.candidate_entry_ceiling_per_query, 56);
+    assert_eq!(work.control_arms_per_query, 8);
+
+    assert_eq!(body.candidate_queries.len(), 6);
+    let required_controls = BTreeSet::from([
+        "current-only",
+        "deterministic-conjugation",
+        "exact-recall-only",
+        "existing-additive-summary",
+        "factor-count",
+        "full-ordered-hierarchy",
+        "hierarchy-disabled",
+        "inverse-h4-intervention",
+    ]);
+    for query in &body.candidate_queries {
+        assert_eq!(query.rows.len(), 7);
+        assert_eq!(query.candidate_entries_examined, 2);
+        assert_eq!(query.candidate_entry_ceiling, 56);
+        assert_eq!(query.unique_candidates_before_admission, 2);
+        assert_eq!(query.unique_candidates_after_admission, 2);
+        assert_eq!(query.retained_candidate_ceiling, 8);
+        assert!(query.full_pre_admission_union_observed);
+        assert_eq!(query.anchored_candidates_after_admission, 2);
+        assert_eq!(query.required_anchored_candidates, 2);
+        assert_eq!(query.exact_candidate_payload_inversions, 2);
+        assert!(!query.admission_truncated_union);
+        assert!(query.exact_direct_rows_miss);
+        assert!(query.divisor_rows_miss);
+        assert!(query.adjacent_spin_only_support);
+        assert!(!query.target_injected);
+        assert!(!query.future_events_visible);
+
+        let payloads = query
+            .candidate_support
+            .iter()
+            .map(|candidate| candidate.payload_bytes.as_slice())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            payloads,
+            BTreeSet::from([b"ll".as_slice(), b"rr".as_slice()])
+        );
+        assert!(query
+            .candidate_support
+            .iter()
+            .all(|candidate| candidate.exact_payload_inversion));
+
+        assert_eq!(query.controls.len(), 8);
+        assert_eq!(
+            query
+                .controls
+                .iter()
+                .map(|control| control.control.as_str())
+                .collect::<BTreeSet<_>>(),
+            required_controls
+        );
+
+        let full = query
+            .controls
+            .iter()
+            .find(|control| control.control == "full-ordered-hierarchy")
+            .expect("full ordered hierarchy arm");
+        assert_eq!(full.status, "EXERCISED_TIE_ABSTAIN");
+        assert!(full.exercised);
+        assert_eq!(full.minimum_energy, Some(2));
+        assert_eq!(full.minimum_energy_candidates, ["ll", "rr"]);
+        assert_eq!(
+            full.canonical_address_tiebreak_rule,
+            "lexicographically-smallest-address-kappa-diagnostic-only"
+        );
+        assert_eq!(full.canonical_address_tiebreak_token.as_deref(), Some("rr"));
+        assert_eq!(full.selected_token, None);
+        assert!(full.tie);
+        assert!(full.abstained);
+        assert!(!full.intended_target_selected);
+
+        let additive = query
+            .controls
+            .iter()
+            .find(|control| control.control == "existing-additive-summary")
+            .expect("existing additive summary arm");
+        assert_eq!(
+            additive.status,
+            "NOT_EXERCISED_NO_PREDECLARED_ADDITIVE_SCORER"
+        );
+        assert!(!additive.exercised);
+        assert!(additive.legacy_additive_state.is_some());
+        assert!(additive
+            .candidates
+            .iter()
+            .all(|candidate| candidate.energy.is_none()));
+        assert!(additive.minimum_energy_candidates.is_empty());
+        assert!(additive.selected_token.is_none());
+        assert!(!additive.tie);
+        assert!(additive.abstained);
+
+        let exact = query
+            .controls
+            .iter()
+            .find(|control| control.control == "exact-recall-only")
+            .expect("exact recall arm");
+        assert_eq!(exact.status, "EXERCISED_NO_EXACT_HIT_ABSTAIN");
+        assert!(exact.exercised);
+        assert_eq!(exact.minimum_energy, None);
+        assert!(exact.minimum_energy_candidates.is_empty());
+        assert!(exact.selected_token.is_none());
+        assert!(!exact.tie);
+        assert!(exact.abstained);
+    }
+
+    let transition = &body.transition_readout_summary;
+    assert_eq!(transition.exercised_queries, 6);
+    assert_eq!(
+        transition.queries_with_distinct_candidate_relative_states,
+        6
+    );
+    assert_eq!(
+        transition.queries_with_distinct_relative_states_but_equal_energy,
+        6
+    );
+    assert_eq!(transition.paired_same_candidate_comparisons, 6);
+    assert_eq!(
+        transition.paired_same_candidate_relative_state_differences,
+        5
+    );
+    assert!(transition.scalar_readout_degeneracy_observed);
+
+    assert_eq!(
+        body.scoring_summary.status,
+        "EXERCISED_WITH_UNAVAILABLE_MATCHED_CONTROL"
+    );
+    assert_eq!(body.scoring_summary.required_queries, 6);
+    assert_eq!(body.scoring_summary.exercised_queries, 6);
+    assert_eq!(body.scoring_summary.full_strict_correct, 0);
+    assert_eq!(body.scoring_summary.full_ties, 6);
+    assert!(body.scoring_summary.all_required_controls_present);
+    assert!(!body.scoring_summary.all_required_controls_exercised);
+    assert!(body.scoring_summary.any_exercised_control_not_weaker);
+    assert!(!body.scoring_summary.every_control_weaker);
+    assert!(!body.scoring_summary.positive_contract_satisfied);
+
+    assert!(body.claim_boundary.representation_repair_only);
+    assert!(!body.claim_boundary.full_recursive_attention_qualified);
+    assert!(!body.claim_boundary.generation_unblocked);
+    assert!(!body.claim_boundary.correctness_established);
+    assert!(!body.claim_boundary.reasoning_established);
+    assert!(!body.claim_boundary.digest_distance_used_as_geometry);
+    assert!(
+        body.claim_boundary
+            .all_identity_and_provenance_bits_excluded_from_geometry
+    );
+    assert!(!body.claim_boundary.candidate_support_or_admission_modified);
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -13,9 +13,14 @@ supplies reversible lexical geometry, payload inversion, and the canonical
 incremental hierarchy identities. The frozen #952 A1.0 probe terminated as
 `REDESIGN_ORDERED_ROUTE_SUMMARY` before scorer implementation: the natural
 candidate/value path was reachable, but the additive/last-child hierarchy
-summaries erased earlier causal order. #967 owns the narrow associative,
-noncommutative ordered-summary repair and blocks #953. #953 owns
-bounded library/CLI inference and generation; #962 separately owns durable
+summaries erased earlier causal order. #967's narrow A1R delivery repaired the
+ordered state but terminated `RETAIN_STATE_ONLY` when shortest Cayley distance
+collapsed distinct candidate-relative states to the same energy on 6/6
+queries. Unassigned #970 follows protected #967 delivery, owns A1P
+candidate-relative readout/placement, and blocks #969. #969 owns A1Q full
+recursive-attention qualification; #953 is
+blocked by #969 and owns bounded library/CLI inference and generation using
+only A1Q-qualified semantic scoring terms. #962 separately owns durable
 multi-turn CLI/HTTP chat, persisted conversation state, session/identity
 isolation, and identity-scoped hive memory.
 
@@ -31,8 +36,9 @@ canonical text/corpus
     -> R4/S3 spin, S2/R3 Hopf observation, torsion, Z[phi] shells
     -> witnessed paired-H4/E8 state
     -> incremental local/sentence/paragraph/conversation/global state
-    -> associative noncommutative ordered-summary repair (#967)
-    -> complete recursive geometric-attention qualification (GI-2/#952)
+    -> associative noncommutative ordered-summary repair (#967, state only)
+    -> candidate-relative readout/placement redesign (#970)
+    -> complete recursive geometric-attention qualification (GI-2/#969)
     -> bounded source-free library/CLI inference and generation (#953)
     -> correctness + typed abstention (#954)
     -> bounded reasoning (#955)
@@ -44,14 +50,29 @@ The manifest stores or references canonical lexical payloads, factorable route
 addresses, spin/harmonic state, transported trajectory summaries, recursive
 scope identities, and rebuild witnesses. Corpus observations populate routes;
 they do not become serving weights. Kappa binds canonical identity and
-provenance, while factor/spin/harmonic coordinates provide locality.
+provenance. Factor/spin/harmonic coordinates provide structural/storage state
+and locality hypotheses; only terms qualified by A1Q/#969 may affect #953
+semantic ranking.
 
 The #952 A1.0 record is a representation-level negative result, not a failure
 of lexical inversion, candidate admission, H4 closure, Hopf state, or the value
 interface. Exact hierarchy identities preserved order as provenance, but their
-digest distance is not geometry; #967 must make that order observable in the
-bounded reusable summaries before semantic scoring resumes. See the
+digest distance is not geometry; #967 made that order observable in bounded
+reusable summaries, while #970 now owns candidate-relative readout/placement before
+semantic scoring resumes. See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
+
+In the frozen #952/A1R fixture, current, previous, last-two, and the immutable
+global snapshot intentionally remain equal; sentence, paragraph, and
+conversation differ under the repaired fold. The separate
+construction-independent global-snapshot permutation changed only global state;
+its content-derived global epochs differed as expected while lower inputs,
+candidate rows/support, budgets, and denominator remained fixed. Group/fold,
+incremental, and support invariants also held. The #967 report kappa is
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+The candidate-relative states were distinct for `ll` and `rr` on 6/6 queries,
+but their shortest-Cayley-distance energies were both 2. These results establish
+ordered state only, not attention or generation.
 
 Long compilation or evaluation is not a lifecycle default. It begins only
 after the smallest decision-bearing probe, reachability arithmetic, finite
@@ -1328,7 +1349,9 @@ Passing `--cover` reuses the measured cover. It may be omitted to re-induce
 the default cover deterministically during scoring. For experiments, `cover`
 also accepts `--depths`, `--k0`, `--regions-budget`, and `--memory-budget`.
 
-**Current production boundary pending #962 after #953–#955.** #953 owns the
+**Current production boundary pending #962 after #970, #969, and #953–#955.**
+#970 owns candidate-relative readout/placement and #969 owns full
+recursive-attention qualification. #953 owns the
 bounded source-free library/CLI inference and generation engine; #962 owns its
 integration into durable multi-turn CLI/HTTP chat, persisted conversation
 state, session/identity isolation, and identity-scoped hive memory. Until that

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -18,8 +18,10 @@ assumptions, or objectives rather than measured results.
 > [Geometric Intelligence Programme](geometric_intelligence_programme.md).
 > The geometric causal decoder roadmap and S0–S7 completion plan are retained
 > as historical evidence. GitHub programme root #820 and the native
-> GI sequence now records #961 closed, #952 A1.0 redirected through the narrow
-> #967 ordered-summary repair before #953–#955, and #962–#965 afterward; legacy
+> GI sequence now records #961 closed, #952 A1.0 redirected through #967 A1R,
+> #967 terminal `RETAIN_STATE_ONLY`, unassigned #970 A1P candidate-relative
+> readout/placement, #969 A1Q full recursive-attention qualification, then
+> #953–#955 and #962–#965 afterward; legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
 > current-summary corrections remain important: **#784** found
@@ -37,9 +39,12 @@ assumptions, or objectives rather than measured results.
 > candidate mechanics, controls, and final worker canary; it did not establish
 > product attention, generation, inference, reasoning, or teacher parity. This
 > is retained foundation evidence, not abandonment. Forward work makes lexical
-> geometry reversible (GI-1/#961), establishes recursive causal attention across
+> geometry reversible (GI-1/#961), repairs ordered state (GI-2 A1R/#967),
+> falsifies and replaces the shortest-Cayley scalar readout within the broader
+> candidate-relative readout/placement scope (GI-2 A1P/#970),
+> establishes recursive causal attention across
 > local/sentence/paragraph/conversation/global state with anti-recall evidence
-> (GI-2/#952), then adds source-free grammatical inference/generation
+> (GI-2 A1Q/#969), then adds source-free grammatical inference/generation
 > (GI-3/#953), correctness/abstention (GI-4/#954), and reasoning (GI-5/#955).
 > Exact route identity must overlap with transported trajectory, hypersphere and
 > winding/window state, window energy, shared factors, resonance, and Hopf
@@ -55,12 +60,31 @@ assumptions, or objectives rather than measured results.
 > identities differed, but digest distance is provenance, not semantic
 > geometry. The deployed schema-2 path still naturally admitted the same two
 > candidates on every query, inverted 12/12 admitted-candidate addresses to
-> exact payload bytes, and reproduced 6/6 incremental next states. #967 holds the
-> candidate/value path fixed and repairs only the reusable ordered summary.
-> #953 remains blocked pending a later full attention qualification; it owns
+> exact payload bytes, and reproduced 6/6 incremental next states. #967 held the
+> candidate/value path fixed and repaired only the reusable ordered summary.
+> In its frozen fixture, current, previous, last-two, and the immutable global
+> snapshot intentionally remain equal; sentence, paragraph, and conversation
+> are the scopes expected to differ after repair. Global order requires a
+> separate matched global-snapshot permutation. #969 owns the later full
+> attention qualification and natively blocks #953. #953 owns
 > source-free inference/generation, while #962 owns product chat and persisted
 > identity-scoped hive memory. See the
 > [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
+>
+> **A1R decision, 2026-08-27.** #967's exact ordered fold satisfied the frozen
+> scope mask, independent-global intervention, fold/group laws, incremental
+> reproduction, and candidate-support invariants. The complete report is bound
+> by
+> `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+> The full arm produced distinct `ll`/`rr` relative states on 6/6 queries and
+> changed the same-candidate state in 5/6 paired comparisons, but shortest
+> Cayley distance collapsed the distinct states to energy 2 and tied on 6/6.
+> The terminal verdict is `RETAIN_STATE_ONLY`, with no attention or generation
+> claim. `any_exercised_control_not_weaker = true` confirms that the verdict
+> follows from exercised full/control evidence, not the unavailable additive
+> scorer. Unassigned #970 follows protected #967 delivery and blocks #969; #969
+> continues to block #953. See the
+> [#967 A1R record](associative_ordered_route_summaries_a1r_967.md).
 
 The current quality-baseline reconciliation is recorded by #933 and the
 [append-only #934 genealogy](canonical_quality_baseline_934.md). The historical
@@ -288,9 +312,13 @@ This project's immediate goal is source-free recursive geometric attention.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
 reusable summaries erased earlier causal order, terminating as
-`REDESIGN_ORDERED_ROUTE_SUMMARY` before scorer implementation. #967 now repairs
-that representation; recursive attention must still pass matched controls
-before GI-3/#953 is allowed to generate.
+`REDESIGN_ORDERED_ROUTE_SUMMARY` before scorer implementation. #967 repaired
+that representation, but its scalar readout mapped distinct candidate-relative
+states to equal energy on 6/6 queries and terminated `RETAIN_STATE_ONLY`. #970
+must now falsify and replace that shortest-Cayley scalar readout within its
+broader candidate-relative readout/placement scope; #969
+must still qualify full recursive attention under matched, scope-isolated
+controls before GI-3/#953 is allowed to generate.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
 point remains allowed for witnessed chart construction; serving arithmetic is
@@ -372,14 +400,21 @@ leaving product attention and generation `NOT_RUN`.
 The active candidate is now the route-native composition specified by the
 [Geometric Intelligence Programme](geometric_intelligence_programme.md): fixed
 zeta state, prime/semiprime/n-let routing, R4/S3 and Hopf transport, exact
-`Z[phi]` shells, the load-bearing project bridge `E8 = H4 x H4` concretely
-serialized as the golden/Galois-coupled icosian pair `H4 ⊕ phi H4`, and
+`Z[phi]` shells, the required structural/storage project bridge
+`E8 = H4 x H4` concretely serialized as the golden/Galois-coupled icosian pair
+`H4 ⊕ phi H4`, and
 recursive attention combining exact identity with overlapping
 trajectory/harmonic summaries. The #952 A1.0 result showed that the current
 additive/last-child summaries do not preserve earlier order even though the
-candidate and value path is reachable. #967 must repair ordered summaries, and
-GI-2 must then establish anti-recall attention before GI-3/#953 adds the
-source-free inference/generation engine. Product chat and persisted hive memory
+candidate and value path is reachable. #967 repaired ordered summaries but
+retained them as state only after shortest Cayley distance tied distinct states
+on 6/6 queries. #970 must falsify and replace that scalar readout within its
+broader candidate-relative readout/placement scope, and #969 must then establish anti-recall
+attention before GI-3/#953 adds the
+source-free inference/generation engine. Structural presence does not qualify a
+field for ranking: unqualified Hopf, H4, zeta, icosian, SpiralCore, trajectory,
+and harmonic terms remain storage, diagnostics, or controls, and #953 may
+consume only terms qualified by A1Q. Product chat and persisted hive memory
 remain GI-6/#962 responsibilities. The
 retained #951 negative
 checkpoint and exact population remain in
@@ -815,9 +850,15 @@ whose only legitimate integration point is an honesty/claim-vocabulary bridge
 ## Open, with defined work
 
 #961 is closed. #952 A1.0 has the terminal representation verdict
-`REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 is the narrow ordered-summary repair and
-blocks #953. After full GI-2 attention qualification, #953 owns source-free
-inference/generation, #954 correctness/abstention, #955 reasoning, and #962
+`REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 repaired the fold and terminated
+`RETAIN_STATE_ONLY`. Unassigned #970 follows protected #967 delivery, owns the
+candidate-relative readout/placement redesign, and is the native blocker of
+#969. #969 is the
+separate full recursive-attention qualification and natively blocks #953, so
+closing #967 cannot make A1Q or generation eligible.
+After #969 qualifies GI-2 attention, #953 owns source-free inference/generation
+using only the qualified semantic terms, #954 correctness/abstention, #955
+reasoning, and #962
 product chat with persisted identity-scoped hive memory; #963–#965 retain cost,
 formal/serving closure, and release ownership. The table below is retained as
 the historical mechanism ledger; rows that still use “open” in their original

--- a/docs/adr/0003-fixed-zeta-prime-route-attention.md
+++ b/docs/adr/0003-fixed-zeta-prime-route-attention.md
@@ -7,13 +7,18 @@
 - **Date:** 2026-08-26
 - **Current attention-stage result:**
   [#952](https://github.com/UOR-Foundation/uor-r4/issues/952) reached
-  `REDESIGN_ORDERED_ROUTE_SUMMARY`; the recursive scorer remains
-  `NOT_IMPLEMENTED`. Ordered-summary repair is isolated in
-  [#967](https://github.com/UOR-Foundation/uor-r4/issues/967).
+  `REDESIGN_ORDERED_ROUTE_SUMMARY`. [#967](https://github.com/UOR-Foundation/uor-r4/issues/967)
+  repaired A1R ordered state and exercised its bounded candidate-relative
+  scalar scorer but terminated `RETAIN_STATE_ONLY`; the full A1Q recursive
+  attention scorer remains unimplemented and unqualified. Unassigned
+  [#970](https://github.com/UOR-Foundation/uor-r4/issues/970) owns A1P
+  candidate-relative readout/placement and blocks
+  [#969](https://github.com/UOR-Foundation/uor-r4/issues/969), which owns A1Q
+  full recursive-attention qualification and blocks #953.
 - **Decision owner:** representation redesign
   [#958](https://github.com/UOR-Foundation/uor-r4/issues/958)
 - **Programme tracker:**
-  [#949](https://github.com/UOR-Foundation/uor-r4/issues/949)
+  [#820](https://github.com/UOR-Foundation/uor-r4/issues/820)
 - **Supersedes:** the learned query/key/value replacement selected by
   [ADR-0002](0002-geometric-causal-decoder.md), after the negative #951
   qualification. ADR-0002 remains the historical record for G0 and G1.
@@ -400,10 +405,26 @@ from the blocking representation defect:
 
 The predeclared terminal verdict is therefore
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. The recursive attention scorer and its
-equal-budget semantic controls were not implemented. Issue #967 owns the
-narrow ordered-summary repair; this result does not revoke the storage,
+equal-budget semantic controls were not implemented. Issue #967 subsequently
+delivered the narrow ordered-summary repair; this result does not revoke the storage,
 candidate-reachability, value-inversion, H4, or SpiralCore mechanics established
 above.
+
+The frozen histories were deliberately matched at current, previous, last-two,
+length/multiset/boundary shape, and the immutable `gg` global project snapshot.
+For A1R/#967, those current, previous, last-two, and global scopes were required
+to remain equal; repaired sentence, paragraph, and conversation ordered state
+were required to differ.
+Any global-order claim requires a separate construction-independent global
+snapshot permutation with all lower scopes and candidate support held fixed.
+#967's repaired fold satisfied this scope contract, the independent-global
+intervention, exact group/fold laws, incremental reproduction, and support
+invariants. The report kappa is
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+Its full arm produced distinct candidate-relative states on 6/6 queries, but
+shortest Cayley distance collapsed both candidates to energy 2 and tied on 6/6,
+so the terminal verdict is `RETAIN_STATE_ONLY`. #970 owns the readout/placement redesign and
+blocks A1Q/#969. Only A1Q-qualified semantic terms may reach #953.
 
 | Component | Status | Current evidence boundary |
 |---|---|---|
@@ -415,7 +436,7 @@ above.
 | Exact 64-state SpiralCore v63 `Cl(0,6)` composition/inverse table | `IMPLEMENTED_CONTROL_ONLY` | Deterministic noncommutative table mechanics are bound and reproduced; `OPTIONAL_CONTROL_PENDING`, no semantic claim. The proposed six-prime `J(6,2)` semantic adapter remains unqualified. |
 | Complete semiprime/n-let manifest tables, chart/quantization binding, and canonical conversion/rebuild witnesses | `PASS_COMPLETE_MANIFEST_V2` | #958 schema 2 binds the prime registry, semiprime experts, ordered n-lets, address order, chart/spin/radial fields, indexes, provenance, and strict rebuild witnesses. This is storage/candidate substrate, not semantic-attention evidence. |
 | Frozen schema-2 child, bounded direct/divisor/adjacent-spin candidate union, and exact address-to-payload value view | `IMPLEMENTED_SUBSTRATE` | The fixed #952 contrasts naturally expose both targets below the ceiling of eight, with exact direct rows absent and no target injection or truncation. Candidate reachability is not attention selection. |
-| Reusable order-sensitive route summary and recursive attention scorer | `NOT_IMPLEMENTED` | All non-digest fields across all seven reusable levels collide on the three required earlier-order contrasts. Verdict: `REDESIGN_ORDERED_ROUTE_SUMMARY`; repair is #967. |
+| Reusable order-sensitive route summary and recursive attention scorer | `A1R_RETAIN_STATE_ONLY_A1P_BLOCKS_A1Q` | #967 repaired ordered state and passed its structural contracts, but shortest Cayley distance mapped distinct candidate-relative states to equal energy on 6/6 queries. #970 owns candidate-relative readout/placement and blocks #969; no full attention or generation claim follows. |
 | Layer-29 caller, equal-budget controls, no-Ollama product probe, and teacher comparison | `NOT_YET_IMPLEMENTED` | No deployed or product capability follows from the substrate. |
 | Binding one-worker/four-worker release canary with positive work on every worker and measured four-worker compile-stage improvement | `PASS_SUBSTRATE_SCOPE` | The frozen schema-2 report records 32/32 exact artifact/kappa matches, all four workers active, and 1.498x median compile-stage speedup. Any later semantic-input or workload-shape change must re-establish this bounded evidence. |
 
@@ -456,6 +477,11 @@ teacher or product run.
 - H4 unit quaternions may provide a discrete spin alphabet in R4. This does not
   identify H4 with E8 or claim that a four-dimensional H4 construction is a
   faithful eight-dimensional E8 representation.
+- Paired-H4/icosian state remains required for canonical storage, address
+  reconstruction, and inverse witnesses. That structural requirement does not
+  qualify H4, Hopf, zeta, icosian, SpiralCore, or other geometric fields for
+  semantic ranking; A1Q/#969 must qualify each scoring term before #953 can use
+  it.
 - Every lossy projection declares what is discarded and what the manifest
   retains for reconstruction.
 - No hours-long run launches until direct-lookup reachability, deterministic

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -1,8 +1,10 @@
 # ADR-0004: Define a bounded geometric-intelligence route hierarchy
 
 - **Status:** Accepted as an architectural definition and evaluation boundary;
-  paragraph, conversation, global, inference, and reasoning capability remain
-  unproven and off the product path.
+  #967 A1R repaired ordered state but terminated `RETAIN_STATE_ONLY`; #970 A1P
+  candidate-relative readout/placement blocks #969 A1Q; and attention, inference,
+  correctness, and reasoning capability remain unproven and off the product
+  path. #969 blocks #953.
 - **Date:** 2026-08-26
 - **Builds on:** [ADR-0003](0003-fixed-zeta-prime-route-attention.md)
 - **Evaluation:**
@@ -44,12 +46,16 @@ Adopt five ordered, identity-scoped route levels: local, sentence, paragraph,
 conversation, and global. Each level is an incremental accumulator over bounded
 child records. A parent commits to ordered child kappas, span boundaries,
 provenance, and a declared factorable geometric summary. That summary preserves
-the signals needed for overlap when an exact kappa misses: the transported
-trajectory commitment, session hypersphere vector, winding/window state,
+structural state that may be tested for overlap when an exact kappa misses: the
+transported trajectory commitment, session hypersphere vector, winding/window state,
 projection energy, shared-prime factors, cosine resonance, accumulated Hopf
 phase, and paired-H4/E8 coordinate. Query reads a fixed artifact-declared
 number of rows at each enabled level; it never enumerates all descendant tokens
 or corpus records.
+
+Those fields are required structural/storage representation until evidence says
+otherwise. A1Q/#969 alone qualifies a subset as semantic scoring terms; #953
+may consume only that qualified subset.
 
 This ADR defines identities, boundaries, and evaluation. It does not promote a
 serving implementation.
@@ -79,7 +85,9 @@ R_t^q = (
 
 **Definition:** `kappa(R_t^q)` is the canonical content identity of this exact
 envelope. The digest supplies equality and integrity, not geometric distance.
-Factor, phase, spin/Hopf, torsion, and radial fields supply declared locality.
+Factor, phase, spin/Hopf, torsion, and radial fields supply declared structural
+coordinates and candidate locality hypotheses. They do not supply semantic
+ranking until qualified by A1Q/#969.
 
 The bridge mode is exact identity data. The project seam is
 `exp(i*pi)+pi^0 =_bridge 0^0`. In `ContinuousNull`, the typed transition
@@ -159,7 +167,20 @@ per row, retained candidates after admission, and patch/epoch depth. Exceeding a
 scope ceiling closes, summarizes, backs off, or abstains according to a typed
 policy; it never silently expands work.
 
-## 4. Load-bearing paired-H4/E8 bridge
+The frozen #952/A1R fixture isolates earlier conversation order while matching
+current, previous, last-two, length/multiset/boundary shape, and the immutable
+`gg` global snapshot. #967's repaired behavior was equality at current,
+previous, last-two, and global, with differences at sentence, paragraph, and
+conversation. Its separate construction-independent global-snapshot
+permutation held lower inputs, candidate rows/support, budgets, and denominator
+fixed while changing only global state; its content-derived epochs differed as
+expected. Exact fold/group, incremental, and support invariants held. The
+full arm produced distinct `ll`/`rr` relative states on 6/6 queries, but shortest
+Cayley distance collapsed them to energy 2 and tied on 6/6. Report kappa:
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+The `RETAIN_STATE_ONLY` verdict establishes no full attention claim.
+
+## 4. Required structural/storage paired-H4/E8 bridge
 
 **Assumption:** the project's conceptual identity is
 `E8 = H4 × H4`. The target hierarchy realizes that shorthand through the
@@ -179,14 +200,13 @@ bind the icosian basis, glue/parity rule, Galois/golden conjugation, scale, shel
 membership, root ordering, orientation, inverse/rebuild witness, and
 operator-table kappa.
 
-The paired coordinate is load-bearing in the target route hierarchy: it is part
-of each transported geometric summary and therefore must participate in
-candidate support or ordering. This architectural requirement does not by
-itself establish held-out advantage. Promotion still requires an equal-budget
-intervention against factor-only and basis/shell-permuted controls on anti-
-recall inputs. If it is not load-bearing, the geometric-intelligence target
-fails or requires a superseding architecture decision; the prime/Hopf store may
-remain useful only as a separately named storage/recall substrate.
+The paired coordinate is required in canonical hierarchy storage, address
+reconstruction, and the inverse witness. That architectural requirement does
+not make it a semantic scoring term. A1Q/#969 may qualify it only through an
+equal-budget intervention against factor-only and basis/shell-permuted controls
+on candidate-relative anti-recall inputs. If it does not qualify, the field
+remains valid structural/storage state, a diagnostic, or a control and may not
+influence #953 ranking.
 
 ## 5. Retrieval, admission, and attention
 
@@ -211,15 +231,16 @@ address, when the union exceeds the artifact ceiling. That rule and the number
 excluded are part of the coverage witness.
 
 When exact hierarchy kappas miss, bounded fallback uses overlapping
-trajectory/harmonic locality rather than digest distance: shared-prime factors,
-projection energy, cosine resonance, winding/window compatibility, accumulated
-Hopf phase, trigonometric chart/quarter-turn transport, and paired-H4/E8
-coordinates.
+trajectory/harmonic locality rather than digest distance. Candidate terms
+include shared-prime factors, projection energy, cosine resonance,
+winding/window compatibility, accumulated Hopf phase, trigonometric
+chart/quarter-turn transport, and paired-H4/E8 coordinates; only the
+A1Q-qualified subset may affect semantic candidate support or ranking.
 
 **Definition:** geometric recall returns a continuation because an exact or
 declared backoff identity was stored. **Definition:** geometric attention ranks
 the admitted causal support using declared geometric energy or compatibility,
-and the complete hierarchy geometry is load-bearing against matched controls.
+and its qualified semantic terms are load-bearing against matched controls.
 Consequently,
 “least energy” means least energy among admitted candidates unless an artifact
 explicitly scores the entire bounded union before admission.
@@ -238,7 +259,8 @@ coverage witness containing:
 - observed route membership result and identity scope;
 - each row key read, scope/source, hit/miss, and entries examined;
 - union size, pre-geometric admission policy, admitted and excluded support;
-- per-candidate source counts and declared energy components;
+- per-candidate source counts, qualified semantic energy components, and
+  separately labeled unqualified structural/diagnostic fields;
 - transported-trajectory fields: session hypersphere vector, winding/window,
   projection energy, shared factors, cosine resonance, accumulated Hopf phase,
   and paired-H4/E8 coordinate;
@@ -253,10 +275,12 @@ itself establish generalization, correctness, reasoning, or product readiness.
 
 ## 7. Inference, correctness, and reasoning boundaries
 
-**Definition:** inference consumes observed hierarchy state, selects next-token
-scores or a token, updates state, and decodes output through the pinned lexical
-codec. Attention supplies bounded context; it is not the complete inference
-mechanism.
+**Definition:** inference consumes observed hierarchy state and only the
+A1Q-qualified semantic scoring terms, selects next-token scores or a token,
+updates state, and decodes output through the pinned lexical codec. Required
+storage fields remain available for reconstruction but cannot influence ranking
+while unqualified. Attention supplies bounded context; it is not the complete
+inference mechanism.
 
 **Empirical Criterion:** correctness is measured against a predeclared
 independent oracle or constraint, with answered, incorrect, and abstained
@@ -281,13 +305,18 @@ rebuild witnesses are prerequisite plumbing. They are not inference.
 
 Delivery proceeds without skipping stages:
 
-1. complete recursive attention through local, sentence, paragraph,
-   conversation, and global scopes, including exact-key misses served by
+1. retain the associative noncommutative ordered state delivered by A1R/#967
+   without claiming full attention;
+2. falsify and replace the shortest-Cayley scalar readout in A1P/#970, within
+   its broader candidate-relative readout/placement scope and with that state,
+   anchors, and support fixed;
+3. qualify full recursive attention in A1Q/#969 through local, sentence,
+   paragraph, conversation, and global scopes, including exact-key misses served by
    transported harmonic/trajectory locality and matched controls;
-2. implement provider-free inference and coherent generation over that complete
-   hierarchy;
-3. measure correctness and typed abstention against independent oracles; and
-4. measure bounded reasoning through novel multi-step state transitions.
+4. implement provider-free inference and coherent generation in #953 over only
+   the qualified hierarchy terms;
+5. measure correctness and typed abstention against independent oracles; and
+6. measure bounded reasoning through novel multi-step state transitions.
 
 No generation score can substitute for incomplete attention scopes, and no
 reasoning claim can precede correctness evidence.
@@ -303,8 +332,9 @@ reasoning claim can precede correctness evidence.
 - Unknown addresses fail closed; unseen ordered combinations may still be
   evaluated through bounded geometric backoff.
 - The target realizes the conceptual `E8 = H4 × H4` identity through the
-  required, basis/glue-bound icosian `H4 ⊕ φH4` serialization and inverse
-  witness.
+  required structural/storage, basis/glue-bound icosian `H4 ⊕ φH4`
+  serialization and inverse witness; semantic use requires separate A1Q
+  qualification.
 - Product, correctness, and reasoning claims require separate anti-recall
   evaluations and real serving evidence.
 
@@ -332,7 +362,8 @@ selection on novel combinations.
 ### Serialize only the words `E8 = H4 × H4`
 
 Rejected as an implementation contract, while retaining it as the project
-shorthand. The load-bearing serialized bridge is the basis/glue-bound icosian
+shorthand. The required structural/storage serialized bridge is the
+basis/glue-bound icosian
 `Z`-module construction with golden-coupled R4 points and the declared
 `H4 ⊕ φH4` folding. Omitting that data would leave the conceptual identity
 without canonical bytes, a rebuild path, or an inverse witness.

--- a/docs/associative_ordered_route_summaries_a1r_967.md
+++ b/docs/associative_ordered_route_summaries_a1r_967.md
@@ -1,0 +1,368 @@
+# #967 A1R associative ordered-summary record
+
+Status: terminal representation evidence (`RETAIN_STATE_ONLY`)
+
+Date: 2026-08-27
+
+Issue: [#967](https://github.com/UOR-Foundation/uor-r4/issues/967)
+
+Pre-evidence contract:
+[corrected A1R decision contract](https://github.com/UOR-Foundation/uor-r4/issues/967#issuecomment-5434971151)
+
+Terminal evidence:
+[corrected public outcome](https://github.com/UOR-Foundation/uor-r4/issues/967#issuecomment-5435663938)
+
+Exact successor: [#970](https://github.com/UOR-Foundation/uor-r4/issues/970),
+the unassigned candidate-relative readout/placement redesign. The verified native
+chain is `#967 → #970 → #969 → #953`; closing #967 therefore cannot make A1Q
+or generation eligible.
+
+## Decision
+
+The associative H4 fold repaired the representation defect found by #952. All
+three frozen earlier-order contrasts produced the required distinct sentence,
+paragraph, and conversation states while current, previous, last-two, and the
+immutable global snapshot stayed equal. A separate global-order fixture changed
+only global state. Exact group laws, flattened-versus-regrouped composition,
+incremental-versus-rebuild equality, prefix preservation, candidate support,
+and payload inversion all held on their frozen denominators.
+
+The predeclared candidate-relative interaction preserved more information than
+the scalar decision exposed. The full arm produced distinct `ll`-versus-`rr`
+relative states on all 6 queries, and the same candidate's relative state
+changed across 5 of the 6 matched left/right comparisons. The construction-only
+anchors therefore did not collapse the state.
+
+The shortest-Cayley-distance readout then mapped every distinct full-arm state
+to scalar energy 2. Both candidates tied on all 6 queries, so no selection was
+made. One required matched arm, the existing additive summary, was recorded but
+could not be ranked because the decision contract predeclared no additive
+candidate scorer. That unavailability prevents a positive contract, but it is
+not the reason for the terminal verdict. The report separately binds both
+`full_ties == exercised_queries` and
+`any_exercised_control_not_weaker = true`; the exercised full/control evidence
+therefore activates the tie branch independently:
+
+`RETAIN_STATE_ONLY`
+
+This retains the ordered fold and candidate-relative states as exact structural
+state. The observed defect is specifically the shortest-Cayley scalar readout,
+not a state or anchor collapse. #970 owns the broader candidate-relative
+readout/placement falsifier; #967 did not establish a placement defect. The
+result does not qualify H4 coordinates, the commutator, or any other stored
+geometric field as a semantic scoring term.
+Full recursive attention, inference, generation, correctness, reasoning, and
+product readiness remain unestablished.
+
+## Frozen identities
+
+The A1R report transitively binds the unchanged #961/#952 inputs and receives a
+new independent identity.
+
+| Binding | Kappa | Binding status |
+|---|---|---:|
+| Frozen #961 S0 artifact | `blake3:3f2043e15a32f6ef799c0073d0c714e3140449591b7d8a18069e39c5182662bd` | bound, not reproduced by A1R |
+| Frozen #952 partition | `blake3:d008b82eda9b16b102cf4c7ffa4a47a40ad514b30f0763ed3f46c0ebae3e277b` | yes |
+| Construction-only canonical route artifact | `blake3:2b70588d654c8e8bb2d8ab063f41853d45a21487d742ff7567f93a42cfb9011b` | yes |
+| Embedded schema-2 attention manifest | `blake3:1c77c4103732964af6776f1dfcabc8b2a9191eea875a8ba205c36ebbf5618a99` | yes |
+| Frozen #952 A1.0 report | `blake3:23e07a17e897abb701c09354d35a3113a1b075ba1d60ee634067fa3ed3fd1904` | bound |
+| A1R symmetric Cayley metric | `blake3:5dfda068473f57afdf33f17ea6a53efea62fd13d9c98082032f00d5198bc96a2` | yes |
+| Independent #967 A1R report | `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881` | yes |
+
+No frozen fixture, target, candidate row, support count, admission rule, or
+candidate ceiling was changed after observing results.
+
+## Representation contract
+
+Each already-registered route maps through the #961 assignment
+
+`leaf(route) = H4[prime mod 120]`.
+
+The reusable ordered state composes left to right:
+
+`S(A || B) = S(A) * S(B)`.
+
+The deployed algebraic step is an integer-indexed lookup in the frozen exact
+120-state table. Table/root construction, exact quaternion multiplication, and
+the full table-identity check remain outside the per-composition lookup. The
+opaque table key is an address only; numeric key differences are not geometry.
+The consumer surface exposes the exact scaled `Z[phi]` quaternion coordinate
+alongside the state and attaches it directly to each `AttentionLevelTrace`.
+
+The A1R overlay has an identity independent of the frozen S0 artifact and binds:
+
+- source artifact identity;
+- fixed root ordering and exact `Z[phi]` coordinate convention;
+- H4 root-table and multiplication-table identities;
+- `prime mod 120` leaf assignment;
+- left-to-right composition convention; and
+- all seven ordered consumer levels.
+
+Legacy additive overlap fields remain present and their state is bound as a
+diagnostic/control. The state remained equal on every matched contrast, but its
+ranking arm is `NOT_EXERCISED_NO_PREDECLARED_ADDITIVE_SCORER`: the frozen
+contract did not declare an additive candidate-energy function. The fields are
+not relabeled as ordered state, and the frozen #952 artifact/report bytes remain
+unchanged.
+
+## Exact finite-algebra evidence
+
+The finite table is an algebraic representation/control, not semantic evidence.
+
+| Measure | Result |
+|---|---:|
+| H4 roots | 120 |
+| Exact products | 14,400 |
+| Identity checks | 240 / 240 |
+| Inverse checks | 240 / 240 |
+| Associativity triples | 1,728,000 / 1,728,000 |
+| Construction-derived symmetric generators | 20 |
+| Cayley states reachable from identity | 120 / 120 |
+| Flattened/regrouped hierarchy checks | 6 / 6 exact |
+| Independent recursive hierarchy fixture | 2 turns / 3 paragraphs / 5 sentences / 9 units, exact |
+
+Root-table kappa:
+`blake3:8d33d62a239fb8001fea2bd14a9a5ec7321d0f07d81c74a5715eaeb3df53aa76`
+
+Multiplication-table kappa:
+`blake3:90ee73a27ee2e8ba5bccd1507d7fb37ed1f044b1640772c86752bc0bb2111759`
+
+For each of the six frozen histories, the direct flat fold equaled an
+independently regrouped fold. Current and previous states reproduced their leaf
+states; last-two reproduced the direct two-leaf fold; and the sentence,
+paragraph, and conversation hierarchy roots reproduced the same flat state.
+An independent multi-level fixture also folded the same nine lexical units
+flat, by sentence, by paragraph, and through a two-turn recursive conversation;
+all regroupings were exact.
+
+## Same-multiset collision census
+
+The predeclared population was every permutation of
+`{aa, bb, cc, dd, qq}`. No target-dependent generator or fold was changed after
+this census.
+
+| Measure | Result |
+|---|---:|
+| Expected permutations | 120 |
+| Exercised permutations | 120 |
+| Distinct final states | 60 |
+| Colliding state buckets | 41 |
+| Largest collision bucket | 5 ordered sequences |
+| Collision-free | no |
+
+Every outcome and every colliding sequence bucket is present in the canonical
+CLI report. The aliases do not invalidate the fixed contrasts because their
+required sentence/paragraph/conversation states are distinct. They do bound the
+claim: a 120-state fold is not a unique identity for arbitrary histories.
+
+## Scope-isolation evidence
+
+The #952 histories match current route, previous route, last-two suffix, length,
+multiset, boundaries, and the immutable `gg` global snapshot. The corrected
+contract therefore required this mask for all three pairs:
+
+| Scope | Expected | Observed |
+|---|---|---|
+| Current | equal | equal in 3 / 3 |
+| Previous | equal | equal in 3 / 3 |
+| Last two | equal | equal in 3 / 3 |
+| Sentence | different | different in 3 / 3 |
+| Paragraph | different | different in 3 / 3 |
+| Conversation | different | different in 3 / 3 |
+| Global | equal | equal in 3 / 3 |
+
+The legacy 46-field non-digest additive summary remained equal for every pair,
+preserving #952's measurement. A1R adds a distinct overlay rather than rewriting
+that historical state.
+
+Global order used a separate construction-independent fixture. Its two arms had
+identical current-through-conversation inputs, candidate rows, support, work
+budgets, and support-denominator kappa. Their global epochs were independently
+derived from the differently ordered immutable snapshots and therefore differed
+as expected. All six lower levels stayed equal and only global ordered state
+differed.
+
+## Incremental evidence
+
+For each of the six query histories, the probe cloned the prefix state, appended
+the declared already-observed target through the API-neutral causal state, and
+compared the result with a clean rebuild.
+
+| Measure | Result |
+|---|---:|
+| Incremental checks | 6 / 6 exercised |
+| Incremental state equals rebuild | 6 / 6 |
+| Prefix clone preserved | 6 / 6 |
+
+The causal accumulator is bound to the construction manifest and both exact H4
+table identities. Construction and mutation are available only through the
+address-validating artifact API. A table mismatch refuses before mutation.
+
+## Unchanged candidate and value path
+
+The real schema-2 path from #952 was reused without changing support or
+admission.
+
+| Measure | Result |
+|---|---:|
+| Frozen contrasts | 3 / 3 |
+| Candidate queries | 6 / 6 |
+| Query rows read | 7 per query / 42 total |
+| Candidate-entry work ceiling | 56 per query |
+| Candidate entries examined | 2 per query |
+| Unique candidates before admission | 2 per query (`ll`, `rr`) |
+| Unique candidates after admission | 2 per query (`ll`, `rr`) |
+| Maximum admitted candidates observed | 2 of ceiling 8 |
+| Candidate/support denominator equality | 3 / 3 pairs |
+| I1 / I2 / IS and divisor direct rows | misses in 6 / 6 queries |
+| Exact address-to-payload inversions | 12 / 12 |
+| Candidate truncations | 0 / 6 |
+| Target injection or future events | 0 / 6 |
+
+Each paired arm had the same row outcomes/origins, source counts, two payloads,
+row and candidate budgets, and support-denominator kappa:
+`blake3:7b17bdc7f3686fd734c1770a4d6c5cc1a0590accbe8ceaa4e143ec1cd3369777`.
+Natural adjacent-spin support supplied both `ll` and `rr`; neither target was an
+exact stored continuation.
+
+## Candidate-relative interaction and controls
+
+The full arm used the predeclared history/candidate commutator
+
+`C(H,c) = H * c * H^-1 * c^-1`
+
+and the construction-only predecessor-relative state
+
+`D(H,c) = C(H,c) * C(P_c,c)^-1`.
+
+`P_ll` is the frozen construction predecessor `uu`; `P_rr` is `vv`. Energy is
+the shortest word distance from `D(H,c)` to identity in the symmetric set of
+nonidentity construction leaf generators plus their inverses. All 120 table
+states were reachable. The canonical candidate address remained a reporting
+order only; it did not turn a tie into a strict selection.
+
+The full arm's `ll` and `rr` relative states were distinct in 6/6 queries.
+Across matched left/right histories, 5/6 same-candidate comparisons also changed
+relative state. The state and construction-only anchors were therefore
+candidate- and history-sensitive. The scalar readout was not: every one of
+those distinct states had shortest Cayley distance 2.
+
+| Arm | Exercised | Strict intended | Ties | Abstentions | Additional outcome |
+|---|---:|---:|---:|---:|---|
+| Full ordered hierarchy | 6 / 6 | 0 / 6 | 6 / 6 | 6 / 6 | distinct states, energy 2 for both candidates |
+| Current only | 6 / 6 | 0 / 6 | 6 / 6 | 6 / 6 | — |
+| Existing additive summary | 0 / 6 | 0 / 6 | 0 / 6 | 6 / 6 | `NOT_EXERCISED_NO_PREDECLARED_ADDITIVE_SCORER` |
+| Factor/count | 6 / 6 | 0 / 6 | 6 / 6 | 6 / 6 | — |
+| Deterministic conjugation | 6 / 6 | 1 / 6 | 4 / 6 | 4 / 6 | one strict wrong selection |
+| Hierarchy disabled | 6 / 6 | 0 / 6 | 6 / 6 | 6 / 6 | — |
+| Exact recall only | 6 / 6 | 0 / 6 | 0 / 6 | 6 / 6 | six `NO_EXACT_HIT` abstentions |
+| Inverse-H4 intervention | 6 / 6 | 1 / 6 | 5 / 6 | 5 / 6 | — |
+
+The full arm's minimum-energy set was `{ll, rr}` for every query. Canonical
+address order reported `rr` as the diagnostic tie-break token, but
+`selected_token` remained absent: the diagnostic never converted a tie into a
+selection. The unavailable additive ranking arm means the report truthfully
+records `EXERCISED_WITH_UNAVAILABLE_MATCHED_CONTROL`; it is not silently counted
+as a tie or a weaker exercised control. Independently,
+`any_exercised_control_not_weaker = true`: current-only, factor/count,
+hierarchy-disabled, and exact-recall matched the full arm's zero strict
+selections, while the inverse and deterministic-conjugation interventions each
+recorded one strict intended selection. `RETAIN_STATE_ONLY` therefore follows
+from the exercised full/control evidence even without using additive
+unavailability as a verdict condition.
+
+## Excluded identity fields and serving boundary
+
+The report names ten legacy trace exclusions explicitly:
+`identity_kappa`, `exact_chain_kappa`,
+`geometric_summary_kappa`, `previous_identity_kappa`,
+`ordered_child_kappa`, `payload_cid`, `address_kappa`,
+`shared_class_kappa`, `paired_h4_e8_coordinate_kappa`, and
+`transported_trajectory_kappa`. Those ten names are the frozen trace-schema
+census, not the limit of the exclusion rule. All identity and provenance bits
+are barred from fold geometry and candidate energy; no digest bits or digest
+distance participated.
+
+Source weights opened, teacher forwards, transformer calls, MoE calls, learned
+router calls, dense-intelligence-matrix calls, Ollama calls, hosted-provider
+calls, and external/corpus population scans were all zero. The declared bounded
+120-permutation collision census was exercised in full and is not an external
+or corpus scan. No text was generated.
+
+## Exact work ceiling
+
+| Work item | Declared | Exercised |
+|---|---:|---:|
+| Matched contrasts | 3 | 3 |
+| Candidate queries | 6 | 6 |
+| Candidate payload inversions | 12 | 12 |
+| Incremental checks | 6 | 6 |
+| Query rows | 7 per query / 42 total | 42 total |
+| Candidate-entry ceiling | 56 per query | 2 examined per query |
+| Candidate ceiling | 8 | maximum 2 observed |
+| Scoring arms | 8 per query | 1 full + 7 matched controls; additive ranking unavailable |
+| Permutation census | 120 | 120 |
+| H4 associativity checks | 1,728,000 | 1,728,000 |
+
+No external/corpus population scan, corpus compile, teacher/source-model pass,
+generation run, BDD suite, fuzz, audit, release QA, product QA, Ollama call,
+hosted-provider call, or hours-long experiment was launched. The finite
+120-permutation census remained within the predeclared local fixture.
+
+## Native successor state
+
+The negative result required a blocker repair before #967 could close. No
+equivalent live issue existed, so #970 was created unassigned in milestone 21,
+attached as a child of #820, blocked by #967, and made a native blocker of
+#969. The earlier direct #967 → #969 edge was retained until the corrected graph
+was re-queried, then removed.
+
+Verified immediate chain:
+
+`#952 CLOSED → #967 → #970 OPEN → #969 OPEN → #953 OPEN`
+
+#969 and #953 are unassigned. #953 remains blocked by open #969 plus closed
+#952. #970 owns only the next candidate-relative readout/placement falsifier;
+the repaired fold, anchors, candidate-relative states, support, and admission
+remain fixed. It does not implement A1Q or generation.
+
+## Reproduction
+
+The dedicated CLI surface emits the complete canonical report:
+
+```text
+cargo run --offline --quiet --bin r4 -- associative-ordered-summary-a1r-probe
+  report_kappa = blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881
+  terminal_verdict = RETAIN_STATE_ONLY
+```
+
+Focused checks executed while authoring this record:
+
+```text
+cargo test -p uor-r4-core --offline --test recursive_geometric_attention_967
+  2 passed; 0 failed
+
+cargo test -p uor-r4-core --offline --test recursive_geometric_attention_952
+  2 passed; 0 failed
+
+cargo check -p uor-r4-core --lib --offline
+  PASS
+
+cargo check --bin r4 --offline
+  PASS
+
+cargo test -p uor-r4-model-source --lib --offline -- \
+  exact_executor_contract_binds_complete_local_source_closure
+  1 passed; 0 failed
+
+cargo check --target wasm32-unknown-unknown \
+  -p uor-r4-wasm-router --lib --offline
+  PASS (existing target-specific warnings only)
+
+cargo fmt --check
+git diff --check
+python3 scripts/check_claim_wording.py
+  PASS
+```
+
+Protected merge-queue CI remains the binding exhaustive verification.

--- a/docs/explainers/ELI5.md
+++ b/docs/explainers/ELI5.md
@@ -28,12 +28,22 @@ your text
    -> turn that route back into text
 ```
 
-The work is deliberately ordered. #961 makes arbitrary text reversible and
-keeps all five route levels up to date. #952 must then prove that the geometry,
-not a memorized answer, actually changes what the system attends to. Only then
-does #953 build the source-free next-word and chat loop. Correct answers (#954)
-and multi-step reasoning (#955) come later. A pretty route or a readable stored
-sentence does not skip those steps.
+The work is deliberately ordered. #961 made arbitrary text reversible and
+kept all five route levels up to date. #952 found that its reusable summaries
+forgot earlier order. #967 repaired that memory and produced different shapes
+for the two possible next pieces, but its one-number ruler assigned both the
+same distance in all six trials. It therefore kept the state without claiming
+attention. #967 established only that the one-number ruler failed; it did not
+establish a placement defect. #970 owns the broader readout/placement check and
+repair. #969 must then prove that the full geometry, not a memorized answer, actually changes what the system
+attends to. Only after that does #953 build the bounded source-free next-word
+loop; durable chat belongs to #962. Correct answers (#954) and multi-step
+reasoning (#955) come later. A pretty route or a readable stored sentence does
+not skip those steps.
+
+The system is allowed to keep a shape because it stores or reconstructs the
+route without letting that shape vote on the next word. A1Q/#969 must earn that
+semantic vote with matched evidence first.
 
 The preserved earlier system below had two robot helpers. One is a **filing
 cabinet robot**, one is a **librarian with a magic map**. Their receipts and

--- a/docs/explainers/UNDERGRADUATE.md
+++ b/docs/explainers/UNDERGRADUATE.md
@@ -32,12 +32,17 @@ golden radial state, the paired-H4/E8 construction, and transported trajectory
 summaries supply the declared locality. Higher route scopes update
 incrementally rather than scanning the full prefix or corpus at every token.
 
-The sequence is capability-ordered: #961 supplies reversible lexical geometry
-and complete hierarchy state; #952 must establish recursive geometric
-attention at every scope under anti-recall matched controls; #953 then builds
-provider-free grammatical generation; #954 measures correctness and typed
-abstention; #955 begins reasoning. #958 is retained storage/recall foundation,
-not proof of attention. There is no working source-free chat path yet.
+The sequence is capability-ordered: #961 supplied reversible lexical geometry
+and complete hierarchy state; #952 exposed an order-erasing reusable summary;
+A1R/#967 repaired that representation but terminated `RETAIN_STATE_ONLY` when
+shortest Cayley distance mapped distinct candidate-relative states to equal
+energy on 6/6 queries; A1P/#970 now owns candidate-relative readout/placement;
+and A1Q/#969 must then establish recursive
+geometric attention at every scope under anti-recall matched controls. #953 can
+then build provider-free grammatical generation from only A1Q-qualified
+semantic terms; #954 measures correctness and typed abstention; #955 begins
+reasoning. #958 is retained storage/recall foundation, not proof of attention.
+There is no working source-free chat path yet.
 
 The sections below explain the historical table/graph system retained as a
 comparator and runtime reference. Its measurements are not the current

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -18,9 +18,13 @@ probe whose possible outcomes cause different next actions.
 
 Lexical ingestion, canonical serialization, registered-address membership,
 and rebuild witnesses are prerequisite plumbing, not inference. The delivery
-sequence is fixed: complete recursive attention across local, sentence,
-paragraph, conversation, and global scopes first; inference/generation second;
-correctness with abstention third; bounded reasoning fourth.
+sequence is fixed: A1R/#967 repaired ordered state but retained it as state only;
+A1P/#970 now falsifies and replaces the shortest-Cayley scalar readout within
+its broader candidate-relative readout/placement scope; A1Q/#969 then
+qualifies complete recursive attention across local, sentence, paragraph,
+conversation, and global scopes; inference/generation follows only after #969;
+correctness with abstention is third; bounded reasoning is fourth. #970 blocks
+#969, and #969 natively blocks #953.
 
 A negative result remains evidence about its declared mechanism and
 distribution. It does not erase a separately established storage, identity,
@@ -35,13 +39,17 @@ The stages are ordered because each later claim depends on the earlier one:
    paragraph, conversation, and global scope, the real path emits a coverage
    witness; exact keys establish recall; and, when exact keys miss, transported
    trajectory/harmonic locality changes admitted support or final ordering
-   relative to matched controls. The load-bearing terms include shared-prime
-   factors, session hypersphere vector, winding/window state, projection energy,
-   cosine resonance, accumulated Hopf phase, and the paired icosian coordinate
-   that realizes the project shorthand `E8 = H4 × H4` as `H4 ⊕ φH4`.
-2. **Inference/generation** — the real decoder uses the completed hierarchy to
-   produce decodable next tokens, update state without future-route input, and
-   run provider-free through the evaluated CLI/HTTP/chat path.
+   relative to matched controls. Candidate terms include shared-prime factors,
+   session hypersphere vector, winding/window state, projection energy, cosine
+   resonance, accumulated Hopf phase, and the paired icosian coordinate that
+   realizes the project shorthand `E8 = H4 × H4` as `H4 ⊕ φH4`. Their presence
+   in the structural/storage representation does not qualify them for scoring;
+   A1Q/#969 must establish the causal value of each term it promotes.
+2. **Inference/generation** — the real decoder uses only A1Q-qualified semantic
+   scoring terms from the completed hierarchy to produce decodable next tokens,
+   update state without future-route input, and run provider-free through the
+   evaluated CLI/HTTP/chat path. Required storage fields that remain
+   unqualified cannot influence ranking.
 3. **Correctness/abstention** — answers satisfy an independent oracle or
    constraint, and typed abstentions are reported explicitly.
 4. **Reasoning** — novel multi-step tasks expose typed intermediate transitions,
@@ -111,6 +119,42 @@ experiment contract; do not reinterpret a miss as a pass, and do not let an
 irrelevant metric erase a load-bearing result established by a more direct
 intervention.
 
+### A1R/#967 frozen scope result
+
+The frozen #952 histories intentionally match current route, previous route,
+last-two suffix, length/multiset/boundary shape, and the immutable `gg` global
+project snapshot. A1R therefore expects current, previous, last-two, and global
+state to be equal, while sentence, paragraph, and conversation ordered state
+must differ. Equality at the control scopes is a fixture requirement, not a
+failure of the repair.
+
+Global behavior is a separate intervention. A claim about global ordered state
+requires a construction-independent global-snapshot permutation fixture in
+which only global order differs while current-through-conversation scopes,
+candidate support, payloads, and work budgets remain matched. Evaluation may
+not mutate global state from the conversation merely to manufacture a
+difference. The #967 report satisfied this scope mask, the independent-global
+intervention—including distinct content-derived global epochs with matched
+lower inputs, rows, support, budgets, and denominator—exact group/fold laws,
+incremental reproduction, and candidate support invariants. Its report kappa is
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+
+The full arm produced distinct `ll`/`rr` relative states on all 6 queries and
+changed the same-candidate relative state in 5/6 paired comparisons. The scalar
+shortest-Cayley-distance readout nevertheless mapped both candidates to energy
+2 and tied on all 6/6 queries. The terminal verdict is `RETAIN_STATE_ONLY`:
+ordered state is retained, but attention, generation, correctness, and reasoning
+remain unestablished. A1P/#970 owns the readout/placement redesign and blocks
+A1Q/#969.
+
+The legacy additive state was bound and remained equal, but its ranking arm is
+`NOT_EXERCISED`: no additive candidate scorer was predeclared. The exact-recall
+arm exercised six `NO_EXACT_HIT` abstentions rather than six ties. Canonical
+address order reported `rr` as a diagnostic tie-break token for the full arm;
+it never converted a tie into a selection. The verdict does not depend on the
+unavailable additive arm: the report binds the 6/6 full tie and
+`any_exercised_control_not_weaker = true` separately.
+
 ## 4. Matched controls
 
 An attention, inference, or reasoning comparison MUST use controls with the
@@ -124,14 +168,19 @@ same causal information and declared budget. At minimum report:
 - candidate support before and after any common pre-geometric admission; and
 - work performed, not merely requested worker count.
 
-Recommended controls are real geometry, deterministic permuted geometry,
-count/source-only ordering, exact-recall-only, and a disabled geometry arm.
+For A1Q/#969, the required equal-budget arms are the full-geometry treatment
+plus current-only, the existing additive summary, factor/count-only ordering,
+deterministic ordered-state permutation, hierarchy-disabled, and
+exact-recall-only controls.
 Permutation must reassign geometry within the same admitted support; it must
 not introduce a different candidate budget. Count-only must retain the same
 rows and candidates. A control that sees future tokens, additional retrieval,
 or a larger candidate set is invalid.
 
-For the recursive hierarchy, choose the smallest term-specific control that
+For the recursive hierarchy, #969 must use independent fixtures that isolate
+sentence, paragraph, conversation, and global causal effects, exercise both
+selection and exact payload decoding, and forbid future-route leakage or target
+injection. Within each scope, choose the smallest term-specific control that
 can change the active decision: full transported trajectory versus last-only;
 shuffled trajectory; session-vector permutation; winding/window permutation;
 projection-energy removal; shared-prime-only versus resonance sub-ranking;
@@ -140,8 +189,13 @@ The active trigonometric chart can be compared with an equal-budget chart
 permutation, and a quarter-turn intervention must retain the same admitted
 support and cost profile. Cross-domain chart comparisons keep units,
 orientation, quantization, error bounds, and tie-breaks fixed.
-These are available controls, not an instruction to run an omnibus ablation.
-Only the control owned by the current decision is activated.
+These term controls supplement the required A1Q arms; they are not an
+instruction to run unrelated omnibus ablations. Only the control owned by the
+current decision is activated.
+
+A1Q records `PROMOTE_TO_I1` only when full recursive attention beats these
+matched controls across its frozen required scopes. A distinct A1R state, a
+single-scoped win, or an exact-hit-only effect cannot promote #953.
 
 If count and source breadth admit support before geometric scoring, reports
 MUST say so. “Least energy” then means least declared energy among admitted
@@ -172,8 +226,10 @@ On this slice, exact hierarchy kappas must miss by construction while bounded
 overlapping summaries remain available. Report whether shared-prime factors,
 cosine resonance, projection energy, winding/window compatibility, accumulated
 Hopf phase, transported hypersphere trajectory, and paired-H4/E8 coordinates
-recover locality. A candidate found only through digest equality is recall and
-does not satisfy this requirement.
+recover locality. Report unqualified terms as storage fields, diagnostics, or
+controls rather than folding them into a winning aggregate score. A candidate
+found only through digest equality is recall and does not satisfy this
+requirement.
 
 ## 6. Correctness and abstention
 

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -43,7 +43,7 @@ output can be credited to geometric inference.
 Optimization, broad QA, formalization, and release certification follow a
 working decision-bearing product slice. They do not replace it.
 
-## Current truth after #958 and #952 A1.0
+## Current truth after #967 A1R
 
 #958 is foundation evidence, not abandonment of geometric intelligence. It
 retained the following source-free mechanisms:
@@ -64,8 +64,9 @@ context signal lived in the transported trajectory, session hypersphere state,
 winding/window classification, window projection energy, shared-prime-factor
 retrieval, cosine resonance, and accumulated Hopf phase—not only in an exact
 route key or final coordinate. That ancestor used Ollama for language and is not
-generation evidence, but its overlapping context mechanism is a required input
-to the new source-free design.
+generation evidence. Its overlapping context fields are retained as structural
+state and as candidate controls; no field becomes a semantic scoring term until
+A1Q/#969 qualifies it with matched causal evidence.
 
 Its terminal outcome was `RETAIN_STORAGE_RECALL_ONLY`. That wording is a claim
 boundary: the core experiment is not connected to a lexical generation loop,
@@ -84,10 +85,22 @@ two-candidate admission, address-to-payload inverse, and incremental next-state
 path remained reachable. See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
 
-#967 now owns the narrow associative, noncommutative ordered-summary repair and
-blocks #953. #953 continues to own source-free inference and language
-generation; #962 separately owns product chat integration and persisted,
-identity-scoped hive memory.
+#967 added the narrow A1R associative, noncommutative ordered-summary repair.
+Its exact scope, independent-global, fold/group, incremental, and support
+invariants passed. The full arm produced distinct `ll`/`rr` relative states on
+6/6 queries and changed the same-candidate state in 5/6 paired comparisons, but
+shortest Cayley distance collapsed the distinct states to energy 2 and tied on
+6/6. The terminal verdict is `RETAIN_STATE_ONLY`, bound by report kappa
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+This establishes ordered state only, not full attention or generation.
+See the [#967 A1R record](associative_ordered_route_summaries_a1r_967.md).
+
+New unassigned #970 owns A1P candidate-relative readout/placement. It follows
+protected #967 delivery and natively blocks #969. #969 owns A1Q full
+recursive-attention qualification and natively blocks #953. #953 continues to
+own source-free inference and language generation, but may consume only the
+semantic scoring terms qualified by A1Q. #962 separately owns product chat
+integration and persisted, identity-scoped hive memory.
 
 ## Architecture invariants
 
@@ -254,7 +267,7 @@ recurrence across shells. Direction remains unchanged while radial scale moves.
 Shell exponent, coefficient pair, orientation, quantization, and round-trip
 witness are manifest-bound.
 
-### 8. Paired H4 to E8 implementation bridge
+### 8. Required paired H4 to E8 structural/storage bridge
 
 The broader UOR action plane keeps the conceptual identity
 
@@ -273,9 +286,10 @@ written mathematically as `H4 ⊕ phi H4`: an E8 lattice point is represented,
 as a `Z`-module construction, by a golden-coupled pair of R4 points under one
 fixed basis and glue convention.
 
-This is a load-bearing **Architecture Assumption**. `E8 = H4 x H4` is the
-project's conceptual name; `H4 ⊕ phi H4` is the exact construction that code
-and canonical serialization must bind. The distinction specifies the
+This is a required **structural/storage Architecture Assumption**. The project
+conceptual name is `E8 = H4 x H4`; `H4 ⊕ phi H4` is the exact construction
+that code and canonical serialization must bind for canonical state, address
+reconstruction, and inverse witnesses. The distinction specifies the
 representation—it does not reject the project identity. It also avoids
 silently treating R4, an S3/Hopf state, or an unbound abstract product as the
 serialized eight-dimensional state. The bridge must declare:
@@ -287,12 +301,13 @@ serialized eight-dimensional state. The bridge must declare:
 - collision and quantization behavior; and
 - a kappa-bound witness for every preserved invariant.
 
-The paired construction participates in route transport and candidate energy.
-A matched factor-only and permuted-pair intervention must show its causal
-contribution before source-free generation is promoted. The factor-only route
-remains the required diagnostic control, not a substitute final architecture.
-The optional six-prime SpiralCore chart retained by #958 is a separate operator
-fixture; it does not satisfy this paired-H4/E8 requirement by itself.
+Structural presence does not authorize the paired coordinate as a semantic
+ranking feature. A1Q/#969 may qualify it only through candidate-relative,
+equal-budget factor-only and permuted-pair interventions on anti-recall inputs.
+Until then it remains storage, reconstruction evidence, a diagnostic, or a
+control. The optional six-prime SpiralCore chart retained by #958 is likewise a
+separate operator fixture and control; it neither satisfies the paired-H4/E8
+storage requirement nor carries a semantic claim by itself.
 
 ### 9. Least-cost certified chart selection
 
@@ -400,11 +415,12 @@ The state hierarchy is:
 | `RG` | global accumulated route over the admitted knowledge/memory scope |
 
 Each level carries both an exact ordered route identity and overlapping
-trajectory/harmonic summaries. The summaries include the transported path,
-session hypersphere vector, accumulated Hopf phase, winding/window state, and
-window projection energy. Each is updated incrementally from its prior state
-and the newly observed route. Higher levels summarize and constrain lower-level
-candidates without rescanning every token or corpus position.
+trajectory/harmonic structural summaries. The summaries include the transported
+path, session hypersphere vector, accumulated Hopf phase, winding/window state,
+and window projection energy. Each is updated incrementally from its prior state
+and the newly observed route. These fields preserve storage and diagnostic
+state; only the subset qualified by A1Q/#969 may constrain or rank lower-level
+candidates as semantic scoring terms.
 
 The candidate set is admitted from bounded exact rows plus shared prime factors,
 n-let overlap, adjacent spin sectors, window/trajectory overlap, and bounded
@@ -419,7 +435,8 @@ overlapping summaries must still distinguish histories whose transported
 trajectory, hypersphere state, winding window, projection energy, factor
 overlap, resonance, or Hopf phase differs.
 
-The energy is an ordered, witnessed comparison over applicable terms such as:
+The energy is an ordered, witnessed comparison over the A1Q-qualified subset of
+candidate terms such as:
 
 - exact context and source breadth;
 - divisor and n-let overlap;
@@ -431,6 +448,11 @@ The energy is an ordered, witnessed comparison over applicable terms such as:
   shared-factor, cosine-resonance, and accumulated-Hopf compatibility;
 - paragraph, conversation, and global constraint agreement; and
 - compiled lexical/grammar continuation evidence.
+
+Required structural/storage representation and qualified semantic scoring are
+separate contracts. Unqualified Hopf, H4, zeta, icosian, SpiralCore,
+trajectory, or harmonic fields remain storage fields, diagnostics, or controls
+even when present in every canonical envelope.
 
 No learned dense Q/K projection, softmax over a full prefix, all-corpus scan,
 MoE gate, or sparse learned router is permitted in the promoted serving path.
@@ -499,9 +521,10 @@ GI-1 does not generate text, add a CLI/chat caller, or claim attention. Its exit
 is deterministic lexical/address round-trip, complete hierarchy identity, and
 rebuildable paired-H4 state.
 
-### GI-2 / #952 — recursive geometric attention
+### GI-2 / #952 → #967 A1R → #970 A1P → #969 A1Q — recursive geometric attention
 
-Status: **A1.0 terminal negative qualification; repair continues in #967**.
+Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
+follows #967 and blocks #969; #969 A1Q blocked by #970**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -509,47 +532,74 @@ pair-level hierarchy cells and all 966 non-digest field comparisons were equal;
 the additive/last-child summaries had erased the only differing signal, earlier
 causal order. Exact chained identities retained provenance, but digest spelling
 is not semantic geometry. Candidate admission and value reachability remained
-intact, so #967 holds those interfaces fixed while replacing only the reusable
+intact, so #967 held those interfaces fixed while replacing only the reusable
 ordered summary with an associative, noncommutative fold.
 
-Implement attention across current/next candidate, previous, last-two,
-sentence, paragraph, conversation, identity-scoped memory, and global
-accumulated route state. Every selection carries the global context coverage
-witness. Interventions must show that each hierarchy level and the paired-H4
-state changes admitted support or ordering on a fixture designed for that
-level, without future-route leakage or a population scan.
+The frozen #952 histories intentionally match the current route, previous
+route, last-two suffix, length/multiset/boundary shape, and immutable `gg`
+global project snapshot. A1R/#967 preserved equality at current, previous,
+last-two, and global while making sentence, paragraph, and conversation ordered
+state distinct. Its separate construction-independent global-snapshot
+permutation changed only global state and its content-derived epochs differed
+as expected, while all lower inputs, candidate rows/support, budgets, and
+denominator remained matched. Exact group/fold laws, incremental reproduction,
+and support invariants also held.
+
+The smallest joint history/candidate interaction produced distinct candidate
+relative states, including 5/6 same-candidate changes across paired histories,
+but shortest Cayley distance mapped both targets to energy 2 on all 6/6 queries.
+That readout degeneracy yielded `RETAIN_STATE_ONLY`. #970 now owns the A1P
+candidate-relative readout/placement redesign with the repaired fold, anchors,
+and support held fixed; it does not implement full recursive attention or
+promote #953.
+#969 owns the later full A1Q scorer and candidate-relative
+anti-recall qualification across sentence, paragraph, conversation, and global
+scope-isolating fixtures. Every selection carries the global-context coverage
+witness, with no future-route leakage, target injection, or external/unbounded
+corpus population scan.
 
 Anti-recall evidence is mandatory: exact-row hits are labeled separately;
 held-out histories cannot be exact stored continuations; real geometry shares
-payload and budgets with exact-recall, factor-only, count-only,
-permuted-geometry, and permuted-pair controls. Unseen paragraph, conversation,
-and global histories must remain distinguishable through their overlapping
-trajectory/harmonic summaries even when exact route kappas miss.
+payload and work budgets with current-only, additive, factor/count-only,
+deterministic ordered-state permutation, hierarchy-disabled, and
+exact-recall-only controls. A1Q must separately isolate sentence, paragraph,
+conversation, and global causal evidence and exercise both selection and exact
+payload decoding. Only terms that beat their matched controls become
+GI-2-qualified semantic scoring terms.
 
-GI-2 closes only when full recursive attention is causally load-bearing. A
-successful #967 representation repair makes the later attention scorer
-reachable; it does not itself promote #953. GI-2 does not emit or score
-grammatical product text.
+GI-2 closes only when #969 shows full recursive attention is causally
+load-bearing and records `PROMOTE_TO_I1`. The #967 representation repair did
+not make A1Q reachable because its scalar readout tied; #970 must first falsify
+and replace that shortest-Cayley readout within its broader candidate-relative
+readout/placement scope. Neither stage promotes #953. GI-2 does not emit or
+score grammatical product text.
 
 ### GI-3 / #953 — source-free grammatical inference and generation
 
-After #967 repairs ordered state and GI-2 attention passes its later matched
-controls, compile explicit lexical class, agreement, punctuation,
+After #969 qualifies full GI-2 attention, compile explicit lexical class,
+agreement, punctuation,
 clause/sentence closure, and ordered continuation geometry. Expose one bounded
 route-native generation interface through the library and CLI, from input bytes
 and hierarchy state to decoded lexical output. Emit bounded autoregressive text
 using no Ollama, source weights, dense matrix model, transformer, MoE, or sparse
 learned router.
 
+The generator consumes only GI-2-qualified semantic scoring terms; mandatory
+storage fields and unqualified Hopf, H4, zeta, icosian, or SpiralCore controls
+cannot influence ranking merely because they are serialized.
+
 #953 owns inference and language formation. Product CLI/HTTP chat integration,
 restart-persistent conversation state, and identity-scoped hive-memory lifecycle
 belong to #962 and are not part of the #953 qualification.
 
-The gate asks whether the attention-qualified geometry produces distinct,
-decodable, non-cycling, prompt-responsive text beyond exact recall. It records
-real, factor-only, permuted-pair/permuted-geometry, count-only, and exact-recall
-arms separately. This is source-free grammatical inference/generation, not yet
-a claim that answers are correct.
+The smallest gate uses a frozen matched prompt pair or triad that requires
+incompatible prompt-conditioned lexical choices while exact continuation rows
+remain absent. It emits at most 32 lexical units per prompt and compares real,
+grammar-disabled, hierarchy-disabled, factor/count-only,
+permuted-geometry, and exact-recall arms. Passing requires distinct,
+decodable, non-cycling, prompt-responsive output—not merely one grammatical
+clause shared by different prompts. This is source-free grammatical
+inference/generation, not yet a claim that answers are correct.
 
 ### GI-4 / #954 — correctness and abstention
 
@@ -642,6 +692,8 @@ hours remains a hard kill ceiling, never an estimate.
 - Project shorthand is `E8 = H4 x H4`; its concrete implementation and
   serialization contract is the golden/Galois-coupled icosian pair
   `H4 ⊕ phi H4` with fixed basis, glue, and inverse witness.
+- Required structural/storage representation is not a qualified semantic
+  scoring term. Only A1Q/#969 may qualify a stored geometric field for #953.
 - S3/R4 compute, Hopf S2/R3 observation, and an E8 action plane are distinct
   objects.
 - Exact recall, grammatical text, correct inference, and reasoning are separate

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,8 @@ enum Command {
     LexicalIngestionWitness,
     /// Run the frozen A1.0 ordered-state/value-reachability gate without a scorer.
     RecursiveAttentionA1Probe,
+    /// Run the frozen A1R associative ordered-summary and candidate-relative probe.
+    AssociativeOrderedSummaryA1rProbe,
     /// List preserved compiler, serving, and certification commands.
     ResearchTools,
     /// Run the full artifact-discovering historical HTTP server.
@@ -1305,6 +1307,17 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             let rendered = serde_json::to_string_pretty(&report).map_err(|error| {
                 RunError::Command(format!(
                     "serialize recursive-attention A1.0 report: {error}"
+                ))
+            })?;
+            println!("{rendered}");
+            Ok(())
+        }
+        Some(Command::AssociativeOrderedSummaryA1rProbe) => {
+            let report = uor_r4_core::recursive_geometric_attention::run_a1r_associative_ordered_summary_probe()
+                .map_err(|error| RunError::Command(error.to_string()))?;
+            let rendered = serde_json::to_string_pretty(&report).map_err(|error| {
+                RunError::Command(format!(
+                    "serialize associative ordered-summary A1R report: {error}"
                 ))
             })?;
             println!("{rendered}");


### PR DESCRIPTION
## Outcome

- adds an exact associative, noncommutative canonical-H4 fold with O(1) incremental append
- exposes ordered scope state without changing frozen #952 legacy trace bytes or candidate admission
- exercises the bounded A1R anti-recall probe and CLI report
- records terminal `RETAIN_STATE_ONLY`: candidate-relative states are distinct on 6/6 queries, but shortest Cayley distance ties both candidates on 6/6

Canonical report kappa: `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`

This is structural state evidence only. It does not establish full recursive attention, inference, generation, correctness, reasoning, or product readiness.

## Bounded evidence

- 3/3 fixed matched contrasts and 6/6 candidate queries
- 12/12 exact candidate payload inversions
- 6/6 exact incremental/prefix checks
- 120/120 fixed H4 permutation census
- 1,728,000/1,728,000 exact H4 associativity checks
- support, row, candidate, and work budgets remained equal
- existing-additive ranking is explicitly `NOT_EXERCISED_NO_PREDECLARED_ADDITIVE_SCORER`

## Focused checks

- `cargo test -p uor-r4-core --offline --test recursive_geometric_attention_967` — 2 passed
- `cargo test -p uor-r4-core --offline --test recursive_geometric_attention_952` — 2 passed
- `cargo check -p uor-r4-core --lib --offline` — passed
- `cargo check --bin r4 --offline` — passed
- exact executor source-closure test — passed
- WASM library check — passed with existing target-specific warnings
- `cargo fmt --check`, `git diff --check`, and claim-wording gate — passed

## Successor safety

The exact native chain is `#967 → #970 → #969 → #953`. #970 is the unassigned A1P candidate-relative readout/placement falsifier and blocks A1Q/#969; #969 continues to block generation/#953. Closing this issue therefore cannot promote attention or generation.

Closes #967