### PR TITLE
A1P: bind paired-H4 R4 heatmap identifiability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,10 @@ graph-compiler implementation plan are retained as historical
 engineering/evidence records; none decides what is built next. Native GitHub
 relationships now mirror the programme: #961 closed with reversible S0 state;
 #952 stopped at `REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 repaired the ordered
-state but terminated `RETAIN_STATE_ONLY`; unassigned #970 owns the A1P
-candidate-relative readout/placement redesign and blocks #969 A1Q; #969 blocks
+state but terminated `RETAIN_STATE_ONLY`; #970's corrected, target-free A1P
+gate produced the bounded paired-H4-derived exact R4-heatmap result
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. #970 must merge through the
+protected path before #969 becomes the next multichannel A1Q stage and blocks
 #953. #953–#955 and #962–#965 follow. Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
@@ -162,13 +164,29 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   both candidates to energy 2 and tied on 6/6. Its terminal verdict is
   `RETAIN_STATE_ONLY`
   (report `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`).
-  Unassigned #970 follows protected #967 delivery, owns only the A1P
-  candidate-relative readout/placement redesign, and natively blocks #969 A1Q.
-  #969 blocks #953, so neither the repaired state nor closure of #967 promotes
-  attention or generation. #953 then owns bounded source-free library/CLI
-  generation, followed by #954 correctness and #955 reasoning. #962 owns
-  durable multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory;
-  #963–#965 then own optimization, formal closure, and release.
+  #970's corrected target-free preflight then enumerated the complete paired-H4
+  domain: 120×120 = 14,400 ordered pairs, 120 relative `D=X*Y^-1` rows, 45
+  exact signed `(1,i)` R4-heatmap classes, and 480 typed-null pairs. Across 36
+  fixture decisions it exercised 14 classes; construction coverage was 12/12
+  and pure, construction classes covered 10/12 validation decisions, the
+  no-class-splitting oracle ceiling was 10/12, strict construction transfer was
+  0/6, and eight exact heatmap classes were incompatible. The hard gate stopped
+  before scalar search; every downstream selection, control, and placement row
+  is `NOT_RUN_IDENTIFIABILITY_HARD_STOP`, not PASS. The terminal literal is
+  `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Its contract, universe, and
+  report identities are respectively
+  `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+  `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+  and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+  This is only a bounded heatmap-readout identifiability negative: fixed-zeta
+  phases, ordered n-lets, exact `phi` radial transport, and typed geometry
+  adapters remain structural, diagnostic, or control state. It does not
+  promote attention or generation. Only after protected #970 merge does #969
+  become the next multichannel A1Q stage and block #953. #953 then owns bounded
+  source-free library/CLI generation, followed by #954 correctness and #955
+  reasoning. #962 owns durable multi-turn CLI/HTTP chat, persistence,
+  isolation, and hive-memory; #963–#965 then own optimization, formal closure,
+  and release.
 - Sequence strictly: lexical/address plumbing → recursive attention →
   source-free grammatical inference/generation → correctness/abstention →
   reasoning → optimization/purity/release.
@@ -355,7 +373,7 @@ CIDs before loading teacher weights.
   graph lane
   (`uor-r4-graph-format::ScoreQ` wire newtype; `uor-r4-core::score_q::ScoreQ`
   with compiler-side f32 conversions). Do not add a third or prioritize their
-  consolidation ahead of the #970 candidate-relative readout/placement redesign.
+  consolidation ahead of the active route-native intelligence sequence.
 
 ## Long-run discipline (process amendment, 2026-08-06)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,17 @@ The experiment must be able to change the next programme decision:
 - **Follow the GI sequence.** GI-1 makes lexical/address state reversible;
   #952 found the reusable ordered-state defect; A1R/#967 repaired the fold but
   terminated `RETAIN_STATE_ONLY` after its scalar readout tied distinct
-  candidate-relative states on 6/6 queries; A1P/#970 now owns the
-  candidate-relative readout/placement; and A1Q/#969 separately qualifies full
-  recursive attention. GI-3/#953 may then add source-free grammatical
+  candidate-relative states on 6/6 queries; A1P/#970's target-free paired-H4
+  exact R4-heatmap gate exercised 14 classes across 36 decisions, had pure
+  12/12 construction coverage, covered 10/12 validation decisions with a 10/12
+  oracle ceiling, transferred 0/6 queries, and found eight incompatible heatmap
+  classes. Downstream readout, selection-control, and placement work is
+  `NOT_RUN_IDENTIFIABILITY_HARD_STOP`, not PASS.
+  That negative is bounded to the heatmap readout; fixed-zeta phases, ordered
+  n-lets, exact `phi` radial transport, and typed geometry adapters remain
+  structural. Only after #970 merges through the protected path does A1Q/#969
+  become the next multi-channel recursive-attention qualification. GI-3/#953
+  may then add source-free grammatical
   inference/generation using only A1Q-qualified semantic terms; GI-4/#954 tests
   correctness/abstention; GI-5/#955 adds reasoning. Do not generate before
   attention passes.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ To reproduce the bounded A1R associative ordered-summary decision:
 cargo run --bin r4 -- associative-ordered-summary-a1r-probe
 ```
 
+To reproduce the corrected A1P paired-H4-derived exact R4-heatmap
+identifiability decision:
+
+```bash
+cargo run --bin r4 -- candidate-relative-identifiability-a1p-probe
+```
+
 The A1R command uses only the frozen construction/evaluation fixture and exact
 finite tables. Its frozen report kappa is
 `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
@@ -63,6 +70,36 @@ incremental, and support invariants. The full arm produced distinct `ll`/`rr`
 relative states on all 6 queries, but shortest Cayley distance mapped both to
 energy 2 and tied every query. The terminal verdict is `RETAIN_STATE_ONLY`: it
 does not generate text or establish full attention.
+
+The A1P command preserves those six queries as regression-only evidence,
+prepares construction and sealed-validation geometry/support without labels,
+and derives S4 parity from each exact history and the frozen role order before
+joining the separate label ledgers. Its paired contract computes
+`X=C(H,c)`, `Y=C(P_c,c)`, and `D=X*Y^-1` in the signed `(1,i)` R4 chart. The
+exact endpoint rule is `sin=±1, cos=0 -> 1` with chirality retained and
+`sin=0, cos=±1 -> 0` with cosine polarity retained; `q0=q1=0` is typed-null
+abstention, not a threshold shortcut. `q2` and `q3` remain in the full `D`
+witness but are not scorer-key fields.
+
+The target-free structural census covers 120×120 = 14,400 ordered pairs, 120
+relative rows, 45 exact heatmap classes, and 480 typed-null pairs. Across 36
+fixture decisions, 14 classes were exercised; construction coverage was 12/12
+and pure, construction classes covered 10/12 validation decisions, the
+no-class-splitting oracle ceiling was 10/12, strict construction transfer was
+0/6, and eight heatmap classes were incompatible. The hard gate therefore
+stops before scalar search; every downstream selection, control, and placement
+row is `NOT_RUN_IDENTIFIABILITY_HARD_STOP`, not PASS. Its terminal literal is
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Contract, universe, and report
+kappas are
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+This negative is bounded to the paired-H4-derived heatmap readout. Fixed-zeta
+phases, ordered n-lets, exact `phi` radial transport, and the typed
+`sqrt(2) <-> 2i <-> [0,2]` adapters remain structural under
+`STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`; they are not
+scorer inputs. It does not establish attention or generation, and #969 becomes
+the next stage only after protected #970 merge.
 
 The ingestion witness maps two turns of text through the pinned lexical codec,
 prime/spin route state, canonical hierarchy manifest, strict reload, and exact
@@ -92,10 +129,12 @@ slots and marks not-yet-established boundaries absent. S0 serializes state and
 numeric geometry only: every candidate row ceiling is zero and marked
 `NOT_IMPLEMENTED_S0_STATE_ONLY`. #952 established candidate/value reachability
 but found its reusable summaries order-erasing. #967 landed the exact ordered
-state repair but retained it as state only after the candidate tie. Unassigned
-#970 owns the candidate-relative readout/placement redesign and blocks #969;
-#969 separately owns full recursive-attention qualification and blocks #953
-generation. Stored H4/Hopf/zeta/icosian and related route fields remain
+state repair but retained it as state only after the candidate tie. #970's
+corrected paired-H4-derived exact R4-heatmap gate stopped at bounded readout
+identifiability without searching another scalar. Until #970 lands through the
+protected merge path, #969 remains blocked; after that merge it becomes the
+next multichannel full recursive-attention qualification and continues to
+block #953 generation. Stored H4/Hopf/zeta/icosian and related route fields remain
 structural state, diagnostics, or controls until A1Q qualifies a term for
 semantic scoring; #953 may use only the qualified terms.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,9 @@ remains in [docs/RESEARCH.md](docs/RESEARCH.md).
 
 _Last reviewed: 2026-08-27 (#961 reversible S0 landed; #952 A1.0 stopped at
 `REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 A1R terminated `RETAIN_STATE_ONLY`;
-#970 A1P now precedes #969 A1Q, which blocks #953–#955 → #962–#965)._
+#970 A1P produced the bounded paired-H4-derived exact R4-heatmap result
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`; #969 A1Q becomes next only
+after protected #970 merge and then blocks #953–#955 → #962–#965)._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -65,44 +67,95 @@ Native GitHub relationships are the source of truth:
    `RETAIN_STATE_ONLY` with kappa
    `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
    This is state evidence only, not attention.
-4. **GI-2 A1P / #970 — candidate-relative readout/placement redesign:** keep the
-   #967 fold, anchors, relative states, and support fixed while replacing the
-   shortest-Cayley scalar readout that tied both admitted targets. #970 is
-   unassigned, owns the broader readout/placement falsifier, follows protected
-   #967 delivery, and natively blocks #969. Do not implement full A1Q or
-   generation here.
-5. **GI-2 A1Q / #969 — full recursive attention qualification:** after #970,
-   independently qualify sentence, paragraph, conversation, and global causal
-   effects with candidate-relative anti-recall fixtures and equal-budget
-   current-only, additive, factor/count-only, deterministic-permutation,
-   hierarchy-disabled, and exact-recall controls. Only terms that pass this
-   qualification become semantic scoring terms; required storage fields remain
-   storage, diagnostics, or controls otherwise.
+4. **GI-2 A1P / #970 — candidate-relative identifiability and
+   construction-derived readout:** keep
+   the #967 fold, anchors, relative states, support, payloads, and work fixed.
+   The visible six-query A1R fixture remains an unchanged regression/root-cause
+   fixture and can never qualify semantic value. The separate construction
+   fixture `A1P-CONSTRUCTION-1`
+   (`blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652`)
+   derives an even/odd permutation-parity candidate rule from six observations;
+   the disjoint sealed anti-recall fixture `A1P-VALIDATION-1`
+   (`blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602`)
+   tests transfer on six different histories. Geometry/support is prepared
+   target-free, label ledgers join only afterward, and S4 parity is mechanically
+   derived from each exact history and frozen role order. The immutable paired
+   contract computes `X=C(H,c)`, `Y=C(P_c,c)`, `D=X*Y^-1`, then uses the exact
+   signed `(1,i)` chart. Its endpoint rule is `sin=±1, cos=0 -> 1` with
+   chirality retained and `sin=0, cos=±1 -> 0` with cosine polarity retained;
+   `q0=q1=0` is typed-null abstention. `q2` and `q3` remain in the full `D`
+   witness but are not scorer-key fields.
+
+   Before fixture labels, the census enumerated 120×120 = 14,400 ordered pairs,
+   120 relative rows, 45 exact R4-heatmap classes, and 480 typed-null pairs.
+   Across 36 fixture decisions it exercised 14 classes; construction coverage
+   was 12/12 and pure, construction classes covered 10/12 validation decisions,
+   the no-class-splitting oracle ceiling was 10/12, strict construction transfer
+   was 0/6, and eight exact heatmap classes were incompatible. The hard gate
+   stopped before scalar search; all downstream selection, control, and
+   placement rows are `NOT_RUN_IDENTIFIABILITY_HARD_STOP`, not PASS. The
+   terminal literal is
+   `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Contract, universe, and
+   report kappas are
+   `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+   `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+   and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+   This negative is bounded to that paired-H4-derived heatmap readout. Fixed-zeta
+   phases, ordered n-lets, exact `phi` radial transport, and typed
+   `sqrt(2) <-> 2i <-> [0,2]` adapters remain structural under
+   `STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE` and are excluded
+   from the scorer. #969 becomes next only after protected #970 merge. See the
+   [A1P record](docs/candidate_relative_identifiability_a1p_970.md).
+5. **GI-2 A1Q / #969 — full recursive attention qualification:** protected
+   merge of #970 is the transition into this stage; the bounded negative does
+   not expose #953 directly. The paired heatmap and its fixed-zeta, ordered
+   n-let, exact-radial, and typed-adapter bindings remain structural,
+   diagnostic, or control state while #969 tests its other predeclared
+   candidate-relative trajectory and harmonic channels. Gate 0 is a bounded
+   2–8 lexical-unit end-to-end composition instrument:
+   `bytes → lexical routes → admitted candidates → frozen select/abstain →
+   payload decode → incremental state update`. It stops before scope expansion
+   on identical matched continuations, an inert qualified-state intervention,
+   decode failure, a period-1–4 cycle, nondeterministic termination, or changed
+   support. Later sentence, paragraph, conversation, and global fixtures remain
+   sealed, disjoint from #970, and use equal-budget current-only, additive,
+   factor/count-only, deterministic-permutation, hierarchy-disabled, and
+   exact-recall controls. Only terms that pass A1Q become semantic scoring
+   terms; required storage fields remain storage, diagnostics, or controls.
 6. **GI-3 / #953 — source-free grammatical inference/generation:** after #969,
    compile grammar and syntax into the attention-qualified route engine using
    only GI-2-qualified semantic terms, and establish bounded source-free
-   generation through the library and CLI. Durable chat, persistence, and HTTP
-   session behavior remain outside this stage.
+   generation through the library and CLI. Reuse the existing source-free
+   table-native continuation/candidate evidence as an offline substrate or
+   comparator where appropriate. The decisive intervention must show that a
+   #969-qualified geometric term changes candidate choice relative to
+   count-only, hierarchy-disabled, permuted, and exact-recall controls. Durable
+   chat, persistence, and HTTP session behavior remain outside this stage.
 7. **GI-4 / #954 — correctness and abstention:** test held-out answer
-   correctness, relevance, abstention, and causal use of required context.
-   Teacher weights may label or compare offline only after the source-free
-   report freezes.
-8. **GI-5 / #955 — reasoning:** add bounded goal-directed route composition, branch
-   comparison, intermediate constraints, and closure/contradiction controls.
+   correctness, relevance, abstention, and causal use of required context only
+   through the accepted #969-qualified terms and #953 generator. Teacher weights
+   may label or compare offline only after the source-free report freezes.
+8. **GI-5 / #955 — reasoning:** invoke the accepted #969/#953/#954 consumer at
+   every bounded goal-directed route-composition step, with branch comparison,
+   intermediate constraints, and closure/contradiction controls. #952 is not a
+   qualified-attention consumer.
 9. **GI-6 / #962–#965 — product, cost, formal closure, and release:** integrate
-   durable multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory
-   (#962); optimize only the measured route-native bottleneck (#963); freeze
-   the serving contract (#964); then explicitly activate only the release QA
-   needed to qualify the product (#965).
+   #969-qualified attention and the accepted #953 generator into durable
+   multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory (#962);
+   optimize only the measured route-native bottleneck (#963); freeze a serving
+   contract that binds the inserted #970 → #969 qualification stages (#964);
+   then activate only the release QA needed to qualify that exact path (#965).
 
 The live issue bodies and native dependencies now mirror this sequence. #961
 is closed. #952's terminal negative evidence is preserved in
 [`docs/recursive_geometric_attention_a1_952.md`](docs/recursive_geometric_attention_a1_952.md).
-#967 is at terminal A1R delivery with `RETAIN_STATE_ONLY`. New unassigned #970
-follows protected #967 delivery and is the native blocker of #969; #969 remains
-the native blocker of #953. The immediate chain is therefore #952 closed →
-#967 terminal delivery → #970 A1P → #969 A1Q → #953. Closing #967 cannot
-make A1Q or generation eligible. Every later stage stays unassigned and blocked
+#967 is at terminal A1R delivery with `RETAIN_STATE_ONLY`. #970 reached its valid
+bounded paired-H4-derived heatmap-readout decision, but protected merge is still
+the eligibility boundary: #969 remains blocked until #970 merges, then becomes
+the next native stage and remains the native blocker of #953. The immediate
+chain is therefore #952 closed → #967 terminal delivery → #970 protected merge
+→ #969 A1Q → #953. #970 did not make generation eligible. Every later stage
+stays unassigned and blocked
 in order. Legacy tracker #949 is closed as superseded; #958 is retained directly
 under programme root #820 as GI-0 foundation.
 
@@ -120,7 +173,7 @@ historical evidence and comparators.
   and reproduced incremental next state. Exact H4 and SpiralCore finite tables
   closed as controls only. Repair is #967; full attention qualification is
   #969; #953 remains blocked by #969. See the
-  [qualification](docs/recursive_geometric_attention_a1_952.md).
+  [A1.0 record](docs/recursive_geometric_attention_a1_952.md).
 
 - [x] **#967 A1R associative ordered-state repair** —
   *`RETAIN_STATE_ONLY`, 2026-08-27*. The exact H4 fold passed the frozen scope,
@@ -129,7 +182,11 @@ historical evidence and comparators.
   mapped both to energy 2 and tied on 6/6, so no attention or generation claim
   follows. Report kappa:
   `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
-  #970 owns the candidate-relative readout/placement redesign and blocks #969. See the
+  #970 subsequently found eight incompatible exact paired-H4-derived R4-heatmap
+  classes and a 0/6 strict transfer ceiling, retaining the heatmap and auxiliary
+  channels as structural/control state while stopping before readout or
+  placement. #969 becomes the next multi-channel qualification only after
+  protected #970 merge. See the
   [A1R record](docs/associative_ordered_route_summaries_a1r_967.md).
 
 - [x] **#961 reversible lexical geometry/state plumbing** —
@@ -210,7 +267,10 @@ historical evidence and comparators.
   runtimes, but no source-free geometric decoder has established coherent
   product behavior. GI-1/#961 closed the lexical route loop, while #952 showed
   that its reusable non-digest hierarchy summaries erase earlier order. #967
-  owns that repair before any attention scorer or #953 generation work.
+  repaired that representation but retained it as state only; #970 then found
+  the bounded paired-H4-derived exact R4-heatmap readout non-identifiable on its
+  frozen union. Its protected merge is required before #969 becomes next, and
+  it does not expose #953.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See
   [Which track can actually produce coherent text](docs/RESEARCH.md#which-track-can-actually-produce-coherent-text--the-honest-current-answer).

--- a/crates/uor-r4-core/src/recursive_geometric_attention.rs
+++ b/crates/uor-r4-core/src/recursive_geometric_attention.rs
@@ -17,7 +17,7 @@ use crate::canonical_lexical_ingestion::{
     CanonicalRouteArtifact, ConversationInput, H4BinaryIcosahedralClosure, H4RootCoordinate,
     OrderedH4FoldState, ParagraphInput, TurnInput,
 };
-use crate::prime_route_attention::{GeometricAddress, PrimeRouteError};
+use crate::prime_route_attention::{GeometricAddress, PrimeRouteError, ZPhi, ZetaGridBinding};
 use crate::prime_route_geometric_attention::{
     AttentionControl, AttentionRowKey, AttentionRowSource, AttentionSourceCounts,
     CausalAttentionState, GeometricAttentionArtifact, GeometricAttentionError,
@@ -32,11 +32,17 @@ pub const REDESIGN_ORDERED_ROUTE_SUMMARY: &str = "REDESIGN_ORDERED_ROUTE_SUMMARY
 pub const A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_SCHEMA: u32 = 1;
 pub const A1R_ASSOCIATIVE_ORDERED_SUMMARY_PROBE_DOMAIN: &str =
     "uor-r4.a1r-associative-ordered-summary-probe/1";
+pub const A1P_IDENTIFIABILITY_PROBE_SCHEMA: u32 = 2;
+pub const A1P_IDENTIFIABILITY_PROBE_DOMAIN: &str =
+    "uor-r4.a1p-candidate-relative-identifiability-probe/2";
 
 pub const REDESIGN_ROUTE_PLACEMENT: &str = "REDESIGN_ROUTE_PLACEMENT";
 pub const RETAIN_STATE_ONLY: &str = "RETAIN_STATE_ONLY";
 pub const REVISE_A1R: &str = "REVISE_A1R";
 pub const PROMOTE_TO_A1Q: &str = "PROMOTE_TO_A1Q";
+pub const RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q: &str =
+    "RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q";
+pub const NOT_RUN_IDENTIFIABILITY_HARD_STOP: &str = "NOT_RUN_IDENTIFIABILITY_HARD_STOP";
 
 const ISSUE_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/952";
 const S0_CONSUMER_CONTRACT_URL: &str =
@@ -51,6 +57,7 @@ const A1R_ISSUE_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/967
 const A1R_SUCCESSOR_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/969";
 const A1R_DECISION_CONTRACT_URL: &str =
     "https://github.com/UOR-Foundation/uor-r4/issues/967#issuecomment-5434971151";
+const A1P_ISSUE_URL: &str = "https://github.com/UOR-Foundation/uor-r4/issues/970";
 const FROZEN_A1_PARTITION_KAPPA: &str =
     "blake3:d008b82eda9b16b102cf4c7ffa4a47a40ad514b30f0763ed3f46c0ebae3e277b";
 const FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA: &str =
@@ -59,6 +66,19 @@ const FROZEN_A1_ATTENTION_MANIFEST_KAPPA: &str =
     "blake3:1c77c4103732964af6776f1dfcabc8b2a9191eea875a8ba205c36ebbf5618a99";
 const FROZEN_A1_REPORT_KAPPA: &str =
     "blake3:23e07a17e897abb701c09354d35a3113a1b075ba1d60ee634067fa3ed3fd1904";
+const FROZEN_A1R_REPORT_KAPPA: &str =
+    "blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881";
+const A1P_CONSTRUCTION_FIXTURE_KAPPA: &str =
+    "blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652";
+const A1P_VALIDATION_FIXTURE_KAPPA: &str =
+    "blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602";
+const A1P_PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA: &str =
+    "blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98";
+const A1P_PAIRED_H4_R4_HEATMAP_CONTRACT_DOMAIN: &str = "uor-r4.a1p-paired-h4-r4-heatmap-contract/1";
+const A1P_PAIRED_H4_PAIR_UNIVERSE_CENSUS_DOMAIN: &str =
+    "uor-r4.a1p-paired-h4-pair-universe-census/1";
+const A1P_SUPPORT_DENOMINATOR_KAPPA: &str =
+    "blake3:7b17bdc7f3686fd734c1770a4d6c5cc1a0590accbe8ceaa4e143ec1cd3369777";
 
 const CANDIDATE_CEILING: usize = 8;
 const ROWS_PER_QUERY_CEILING: usize = 7;
@@ -72,6 +92,18 @@ const A1R_REQUIRED_CONTROLS: [&str; 8] = [
     "hierarchy-disabled",
     "exact-recall-only",
     "inverse-h4-intervention",
+];
+const A1P_DOWNSTREAM_CONTROL_CONTRACT: [(&str, bool); 10] = [
+    ("full-paired-h4-r4-heatmap", true),
+    ("current-only", true),
+    ("additive-summary-compiled-scorer", true),
+    ("factor-count-only", true),
+    ("deterministic-geometry-permutation", true),
+    ("candidate-relabeling", true),
+    ("prime-assignment-permutation", true),
+    ("hierarchy-disabled", true),
+    ("exact-recall-only", true),
+    ("placement-intervention", false),
 ];
 const GLOBAL_TOKEN: &str = "gg";
 const REQUIRED_LEVELS: [&str; 7] = [
@@ -1201,6 +1233,491 @@ pub struct A1RClaimBoundary {
     pub reasoning_established: bool,
     pub digest_distance_used_as_geometry: bool,
     pub all_identity_and_provenance_bits_excluded_from_geometry: bool,
+    pub candidate_support_or_admission_modified: bool,
+}
+
+/// Canonical #970 identifiability envelope. This report is deliberately a
+/// pre-scorer artifact: exact state-class membership and public-label ceilings
+/// are observable, while scalar fitting and validation selection are not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PIdentifiabilityProbeReport {
+    pub schema: u32,
+    pub domain: String,
+    pub report_kappa: String,
+    pub body: A1PIdentifiabilityProbeBody,
+}
+
+impl A1PIdentifiabilityProbeReport {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RecursiveGeometricAttentionError> {
+        if self.schema != A1P_IDENTIFIABILITY_PROBE_SCHEMA
+            || self.domain != A1P_IDENTIFIABILITY_PROBE_DOMAIN
+        {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                "A1P report schema/domain is unsupported".to_owned(),
+            ));
+        }
+        if a1p_report_identity_kappa(&self.body)? != self.report_kappa {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                "A1P report kappa does not reproduce".to_owned(),
+            ));
+        }
+        canonical_json(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PIdentifiabilityProbeBody {
+    pub probe_status: String,
+    pub contract_status: String,
+    pub terminal_verdict: String,
+    pub successor_effect: String,
+    pub provenance: A1PProvenance,
+    pub fixture_contract: A1PFixtureContract,
+    pub paired_h4_r4_heatmap_contract: A1PPairedH4R4HeatmapContractEvidence,
+    pub paired_h4_structural_universe: A1PPairedH4StructuralUniverse,
+    pub inherited_regression: A1PInheritedRegression,
+    pub support_and_work: Vec<A1PSupportAndWork>,
+    pub paired_h4_r4_heatmap: A1PPairedH4Identifiability,
+    /// Superseded single-relative-H4 diagnostic retained only so the #967
+    /// report surface remains inspectable. It is not a #970 scorer key.
+    pub full_h4: A1PH4Identifiability,
+    pub additive: A1PAdditiveIdentifiability,
+    pub hard_stop_reasons: Vec<String>,
+    pub scalar_functions_searched: usize,
+    pub readout_artifacts_compiled: usize,
+    pub validation_selection_outputs_opened: bool,
+    pub downstream_controls: Vec<A1PDownstreamControl>,
+    pub serving_boundary: A10ServingBoundary,
+    pub claim_boundary: A1PClaimBoundary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PProvenance {
+    pub issue_url: String,
+    pub frozen_partition_kappa: String,
+    pub frozen_partition_kappa_reproduces: bool,
+    pub frozen_construction_artifact_kappa: String,
+    pub construction_artifact_kappa_reproduces: bool,
+    pub frozen_attention_manifest_kappa: String,
+    pub attention_manifest_kappa_reproduces: bool,
+    pub inherited_a1r_report_kappa: String,
+    pub inherited_a1r_report_kappa_reproduces: bool,
+    pub frozen_inputs_modified: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PFixtureContract {
+    pub construction: A1PFixtureEvidence,
+    pub validation: A1PFixtureEvidence,
+    pub construction_parity_audit: Vec<A1PParityAudit>,
+    pub validation_parity_audit: Vec<A1PParityAudit>,
+    pub parity_derived_from_history: bool,
+    pub new_split_preparation_target_free: bool,
+    pub labels_attached_after_preparation: bool,
+    pub histories_disjoint_across_all_splits: bool,
+    pub construction_rule_family: String,
+    pub construction_rule_selected: String,
+    pub trivial_map_rejected: bool,
+    pub construction_rule_confirmed: bool,
+    pub regression_labels_falsification_only: bool,
+    pub no_a1q_fixture_consumed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PParityAudit {
+    pub observation_id: String,
+    pub declared_parity: String,
+    pub derived_parity: String,
+    pub exact_match: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PFixtureEvidence {
+    pub fixture_id: String,
+    pub split: String,
+    pub expected_kappa: String,
+    pub observed_kappa: String,
+    pub kappa_reproduces: bool,
+    pub role_order: Vec<String>,
+    pub current_token: String,
+    pub natural_candidates: Vec<String>,
+    pub construction_predecessors: Vec<A1PPredecessor>,
+    pub observations: Vec<A1PFixtureObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct A1PPredecessor {
+    pub candidate: String,
+    pub predecessor: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PFixtureObservation {
+    pub id: String,
+    pub history: Vec<String>,
+    pub observed_next: String,
+    pub permutation_parity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PInheritedRegression {
+    pub fixture_id: String,
+    pub labels_status: String,
+    pub partition_kappa: String,
+    pub report_kappa: String,
+    pub query_denominator: usize,
+    pub candidate_decision_denominator: usize,
+    pub shortest_cayley_strict_selections: usize,
+    pub shortest_cayley_ties: usize,
+    pub shortest_cayley_abstentions: usize,
+    pub queries_with_distinct_candidate_relative_states: usize,
+    pub paired_same_candidate_comparisons: usize,
+    pub paired_same_candidate_relative_state_differences: usize,
+    pub aggregate_reproduces: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PSupportAndWork {
+    pub split: String,
+    pub histories: usize,
+    pub candidate_decisions: usize,
+    pub natural_candidates: Vec<String>,
+    pub natural_candidate_union_exact: bool,
+    pub support_denominator_kappas: Vec<String>,
+    pub support_denominator_exact: bool,
+    pub rows_per_query: usize,
+    pub row_reads: usize,
+    pub candidate_entries_examined: usize,
+    pub candidate_entry_ceiling_per_query: usize,
+    pub candidate_ceiling: usize,
+    pub maximum_admitted_candidates: usize,
+    pub exact_direct_rows_miss: bool,
+    pub divisor_rows_miss: bool,
+    pub adjacent_spin_only_support: bool,
+    pub exact_payload_inversions: usize,
+    pub target_injected: bool,
+    pub future_events_visible: bool,
+    pub admission_truncation_observed: bool,
+    pub contract_exact: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PClassMember {
+    pub split: String,
+    pub observation_id: String,
+    pub candidate: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PClassCounts {
+    pub inherited_select: usize,
+    pub inherited_reject: usize,
+    pub construction_select: usize,
+    pub construction_reject: usize,
+    pub validation_select: usize,
+    pub validation_reject: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PH4Class {
+    pub class_id: String,
+    pub state: A1RStateWitness,
+    pub members: Vec<A1PClassMember>,
+    pub counts: A1PClassCounts,
+    pub construction_outcome_if_pure: Option<String>,
+    pub incompatible_outcomes: bool,
+}
+
+/// The exact public #970 contract wire. Field order is intentionally the
+/// canonical JSON order frozen in the issue; changing declaration order changes
+/// the contract identity and must fail reproduction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4R4HeatmapContract {
+    pub schema: u32,
+    pub domain: String,
+    pub construction_artifact_kappa: String,
+    pub manifest_kappa: String,
+    pub frozen_partition_kappa: String,
+    pub construction_fixture_kappa: String,
+    pub validation_fixture_kappa: String,
+    pub h4_root_table_kappa: String,
+    pub h4_multiplication_table_kappa: String,
+    pub zeta_grid_revision: String,
+    pub zeta_grid_kappa: String,
+    pub paired_h4_operands: Vec<String>,
+    pub pair_space_rule: String,
+    pub relative_product: String,
+    pub relative_image_rule: String,
+    pub r4_basis: Vec<String>,
+    pub oriented_heatmap_plane: String,
+    pub coordinate_scale_denominator: u32,
+    pub exact_ring: String,
+    pub sin_coordinate_rule: String,
+    pub cos_coordinate_rule: String,
+    pub activation_rule: String,
+    pub activation_denominator: u32,
+    pub chirality_rule: String,
+    pub cosine_polarity_rule: String,
+    pub typed_null_rule: String,
+    pub heatmap_class_key: Vec<String>,
+    pub binary_landmarks: Vec<A1PBinaryLandmark>,
+    pub intermediate_rule: String,
+    pub q30_rule: String,
+    pub zeta_phase_rule: String,
+    pub ordered_nlet_rule: String,
+    pub golden_radial_forward: String,
+    pub golden_radial_inverse: String,
+    pub normalized_direction_rule: String,
+    pub radial_ratio_rule: String,
+    pub radial_coupling_status: String,
+    pub typed_geometry_equivalence: Vec<String>,
+    pub typed_geometry_adapter_rule: String,
+    pub semantic_exclusions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PBinaryLandmark {
+    pub sin_zphi_numerator: [i64; 2],
+    pub cos_zphi_numerator: [i64; 2],
+    pub activation_zphi_numerator: [i64; 2],
+    pub chirality: String,
+    pub cosine_polarity: String,
+    pub output: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4R4HeatmapContractEvidence {
+    pub expected_kappa: String,
+    pub observed_kappa: String,
+    pub kappa_reproduces: bool,
+    pub contract: A1PPairedH4R4HeatmapContract,
+}
+
+/// The complete exact signed `(1,i)` heatmap class. The remaining `q2/q3`
+/// coordinates are retained in the relative H4 witness, not added to equality.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct A1PExactR4HeatmapClassKey {
+    pub sin_zphi_numerator: [i64; 2],
+    pub cos_zphi_numerator: [i64; 2],
+    pub activation_zphi_numerator: [i64; 2],
+    pub chirality: String,
+    pub cosine_polarity: String,
+    pub chart_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4OperandWitness {
+    pub x_interaction: A1RStateWitness,
+    pub y_predecessor_interaction: A1RStateWitness,
+    pub relative_projection: A1RStateWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4ClassMember {
+    pub decision: A1PClassMember,
+    pub operands: A1PPairedH4OperandWitness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4HeatmapClass {
+    pub class_id: String,
+    pub heatmap_key: A1PExactR4HeatmapClassKey,
+    pub binary_landmark_output: Option<u8>,
+    pub members: Vec<A1PPairedH4ClassMember>,
+    pub counts: A1PClassCounts,
+    pub construction_outcome_if_pure: Option<String>,
+    pub typed_null_abstain: bool,
+    pub incompatible_outcomes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4Identifiability {
+    pub operand_definition: String,
+    pub class_definition: String,
+    pub coordinate_scale_denominator: u32,
+    pub activation_denominator: u32,
+    pub integer_only_no_rounding: bool,
+    pub classes: Vec<A1PPairedH4HeatmapClass>,
+    pub metrics: A1PIdentifiabilityMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4RelativeImageRow {
+    pub relative_state: A1RStateWitness,
+    pub ordered_pair_multiplicity: usize,
+    pub heatmap_key: A1PExactR4HeatmapClassKey,
+    pub binary_landmark_output: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PPairedH4StructuralUniverse {
+    pub root_table_kappa: String,
+    pub multiplication_table_kappa: String,
+    pub pair_universe_census_schema: u32,
+    pub pair_universe_census_domain: String,
+    pub pair_universe_row_encoding: String,
+    pub pair_universe_row_width_bytes: usize,
+    pub pair_universe_kappa: String,
+    pub operand_count: usize,
+    pub expected_ordered_pair_count: usize,
+    pub enumerated_ordered_pair_count: usize,
+    pub relative_image_count: usize,
+    pub exact_relative_image_complete: bool,
+    pub pair_multiplicity_per_relative_image_row: usize,
+    pub uniform_pair_multiplicity_exact: bool,
+    pub heatmap_class_count: usize,
+    pub typed_null_pair_count: usize,
+    pub target_free: bool,
+    pub integer_only_no_rounding: bool,
+    pub relative_image_rows: Vec<A1PPairedH4RelativeImageRow>,
+}
+
+/// Exact projection of the existing additive non-digest summary. Positional,
+/// lexical, prime/address, boundary/chain, digest, kappa, and provenance fields
+/// are absent by construction rather than masked after class comparison.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct A1PAdditiveState {
+    pub direct_child_count: u32,
+    pub observed_descendant_routes: u32,
+    pub session_hypersphere_q30: [i64; 4],
+    pub winding_turns: i64,
+    pub projection_energy_q30: u64,
+    pub shared_factor_multiplicities: Vec<u32>,
+    pub cosine_resonance_q30: [i64; 8],
+    pub accumulated_hopf_phase_q29: i32,
+    pub zeta_phase_signature_q29: [i32; 8],
+    pub s3_spin_q30: [i32; 4],
+    pub s2_hopf_observation_q30: [i32; 3],
+    pub fiber_q29: i32,
+    pub torsion_q29: i32,
+    pub radial_zphi: [i64; 2],
+    pub bridge_mode: String,
+    pub active_chart: String,
+    pub selected_adapter: String,
+    pub chart_sin_q30: i32,
+    pub chart_cos_q30: i32,
+    pub chart_activation_q30: u32,
+    pub chart_chirality: i8,
+    pub chart_cosine_polarity: i8,
+    pub quarter_turn_orientation: i8,
+    pub phase_shift_q29: i32,
+    pub torsion_shift_q29: i32,
+    pub transported_fiber_q29: i32,
+    pub transported_torsion_q29: i32,
+    pub inverse_fiber_q29: i32,
+    pub inverse_torsion_q29: i32,
+    pub chart_inverse_exact: bool,
+    pub paired_h4_e8_coordinate_sum: [i64; 8],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct A1PAdditiveClassState {
+    pub history: A1PAdditiveState,
+    pub candidate: A1PAdditiveState,
+    pub predecessor: A1PAdditiveState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PAdditiveClass {
+    pub class_id: String,
+    pub state: A1PAdditiveClassState,
+    pub members: Vec<A1PClassMember>,
+    pub counts: A1PClassCounts,
+    pub construction_outcome_if_pure: Option<String>,
+    pub incompatible_outcomes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PRationalCeiling {
+    pub numerator: usize,
+    pub denominator: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PIdentifiabilityMetrics {
+    pub exact_class_count: usize,
+    pub inherited_class_count: usize,
+    pub construction_class_count: usize,
+    pub validation_class_count: usize,
+    pub construction_decisions_covered: A1PRationalCeiling,
+    pub construction_impure_class_count: usize,
+    pub construction_classes_pure: bool,
+    pub validation_decisions_covered_by_construction: A1PRationalCeiling,
+    pub validation_no_class_splitting_oracle_ceiling: A1PRationalCeiling,
+    pub validation_construction_transfer_selection_ceiling: A1PRationalCeiling,
+    pub incompatible_class_count_across_all_splits: usize,
+    pub exact_class_aliasing_observed: bool,
+    pub transferable_construction_rule_exists: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PH4Identifiability {
+    pub class_definition: String,
+    pub classes: Vec<A1PH4Class>,
+    pub metrics: A1PIdentifiabilityMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PAdditiveIdentifiability {
+    pub class_definition: String,
+    pub excluded_fields: Vec<String>,
+    pub leaf_evaluator_seam: A1PAdditiveLeafEvaluatorSeam,
+    pub classes: Vec<A1PAdditiveClass>,
+    pub metrics: A1PIdentifiabilityMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PAdditiveLeafEvaluatorSeam {
+    pub status: String,
+    pub fixed_prefix_token: String,
+    pub evaluator_history_shape: String,
+    pub extracted_level: String,
+    pub construction_only: bool,
+    pub current_projection_has_prefix_occurrence_or_identity_fields: bool,
+    pub fixture_histories_modified: bool,
+    pub candidate_path_queries_affected: usize,
+    pub candidate_support_or_work_modified: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PControlWork {
+    pub validation_queries: usize,
+    pub candidate_decisions: usize,
+    pub row_reads: usize,
+    pub candidate_entry_ceiling_per_query: usize,
+    pub candidate_ceiling: usize,
+    pub maximum_admitted_candidates: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PDownstreamControl {
+    pub control: String,
+    pub required: bool,
+    pub status: String,
+    pub selections: usize,
+    pub ties: usize,
+    pub abstentions: usize,
+    pub exact_hits: usize,
+    pub support_equal: Option<bool>,
+    pub work: A1PControlWork,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct A1PClaimBoundary {
+    pub identifiability_falsifier_only: bool,
+    pub h4_state_retained_as_structural_only: bool,
+    pub paired_h4_r4_heatmap_retained_as_structural_only: bool,
+    pub superseded_single_h4_diagnostic_is_terminal_evidence: bool,
+    pub attention_established: bool,
+    pub inference_established: bool,
+    pub generation_established: bool,
+    pub correctness_established: bool,
+    pub reasoning_established: bool,
+    pub semantic_value_established: bool,
+    pub validation_selection_performed: bool,
+    pub digest_or_kappa_used_as_geometry: bool,
+    pub opaque_table_offset_used_as_scalar: bool,
     pub candidate_support_or_admission_modified: bool,
 }
 
@@ -3840,4 +4357,2048 @@ fn canonical_kappa(bytes: &[u8]) -> Result<String, RecursiveGeometricAttentionEr
     uor_addr::json::address_blake3(&identity)
         .map(|outcome| outcome.address.to_string())
         .map_err(|error| RecursiveGeometricAttentionError::Addressing(format!("{error:?}")))
+}
+
+#[derive(Serialize)]
+struct A1PFixtureIdentityWire<'a> {
+    schema: u32,
+    domain: &'a str,
+    fixture_id: &'a str,
+    split: &'a str,
+    construction_artifact_kappa: &'a str,
+    manifest_kappa: &'a str,
+    frozen_partition_kappa: &'a str,
+    role_order: &'a [String],
+    current_token: &'a str,
+    natural_candidates: &'a [String],
+    construction_predecessors: &'a [A1PPredecessor],
+    observations: &'a [A1PFixtureObservation],
+}
+
+#[derive(Serialize)]
+struct A1PReportIdentityWire<'a> {
+    schema: u32,
+    domain: &'static str,
+    report_kappa: &'static str,
+    body: &'a A1PIdentifiabilityProbeBody,
+}
+
+#[derive(Debug, Clone)]
+struct A1PClassEvent {
+    split: String,
+    observation_id: String,
+    candidate: String,
+    outcome: String,
+    x_interaction: OrderedH4FoldState,
+    y_predecessor_interaction: OrderedH4FoldState,
+    h4_state: OrderedH4FoldState,
+    heatmap_key: A1PExactR4HeatmapClassKey,
+    binary_landmark_output: Option<u8>,
+    additive_state: A1PAdditiveClassState,
+}
+
+#[derive(Debug, Clone)]
+struct A1PPreparedClassEvent {
+    split: String,
+    observation_id: String,
+    candidate: String,
+    x_interaction: OrderedH4FoldState,
+    y_predecessor_interaction: OrderedH4FoldState,
+    h4_state: OrderedH4FoldState,
+    heatmap_key: A1PExactR4HeatmapClassKey,
+    binary_landmark_output: Option<u8>,
+    additive_state: A1PAdditiveClassState,
+}
+
+#[derive(Debug, Clone)]
+struct A1PUnlabeledHistory {
+    observation_id: String,
+    history: Vec<String>,
+}
+
+#[derive(Debug)]
+struct A1PPreparedSplit {
+    queries: Vec<A1RCandidateQuery>,
+    events: Vec<A1PPreparedClassEvent>,
+}
+
+fn a1p_paired_h4_r4_heatmap_contract(
+    table: &H4BinaryIcosahedralClosure,
+    zeta_grid: &ZetaGridBinding,
+) -> A1PPairedH4R4HeatmapContract {
+    A1PPairedH4R4HeatmapContract {
+        schema: 1,
+        domain: A1P_PAIRED_H4_R4_HEATMAP_CONTRACT_DOMAIN.to_owned(),
+        construction_artifact_kappa: FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA.to_owned(),
+        manifest_kappa: FROZEN_A1_ATTENTION_MANIFEST_KAPPA.to_owned(),
+        frozen_partition_kappa: FROZEN_A1_PARTITION_KAPPA.to_owned(),
+        construction_fixture_kappa: A1P_CONSTRUCTION_FIXTURE_KAPPA.to_owned(),
+        validation_fixture_kappa: A1P_VALIDATION_FIXTURE_KAPPA.to_owned(),
+        h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+        h4_multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+        zeta_grid_revision: zeta_grid.revision.clone(),
+        zeta_grid_kappa: zeta_grid.grid_kappa.clone(),
+        paired_h4_operands: ["X(H,c)=C(H,c)", "Y(P_c,c)=C(P_c,c)"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        pair_space_rule: "ordered H4xH4 witness; neither operand may be discarded".to_owned(),
+        relative_product: "D(H,c)=X(H,c)*Y(P_c,c)^-1".to_owned(),
+        relative_image_rule:
+            "exact closure through the frozen 120-state H4 multiplication table".to_owned(),
+        r4_basis: ["1", "i", "j", "k"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        oriented_heatmap_plane:
+            "ordered (1,i) coordinates with signs fixed by the canonical root-table orientation"
+                .to_owned(),
+        coordinate_scale_denominator: 2,
+        exact_ring: "Z[phi]".to_owned(),
+        sin_coordinate_rule: "sin=q0/2".to_owned(),
+        cos_coordinate_rule: "cos=q1/2".to_owned(),
+        activation_rule: "activation=sin^2=q0^2/4".to_owned(),
+        activation_denominator: 4,
+        chirality_rule: "sign(q0/2)".to_owned(),
+        cosine_polarity_rule: "sign(q1/2)".to_owned(),
+        typed_null_rule: "q0=0 AND q1=0 => TYPED_NULL_ABSTAIN".to_owned(),
+        heatmap_class_key: [
+            "sin_zphi_numerator",
+            "cos_zphi_numerator",
+            "activation_zphi_numerator",
+            "chirality",
+            "cosine_polarity",
+            "chart_status",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        binary_landmarks: vec![
+            A1PBinaryLandmark {
+                sin_zphi_numerator: [2, 0],
+                cos_zphi_numerator: [0, 0],
+                activation_zphi_numerator: [4, 0],
+                chirality: "POSITIVE".to_owned(),
+                cosine_polarity: "ZERO".to_owned(),
+                output: 1,
+            },
+            A1PBinaryLandmark {
+                sin_zphi_numerator: [-2, 0],
+                cos_zphi_numerator: [0, 0],
+                activation_zphi_numerator: [4, 0],
+                chirality: "NEGATIVE".to_owned(),
+                cosine_polarity: "ZERO".to_owned(),
+                output: 1,
+            },
+            A1PBinaryLandmark {
+                sin_zphi_numerator: [0, 0],
+                cos_zphi_numerator: [2, 0],
+                activation_zphi_numerator: [0, 0],
+                chirality: "ZERO".to_owned(),
+                cosine_polarity: "POSITIVE".to_owned(),
+                output: 0,
+            },
+            A1PBinaryLandmark {
+                sin_zphi_numerator: [0, 0],
+                cos_zphi_numerator: [-2, 0],
+                activation_zphi_numerator: [0, 0],
+                chirality: "ZERO".to_owned(),
+                cosine_polarity: "NEGATIVE".to_owned(),
+                output: 0,
+            },
+        ],
+        intermediate_rule: "retain the complete exact heatmap class; compile only a pure construction outcome; unseen or impure classes abstain; no threshold".to_owned(),
+        q30_rule: "exact rational landmarks only; no general Q1.30 projection without a separately bound quantizer and error contract".to_owned(),
+        zeta_phase_rule: "theta_j(p)=wrap(gamma_j*log(p)) on the immutable fixed-zeta grid; phase identity is structural and not a target feature".to_owned(),
+        ordered_nlet_rule: "ordered multiplicity-preserving combinatorial prime n-lets carry route growth; ordered primes and factor multiset are both retained".to_owned(),
+        golden_radial_forward: "R_phi(z)=phi*E(z); (a,b)*phi=(b,a+b)".to_owned(),
+        golden_radial_inverse: "(a,b)*phi^-1=(b-a,a)".to_owned(),
+        normalized_direction_rule: "normalize(R_phi(z))=normalize(E(z)) for nonzero z".to_owned(),
+        radial_ratio_rule: "norm(R_phi(z))/norm(E(z))=phi for nonzero z".to_owned(),
+        radial_coupling_status:
+            "STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE".to_owned(),
+        typed_geometry_equivalence: [
+            "EUCLIDEAN_ROOT_2",
+            "COMPLEX_2I",
+            "RIEMANNIAN_0_2",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        typed_geometry_adapter_rule: "Euclidean sqrt(2) <-> complex 2i <-> Riemannian [0,2] is a declared typed cross-chart equivalence; compare only through versioned unit, orientation, normalization, and error adapters, never as raw untyped scalars".to_owned(),
+        semantic_exclusions: [
+            "validation labels",
+            "target token spelling",
+            "lexical/token IDs",
+            "prime/address identity",
+            "kappa/digest as geometry",
+            "raw zeta channel identity as scorer input",
+            "raw n-let identity as scorer input",
+            "raw radial magnitude as scorer input",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+    }
+}
+
+fn a1p_zphi_sign(value: [i64; 2]) -> Result<&'static str, RecursiveGeometricAttentionError> {
+    let a = i128::from(value[0]);
+    let b = i128::from(value[1]);
+    if a == 0 && b == 0 {
+        return Ok("ZERO");
+    }
+    // 2(a+b*phi)=(2a+b)+b*sqrt(5). Comparing squared integer
+    // magnitudes gives the exact sign without a floating-point approximation.
+    let rational = a
+        .checked_mul(2)
+        .and_then(|twice_a| twice_a.checked_add(b))
+        .ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "Z[phi] sign comparison overflowed".to_owned(),
+            )
+        })?;
+    if rational == 0 {
+        return Ok(if b > 0 { "POSITIVE" } else { "NEGATIVE" });
+    }
+    if b == 0 || rational.signum() == b.signum() {
+        return Ok(if rational > 0 { "POSITIVE" } else { "NEGATIVE" });
+    }
+    let rational_square = rational.checked_mul(rational).ok_or_else(|| {
+        RecursiveGeometricAttentionError::InvalidProbe(
+            "Z[phi] rational magnitude overflowed".to_owned(),
+        )
+    })?;
+    let irrational_square = b
+        .checked_mul(b)
+        .and_then(|square| square.checked_mul(5))
+        .ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "Z[phi] irrational magnitude overflowed".to_owned(),
+            )
+        })?;
+    if rational_square == irrational_square {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "nonzero Z[phi] sign comparison was unexpectedly indeterminate".to_owned(),
+        ));
+    }
+    let sign = if rational_square > irrational_square {
+        rational.signum()
+    } else {
+        b.signum()
+    };
+    Ok(if sign > 0 { "POSITIVE" } else { "NEGATIVE" })
+}
+
+fn a1p_exact_r4_heatmap(
+    relative: OrderedH4FoldState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<(A1PExactR4HeatmapClassKey, Option<u8>), RecursiveGeometricAttentionError> {
+    let root = relative.root_coordinate(table)?;
+    let sin = root.scaled_zphi_quaternion[0];
+    let cos = root.scaled_zphi_quaternion[1];
+    let activation = ZPhi::new(sin[0], sin[1]).checked_mul(ZPhi::new(sin[0], sin[1]))?;
+    let activation = [activation.a, activation.b];
+    let chirality = a1p_zphi_sign(sin)?.to_owned();
+    let cosine_polarity = a1p_zphi_sign(cos)?.to_owned();
+    let binary_landmark_output = match (sin, cos) {
+        ([2, 0], [0, 0]) | ([-2, 0], [0, 0]) => Some(1),
+        ([0, 0], [2, 0]) | ([0, 0], [-2, 0]) => Some(0),
+        _ => None,
+    };
+    let chart_status = if sin == [0, 0] && cos == [0, 0] {
+        "TYPED_NULL_ABSTAIN"
+    } else if binary_landmark_output.is_some() {
+        "BINARY_LANDMARK"
+    } else {
+        "NON_LANDMARK_EXACT_ZPHI"
+    };
+    Ok((
+        A1PExactR4HeatmapClassKey {
+            sin_zphi_numerator: sin,
+            cos_zphi_numerator: cos,
+            activation_zphi_numerator: activation,
+            chirality,
+            cosine_polarity,
+            chart_status: chart_status.to_owned(),
+        },
+        binary_landmark_output,
+    ))
+}
+
+fn a1p_paired_h4_structural_universe(
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1PPairedH4StructuralUniverse, RecursiveGeometricAttentionError> {
+    let operand_count = table.root_count;
+    let expected_ordered_pair_count =
+        operand_count.checked_mul(operand_count).ok_or_else(|| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "paired-H4 universe cardinality overflowed".to_owned(),
+            )
+        })?;
+    // The fixed-width census is the complete ordered pair universe in canonical
+    // nested `(x,y)` order. Its header binds both exact table identities; every
+    // row is the big-endian `(x_offset,y_offset,D_offset)` triple. Only its κ is
+    // serialized into the report, avoiding 14,400 repeated JSON objects.
+    let mut pair_census = Vec::with_capacity(
+        expected_ordered_pair_count
+            .saturating_mul(6)
+            .saturating_add(256),
+    );
+    for component in [
+        A1P_PAIRED_H4_PAIR_UNIVERSE_CENSUS_DOMAIN.as_bytes(),
+        table.h4_root_table_kappa.as_bytes(),
+        table.multiplication_table_kappa.as_bytes(),
+    ] {
+        let length = u32::try_from(component.len()).map_err(|_| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "paired-H4 census header component exceeds u32".to_owned(),
+            )
+        })?;
+        pair_census.extend_from_slice(&length.to_be_bytes());
+        pair_census.extend_from_slice(component);
+    }
+    pair_census.extend_from_slice(
+        &u32::try_from(operand_count)
+            .map_err(|_| {
+                RecursiveGeometricAttentionError::InvalidProbe(
+                    "paired-H4 census operand count exceeds u32".to_owned(),
+                )
+            })?
+            .to_be_bytes(),
+    );
+    pair_census.extend_from_slice(
+        &u32::try_from(expected_ordered_pair_count)
+            .map_err(|_| {
+                RecursiveGeometricAttentionError::InvalidProbe(
+                    "paired-H4 census pair count exceeds u32".to_owned(),
+                )
+            })?
+            .to_be_bytes(),
+    );
+    pair_census.extend_from_slice(&6u16.to_be_bytes());
+
+    // Root-coordinate recovery rebuilds and verifies the frozen exact root
+    // table. Do that once per possible relative state, then keep the complete
+    // 120x120 pair enumeration as cheap exact-table indexing. The census bytes
+    // and report rows are unchanged; only redundant reconstruction is removed.
+    let heatmap_by_relative = (0..operand_count)
+        .map(|offset| {
+            let offset = u16::try_from(offset).map_err(|_| {
+                RecursiveGeometricAttentionError::InvalidProbe(
+                    "H4 relative offset exceeds u16".to_owned(),
+                )
+            })?;
+            a1p_exact_r4_heatmap(a1r_state_from_offset(offset, table)?, table)
+        })
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+
+    let mut enumerated_ordered_pair_count = 0usize;
+    let mut relative_image = BTreeMap::<u16, (usize, A1PExactR4HeatmapClassKey, Option<u8>)>::new();
+    let mut heatmap_classes = BTreeSet::new();
+    let mut typed_null_pair_count = 0usize;
+    for x_offset in 0..operand_count {
+        let x_offset = u16::try_from(x_offset).map_err(|_| {
+            RecursiveGeometricAttentionError::InvalidProbe(
+                "H4 operand offset exceeds u16".to_owned(),
+            )
+        })?;
+        let x = a1r_state_from_offset(x_offset, table)?;
+        for y_offset in 0..operand_count {
+            let y_offset = u16::try_from(y_offset).map_err(|_| {
+                RecursiveGeometricAttentionError::InvalidProbe(
+                    "H4 operand offset exceeds u16".to_owned(),
+                )
+            })?;
+            let y = a1r_state_from_offset(y_offset, table)?;
+            let relative = x.compose(y.inverse(table)?, table)?;
+            let relative_offset = relative.table_index().table_offset();
+            let (heatmap_key, binary_landmark_output) = heatmap_by_relative
+                .get(usize::from(relative_offset))
+                .cloned()
+                .ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(
+                        "relative H4 state is outside the precomputed heatmap".to_owned(),
+                    )
+                })?;
+            pair_census.extend_from_slice(&x_offset.to_be_bytes());
+            pair_census.extend_from_slice(&y_offset.to_be_bytes());
+            pair_census.extend_from_slice(&relative_offset.to_be_bytes());
+            enumerated_ordered_pair_count = enumerated_ordered_pair_count.saturating_add(1);
+            if heatmap_key.chart_status == "TYPED_NULL_ABSTAIN" {
+                typed_null_pair_count = typed_null_pair_count.saturating_add(1);
+            }
+            heatmap_classes.insert(heatmap_key.clone());
+            let row = relative_image
+                .entry(relative_offset)
+                .or_insert_with(|| (0, heatmap_key.clone(), binary_landmark_output));
+            if row.1 != heatmap_key || row.2 != binary_landmark_output {
+                return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                    "one relative H4 image state produced inconsistent heatmap rows".to_owned(),
+                ));
+            }
+            row.0 = row.0.saturating_add(1);
+        }
+    }
+    let pair_universe_kappa = canonical_kappa(&pair_census)?;
+    let relative_image_rows = relative_image
+        .iter()
+        .map(
+            |(relative_offset, (multiplicity, heatmap_key, binary_landmark_output))| {
+                Ok(A1PPairedH4RelativeImageRow {
+                    relative_state: a1r_state_witness(
+                        a1r_state_from_offset(*relative_offset, table)?,
+                        table,
+                    )?,
+                    ordered_pair_multiplicity: *multiplicity,
+                    heatmap_key: heatmap_key.clone(),
+                    binary_landmark_output: *binary_landmark_output,
+                })
+            },
+        )
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let uniform_pair_multiplicity_exact = relative_image_rows
+        .iter()
+        .all(|row| row.ordered_pair_multiplicity == operand_count);
+    Ok(A1PPairedH4StructuralUniverse {
+        root_table_kappa: table.h4_root_table_kappa.clone(),
+        multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+        pair_universe_census_schema: 1,
+        pair_universe_census_domain: A1P_PAIRED_H4_PAIR_UNIVERSE_CENSUS_DOMAIN.to_owned(),
+        pair_universe_row_encoding:
+            "HEADER=len32be(domain)||domain||len32be(root_kappa)||root_kappa||len32be(multiplication_kappa)||multiplication_kappa||operand_count_u32be||pair_count_u32be||row_width_u16be; ROW=x_u16be||y_u16be||D_u16be; ORDER=x_then_y_ascending"
+                .to_owned(),
+        pair_universe_row_width_bytes: 6,
+        pair_universe_kappa,
+        operand_count,
+        expected_ordered_pair_count,
+        enumerated_ordered_pair_count,
+        relative_image_count: relative_image.len(),
+        exact_relative_image_complete: relative_image.len() == operand_count,
+        pair_multiplicity_per_relative_image_row: operand_count,
+        uniform_pair_multiplicity_exact,
+        heatmap_class_count: heatmap_classes.len(),
+        typed_null_pair_count,
+        target_free: true,
+        integer_only_no_rounding: table.integer_only_no_rounding,
+        relative_image_rows,
+    })
+}
+
+/// Execute the frozen #970 exact-class identifiability gate.
+///
+/// Validation labels are used only to count exact public equivalence classes
+/// and mathematical ceilings. This function does not fit a scalar, compile a
+/// selector, or execute any validation-selection/control arm after the hard
+/// stop. The inherited #967 selector is reproduced only as historical
+/// regression evidence.
+pub fn run_a1p_candidate_relative_identifiability_probe(
+) -> Result<A1PIdentifiabilityProbeReport, RecursiveGeometricAttentionError> {
+    let inherited = run_a1r_associative_ordered_summary_probe()?;
+    let fixed_partition = frozen_partition();
+    validate_frozen_partition(&fixed_partition)?;
+    let partition_kappa = frozen_partition_kappa(&fixed_partition)?;
+    let registry_input = registration_input(&fixed_partition)?;
+    let codec = CanonicalLexicalCodec::compile(&registry_input)?;
+    let construction_input = construction_input(&fixed_partition)?;
+    let construction_artifact = CanonicalRouteArtifact::ingest(&codec, &construction_input)?;
+    let embedded_manifest = construction_artifact.embedded_spin_manifest()?;
+    let attention =
+        GeometricAttentionArtifact::compile_from_manifest_witnesses(&embedded_manifest)?;
+    let table = validate_h4_binary_icosahedral_closure()?;
+    let zeta_grid = ZetaGridBinding::fixed()?;
+    let paired_h4_r4_heatmap_contract = a1p_paired_h4_r4_heatmap_contract(&table, &zeta_grid);
+    let paired_h4_r4_heatmap_contract_kappa =
+        canonical_kappa(&canonical_json(&paired_h4_r4_heatmap_contract)?)?;
+    let paired_h4_r4_heatmap_contract_reproduces =
+        paired_h4_r4_heatmap_contract_kappa == A1P_PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA;
+    let paired_h4_structural_universe = a1p_paired_h4_structural_universe(&table)?;
+    let paired_h4_structural_universe_exact = paired_h4_structural_universe.operand_count == 120
+        && paired_h4_structural_universe.expected_ordered_pair_count == 14_400
+        && paired_h4_structural_universe.enumerated_ordered_pair_count == 14_400
+        && paired_h4_structural_universe.relative_image_count == 120
+        && paired_h4_structural_universe.relative_image_rows.len() == 120
+        && paired_h4_structural_universe.exact_relative_image_complete
+        && paired_h4_structural_universe.pair_multiplicity_per_relative_image_row == 120
+        && paired_h4_structural_universe.uniform_pair_multiplicity_exact
+        && !paired_h4_structural_universe.pair_universe_kappa.is_empty()
+        && paired_h4_structural_universe.target_free
+        && paired_h4_structural_universe.integer_only_no_rounding;
+    let predecessors = a1r_candidate_predecessors(&fixed_partition)?;
+    let metric = a1r_cayley_metric(
+        &codec,
+        &construction_artifact,
+        &embedded_manifest.addresses,
+        &table,
+    )?;
+
+    let construction_observations = a1p_construction_observations();
+    let validation_observations = a1p_validation_observations();
+    let inherited_observations = a1p_inherited_observations();
+    let role_order = ["aa", "bb", "cc", "dd"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let natural_candidates = ["ll", "rr"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let construction_predecessors = vec![
+        A1PPredecessor {
+            candidate: "ll".to_owned(),
+            predecessor: "uu".to_owned(),
+        },
+        A1PPredecessor {
+            candidate: "rr".to_owned(),
+            predecessor: "vv".to_owned(),
+        },
+    ];
+    let construction_fixture_kappa = a1p_fixture_kappa(
+        "uor-r4.a1p-independent-candidate-construction/1",
+        "A1P-CONSTRUCTION-1",
+        "CONSTRUCTION",
+        &role_order,
+        &natural_candidates,
+        &construction_predecessors,
+        &construction_observations,
+    )?;
+    let validation_fixture_kappa = a1p_fixture_kappa(
+        "uor-r4.a1p-independent-candidate-validation/1",
+        "A1P-VALIDATION-1",
+        "SEALED_VALIDATION",
+        &role_order,
+        &natural_candidates,
+        &construction_predecessors,
+        &validation_observations,
+    )?;
+    let construction_kappa_reproduces =
+        construction_fixture_kappa == A1P_CONSTRUCTION_FIXTURE_KAPPA;
+    let validation_kappa_reproduces = validation_fixture_kappa == A1P_VALIDATION_FIXTURE_KAPPA;
+    let artifact_identities_reproduce = partition_kappa == FROZEN_A1_PARTITION_KAPPA
+        && construction_artifact.manifest_kappa() == FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA
+        && attention.manifest_kappa() == FROZEN_A1_ATTENTION_MANIFEST_KAPPA;
+    let inherited_report_reproduces = inherited.report_kappa == FROZEN_A1R_REPORT_KAPPA;
+    let histories_disjoint = a1p_histories_disjoint(
+        &inherited_observations,
+        &construction_observations,
+        &validation_observations,
+    );
+    let construction_parity_audit =
+        a1p_parity_audit(&construction_observations, &role_order, "qq")?;
+    let validation_parity_audit = a1p_parity_audit(&validation_observations, &role_order, "qq")?;
+    let parity_reproduces = construction_parity_audit
+        .iter()
+        .chain(&validation_parity_audit)
+        .all(|audit| audit.exact_match);
+    let construction_rule_confirmed =
+        a1p_construction_rule_confirmed(&construction_observations, &role_order, "qq")?;
+    if !construction_kappa_reproduces
+        || !validation_kappa_reproduces
+        || !paired_h4_r4_heatmap_contract_reproduces
+        || !paired_h4_structural_universe_exact
+        || !artifact_identities_reproduce
+        || !inherited_report_reproduces
+        || !histories_disjoint
+        || !parity_reproduces
+        || !construction_rule_confirmed
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+            "INVALID_CONTRACT: fixture_kappas=({construction_fixture_kappa},{validation_fixture_kappa}), paired_heatmap_contract_kappa={paired_h4_r4_heatmap_contract_kappa}, paired_structural_universe_exact={paired_h4_structural_universe_exact}, artifact_identities_reproduce={artifact_identities_reproduce}, inherited_report_reproduces={inherited_report_reproduces}, histories_disjoint={histories_disjoint}, parity_reproduces={parity_reproduces}, construction_rule_confirmed={construction_rule_confirmed}"
+        )));
+    }
+
+    let additive_leaves = a1p_additive_leaf_states(&codec)?;
+    let inherited_events = a1p_inherited_events(
+        &inherited,
+        &inherited_observations,
+        &additive_leaves,
+        &table,
+    )?;
+    let construction_histories = a1p_unlabeled_histories(&construction_observations);
+    let validation_histories = a1p_unlabeled_histories(&validation_observations);
+    let construction_split = a1p_prepare_split(
+        "CONSTRUCTION",
+        &construction_histories,
+        &codec,
+        &construction_artifact,
+        &attention,
+        &embedded_manifest.addresses,
+        &predecessors,
+        &metric,
+        &additive_leaves,
+        &table,
+    )?;
+    let validation_split = a1p_prepare_split(
+        "SEALED_VALIDATION",
+        &validation_histories,
+        &codec,
+        &construction_artifact,
+        &attention,
+        &embedded_manifest.addresses,
+        &predecessors,
+        &metric,
+        &additive_leaves,
+        &table,
+    )?;
+
+    let inherited_support =
+        a1p_support_and_work("A1R_REGRESSION", &inherited.body.candidate_queries, None);
+    let construction_support =
+        a1p_support_and_work("CONSTRUCTION", &construction_split.queries, None);
+    let validation_support =
+        a1p_support_and_work("SEALED_VALIDATION", &validation_split.queries, None);
+    if !inherited_support.contract_exact
+        || !construction_support.contract_exact
+        || !validation_support.contract_exact
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "INVALID_CONTRACT: natural candidate support, fixed work, payload, or causal mechanics drifted"
+                .to_owned(),
+        ));
+    }
+
+    // Both new-split geometry/support preparations are complete before either
+    // label ledger is joined to candidate decisions.
+    let construction_events =
+        a1p_attach_outcomes(construction_split.events, &construction_observations)?;
+    let validation_events = a1p_attach_outcomes(validation_split.events, &validation_observations)?;
+    let mut all_events = inherited_events;
+    all_events.extend(construction_events);
+    all_events.extend(validation_events);
+    if all_events.len() != 36 {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+            "INVALID_CONTRACT: expected 36 candidate decisions, observed {}",
+            all_events.len()
+        )));
+    }
+    let paired_h4_r4_heatmap = a1p_paired_h4_identifiability(&all_events, &table)?;
+    let full_h4 = a1p_h4_identifiability(&all_events, &table)?;
+    let additive = a1p_additive_identifiability(&all_events);
+
+    let mut hard_stop_reasons = paired_h4_r4_heatmap
+        .classes
+        .iter()
+        .filter(|class| class.incompatible_outcomes)
+        .map(|class| format!("INCOMPATIBLE_EXACT_R4_HEATMAP_CLASS:{}", class.class_id))
+        .collect::<Vec<_>>();
+    hard_stop_reasons.extend(
+        paired_h4_r4_heatmap
+            .classes
+            .iter()
+            .filter(|class| class.typed_null_abstain && !class.members.is_empty())
+            .map(|class| {
+                format!(
+                    "TYPED_NULL_EXACT_R4_HEATMAP_SELECTION_REQUIRED:{}",
+                    class.class_id
+                )
+            }),
+    );
+    if !paired_h4_r4_heatmap.metrics.construction_classes_pure {
+        hard_stop_reasons.push("IMPURE_EXACT_R4_HEATMAP_CONSTRUCTION_CLASS".to_owned());
+    }
+    if !paired_h4_r4_heatmap
+        .metrics
+        .transferable_construction_rule_exists
+    {
+        hard_stop_reasons.push("NO_COMPLETE_EXACT_R4_HEATMAP_CONSTRUCTION_TRANSFER".to_owned());
+    }
+    hard_stop_reasons.sort();
+    hard_stop_reasons.dedup();
+    if hard_stop_reasons.is_empty() {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "INVALID_CONTRACT: #970 exact classes unexpectedly cleared the hard gate, but this hard-stop probe contains no authorized post-gate selector"
+                .to_owned(),
+        ));
+    }
+
+    let transition = &inherited.body.transition_readout_summary;
+    let scoring = &inherited.body.scoring_summary;
+    let inherited_aggregate_reproduces = inherited.body.terminal_verdict == RETAIN_STATE_ONLY
+        && scoring.required_queries == 6
+        && scoring.exercised_queries == 6
+        && scoring.full_strict_correct == 0
+        && scoring.full_ties == 6
+        && transition.queries_with_distinct_candidate_relative_states == 6
+        && transition.paired_same_candidate_comparisons == 6
+        && transition.paired_same_candidate_relative_state_differences == 5;
+    if !inherited_aggregate_reproduces {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "INVALID_CONTRACT: inherited #967 aggregate did not reproduce".to_owned(),
+        ));
+    }
+
+    let body = A1PIdentifiabilityProbeBody {
+        probe_status: "EXERCISED_FIXED_PAIRED_H4_R4_HEATMAP_IDENTIFIABILITY_HARD_STOP".to_owned(),
+        contract_status: "VALID_PUBLIC_CONTRACT".to_owned(),
+        terminal_verdict: RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q.to_owned(),
+        successor_effect:
+            "PAIRED_H4_R4_HEATMAP_RETAINED_STRUCTURAL_ONLY_A1Q_969_MAY_TEST_PREDECLARED_MULTICHANNEL_TERMS_953_REMAINS_BLOCKED"
+                .to_owned(),
+        provenance: A1PProvenance {
+            issue_url: A1P_ISSUE_URL.to_owned(),
+            frozen_partition_kappa: partition_kappa,
+            frozen_partition_kappa_reproduces: true,
+            frozen_construction_artifact_kappa: construction_artifact.manifest_kappa().to_owned(),
+            construction_artifact_kappa_reproduces: true,
+            frozen_attention_manifest_kappa: attention.manifest_kappa().to_owned(),
+            attention_manifest_kappa_reproduces: true,
+            inherited_a1r_report_kappa: inherited.report_kappa.clone(),
+            inherited_a1r_report_kappa_reproduces: true,
+            frozen_inputs_modified: false,
+        },
+        fixture_contract: A1PFixtureContract {
+            construction: A1PFixtureEvidence {
+                fixture_id: "A1P-CONSTRUCTION-1".to_owned(),
+                split: "CONSTRUCTION".to_owned(),
+                expected_kappa: A1P_CONSTRUCTION_FIXTURE_KAPPA.to_owned(),
+                observed_kappa: construction_fixture_kappa,
+                kappa_reproduces: true,
+                role_order: role_order.clone(),
+                current_token: "qq".to_owned(),
+                natural_candidates: natural_candidates.clone(),
+                construction_predecessors: construction_predecessors.clone(),
+                observations: construction_observations,
+            },
+            validation: A1PFixtureEvidence {
+                fixture_id: "A1P-VALIDATION-1".to_owned(),
+                split: "SEALED_VALIDATION".to_owned(),
+                expected_kappa: A1P_VALIDATION_FIXTURE_KAPPA.to_owned(),
+                observed_kappa: validation_fixture_kappa,
+                kappa_reproduces: true,
+                role_order,
+                current_token: "qq".to_owned(),
+                natural_candidates,
+                construction_predecessors,
+                observations: validation_observations,
+            },
+            construction_parity_audit,
+            validation_parity_audit,
+            parity_derived_from_history: true,
+            new_split_preparation_target_free: true,
+            labels_attached_after_preparation: true,
+            histories_disjoint_across_all_splits: true,
+            construction_rule_family: "S4_ABELIANIZATION_TO_C2_TRIVIAL_OR_SIGN".to_owned(),
+            construction_rule_selected: "SIGN_WITH_C01_ORIENTATION_EVEN_LL_ODD_RR".to_owned(),
+            trivial_map_rejected: true,
+            construction_rule_confirmed: true,
+            regression_labels_falsification_only: true,
+            no_a1q_fixture_consumed: true,
+        },
+        paired_h4_r4_heatmap_contract: A1PPairedH4R4HeatmapContractEvidence {
+            expected_kappa: A1P_PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA.to_owned(),
+            observed_kappa: paired_h4_r4_heatmap_contract_kappa,
+            kappa_reproduces: true,
+            contract: paired_h4_r4_heatmap_contract,
+        },
+        paired_h4_structural_universe,
+        inherited_regression: A1PInheritedRegression {
+            fixture_id: "A1R-REGRESSION-UNCHANGED".to_owned(),
+            labels_status: "FALSIFICATION_ONLY_NON_PROMOTIONAL".to_owned(),
+            partition_kappa: FROZEN_A1_PARTITION_KAPPA.to_owned(),
+            report_kappa: inherited.report_kappa,
+            query_denominator: scoring.required_queries,
+            candidate_decision_denominator: scoring.required_queries.saturating_mul(2),
+            shortest_cayley_strict_selections: scoring.full_strict_correct,
+            shortest_cayley_ties: scoring.full_ties,
+            shortest_cayley_abstentions: inherited
+                .body
+                .candidate_queries
+                .iter()
+                .filter_map(|query| {
+                    query
+                        .controls
+                        .iter()
+                        .find(|control| control.control == "full-ordered-hierarchy")
+                })
+                .filter(|control| control.abstained)
+                .count(),
+            queries_with_distinct_candidate_relative_states: transition
+                .queries_with_distinct_candidate_relative_states,
+            paired_same_candidate_comparisons: transition.paired_same_candidate_comparisons,
+            paired_same_candidate_relative_state_differences: transition
+                .paired_same_candidate_relative_state_differences,
+            aggregate_reproduces: true,
+        },
+        support_and_work: vec![
+            inherited_support,
+            construction_support,
+            validation_support,
+        ],
+        paired_h4_r4_heatmap,
+        full_h4,
+        additive,
+        hard_stop_reasons,
+        scalar_functions_searched: 0,
+        readout_artifacts_compiled: 0,
+        validation_selection_outputs_opened: false,
+        downstream_controls: a1p_not_run_controls(),
+        serving_boundary: A10ServingBoundary {
+            source_model_weights_opened: false,
+            teacher_forwards: 0,
+            transformer_calls: 0,
+            moe_calls: 0,
+            learned_router_calls: 0,
+            dense_intelligence_matrix_calls: 0,
+            ollama_calls: 0,
+            hosted_provider_calls: 0,
+        },
+        claim_boundary: A1PClaimBoundary {
+            identifiability_falsifier_only: true,
+            h4_state_retained_as_structural_only: true,
+            paired_h4_r4_heatmap_retained_as_structural_only: true,
+            superseded_single_h4_diagnostic_is_terminal_evidence: false,
+            attention_established: false,
+            inference_established: false,
+            generation_established: false,
+            correctness_established: false,
+            reasoning_established: false,
+            semantic_value_established: false,
+            validation_selection_performed: false,
+            digest_or_kappa_used_as_geometry: false,
+            opaque_table_offset_used_as_scalar: false,
+            candidate_support_or_admission_modified: false,
+        },
+    };
+    let report_kappa = a1p_report_identity_kappa(&body)?;
+    let report = A1PIdentifiabilityProbeReport {
+        schema: A1P_IDENTIFIABILITY_PROBE_SCHEMA,
+        domain: A1P_IDENTIFIABILITY_PROBE_DOMAIN.to_owned(),
+        report_kappa,
+        body,
+    };
+    report.canonical_bytes()?;
+    Ok(report)
+}
+
+fn a1p_observation(
+    id: &str,
+    history: &[&str],
+    observed_next: &str,
+    permutation_parity: &str,
+) -> A1PFixtureObservation {
+    A1PFixtureObservation {
+        id: id.to_owned(),
+        history: history.iter().map(|token| (*token).to_owned()).collect(),
+        observed_next: observed_next.to_owned(),
+        permutation_parity: permutation_parity.to_owned(),
+    }
+}
+
+fn a1p_inherited_observations() -> Vec<A1PFixtureObservation> {
+    vec![
+        a1p_observation("A1R-R01", &["aa", "bb", "dd", "cc", "qq"], "ll", ""),
+        a1p_observation("A1R-R02", &["bb", "aa", "dd", "cc", "qq"], "rr", ""),
+        a1p_observation("A1R-R03", &["aa", "dd", "bb", "cc", "qq"], "ll", ""),
+        a1p_observation("A1R-R04", &["dd", "aa", "bb", "cc", "qq"], "rr", ""),
+        a1p_observation("A1R-R05", &["bb", "dd", "aa", "cc", "qq"], "ll", ""),
+        a1p_observation("A1R-R06", &["dd", "bb", "aa", "cc", "qq"], "rr", ""),
+    ]
+}
+
+fn a1p_construction_observations() -> Vec<A1PFixtureObservation> {
+    vec![
+        a1p_observation("A1P-C01", &["aa", "bb", "cc", "dd", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-C02", &["aa", "cc", "bb", "dd", "qq"], "rr", "ODD"),
+        a1p_observation("A1P-C03", &["bb", "aa", "cc", "dd", "qq"], "rr", "ODD"),
+        a1p_observation("A1P-C04", &["bb", "cc", "aa", "dd", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-C05", &["cc", "aa", "bb", "dd", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-C06", &["cc", "bb", "aa", "dd", "qq"], "rr", "ODD"),
+    ]
+}
+
+fn a1p_validation_observations() -> Vec<A1PFixtureObservation> {
+    vec![
+        a1p_observation("A1P-V01", &["aa", "cc", "dd", "bb", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-V02", &["aa", "dd", "cc", "bb", "qq"], "rr", "ODD"),
+        a1p_observation("A1P-V03", &["cc", "aa", "dd", "bb", "qq"], "rr", "ODD"),
+        a1p_observation("A1P-V04", &["cc", "dd", "aa", "bb", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-V05", &["dd", "aa", "cc", "bb", "qq"], "ll", "EVEN"),
+        a1p_observation("A1P-V06", &["dd", "cc", "aa", "bb", "qq"], "rr", "ODD"),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn a1p_fixture_kappa(
+    domain: &str,
+    fixture_id: &str,
+    split: &str,
+    role_order: &[String],
+    natural_candidates: &[String],
+    construction_predecessors: &[A1PPredecessor],
+    observations: &[A1PFixtureObservation],
+) -> Result<String, RecursiveGeometricAttentionError> {
+    canonical_kappa(&canonical_json(&A1PFixtureIdentityWire {
+        schema: 1,
+        domain,
+        fixture_id,
+        split,
+        construction_artifact_kappa: FROZEN_A1_CONSTRUCTION_ARTIFACT_KAPPA,
+        manifest_kappa: FROZEN_A1_ATTENTION_MANIFEST_KAPPA,
+        frozen_partition_kappa: FROZEN_A1_PARTITION_KAPPA,
+        role_order,
+        current_token: "qq",
+        natural_candidates,
+        construction_predecessors,
+        observations,
+    })?)
+}
+
+fn a1p_histories_disjoint(
+    inherited: &[A1PFixtureObservation],
+    construction: &[A1PFixtureObservation],
+    validation: &[A1PFixtureObservation],
+) -> bool {
+    let histories = inherited
+        .iter()
+        .chain(construction)
+        .chain(validation)
+        .map(|observation| observation.history.clone())
+        .collect::<BTreeSet<_>>();
+    histories.len() == inherited.len() + construction.len() + validation.len()
+        && inherited
+            .iter()
+            .all(|observation| observation.history.last().map(String::as_str) == Some("qq"))
+        && construction.iter().all(|observation| {
+            observation.history.as_slice().get(3).map(String::as_str) == Some("dd")
+                && observation.history.last().map(String::as_str) == Some("qq")
+        })
+        && validation.iter().all(|observation| {
+            observation.history.as_slice().get(3).map(String::as_str) == Some("bb")
+                && observation.history.last().map(String::as_str) == Some("qq")
+        })
+}
+
+fn a1p_derive_s4_parity(
+    history: &[String],
+    role_order: &[String],
+    current_token: &str,
+) -> Result<String, RecursiveGeometricAttentionError> {
+    if history.len() != role_order.len().saturating_add(1)
+        || history.last().map(String::as_str) != Some(current_token)
+    {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "A1P S4 history does not have the frozen role/current shape".to_owned(),
+        ));
+    }
+    let mut permutation = Vec::with_capacity(role_order.len());
+    for token in &history[..role_order.len()] {
+        let position = role_order
+            .iter()
+            .position(|role| role == token)
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "A1P S4 history contains non-role token {token:?}"
+                ))
+            })?;
+        permutation.push(position);
+    }
+    if permutation.iter().copied().collect::<BTreeSet<_>>().len() != role_order.len() {
+        return Err(RecursiveGeometricAttentionError::InvalidProbe(
+            "A1P S4 history is not a permutation of the frozen roles".to_owned(),
+        ));
+    }
+    let inversions = permutation
+        .iter()
+        .enumerate()
+        .map(|(left_index, left)| {
+            permutation[left_index.saturating_add(1)..]
+                .iter()
+                .filter(|right| left > *right)
+                .count()
+        })
+        .sum::<usize>();
+    Ok(if inversions % 2 == 0 { "EVEN" } else { "ODD" }.to_owned())
+}
+
+fn a1p_parity_audit(
+    observations: &[A1PFixtureObservation],
+    role_order: &[String],
+    current_token: &str,
+) -> Result<Vec<A1PParityAudit>, RecursiveGeometricAttentionError> {
+    observations
+        .iter()
+        .map(|observation| {
+            let derived_parity =
+                a1p_derive_s4_parity(&observation.history, role_order, current_token)?;
+            Ok(A1PParityAudit {
+                observation_id: observation.id.clone(),
+                declared_parity: observation.permutation_parity.clone(),
+                exact_match: derived_parity == observation.permutation_parity,
+                derived_parity,
+            })
+        })
+        .collect()
+}
+
+fn a1p_construction_rule_confirmed(
+    observations: &[A1PFixtureObservation],
+    role_order: &[String],
+    current_token: &str,
+) -> Result<bool, RecursiveGeometricAttentionError> {
+    if observations.len() != 6 {
+        return Ok(false);
+    }
+    let mut derived = Vec::with_capacity(observations.len());
+    for observation in observations {
+        derived.push((
+            a1p_derive_s4_parity(&observation.history, role_order, current_token)?,
+            observation.observed_next.as_str(),
+        ));
+    }
+    Ok(derived.iter().all(|(parity, observed_next)| {
+        matches!(parity.as_str(), "EVEN" | "ODD")
+            && match parity.as_str() {
+                "EVEN" => *observed_next == "ll",
+                "ODD" => *observed_next == "rr",
+                _ => false,
+            }
+    }) && derived
+        .iter()
+        .map(|(_, observed_next)| *observed_next)
+        .collect::<BTreeSet<_>>()
+        == BTreeSet::from(["ll", "rr"]))
+}
+
+fn a1p_unlabeled_histories(observations: &[A1PFixtureObservation]) -> Vec<A1PUnlabeledHistory> {
+    observations
+        .iter()
+        .map(|observation| A1PUnlabeledHistory {
+            observation_id: observation.id.clone(),
+            history: observation.history.clone(),
+        })
+        .collect()
+}
+
+fn a1p_additive_leaf_states(
+    codec: &CanonicalLexicalCodec,
+) -> Result<BTreeMap<String, A1PAdditiveState>, RecursiveGeometricAttentionError> {
+    let mut states = BTreeMap::new();
+    for token in ["ll", "rr", "uu", "vv"] {
+        // Canonical route artifacts require one causal transition. The
+        // additive class takes only the existing `current` projection, and A*
+        // removes every prefix/occurrence/identity field, so this fixed prefix
+        // cannot enter class equality.
+        let history = vec![GLOBAL_TOKEN.to_owned(), token.to_owned()];
+        let artifact = CanonicalRouteArtifact::ingest(
+            codec,
+            &evaluation_input(&format!("a1p-additive-leaf-{token}"), &history)?,
+        )?;
+        let trace = artifact.attention_consumer_trace()?;
+        let current = trace
+            .ordered_levels
+            .iter()
+            .find(|level| level.level == "current")
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "A1P additive leaf trace is missing current for {token}"
+                ))
+            })?;
+        states.insert(
+            token.to_owned(),
+            a1p_additive_projection(&non_digest_level(current)),
+        );
+    }
+    Ok(states)
+}
+
+fn a1p_additive_projection(level: &A10AttentionLevelNonDigest) -> A1PAdditiveState {
+    let mut shared_factor_multiplicities = level
+        .shared_prime_factors
+        .iter()
+        .map(|factor| factor.count)
+        .collect::<Vec<_>>();
+    shared_factor_multiplicities.sort_unstable();
+    A1PAdditiveState {
+        direct_child_count: level.direct_child_count,
+        observed_descendant_routes: level.observed_descendant_routes,
+        session_hypersphere_q30: level.session_hypersphere_q30,
+        winding_turns: level.winding_turns,
+        projection_energy_q30: level.projection_energy_q30,
+        shared_factor_multiplicities,
+        cosine_resonance_q30: level.cosine_resonance_q30,
+        accumulated_hopf_phase_q29: level.accumulated_hopf_phase_q29,
+        zeta_phase_signature_q29: level.zeta_phase_signature_q29,
+        s3_spin_q30: level.s3_spin_q30,
+        s2_hopf_observation_q30: level.s2_hopf_observation_q30,
+        fiber_q29: level.fiber_q29,
+        torsion_q29: level.torsion_q29,
+        radial_zphi: level.radial_zphi,
+        bridge_mode: level.bridge_mode.clone(),
+        active_chart: level.active_chart.clone(),
+        selected_adapter: level.selected_adapter.clone(),
+        chart_sin_q30: level.chart_sin_q30,
+        chart_cos_q30: level.chart_cos_q30,
+        chart_activation_q30: level.chart_activation_q30,
+        chart_chirality: level.chart_chirality,
+        chart_cosine_polarity: level.chart_cosine_polarity,
+        quarter_turn_orientation: level.quarter_turn_orientation,
+        phase_shift_q29: level.phase_shift_q29,
+        torsion_shift_q29: level.torsion_shift_q29,
+        transported_fiber_q29: level.transported_fiber_q29,
+        transported_torsion_q29: level.transported_torsion_q29,
+        inverse_fiber_q29: level.inverse_fiber_q29,
+        inverse_torsion_q29: level.inverse_torsion_q29,
+        chart_inverse_exact: level.chart_inverse_exact,
+        paired_h4_e8_coordinate_sum: level.paired_h4_e8_coordinate_sum,
+    }
+}
+
+fn a1p_inherited_events(
+    report: &A1RAssociativeOrderedSummaryProbeReport,
+    observations: &[A1PFixtureObservation],
+    additive_leaves: &BTreeMap<String, A1PAdditiveState>,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<Vec<A1PClassEvent>, RecursiveGeometricAttentionError> {
+    let mut events = Vec::with_capacity(observations.len().saturating_mul(2));
+    for observation in observations {
+        let query = report
+            .body
+            .candidate_queries
+            .iter()
+            .find(|query| {
+                query.history == observation.history
+                    && query.intended_target == observation.observed_next
+            })
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R report is missing {}",
+                    observation.id
+                ))
+            })?;
+        let full = query
+            .controls
+            .iter()
+            .find(|control| control.control == "full-ordered-hierarchy")
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R query {} is missing the full arm",
+                    observation.id
+                ))
+            })?;
+        let additive_history = query
+            .controls
+            .iter()
+            .find(|control| control.control == "existing-additive-summary")
+            .and_then(|control| control.legacy_additive_state.as_ref())
+            .map(a1p_additive_projection)
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R query {} is missing the additive state",
+                    observation.id
+                ))
+            })?;
+        if full.candidates.len() != 2 {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                "inherited A1R query {} has {} rather than two candidates",
+                observation.id,
+                full.candidates.len()
+            )));
+        }
+        for candidate in &full.candidates {
+            let interaction = candidate.interaction_state.as_ref().ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R candidate {}/{} is missing X(H,c)",
+                    observation.id, candidate.token
+                ))
+            })?;
+            let predecessor_interaction = candidate
+                .predecessor_interaction_state
+                .as_ref()
+                .ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(format!(
+                        "inherited A1R candidate {}/{} is missing Y(P_c,c)",
+                        observation.id, candidate.token
+                    ))
+                })?;
+            let relative = candidate.relative_state.as_ref().ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R candidate {}/{} is missing D(H,c)",
+                    observation.id, candidate.token
+                ))
+            })?;
+            let candidate_additive = additive_leaves.get(&candidate.token).ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "missing additive candidate leaf {}",
+                    candidate.token
+                ))
+            })?;
+            let predecessor_additive = additive_leaves
+                .get(&candidate.predecessor_token)
+                .ok_or_else(|| {
+                    RecursiveGeometricAttentionError::InvalidProbe(format!(
+                        "missing additive predecessor leaf {}",
+                        candidate.predecessor_token
+                    ))
+                })?;
+            let x_interaction = a1r_state_from_offset(interaction.opaque_table_offset, table)?;
+            let y_predecessor_interaction =
+                a1r_state_from_offset(predecessor_interaction.opaque_table_offset, table)?;
+            let h4_state = a1r_state_from_offset(relative.opaque_table_offset, table)?;
+            if x_interaction.compose(y_predecessor_interaction.inverse(table)?, table)? != h4_state
+            {
+                return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "inherited A1R candidate {}/{} does not reproduce D=X*Y^-1",
+                    observation.id, candidate.token
+                )));
+            }
+            let (heatmap_key, binary_landmark_output) = a1p_exact_r4_heatmap(h4_state, table)?;
+            events.push(A1PClassEvent {
+                split: "A1R_REGRESSION".to_owned(),
+                observation_id: observation.id.clone(),
+                candidate: candidate.token.clone(),
+                outcome: a1p_binary_outcome(&candidate.token, &observation.observed_next),
+                x_interaction,
+                y_predecessor_interaction,
+                h4_state,
+                heatmap_key,
+                binary_landmark_output,
+                additive_state: A1PAdditiveClassState {
+                    history: additive_history.clone(),
+                    candidate: candidate_additive.clone(),
+                    predecessor: predecessor_additive.clone(),
+                },
+            });
+        }
+    }
+    Ok(events)
+}
+
+fn a1p_target_free_candidate_path(
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    attention: &GeometricAttentionArtifact,
+    child_manifest_addresses: &[GeometricAddress],
+    history_tokens: &[String],
+) -> Result<A10CandidatePath, RecursiveGeometricAttentionError> {
+    let history = history_tokens
+        .iter()
+        .map(|token| lexical_address(codec, construction_artifact, token))
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let state = attention.causal_state_from_history(&history)?;
+    let trace = attention.query(&state, AttentionControl::CountOnly)?;
+    let rows = trace
+        .rows_read
+        .iter()
+        .map(row_origin)
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let exact_direct_rows_miss = trace.rows_read.iter().all(|row| {
+        !matches!(
+            row.source,
+            AttentionRowSource::LastOne
+                | AttentionRowSource::LastTwo
+                | AttentionRowSource::OrderedSentence
+        ) || !row.hit
+    });
+    let exclusions = leakage_exclusions(&trace);
+    let candidates = trace
+        .candidates
+        .iter()
+        .map(|candidate| {
+            let counts = source_counts(candidate.source_counts);
+            Ok(A10CandidateOrigin {
+                address_value: address_value(
+                    construction_artifact,
+                    child_manifest_addresses,
+                    &candidate.next,
+                )?,
+                contributing_sources: contributing_sources(counts),
+                source_counts: counts,
+            })
+        })
+        .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+    let admission_truncated_union = trace.unique_candidates_before_ceiling > trace.candidates.len();
+    Ok(A10CandidatePath {
+        intended_target_token: String::new(),
+        intended_target_address_kappa: String::new(),
+        rows,
+        exclusions,
+        candidate_entries_examined: trace.candidate_entries_examined,
+        candidate_entry_ceiling: trace.candidate_entry_ceiling,
+        unique_candidates_before_admission: trace.unique_candidates_before_ceiling,
+        unique_candidates_after_admission: trace.candidates.len(),
+        retained_candidate_ceiling: trace.candidate_ceiling,
+        admission_truncated_union,
+        full_pre_admission_union_observed: !admission_truncated_union,
+        candidates,
+        intended_target_pre_admission_reachable: None,
+        intended_target_post_admission_reachable: false,
+        intended_target_truncated_before_geometry: None,
+        exact_direct_rows_miss,
+        target_injected: false,
+        future_events_visible: false,
+        incremental_next_state: None,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn a1p_prepare_split(
+    split: &str,
+    histories: &[A1PUnlabeledHistory],
+    codec: &CanonicalLexicalCodec,
+    construction_artifact: &CanonicalRouteArtifact,
+    attention: &GeometricAttentionArtifact,
+    child_manifest_addresses: &[GeometricAddress],
+    predecessors: &BTreeMap<String, String>,
+    metric: &A1RCayleyMetric,
+    additive_leaves: &BTreeMap<String, A1PAdditiveState>,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1PPreparedSplit, RecursiveGeometricAttentionError> {
+    let mut queries = Vec::with_capacity(histories.len());
+    let mut events = Vec::with_capacity(histories.len().saturating_mul(2));
+    for unlabeled in histories {
+        let artifact = CanonicalRouteArtifact::ingest(
+            codec,
+            &evaluation_input(&unlabeled.observation_id, &unlabeled.history)?,
+        )?;
+        let trace = artifact.attention_consumer_trace_with_ordered_h4(table)?;
+        let path = a1p_target_free_candidate_path(
+            codec,
+            construction_artifact,
+            attention,
+            child_manifest_addresses,
+            &unlabeled.history,
+        )?;
+        // Empty targets are a typed sentinel local to this structural query.
+        // `score_controls=false`, so no target comparison or selection occurs.
+        let contract = A10EvaluationContract {
+            contrast_id: unlabeled.observation_id.clone(),
+            left_history: unlabeled.history.clone(),
+            right_history: unlabeled.history.clone(),
+            left_target: String::new(),
+            right_target: String::new(),
+        };
+        let query = a1r_candidate_query(
+            &contract,
+            "left",
+            &unlabeled.history,
+            &path,
+            &trace,
+            codec,
+            construction_artifact,
+            predecessors,
+            metric,
+            table,
+            false,
+        )?;
+        let history_h4 = a1r_ordered_level_state(&trace, "sentence")?;
+        let history_additive = trace
+            .ordered_levels
+            .iter()
+            .find(|level| level.level == "sentence")
+            .map(|level| a1p_additive_projection(&non_digest_level(&level.consumer_level)))
+            .ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "A1P query {} is missing the additive sentence state",
+                    unlabeled.observation_id
+                ))
+            })?;
+        if query.candidate_support.len() != 2 {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(format!(
+                "A1P query {} has {} rather than two candidates",
+                unlabeled.observation_id,
+                query.candidate_support.len()
+            )));
+        }
+        for candidate in &query.candidate_support {
+            let predecessor_token = predecessors.get(&candidate.token).ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "A1P candidate {} has no fixed predecessor",
+                    candidate.token
+                ))
+            })?;
+            let candidate_address =
+                lexical_address(codec, construction_artifact, &candidate.token)?;
+            let predecessor_address =
+                lexical_address(codec, construction_artifact, predecessor_token)?;
+            let candidate_h4 = h4_leaf_state_for_address(&candidate_address, table)?;
+            let predecessor_h4 = h4_leaf_state_for_address(&predecessor_address, table)?;
+            let interaction = a1r_commutator(history_h4, candidate_h4, table)?;
+            let predecessor_interaction = a1r_commutator(predecessor_h4, candidate_h4, table)?;
+            let relative = interaction.compose(predecessor_interaction.inverse(table)?, table)?;
+            let candidate_additive = additive_leaves.get(&candidate.token).ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "missing additive candidate leaf {}",
+                    candidate.token
+                ))
+            })?;
+            let predecessor_additive = additive_leaves.get(predecessor_token).ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "missing additive predecessor leaf {predecessor_token}"
+                ))
+            })?;
+            let (heatmap_key, binary_landmark_output) = a1p_exact_r4_heatmap(relative, table)?;
+            events.push(A1PPreparedClassEvent {
+                split: split.to_owned(),
+                observation_id: unlabeled.observation_id.clone(),
+                candidate: candidate.token.clone(),
+                x_interaction: interaction,
+                y_predecessor_interaction: predecessor_interaction,
+                h4_state: relative,
+                heatmap_key,
+                binary_landmark_output,
+                additive_state: A1PAdditiveClassState {
+                    history: history_additive.clone(),
+                    candidate: candidate_additive.clone(),
+                    predecessor: predecessor_additive.clone(),
+                },
+            });
+        }
+        queries.push(query);
+    }
+    Ok(A1PPreparedSplit { queries, events })
+}
+
+fn a1p_attach_outcomes(
+    events: Vec<A1PPreparedClassEvent>,
+    observations: &[A1PFixtureObservation],
+) -> Result<Vec<A1PClassEvent>, RecursiveGeometricAttentionError> {
+    let labels = observations
+        .iter()
+        .map(|observation| (observation.id.as_str(), observation.observed_next.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    events
+        .into_iter()
+        .map(|event| {
+            let observed_next = labels.get(event.observation_id.as_str()).ok_or_else(|| {
+                RecursiveGeometricAttentionError::InvalidProbe(format!(
+                    "A1P label ledger is missing {}",
+                    event.observation_id
+                ))
+            })?;
+            Ok(A1PClassEvent {
+                split: event.split,
+                observation_id: event.observation_id,
+                outcome: a1p_binary_outcome(&event.candidate, observed_next),
+                candidate: event.candidate,
+                x_interaction: event.x_interaction,
+                y_predecessor_interaction: event.y_predecessor_interaction,
+                h4_state: event.h4_state,
+                heatmap_key: event.heatmap_key,
+                binary_landmark_output: event.binary_landmark_output,
+                additive_state: event.additive_state,
+            })
+        })
+        .collect()
+}
+
+fn a1p_binary_outcome(candidate: &str, observed_next: &str) -> String {
+    if candidate == observed_next {
+        "SELECT"
+    } else {
+        "REJECT"
+    }
+    .to_owned()
+}
+
+fn a1p_support_and_work(
+    split: &str,
+    queries: &[A1RCandidateQuery],
+    paths: Option<&[A10CandidatePath]>,
+) -> A1PSupportAndWork {
+    let natural_candidate_set = queries
+        .iter()
+        .flat_map(|query| query.candidate_support.iter())
+        .map(|candidate| candidate.token.as_str())
+        .collect::<BTreeSet<_>>();
+    let natural_candidate_union_exact = queries.len() == 6
+        && queries.iter().all(|query| {
+            query
+                .candidate_support
+                .iter()
+                .map(|candidate| candidate.token.as_str())
+                .collect::<BTreeSet<_>>()
+                == BTreeSet::from(["ll", "rr"])
+        });
+    let support_denominator_kappas = queries
+        .iter()
+        .map(|query| query.support_denominator_kappa.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let support_denominator_exact =
+        support_denominator_kappas.as_slice() == [A1P_SUPPORT_DENOMINATOR_KAPPA];
+    let exact_direct_rows_miss = queries.iter().all(|query| query.exact_direct_rows_miss);
+    let divisor_rows_miss = queries.iter().all(|query| query.divisor_rows_miss);
+    let adjacent_spin_only_support = queries.iter().all(|query| query.adjacent_spin_only_support);
+    let exact_payload_inversions = queries
+        .iter()
+        .map(|query| query.exact_candidate_payload_inversions)
+        .sum();
+    let target_injected = queries.iter().any(|query| query.target_injected);
+    let future_events_visible = queries.iter().any(|query| query.future_events_visible);
+    let admission_truncation_observed = queries.iter().any(|query| query.admission_truncated_union);
+    let row_reads = queries.iter().map(|query| query.rows.len()).sum();
+    let candidate_entries_examined = queries
+        .iter()
+        .map(|query| query.candidate_entries_examined)
+        .sum();
+    let maximum_admitted_candidates = queries
+        .iter()
+        .map(|query| query.unique_candidates_after_admission)
+        .max()
+        .unwrap_or(0);
+    let path_contract_exact = paths.is_none_or(|paths| {
+        paths.len() == queries.len() && paths.iter().all(a1r_candidate_path_contract_exact)
+    });
+    let query_contract_exact = queries.iter().all(|query| {
+        query.rows.len() == ROWS_PER_QUERY_CEILING
+            && query.candidate_entries_examined == 2
+            && query.candidate_entry_ceiling
+                == ROWS_PER_QUERY_CEILING.saturating_mul(CANDIDATE_CEILING)
+            && query.unique_candidates_before_admission == 2
+            && query.unique_candidates_after_admission == 2
+            && query.retained_candidate_ceiling == CANDIDATE_CEILING
+            && query.full_pre_admission_union_observed
+            && query.anchored_candidates_after_admission == 2
+            && query.required_anchored_candidates == 2
+            && query.exact_candidate_payload_inversions == 2
+            && !query.admission_truncated_union
+            && query.exact_direct_rows_miss
+            && query.divisor_rows_miss
+            && query.adjacent_spin_only_support
+            && !query.target_injected
+            && !query.future_events_visible
+    });
+    let contract_exact = queries.len() == 6
+        && natural_candidate_union_exact
+        && support_denominator_exact
+        && row_reads == 42
+        && candidate_entries_examined == 12
+        && exact_payload_inversions == 12
+        && !target_injected
+        && !future_events_visible
+        && !admission_truncation_observed
+        && query_contract_exact
+        && path_contract_exact;
+    A1PSupportAndWork {
+        split: split.to_owned(),
+        histories: queries.len(),
+        candidate_decisions: queries
+            .iter()
+            .map(|query| query.candidate_support.len())
+            .sum(),
+        natural_candidates: natural_candidate_set
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        natural_candidate_union_exact,
+        support_denominator_kappas,
+        support_denominator_exact,
+        rows_per_query: ROWS_PER_QUERY_CEILING,
+        row_reads,
+        candidate_entries_examined,
+        candidate_entry_ceiling_per_query: ROWS_PER_QUERY_CEILING.saturating_mul(CANDIDATE_CEILING),
+        candidate_ceiling: CANDIDATE_CEILING,
+        maximum_admitted_candidates,
+        exact_direct_rows_miss,
+        divisor_rows_miss,
+        adjacent_spin_only_support,
+        exact_payload_inversions,
+        target_injected,
+        future_events_visible,
+        admission_truncation_observed,
+        contract_exact,
+    }
+}
+
+fn a1p_class_member(event: &A1PClassEvent) -> A1PClassMember {
+    A1PClassMember {
+        split: event.split.clone(),
+        observation_id: event.observation_id.clone(),
+        candidate: event.candidate.clone(),
+        outcome: event.outcome.clone(),
+    }
+}
+
+fn a1p_class_counts(events: &[&A1PClassEvent]) -> A1PClassCounts {
+    let count = |split: &str, outcome: &str| {
+        events
+            .iter()
+            .filter(|event| event.split == split && event.outcome == outcome)
+            .count()
+    };
+    A1PClassCounts {
+        inherited_select: count("A1R_REGRESSION", "SELECT"),
+        inherited_reject: count("A1R_REGRESSION", "REJECT"),
+        construction_select: count("CONSTRUCTION", "SELECT"),
+        construction_reject: count("CONSTRUCTION", "REJECT"),
+        validation_select: count("SEALED_VALIDATION", "SELECT"),
+        validation_reject: count("SEALED_VALIDATION", "REJECT"),
+    }
+}
+
+fn a1p_pure_construction_outcome(counts: &A1PClassCounts) -> Option<String> {
+    match (counts.construction_select, counts.construction_reject) {
+        (select, 0) if select > 0 => Some("SELECT".to_owned()),
+        (0, reject) if reject > 0 => Some("REJECT".to_owned()),
+        _ => None,
+    }
+}
+
+fn a1p_incompatible(counts: &A1PClassCounts) -> bool {
+    let selects = counts
+        .inherited_select
+        .saturating_add(counts.construction_select)
+        .saturating_add(counts.validation_select);
+    let rejects = counts
+        .inherited_reject
+        .saturating_add(counts.construction_reject)
+        .saturating_add(counts.validation_reject);
+    selects > 0 && rejects > 0
+}
+
+fn a1p_paired_h4_identifiability(
+    events: &[A1PClassEvent],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1PPairedH4Identifiability, RecursiveGeometricAttentionError> {
+    let mut grouped = BTreeMap::<A1PExactR4HeatmapClassKey, Vec<&A1PClassEvent>>::new();
+    for event in events {
+        grouped
+            .entry(event.heatmap_key.clone())
+            .or_default()
+            .push(event);
+    }
+    let metrics = a1p_identifiability_metrics(
+        &grouped,
+        events,
+        |event| event.heatmap_key.clone(),
+        |key| key.chart_status != "TYPED_NULL_ABSTAIN",
+    );
+    let mut classes = Vec::with_capacity(grouped.len());
+    for (position, (heatmap_key, grouped_events)) in grouped.iter().enumerate() {
+        let counts = a1p_class_counts(grouped_events);
+        let binary_landmark_output = grouped_events
+            .first()
+            .and_then(|event| event.binary_landmark_output);
+        if grouped_events
+            .iter()
+            .any(|event| event.binary_landmark_output != binary_landmark_output)
+        {
+            return Err(RecursiveGeometricAttentionError::InvalidProbe(
+                "one exact R4 heatmap class produced inconsistent landmark outputs".to_owned(),
+            ));
+        }
+        let mut members = grouped_events
+            .iter()
+            .map(|event| {
+                Ok(A1PPairedH4ClassMember {
+                    decision: a1p_class_member(event),
+                    operands: A1PPairedH4OperandWitness {
+                        x_interaction: a1r_state_witness(event.x_interaction, table)?,
+                        y_predecessor_interaction: a1r_state_witness(
+                            event.y_predecessor_interaction,
+                            table,
+                        )?,
+                        relative_projection: a1r_state_witness(event.h4_state, table)?,
+                    },
+                })
+            })
+            .collect::<Result<Vec<_>, RecursiveGeometricAttentionError>>()?;
+        members.sort_by(|left, right| {
+            (
+                left.decision.split.as_str(),
+                left.decision.observation_id.as_str(),
+                left.decision.candidate.as_str(),
+            )
+                .cmp(&(
+                    right.decision.split.as_str(),
+                    right.decision.observation_id.as_str(),
+                    right.decision.candidate.as_str(),
+                ))
+        });
+        classes.push(A1PPairedH4HeatmapClass {
+            class_id: format!("R4-HEATMAP-{:03}", position.saturating_add(1)),
+            heatmap_key: heatmap_key.clone(),
+            binary_landmark_output,
+            members,
+            construction_outcome_if_pure: a1p_pure_construction_outcome(&counts),
+            typed_null_abstain: heatmap_key.chart_status == "TYPED_NULL_ABSTAIN",
+            incompatible_outcomes: a1p_incompatible(&counts),
+            counts,
+        });
+    }
+    Ok(A1PPairedH4Identifiability {
+        operand_definition:
+            "ORDERED_PAIR_X(H,c)=C(H,c)_Y(P_c,c)=C(P_c,c)_WITH_D=X*Y^-1".to_owned(),
+        class_definition: "EXACT_SIGNED_R4_HEATMAP_(sin_Zphi/2,cos_Zphi/2,sin2_Zphi/4,chirality,cosine_polarity,chart_status);_X_Y_AND_q2_q3_WITNESS_ONLY"
+            .to_owned(),
+        coordinate_scale_denominator: 2,
+        activation_denominator: 4,
+        integer_only_no_rounding: true,
+        classes,
+        metrics,
+    })
+}
+
+fn a1p_h4_identifiability(
+    events: &[A1PClassEvent],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<A1PH4Identifiability, RecursiveGeometricAttentionError> {
+    let mut grouped = BTreeMap::<u16, Vec<&A1PClassEvent>>::new();
+    for event in events {
+        grouped
+            .entry(event.h4_state.table_index().table_offset())
+            .or_default()
+            .push(event);
+    }
+    let metrics = a1p_identifiability_metrics(
+        &grouped,
+        events,
+        |event| event.h4_state.table_index().table_offset(),
+        |_| true,
+    );
+    let mut classes = Vec::with_capacity(grouped.len());
+    for (position, (offset, grouped_events)) in grouped.iter().enumerate() {
+        let counts = a1p_class_counts(grouped_events);
+        let mut members = grouped_events
+            .iter()
+            .map(|event| a1p_class_member(event))
+            .collect::<Vec<_>>();
+        a1p_sort_members(&mut members);
+        classes.push(A1PH4Class {
+            class_id: format!("H4-D-{:03}", position.saturating_add(1)),
+            state: a1r_state_witness(a1r_state_from_offset(*offset, table)?, table)?,
+            members,
+            construction_outcome_if_pure: a1p_pure_construction_outcome(&counts),
+            incompatible_outcomes: a1p_incompatible(&counts),
+            counts,
+        });
+    }
+    Ok(A1PH4Identifiability {
+        class_definition: "SUPERSEDED_SCOPE_DIAGNOSTIC_ONLY_NOT_A1P_SCORER_KEY:D(H,c)=C(H,c)*C(P_c,c)^-1_EXACT_ORDERED_H4_STATE".to_owned(),
+        classes,
+        metrics,
+    })
+}
+
+fn a1p_additive_identifiability(events: &[A1PClassEvent]) -> A1PAdditiveIdentifiability {
+    let mut grouped = BTreeMap::<A1PAdditiveClassState, Vec<&A1PClassEvent>>::new();
+    for event in events {
+        grouped
+            .entry(event.additive_state.clone())
+            .or_default()
+            .push(event);
+    }
+    let metrics = a1p_identifiability_metrics(
+        &grouped,
+        events,
+        |event| event.additive_state.clone(),
+        |_| true,
+    );
+    let mut classes = Vec::with_capacity(grouped.len());
+    for (position, (state, grouped_events)) in grouped.iter().enumerate() {
+        let counts = a1p_class_counts(grouped_events);
+        let mut members = grouped_events
+            .iter()
+            .map(|event| a1p_class_member(event))
+            .collect::<Vec<_>>();
+        a1p_sort_members(&mut members);
+        classes.push(A1PAdditiveClass {
+            class_id: format!("ADDITIVE-{:03}", position.saturating_add(1)),
+            state: state.clone(),
+            members,
+            construction_outcome_if_pure: a1p_pure_construction_outcome(&counts),
+            incompatible_outcomes: a1p_incompatible(&counts),
+            counts,
+        });
+    }
+    A1PAdditiveIdentifiability {
+        class_definition: "(A*(H),A*(c),A*(P_c))_EXACT_EXISTING_ADDITIVE_NON_DIGEST_STATE"
+            .to_owned(),
+        excluded_fields: vec![
+            "token-spelling",
+            "level",
+            "identity-kind",
+            "occurrence",
+            "turn",
+            "paragraph",
+            "sentence",
+            "ordinal-in-sentence",
+            "window-start",
+            "window-end",
+            "lexical-unit-id",
+            "prime",
+            "shared-prime-factor-values",
+            "address-index",
+            "boundary-kind",
+            "boundary-identity",
+            "chain-identity",
+            "kappas",
+            "digests",
+            "provenance",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        leaf_evaluator_seam: A1PAdditiveLeafEvaluatorSeam {
+            status: "FIXED_GG_PREFIX_CURRENT_LEVEL_PROJECTION_ONLY".to_owned(),
+            fixed_prefix_token: GLOBAL_TOKEN.to_owned(),
+            evaluator_history_shape: "[gg, token]".to_owned(),
+            extracted_level: "current".to_owned(),
+            construction_only: true,
+            current_projection_has_prefix_occurrence_or_identity_fields: false,
+            fixture_histories_modified: false,
+            candidate_path_queries_affected: 0,
+            candidate_support_or_work_modified: false,
+        },
+        classes,
+        metrics,
+    }
+}
+
+fn a1p_sort_members(members: &mut [A1PClassMember]) {
+    members.sort_by(|left, right| {
+        (
+            left.split.as_str(),
+            left.observation_id.as_str(),
+            left.candidate.as_str(),
+        )
+            .cmp(&(
+                right.split.as_str(),
+                right.observation_id.as_str(),
+                right.candidate.as_str(),
+            ))
+    });
+}
+
+fn a1p_identifiability_metrics<K, F, P>(
+    grouped: &BTreeMap<K, Vec<&A1PClassEvent>>,
+    events: &[A1PClassEvent],
+    key_for: F,
+    key_admissible: P,
+) -> A1PIdentifiabilityMetrics
+where
+    K: Clone + Ord,
+    F: Fn(&A1PClassEvent) -> K,
+    P: Fn(&K) -> bool,
+{
+    let has_split = |class_events: &[&A1PClassEvent], split: &str| {
+        class_events.iter().any(|event| event.split == split)
+    };
+    let inherited_class_count = grouped
+        .values()
+        .filter(|class_events| has_split(class_events, "A1R_REGRESSION"))
+        .count();
+    let construction_class_count = grouped
+        .values()
+        .filter(|class_events| has_split(class_events, "CONSTRUCTION"))
+        .count();
+    let validation_class_count = grouped
+        .values()
+        .filter(|class_events| has_split(class_events, "SEALED_VALIDATION"))
+        .count();
+    let construction_decisions = events
+        .iter()
+        .filter(|event| event.split == "CONSTRUCTION")
+        .count();
+    let construction_impure_class_count = grouped
+        .values()
+        .filter(|class_events| {
+            let counts = a1p_class_counts(class_events);
+            counts.construction_select > 0 && counts.construction_reject > 0
+        })
+        .count();
+    let construction_classes_pure = construction_class_count > 0
+        && construction_impure_class_count == 0
+        && construction_decisions == 12;
+    let validation_decisions = events
+        .iter()
+        .filter(|event| event.split == "SEALED_VALIDATION")
+        .count();
+    let validation_decisions_covered = events
+        .iter()
+        .filter(|event| event.split == "SEALED_VALIDATION")
+        .filter(|event| {
+            grouped
+                .get(&key_for(event))
+                .is_some_and(|class_events| has_split(class_events, "CONSTRUCTION"))
+        })
+        .count();
+    let validation_oracle_numerator = grouped
+        .values()
+        .map(|class_events| a1p_class_counts(class_events))
+        .map(|counts| counts.validation_select.max(counts.validation_reject))
+        .sum();
+    let incompatible_class_count = grouped
+        .values()
+        .map(|class_events| a1p_class_counts(class_events))
+        .filter(a1p_incompatible)
+        .count();
+
+    let construction_map = grouped
+        .iter()
+        .filter(|(key, _)| key_admissible(key))
+        .filter_map(|(key, class_events)| {
+            let counts = a1p_class_counts(class_events);
+            a1p_pure_construction_outcome(&counts).map(|outcome| (key.clone(), outcome))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut validation_by_observation = BTreeMap::<String, Vec<&A1PClassEvent>>::new();
+    for event in events
+        .iter()
+        .filter(|event| event.split == "SEALED_VALIDATION")
+    {
+        validation_by_observation
+            .entry(event.observation_id.clone())
+            .or_default()
+            .push(event);
+    }
+    let validation_transfer_numerator = validation_by_observation
+        .values()
+        .filter(|query_events| {
+            query_events.len() == 2
+                && query_events.iter().all(|event| {
+                    construction_map
+                        .get(&key_for(event))
+                        .is_some_and(|outcome| outcome == &event.outcome)
+                })
+                && query_events
+                    .iter()
+                    .filter(|event| event.outcome == "SELECT")
+                    .count()
+                    == 1
+                && query_events
+                    .iter()
+                    .filter(|event| event.outcome == "REJECT")
+                    .count()
+                    == 1
+        })
+        .count();
+    let validation_query_denominator = validation_by_observation.len();
+    A1PIdentifiabilityMetrics {
+        exact_class_count: grouped.len(),
+        inherited_class_count,
+        construction_class_count,
+        validation_class_count,
+        construction_decisions_covered: A1PRationalCeiling {
+            numerator: construction_decisions,
+            denominator: 12,
+        },
+        construction_impure_class_count,
+        construction_classes_pure,
+        validation_decisions_covered_by_construction: A1PRationalCeiling {
+            numerator: validation_decisions_covered,
+            denominator: validation_decisions,
+        },
+        validation_no_class_splitting_oracle_ceiling: A1PRationalCeiling {
+            numerator: validation_oracle_numerator,
+            denominator: validation_decisions,
+        },
+        validation_construction_transfer_selection_ceiling: A1PRationalCeiling {
+            numerator: validation_transfer_numerator,
+            denominator: validation_query_denominator,
+        },
+        incompatible_class_count_across_all_splits: incompatible_class_count,
+        exact_class_aliasing_observed: grouped.values().any(|class_events| class_events.len() > 1),
+        transferable_construction_rule_exists: validation_query_denominator == 6
+            && validation_transfer_numerator == validation_query_denominator,
+    }
+}
+
+fn a1p_not_run_controls() -> Vec<A1PDownstreamControl> {
+    A1P_DOWNSTREAM_CONTROL_CONTRACT
+        .into_iter()
+        .map(|(control, required)| A1PDownstreamControl {
+            control: control.to_owned(),
+            required,
+            status: NOT_RUN_IDENTIFIABILITY_HARD_STOP.to_owned(),
+            selections: 0,
+            ties: 0,
+            abstentions: 0,
+            exact_hits: 0,
+            support_equal: None,
+            work: A1PControlWork {
+                validation_queries: 0,
+                candidate_decisions: 0,
+                row_reads: 0,
+                candidate_entry_ceiling_per_query: 56,
+                candidate_ceiling: 8,
+                maximum_admitted_candidates: 0,
+            },
+        })
+        .collect()
+}
+
+fn a1p_report_identity_kappa(
+    body: &A1PIdentifiabilityProbeBody,
+) -> Result<String, RecursiveGeometricAttentionError> {
+    canonical_kappa(&canonical_json(&A1PReportIdentityWire {
+        schema: A1P_IDENTIFIABILITY_PROBE_SCHEMA,
+        domain: A1P_IDENTIFIABILITY_PROBE_DOMAIN,
+        report_kappa: "",
+        body,
+    })?)
+}
+
+#[cfg(test)]
+mod a1p_contract_tests {
+    use super::*;
+
+    fn role_order() -> Vec<String> {
+        ["aa", "bb", "cc", "dd"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn s4_parity_is_derived_and_malformed_histories_fail_closed() {
+        let roles = role_order();
+        assert_eq!(
+            a1p_derive_s4_parity(
+                &["aa", "bb", "cc", "dd", "qq"]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>(),
+                &roles,
+                "qq",
+            )
+            .expect("identity permutation parity"),
+            "EVEN"
+        );
+        assert_eq!(
+            a1p_derive_s4_parity(
+                &["bb", "aa", "cc", "dd", "qq"]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>(),
+                &roles,
+                "qq",
+            )
+            .expect("single transposition parity"),
+            "ODD"
+        );
+        for malformed in [
+            ["aa", "aa", "cc", "dd", "qq"],
+            ["aa", "bb", "cc", "xx", "qq"],
+            ["aa", "bb", "cc", "dd", "rr"],
+        ] {
+            assert!(a1p_derive_s4_parity(
+                &malformed.into_iter().map(str::to_owned).collect::<Vec<_>>(),
+                &roles,
+                "qq",
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn validation_label_permutation_cannot_change_preparation_inputs() {
+        let original = a1p_validation_observations();
+        let mut relabeled = original.clone();
+        for observation in &mut relabeled {
+            observation.observed_next = if observation.observed_next == "ll" {
+                "rr".to_owned()
+            } else {
+                "ll".to_owned()
+            };
+        }
+        let original_unlabeled = a1p_unlabeled_histories(&original);
+        let relabeled_unlabeled = a1p_unlabeled_histories(&relabeled);
+        assert_eq!(original_unlabeled.len(), relabeled_unlabeled.len());
+        for (left, right) in original_unlabeled.iter().zip(&relabeled_unlabeled) {
+            assert_eq!(left.observation_id, right.observation_id);
+            assert_eq!(left.history, right.history);
+        }
+    }
 }

--- a/crates/uor-r4-core/tests/recursive_geometric_attention_970.rs
+++ b/crates/uor-r4-core/tests/recursive_geometric_attention_970.rs
@@ -1,0 +1,590 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use uor_r4_core::canonical_lexical_ingestion::validate_h4_binary_icosahedral_closure;
+use uor_r4_core::prime_route_attention::{
+    zeta_grid_kappa, ZETA_GRID_KAPPA_REFERENCE, ZETA_GRID_REVISION,
+};
+use uor_r4_core::recursive_geometric_attention::{
+    run_a1p_candidate_relative_identifiability_probe, A1PExactR4HeatmapClassKey,
+    A1PFixtureObservation, NOT_RUN_IDENTIFIABILITY_HARD_STOP,
+    RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q,
+};
+
+const CONSTRUCTION_FIXTURE_KAPPA: &str =
+    "blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652";
+const VALIDATION_FIXTURE_KAPPA: &str =
+    "blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602";
+const INHERITED_A1R_REPORT_KAPPA: &str =
+    "blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881";
+const PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA: &str =
+    "blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98";
+const PAIRED_H4_UNIVERSE_KAPPA: &str =
+    "blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796";
+const A1P_REPORT_KAPPA: &str =
+    "blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f";
+
+const DOWNSTREAM_CONTROL_CONTRACT: [(&str, bool); 10] = [
+    ("full-paired-h4-r4-heatmap", true),
+    ("current-only", true),
+    ("additive-summary-compiled-scorer", true),
+    ("factor-count-only", true),
+    ("deterministic-geometry-permutation", true),
+    ("candidate-relabeling", true),
+    ("prime-assignment-permutation", true),
+    ("hierarchy-disabled", true),
+    ("exact-recall-only", true),
+    ("placement-intervention", false),
+];
+
+fn square_zphi([a, b]: [i64; 2]) -> [i64; 2] {
+    [a * a + b * b, 2 * a * b + b * b]
+}
+
+fn expected_landmark_output(key: &A1PExactR4HeatmapClassKey) -> Option<u8> {
+    match (key.sin_zphi_numerator, key.cos_zphi_numerator) {
+        ([2, 0], [0, 0]) | ([-2, 0], [0, 0]) => Some(1),
+        ([0, 0], [2, 0]) | ([0, 0], [-2, 0]) => Some(0),
+        _ => None,
+    }
+}
+
+fn independent_s4_parity(observation: &A1PFixtureObservation, role_order: &[String]) -> String {
+    assert_eq!(observation.history.len(), role_order.len() + 1);
+    assert_eq!(observation.history.last().map(String::as_str), Some("qq"));
+    let permutation = observation.history[..role_order.len()]
+        .iter()
+        .map(|token| {
+            role_order
+                .iter()
+                .position(|role| role == token)
+                .expect("frozen history role")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        permutation.iter().copied().collect::<BTreeSet<_>>().len(),
+        role_order.len()
+    );
+    let inversions = permutation
+        .iter()
+        .enumerate()
+        .map(|(left_index, left)| {
+            permutation[left_index + 1..]
+                .iter()
+                .filter(|right| left > *right)
+                .count()
+        })
+        .sum::<usize>();
+    if inversions % 2 == 0 { "EVEN" } else { "ODD" }.to_owned()
+}
+
+#[test]
+fn paired_h4_r4_heatmap_identifiability_hard_stops_before_selection() {
+    let first = run_a1p_candidate_relative_identifiability_probe()
+        .expect("fixed #970 paired-H4/R4 heatmap probe");
+    let second = run_a1p_candidate_relative_identifiability_probe()
+        .expect("deterministic second #970 execution");
+    let first_bytes = first.canonical_bytes().expect("canonical first report");
+    let second_bytes = second.canonical_bytes().expect("canonical second report");
+    assert_eq!(first, second);
+    assert_eq!(first.report_kappa, second.report_kappa);
+    assert_eq!(first_bytes, second_bytes);
+    assert_eq!(first.schema, 2);
+    assert_eq!(
+        first.domain,
+        "uor-r4.a1p-candidate-relative-identifiability-probe/2"
+    );
+
+    let body = &first.body;
+    assert_eq!(body.contract_status, "VALID_PUBLIC_CONTRACT");
+    assert_eq!(
+        body.probe_status,
+        "EXERCISED_FIXED_PAIRED_H4_R4_HEATMAP_IDENTIFIABILITY_HARD_STOP"
+    );
+    assert_eq!(
+        body.terminal_verdict,
+        RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q
+    );
+    assert_eq!(body.scalar_functions_searched, 0);
+    assert_eq!(body.readout_artifacts_compiled, 0);
+    assert!(!body.validation_selection_outputs_opened);
+
+    let contract = &body.paired_h4_r4_heatmap_contract;
+    assert_eq!(contract.expected_kappa, PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA);
+    assert_eq!(contract.observed_kappa, PAIRED_H4_R4_HEATMAP_CONTRACT_KAPPA);
+    assert!(contract.kappa_reproduces);
+    assert_eq!(contract.contract.paired_h4_operands.len(), 2);
+    assert_eq!(
+        contract.contract.relative_product,
+        "D(H,c)=X(H,c)*Y(P_c,c)^-1"
+    );
+    assert_eq!(contract.contract.r4_basis, ["1", "i", "j", "k"]);
+    assert_eq!(contract.contract.coordinate_scale_denominator, 2);
+    assert_eq!(contract.contract.activation_denominator, 4);
+    assert_eq!(contract.contract.exact_ring, "Z[phi]");
+    assert_eq!(contract.contract.zeta_grid_revision, ZETA_GRID_REVISION);
+    assert_eq!(contract.contract.zeta_grid_kappa, ZETA_GRID_KAPPA_REFERENCE);
+    assert_eq!(
+        zeta_grid_kappa().expect("live fixed-zeta grid kappa"),
+        ZETA_GRID_KAPPA_REFERENCE
+    );
+    assert_eq!(contract.contract.binary_landmarks.len(), 4);
+    assert_eq!(
+        contract.contract.radial_coupling_status,
+        "STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE"
+    );
+    assert_eq!(
+        contract.contract.typed_geometry_equivalence,
+        ["EUCLIDEAN_ROOT_2", "COMPLEX_2I", "RIEMANNIAN_0_2"]
+    );
+    assert!(contract.contract.intermediate_rule.contains("no threshold"));
+    assert!(contract
+        .contract
+        .semantic_exclusions
+        .contains(&"validation labels".to_owned()));
+    assert!(contract
+        .contract
+        .semantic_exclusions
+        .contains(&"raw zeta channel identity as scorer input".to_owned()));
+
+    let fixtures = &body.fixture_contract;
+    assert_eq!(
+        fixtures.construction.expected_kappa,
+        CONSTRUCTION_FIXTURE_KAPPA
+    );
+    assert_eq!(
+        fixtures.construction.observed_kappa,
+        CONSTRUCTION_FIXTURE_KAPPA
+    );
+    assert!(fixtures.construction.kappa_reproduces);
+    assert_eq!(fixtures.validation.expected_kappa, VALIDATION_FIXTURE_KAPPA);
+    assert_eq!(fixtures.validation.observed_kappa, VALIDATION_FIXTURE_KAPPA);
+    assert!(fixtures.validation.kappa_reproduces);
+    assert!(fixtures.parity_derived_from_history);
+    assert!(fixtures.new_split_preparation_target_free);
+    assert!(fixtures.labels_attached_after_preparation);
+    assert_eq!(fixtures.construction_parity_audit.len(), 6);
+    assert_eq!(fixtures.validation_parity_audit.len(), 6);
+    for (observations, audits) in [
+        (
+            &fixtures.construction.observations,
+            &fixtures.construction_parity_audit,
+        ),
+        (
+            &fixtures.validation.observations,
+            &fixtures.validation_parity_audit,
+        ),
+    ] {
+        for observation in observations {
+            let derived = independent_s4_parity(observation, &fixtures.construction.role_order);
+            let audit = audits
+                .iter()
+                .find(|audit| audit.observation_id == observation.id)
+                .expect("parity audit row");
+            assert_eq!(derived, observation.permutation_parity);
+            assert_eq!(audit.derived_parity, derived);
+            assert_eq!(audit.declared_parity, derived);
+            assert!(audit.exact_match);
+        }
+    }
+    assert!(fixtures.histories_disjoint_across_all_splits);
+    assert!(fixtures.trivial_map_rejected);
+    assert!(fixtures.construction_rule_confirmed);
+    assert!(fixtures.regression_labels_falsification_only);
+    assert!(fixtures.no_a1q_fixture_consumed);
+
+    let universe = &body.paired_h4_structural_universe;
+    assert_eq!(universe.operand_count, 120);
+    assert_eq!(universe.expected_ordered_pair_count, 14_400);
+    assert_eq!(universe.enumerated_ordered_pair_count, 14_400);
+    assert_eq!(universe.relative_image_count, 120);
+    assert_eq!(universe.relative_image_rows.len(), 120);
+    assert!(universe.exact_relative_image_complete);
+    assert_eq!(universe.pair_universe_census_schema, 1);
+    assert_eq!(universe.pair_universe_row_width_bytes, 6);
+    assert!(universe
+        .pair_universe_row_encoding
+        .contains("x_u16be||y_u16be||D_u16be"));
+    assert_eq!(universe.pair_universe_kappa, PAIRED_H4_UNIVERSE_KAPPA);
+    assert_eq!(universe.pair_multiplicity_per_relative_image_row, 120);
+    assert!(universe.uniform_pair_multiplicity_exact);
+    assert!(universe.heatmap_class_count > 4);
+    assert!(universe.heatmap_class_count <= 120);
+    assert_eq!(universe.heatmap_class_count, 45);
+    assert!(universe.typed_null_pair_count > 0);
+    assert_eq!(universe.typed_null_pair_count % 120, 0);
+    assert_eq!(universe.typed_null_pair_count, 480);
+    assert!(universe.target_free);
+    assert!(universe.integer_only_no_rounding);
+    let table = validate_h4_binary_icosahedral_closure().expect("exact H4 closure");
+    let mut relative_counts = BTreeMap::<u16, usize>::new();
+    for x in 0..u16::try_from(table.root_count).expect("root count fits u16") {
+        for y in 0..u16::try_from(table.root_count).expect("root count fits u16") {
+            let inverse_y = table.inverse_indices[usize::from(y)];
+            let relative = table
+                .product_index(x, inverse_y)
+                .expect("closed pair product");
+            *relative_counts.entry(relative).or_default() += 1;
+        }
+    }
+    assert_eq!(relative_counts.len(), 120);
+    assert!(relative_counts.values().all(|count| *count == 120));
+
+    let mut observed_landmark_outputs = BTreeSet::new();
+    for entry in &universe.relative_image_rows {
+        let relative_offset = entry.relative_state.opaque_table_offset;
+        assert!(usize::from(relative_offset) < table.root_count);
+        assert_eq!(
+            entry.ordered_pair_multiplicity,
+            relative_counts[&relative_offset]
+        );
+        assert_eq!(
+            entry.relative_state.root_coordinate.scaled_zphi_quaternion[0],
+            entry.heatmap_key.sin_zphi_numerator
+        );
+        assert_eq!(
+            entry.relative_state.root_coordinate.scaled_zphi_quaternion[1],
+            entry.heatmap_key.cos_zphi_numerator
+        );
+        assert_eq!(
+            entry.heatmap_key.activation_zphi_numerator,
+            square_zphi(entry.heatmap_key.sin_zphi_numerator)
+        );
+        assert_eq!(
+            entry.binary_landmark_output,
+            expected_landmark_output(&entry.heatmap_key)
+        );
+        if let Some(output) = entry.binary_landmark_output {
+            observed_landmark_outputs.insert(output);
+        }
+    }
+    assert_eq!(observed_landmark_outputs, BTreeSet::from([0, 1]));
+
+    let inherited = &body.inherited_regression;
+    assert_eq!(inherited.report_kappa, INHERITED_A1R_REPORT_KAPPA);
+    assert_eq!(
+        inherited.labels_status,
+        "FALSIFICATION_ONLY_NON_PROMOTIONAL"
+    );
+    assert_eq!(inherited.query_denominator, 6);
+    assert_eq!(inherited.candidate_decision_denominator, 12);
+    assert_eq!(inherited.shortest_cayley_strict_selections, 0);
+    assert_eq!(inherited.shortest_cayley_ties, 6);
+    assert_eq!(inherited.shortest_cayley_abstentions, 6);
+    assert_eq!(inherited.queries_with_distinct_candidate_relative_states, 6);
+    assert_eq!(inherited.paired_same_candidate_comparisons, 6);
+    assert_eq!(
+        inherited.paired_same_candidate_relative_state_differences,
+        5
+    );
+    assert!(inherited.aggregate_reproduces);
+
+    assert_eq!(body.support_and_work.len(), 3);
+    assert_eq!(
+        body.support_and_work
+            .iter()
+            .map(|split| split.split.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["A1R_REGRESSION", "CONSTRUCTION", "SEALED_VALIDATION"])
+    );
+    for split in &body.support_and_work {
+        assert_eq!(split.histories, 6);
+        assert_eq!(split.candidate_decisions, 12);
+        assert_eq!(split.natural_candidates, ["ll", "rr"]);
+        assert!(split.natural_candidate_union_exact);
+        assert!(split.support_denominator_exact);
+        assert_eq!(split.rows_per_query, 7);
+        assert_eq!(split.row_reads, 42);
+        assert_eq!(split.candidate_entries_examined, 12);
+        assert_eq!(split.candidate_entry_ceiling_per_query, 56);
+        assert_eq!(split.candidate_ceiling, 8);
+        assert_eq!(split.maximum_admitted_candidates, 2);
+        assert!(split.exact_direct_rows_miss);
+        assert!(split.divisor_rows_miss);
+        assert!(split.adjacent_spin_only_support);
+        assert_eq!(split.exact_payload_inversions, 12);
+        assert!(!split.target_injected);
+        assert!(!split.future_events_visible);
+        assert!(!split.admission_truncation_observed);
+        assert!(split.contract_exact);
+    }
+
+    let heatmap = &body.paired_h4_r4_heatmap;
+    assert_eq!(
+        heatmap
+            .classes
+            .iter()
+            .map(|class| class.members.len())
+            .sum::<usize>(),
+        36
+    );
+    assert_eq!(heatmap.coordinate_scale_denominator, 2);
+    assert_eq!(heatmap.activation_denominator, 4);
+    assert!(heatmap.integer_only_no_rounding);
+    assert_eq!(
+        heatmap.metrics.construction_decisions_covered.denominator,
+        12
+    );
+    assert_eq!(
+        heatmap
+            .metrics
+            .validation_decisions_covered_by_construction
+            .denominator,
+        12
+    );
+    assert_eq!(
+        heatmap
+            .metrics
+            .validation_no_class_splitting_oracle_ceiling
+            .denominator,
+        12
+    );
+    assert_eq!(
+        heatmap
+            .metrics
+            .validation_construction_transfer_selection_ceiling
+            .denominator,
+        6
+    );
+    assert!(heatmap.metrics.exact_class_aliasing_observed);
+    assert_eq!(heatmap.metrics.exact_class_count, 14);
+    assert_eq!(heatmap.metrics.inherited_class_count, 9);
+    assert_eq!(heatmap.metrics.construction_class_count, 10);
+    assert_eq!(heatmap.metrics.validation_class_count, 7);
+    assert_eq!(heatmap.metrics.construction_impure_class_count, 0);
+    assert!(heatmap.metrics.construction_classes_pure);
+    assert_eq!(
+        (
+            heatmap
+                .metrics
+                .validation_decisions_covered_by_construction
+                .numerator,
+            heatmap
+                .metrics
+                .validation_decisions_covered_by_construction
+                .denominator,
+        ),
+        (10, 12)
+    );
+    assert_eq!(
+        (
+            heatmap
+                .metrics
+                .validation_no_class_splitting_oracle_ceiling
+                .numerator,
+            heatmap
+                .metrics
+                .validation_no_class_splitting_oracle_ceiling
+                .denominator,
+        ),
+        (10, 12)
+    );
+    assert_eq!(
+        heatmap
+            .metrics
+            .validation_construction_transfer_selection_ceiling
+            .numerator,
+        0
+    );
+    assert_eq!(
+        heatmap.metrics.incompatible_class_count_across_all_splits,
+        8
+    );
+    assert!(!heatmap.metrics.transferable_construction_rule_exists);
+    for class in &heatmap.classes {
+        assert_eq!(
+            class.heatmap_key.activation_zphi_numerator,
+            square_zphi(class.heatmap_key.sin_zphi_numerator)
+        );
+        assert_eq!(
+            class.binary_landmark_output,
+            expected_landmark_output(&class.heatmap_key)
+        );
+        assert_eq!(
+            class.typed_null_abstain,
+            class.heatmap_key.chart_status == "TYPED_NULL_ABSTAIN"
+        );
+        for member in &class.members {
+            let x = member.operands.x_interaction.opaque_table_offset;
+            let y = member
+                .operands
+                .y_predecessor_interaction
+                .opaque_table_offset;
+            let d = member.operands.relative_projection.opaque_table_offset;
+            let inverse_y = table.inverse_indices[usize::from(y)];
+            assert_eq!(table.product_index(x, inverse_y), Some(d));
+            assert_eq!(
+                member
+                    .operands
+                    .relative_projection
+                    .root_coordinate
+                    .scaled_zphi_quaternion[0],
+                class.heatmap_key.sin_zphi_numerator
+            );
+            assert_eq!(
+                member
+                    .operands
+                    .relative_projection
+                    .root_coordinate
+                    .scaled_zphi_quaternion[1],
+                class.heatmap_key.cos_zphi_numerator
+            );
+        }
+    }
+    let decisive_alias = heatmap
+        .classes
+        .iter()
+        .find(|class| {
+            class.members.iter().any(|member| {
+                member.decision.observation_id == "A1R-R05"
+                    && member.decision.candidate == "ll"
+                    && member.decision.outcome == "SELECT"
+            }) && class.members.iter().any(|member| {
+                member.decision.observation_id == "A1R-R06"
+                    && member.decision.candidate == "ll"
+                    && member.decision.outcome == "REJECT"
+            })
+        })
+        .expect("same exact heatmap class retains incompatible old-six outcomes");
+    assert!(decisive_alias.incompatible_outcomes);
+    for observation_id in ["A1R-R05", "A1R-R06"] {
+        assert_eq!(
+            decisive_alias
+                .members
+                .iter()
+                .find(|member| {
+                    member.decision.observation_id == observation_id
+                        && member.decision.candidate == "ll"
+                })
+                .expect("decisive alias member")
+                .operands
+                .relative_projection
+                .opaque_table_offset,
+            70
+        );
+    }
+    assert!(body.hard_stop_reasons.contains(&format!(
+        "INCOMPATIBLE_EXACT_R4_HEATMAP_CLASS:{}",
+        decisive_alias.class_id
+    )));
+    assert!(body
+        .hard_stop_reasons
+        .iter()
+        .any(|reason| reason == "NO_COMPLETE_EXACT_R4_HEATMAP_CONSTRUCTION_TRANSFER"));
+    assert_eq!(body.hard_stop_reasons.len(), 9);
+
+    let old_d = &body.full_h4;
+    assert!(old_d
+        .class_definition
+        .starts_with("SUPERSEDED_SCOPE_DIAGNOSTIC_ONLY_NOT_A1P_SCORER_KEY:"));
+    assert_eq!(
+        old_d
+            .classes
+            .iter()
+            .map(|class| class.members.len())
+            .sum::<usize>(),
+        36
+    );
+
+    let additive = &body.additive;
+    assert_eq!(
+        additive
+            .classes
+            .iter()
+            .map(|class| class.members.len())
+            .sum::<usize>(),
+        36
+    );
+    assert_eq!(additive.metrics.exact_class_count, 2);
+    assert_eq!(additive.metrics.construction_impure_class_count, 2);
+    assert!(!additive.metrics.construction_classes_pure);
+    assert_eq!(
+        additive
+            .metrics
+            .validation_construction_transfer_selection_ceiling
+            .numerator,
+        0
+    );
+    assert!(!additive.metrics.transferable_construction_rule_exists);
+    assert!(additive
+        .excluded_fields
+        .contains(&"token-spelling".to_owned()));
+    assert!(additive.excluded_fields.contains(&"prime".to_owned()));
+    assert!(additive.excluded_fields.contains(&"kappas".to_owned()));
+    assert!(additive.excluded_fields.contains(&"provenance".to_owned()));
+
+    assert_eq!(
+        body.downstream_controls
+            .iter()
+            .map(|control| (control.control.as_str(), control.required))
+            .collect::<Vec<_>>(),
+        DOWNSTREAM_CONTROL_CONTRACT
+    );
+    assert!(body.downstream_controls.iter().all(|control| {
+        control.status == NOT_RUN_IDENTIFIABILITY_HARD_STOP
+            && control.selections == 0
+            && control.ties == 0
+            && control.abstentions == 0
+            && control.exact_hits == 0
+            && control.support_equal.is_none()
+            && control.work.validation_queries == 0
+            && control.work.candidate_decisions == 0
+            && control.work.row_reads == 0
+            && control.work.candidate_entry_ceiling_per_query == 56
+            && control.work.candidate_ceiling == 8
+            && control.work.maximum_admitted_candidates == 0
+    }));
+
+    assert!(body.claim_boundary.identifiability_falsifier_only);
+    assert!(body.claim_boundary.h4_state_retained_as_structural_only);
+    assert!(
+        body.claim_boundary
+            .paired_h4_r4_heatmap_retained_as_structural_only
+    );
+    assert!(
+        !body
+            .claim_boundary
+            .superseded_single_h4_diagnostic_is_terminal_evidence
+    );
+    assert!(!body.claim_boundary.attention_established);
+    assert!(!body.claim_boundary.inference_established);
+    assert!(!body.claim_boundary.generation_established);
+    assert!(!body.claim_boundary.correctness_established);
+    assert!(!body.claim_boundary.reasoning_established);
+    assert!(!body.claim_boundary.semantic_value_established);
+    assert!(!body.claim_boundary.validation_selection_performed);
+    assert!(!body.claim_boundary.digest_or_kappa_used_as_geometry);
+    assert!(!body.claim_boundary.opaque_table_offset_used_as_scalar);
+    assert!(!body.claim_boundary.candidate_support_or_admission_modified);
+
+    eprintln!("A1P_REPORT_KAPPA={}", first.report_kappa);
+    eprintln!("PAIRED_HEATMAP_METRICS={:?}", heatmap.metrics);
+    eprintln!(
+        "STRUCTURAL_UNIVERSE_KAPPA={} heatmap_classes:{} typed_null_pairs:{}",
+        universe.pair_universe_kappa, universe.heatmap_class_count, universe.typed_null_pair_count
+    );
+    eprintln!("ADDITIVE_METRICS={:?}", additive.metrics);
+    for class in heatmap
+        .classes
+        .iter()
+        .filter(|class| class.incompatible_outcomes)
+    {
+        eprintln!(
+            "HEATMAP_ALIAS={} key={:?} members={:?}",
+            class.class_id,
+            class.heatmap_key,
+            class
+                .members
+                .iter()
+                .map(|member| (
+                    member.decision.split.as_str(),
+                    member.decision.observation_id.as_str(),
+                    member.decision.candidate.as_str(),
+                    member.decision.outcome.as_str(),
+                    member.operands.relative_projection.opaque_table_offset,
+                ))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    assert_eq!(first.report_kappa, A1P_REPORT_KAPPA);
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -16,11 +16,22 @@ candidate/value path was reachable, but the additive/last-child hierarchy
 summaries erased earlier causal order. #967's narrow A1R delivery repaired the
 ordered state but terminated `RETAIN_STATE_ONLY` when shortest Cayley distance
 collapsed distinct candidate-relative states to the same energy on 6/6
-queries. Unassigned #970 follows protected #967 delivery, owns A1P
-candidate-relative readout/placement, and blocks #969. #969 owns A1Q full
-recursive-attention qualification; #953 is
-blocked by #969 and owns bounded library/CLI inference and generation using
-only A1Q-qualified semantic scoring terms. #962 separately owns durable
+queries. #970's corrected target-free construction/validation preflight then
+enumerated 120×120 = 14,400 paired-H4 operands as 120 relative rows, 45 exact
+signed `(1,i)` R4-heatmap classes, and 480 typed-null pairs. Across 36 decisions
+it exercised 14 classes, had pure 12/12 construction coverage, covered 10/12
+validation decisions with a 10/12 no-class-splitting oracle ceiling,
+transferred 0/6 queries, and found eight incompatible classes. It terminated
+the bounded heatmap-readout question as
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` before scalar search. Contract,
+universe, and report kappas are
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+#969 becomes the next A1Q multichannel full recursive-attention qualification
+only after protected #970 merge; #953 remains blocked by #969 and owns bounded
+library/CLI inference and generation using only A1Q-qualified semantic scoring
+terms. #962 separately owns durable
 multi-turn CLI/HTTP chat, persisted conversation state, session/identity
 isolation, and identity-scoped hive memory.
 
@@ -37,7 +48,7 @@ canonical text/corpus
     -> witnessed paired-H4/E8 state
     -> incremental local/sentence/paragraph/conversation/global state
     -> associative noncommutative ordered-summary repair (#967, state only)
-    -> candidate-relative readout/placement redesign (#970)
+    -> paired-H4-derived exact R4-heatmap readout hard stop (#970, bounded negative)
     -> complete recursive geometric-attention qualification (GI-2/#969)
     -> bounded source-free library/CLI inference and generation (#953)
     -> correctness + typed abstention (#954)
@@ -58,8 +69,19 @@ The #952 A1.0 record is a representation-level negative result, not a failure
 of lexical inversion, candidate admission, H4 closure, Hopf state, or the value
 interface. Exact hierarchy identities preserved order as provenance, but their
 digest distance is not geometry; #967 made that order observable in bounded
-reusable summaries, while #970 now owns candidate-relative readout/placement before
-semantic scoring resumes. See the
+reusable summaries. #970's paired contract computes `D=X*Y^-1`; its exact
+endpoint rule is `sin=±1, cos=0 -> 1` with chirality retained and
+`sin=0, cos=±1 -> 0` with cosine polarity retained, while `q0=q1=0` is a
+typed-null abstention. Geometry/support was prepared without labels and S4
+parity was derived from each history before label-ledger join. The resulting
+negative is scoped only to the bounded heatmap readout; `q2` and `q3` remain in
+the full `D` witness but are not scorer-key fields. Fixed-zeta phases,
+ordered n-lets, exact `phi` radial transport, and typed
+`sqrt(2) <-> 2i <-> [0,2]` adapters remain structural under
+`STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`, not semantic scorer
+inputs. #969 becomes the next multichannel qualification only after protected
+#970 merge.
+See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
 
 In the frozen #952/A1R fixture, current, previous, last-two, and the immutable
@@ -1349,9 +1371,10 @@ Passing `--cover` reuses the measured cover. It may be omitted to re-induce
 the default cover deterministically during scoring. For experiments, `cover`
 also accepts `--depths`, `--k0`, `--regions-budget`, and `--memory-budget`.
 
-**Current production boundary pending #962 after #970, #969, and #953–#955.**
-#970 owns candidate-relative readout/placement and #969 owns full
-recursive-attention qualification. #953 owns the
+**Current production boundary pending #962 after #969 and #953–#955.**
+#970 has bounded paired-H4-derived exact R4-heatmap readout evidence awaiting
+protected merge; #969 becomes the next multichannel full recursive-attention
+qualification only after that merge. #953 owns the
 bounded source-free library/CLI inference and generation engine; #962 owns its
 integration into durable multi-turn CLI/HTTP chat, persisted conversation
 state, session/identity isolation, and identity-scoped hive memory. Until that

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -19,9 +19,12 @@ assumptions, or objectives rather than measured results.
 > The geometric causal decoder roadmap and S0–S7 completion plan are retained
 > as historical evidence. GitHub programme root #820 and the native
 > GI sequence now records #961 closed, #952 A1.0 redirected through #967 A1R,
-> #967 terminal `RETAIN_STATE_ONLY`, unassigned #970 A1P candidate-relative
-> readout/placement, #969 A1Q full recursive-attention qualification, then
-> #953–#955 and #962–#965 afterward; legacy
+> #967 terminal `RETAIN_STATE_ONLY`, and #970 A1P's bounded paired-H4-derived
+> exact R4-heatmap result
+> `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Protected #970 merge is the
+> eligibility boundary; only afterward does #969 become the A1Q multichannel
+> full recursive-attention qualification, followed by
+> #953–#955 and #962–#965; legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
 > current-summary corrections remain important: **#784** found
@@ -40,8 +43,8 @@ assumptions, or objectives rather than measured results.
 > product attention, generation, inference, reasoning, or teacher parity. This
 > is retained foundation evidence, not abandonment. Forward work makes lexical
 > geometry reversible (GI-1/#961), repairs ordered state (GI-2 A1R/#967),
-> falsifies and replaces the shortest-Cayley scalar readout within the broader
-> candidate-relative readout/placement scope (GI-2 A1P/#970),
+> tests candidate-relative identifiability and one construction-derived readout
+> without assuming a replacement or placement defect (GI-2 A1P/#970),
 > establishes recursive causal attention across
 > local/sentence/paragraph/conversation/global state with anti-recall evidence
 > (GI-2 A1Q/#969), then adds source-free grammatical inference/generation
@@ -65,8 +68,9 @@ assumptions, or objectives rather than measured results.
 > In its frozen fixture, current, previous, last-two, and the immutable global
 > snapshot intentionally remain equal; sentence, paragraph, and conversation
 > are the scopes expected to differ after repair. Global order requires a
-> separate matched global-snapshot permutation. #969 owns the later full
-> attention qualification and natively blocks #953. #953 owns
+> separate matched global-snapshot permutation. After protected #970 merge,
+> #969 owns the later full attention qualification and natively blocks #953.
+> #953 owns
 > source-free inference/generation, while #962 owns product chat and persisted
 > identity-scoped hive memory. See the
 > [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
@@ -82,9 +86,49 @@ assumptions, or objectives rather than measured results.
 > The terminal verdict is `RETAIN_STATE_ONLY`, with no attention or generation
 > claim. `any_exercised_control_not_weaker = true` confirms that the verdict
 > follows from exercised full/control evidence, not the unavailable additive
-> scorer. Unassigned #970 follows protected #967 delivery and blocks #969; #969
-> continues to block #953. See the
+> scorer. #970's exact preflight follows below; #969 continues to block #953.
+> See the
 > [#967 A1R record](associative_ordered_route_summaries_a1r_967.md).
+>
+> **A1P decision, 2026-08-27.** The six visible A1R labels remain unchanged
+> regression/root-cause evidence and cannot qualify a new readout. Construction
+> fixture `A1P-CONSTRUCTION-1`, kappa
+> `blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652`,
+> derives its candidate rule from permutation parity. The
+> disjoint sealed anti-recall fixture `A1P-VALIDATION-1`, kappa
+> `blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602`,
+> tests transfer on different histories. Geometry/support is prepared with no
+> observed-next labels, label ledgers join only after preparation, and S4 parity
+> is mechanically derived by inversion count from each exact history and the
+> frozen role order.
+>
+> The corrected paired contract computes `X=C(H,c)`, `Y=C(P_c,c)`, and
+> `D=X*Y^-1` in the exact signed `(1,i)` R4 chart. Its endpoint rule is
+> `sin=±1, cos=0 -> 1` with chirality retained and
+> `sin=0, cos=±1 -> 0` with cosine polarity retained; `q0=q1=0` is typed-null
+> abstention. `q2` and `q3` remain in the full `D` witness but are not
+> scorer-key fields. Before labels, the target-free universe enumerated 120×120 =
+> 14,400 ordered pairs, 120 relative rows, 45 exact heatmap classes, and 480
+> typed-null pairs. Across 36 fixture decisions it exercised 14 classes;
+> construction coverage was 12/12 and pure, construction classes covered 10/12
+> validation decisions, the
+> no-class-splitting oracle ceiling was 10/12, strict construction transfer was
+> 0/6, and eight exact heatmap classes were incompatible. The additive
+> comparator retained two impure classes and 0/6 transfer. No scalar/readout or
+> selection control ran; every downstream row is
+> `NOT_RUN_IDENTIFIABILITY_HARD_STOP`, not PASS. The terminal literal is
+> `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Contract, universe, and
+> report kappas are
+> `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+> `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+> and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+> This is only a bounded heatmap-readout identifiability negative. Fixed-zeta
+> phases, ordered n-lets, exact `phi` radial transport, and typed
+> `sqrt(2) <-> 2i <-> [0,2]` adapters remain structural under
+> `STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE` and are excluded
+> from the scorer. #969 remains blocked until protected #970 merge and #953
+> remains blocked by #969. See the
+> [#970 A1P record](candidate_relative_identifiability_a1p_970.md).
 
 The current quality-baseline reconciliation is recorded by #933 and the
 [append-only #934 genealogy](canonical_quality_baseline_934.md). The historical
@@ -315,10 +359,13 @@ reusable summaries erased earlier causal order, terminating as
 `REDESIGN_ORDERED_ROUTE_SUMMARY` before scorer implementation. #967 repaired
 that representation, but its scalar readout mapped distinct candidate-relative
 states to equal energy on 6/6 queries and terminated `RETAIN_STATE_ONLY`. #970
-must now falsify and replace that shortest-Cayley scalar readout within its
-broader candidate-relative readout/placement scope; #969
-must still qualify full recursive attention under matched, scope-isolated
-controls before GI-3/#953 is allowed to generate.
+then applied its target-free paired-H4-derived exact R4-heatmap gate. Across 36
+decisions, 14 exercised classes covered 10/12 validation decisions with a
+10/12 oracle ceiling, transferred 0/6 queries, and contained eight incompatible
+classes, so the gate stopped before scalar design. The old six labels remained
+diagnostic/falsification-only. After protected #970 merge, #969 must still
+qualify full recursive attention under matched, scope-isolated controls before
+GI-3/#953 is allowed to generate.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
 point remains allowed for witnessed chart construction; serving arithmetic is
@@ -408,22 +455,28 @@ trajectory/harmonic summaries. The #952 A1.0 result showed that the current
 additive/last-child summaries do not preserve earlier order even though the
 candidate and value path is reachable. #967 repaired ordered summaries but
 retained them as state only after shortest Cayley distance tied distinct states
-on 6/6 queries. #970 must falsify and replace that scalar readout within its
-broader candidate-relative readout/placement scope, and #969 must then establish anti-recall
-attention before GI-3/#953 adds the
+on 6/6 queries. #970 then found that the paired-H4-derived exact R4-heatmap
+classes alias outcomes and that the construction-derived rule has a 0/6 strict
+transfer ceiling on the separate sealed validation fixture. It stopped without
+scalar search; protected #970 merge must land before #969 becomes next and
+establishes anti-recall attention before GI-3/#953 adds the
 source-free inference/generation engine. Structural presence does not qualify a
-field for ranking: unqualified Hopf, H4, zeta, icosian, SpiralCore, trajectory,
-and harmonic terms remain storage, diagnostics, or controls, and #953 may
-consume only terms qualified by A1Q. Product chat and persisted hive memory
-remain GI-6/#962 responsibilities. The
+field for ranking: the paired heatmap, fixed-zeta phases, ordered n-lets, exact
+`phi` radial transport, typed adapters, and unqualified Hopf, H4, icosian,
+SpiralCore, trajectory, and harmonic terms remain storage, diagnostics, or
+controls, and #953 may consume only terms qualified by A1Q. Product chat and
+persisted hive memory remain GI-6/#962 responsibilities. The
 retained #951 negative
 checkpoint and exact population remain in
 [`geometric_mixer_qualification_951.md`](geometric_mixer_qualification_951.md),
 and the #958 boundary remains in
 [`prime_route_attention_qualification_958.md`](prime_route_attention_qualification_958.md).
-The older pointwise signal remains useful as a comparator, not the product
-sequencing authority. (As of #831, the one normative scorer for the historical
-deployed
+The older source-free table-native continuation/candidate and pointwise evidence
+remains useful to #953 as an offline substrate or comparator, not the product
+sequencing authority. #953 must still show that a #969-qualified intervention
+changes candidate choice relative to count-only, hierarchy-disabled, permuted,
+and exact-recall controls. (As of #831, the one normative scorer for the
+historical deployed
 inference — the R4G1Runtime scoring path — is designated in
 [ADR-0001](adr/0001-normative-r4g1-scorer.md), and the reference/certifier
 scorers are explicitly scoped; a certifier measurement is no longer read as a
@@ -851,18 +904,24 @@ whose only legitimate integration point is an honesty/claim-vocabulary bridge
 
 #961 is closed. #952 A1.0 has the terminal representation verdict
 `REDESIGN_ORDERED_ROUTE_SUMMARY`; #967 repaired the fold and terminated
-`RETAIN_STATE_ONLY`. Unassigned #970 follows protected #967 delivery, owns the
-candidate-relative readout/placement redesign, and is the native blocker of
-#969. #969 is the
-separate full recursive-attention qualification and natively blocks #953, so
-closing #967 cannot make A1Q or generation eligible.
-After #969 qualifies GI-2 attention, #953 owns source-free inference/generation
-using only the qualified semantic terms, #954 correctness/abstention, #955
-reasoning, and #962
-product chat with persisted identity-scoped hive memory; #963–#965 retain cost,
-formal/serving closure, and release ownership. The table below is retained as
-the historical mechanism ledger; rows that still use “open” in their original
-prose are not the live backlog. GitHub native issue state wins.
+`RETAIN_STATE_ONLY`. #970 produced the bounded paired-H4-derived exact
+R4-heatmap readout-identifiability result without compiling a readout and now
+awaits protected merge. #969 remains blocked until that merge; afterward it
+becomes the separate full recursive-attention qualification and natively blocks
+#953, so the #970 negative cannot make generation eligible. #969 starts
+with a bounded 2–8 lexical-unit composition instrument and stops on identical
+matched continuations, an inert qualified-state intervention, decode failure, a
+period-1–4 cycle, nondeterministic termination, or changed support before opening
+its sealed scope fixtures. After #969 qualifies GI-2 attention, #953 owns
+source-free inference/generation using only qualified semantic terms and must
+exercise the qualified-geometry candidate-choice intervention against its
+declared controls. #954 consumes only that #969/#953 path; #955 invokes the
+accepted #969/#953/#954 consumer; #962 integrates #969-qualified attention and
+the accepted #953 generator into product chat with persisted identity-scoped
+hive memory. #963 retains measured cost; #964 binds the inserted #970 → #969
+stages in the serving contract; #965 qualifies only that release path. The table
+below is retained as the historical mechanism ledger; rows that still use “open”
+in their original prose are not the live backlog. GitHub native issue state wins.
 
 *Recently landed and closed (GitHub is the source of truth; this table tracks what is still open): **#743** — `R4Engine::load` failed closed with a typed `SourceUnavailable` decline on a teacher_cid pairing mismatch instead of panicking (PR #746); the root cause was data-pairing drift between two independently-sourced bundle files, not format/era drift as first hypothesized. **#502** — dropped the lexical weight (W=0) on the deployed content-query path (+0.022 MRR / +0.032 top-1, a simplification); the #421 rows are invariant under the weight, so the gate was moot the same way #490's was (below). **#488** — phase-timing instrument (DoD met); the at-scale run is now **#503**. **#457** — IPF Arm B landed NEGATIVE, consistency operator reaches only the unigram floor (below). **#486/#490** — the serving path compared a routing vector to a content vector; the content-vector query is now the deployed default (+0.1363 MRR), with the serde-default and blast-radius findings recorded on #490. **#487** — corrected #434's Spectral record (lexical, not geometry). **#493** — the VSA switch made honest; its `0.0000` is a scoring category error, not a wiring gap (below). **#458/#459** — interaction information and the estimation ladder, both landed NEGATIVE/count-limited. **#456** — reconstructability certificate + null arm (below).*
 

--- a/docs/adr/0003-fixed-zeta-prime-route-attention.md
+++ b/docs/adr/0003-fixed-zeta-prime-route-attention.md
@@ -10,11 +10,14 @@
   `REDESIGN_ORDERED_ROUTE_SUMMARY`. [#967](https://github.com/UOR-Foundation/uor-r4/issues/967)
   repaired A1R ordered state and exercised its bounded candidate-relative
   scalar scorer but terminated `RETAIN_STATE_ONLY`; the full A1Q recursive
-  attention scorer remains unimplemented and unqualified. Unassigned
-  [#970](https://github.com/UOR-Foundation/uor-r4/issues/970) owns A1P
-  candidate-relative readout/placement and blocks
-  [#969](https://github.com/UOR-Foundation/uor-r4/issues/969), which owns A1Q
-  full recursive-attention qualification and blocks #953.
+  attention scorer remains unimplemented and unqualified.
+  [#970](https://github.com/UOR-Foundation/uor-r4/issues/970) has a corrected
+  local paired-H4-derived exact R4-heatmap result pending protected delivery.
+  Eight of its 14 exercised heatmap classes alias incompatible outcomes and
+  construction transfer is 0/6, so it retains the paired state as structural
+  evidence and stops before readout or placement. #970 remains active until
+  that result merges; [#969](https://github.com/UOR-Foundation/uor-r4/issues/969)
+  remains blocked and continues to own A1Q multi-channel qualification.
 - **Decision owner:** representation redesign
   [#958](https://github.com/UOR-Foundation/uor-r4/issues/958)
 - **Programme tracker:**
@@ -423,8 +426,31 @@ invariants. The report kappa is
 `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
 Its full arm produced distinct candidate-relative states on 6/6 queries, but
 shortest Cayley distance collapsed both candidates to energy 2 and tied on 6/6,
-so the terminal verdict is `RETAIN_STATE_ONLY`. #970 owns the readout/placement redesign and
-blocks A1Q/#969. Only A1Q-qualified semantic terms may reach #953.
+so the terminal verdict is `RETAIN_STATE_ONLY`. #970's corrected independent
+preflight retains both exact operands `X=C(H,c)` and `Y=C(P_c,c)`, derives
+`D=X*Y^-1`, and keys equality only by the exact signed R4 heatmap
+`(sin=q0/2, cos=q1/2, sin^2=q0^2/4, chirality, cosine polarity, chart status)`
+in `Z[phi]`. Its frozen endpoints map `sin=+/-1, cos=0` to bit 1 and
+`sin=0, cos=+/-1` to bit 0 while retaining chirality/polarity. Across 36
+decisions it found 14 heatmap classes, 10/12 validation
+coverage, a 10/12 no-splitting ceiling, 0/6 strict construction transfer, and
+eight incompatible classes. It therefore stopped before readout or placement
+with `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`.
+
+The contract, complete 14,400-pair/120-relative-state universe, and corrected
+report are bound respectively by
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and
+`blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+The 120 relative rows form 45 heatmap classes; 480 ordered pairs are typed-null.
+Preparation is target-free and S4 parity is derived from each history. The
+fixed-zeta grid, ordered n-lets, golden `phi` maps, and typed cross-chart adapter
+are bound only as structural transport: no zeta/n-let-to-`phi` shell-exponent
+rule is established. This negative is only a bounded readout-identifiability
+result; it does not negate those structures or establish attention. #970 stays
+active and #969 stays blocked until protected merge. Only later A1Q-qualified
+semantic terms may reach #953.
 
 | Component | Status | Current evidence boundary |
 |---|---|---|
@@ -436,7 +462,7 @@ blocks A1Q/#969. Only A1Q-qualified semantic terms may reach #953.
 | Exact 64-state SpiralCore v63 `Cl(0,6)` composition/inverse table | `IMPLEMENTED_CONTROL_ONLY` | Deterministic noncommutative table mechanics are bound and reproduced; `OPTIONAL_CONTROL_PENDING`, no semantic claim. The proposed six-prime `J(6,2)` semantic adapter remains unqualified. |
 | Complete semiprime/n-let manifest tables, chart/quantization binding, and canonical conversion/rebuild witnesses | `PASS_COMPLETE_MANIFEST_V2` | #958 schema 2 binds the prime registry, semiprime experts, ordered n-lets, address order, chart/spin/radial fields, indexes, provenance, and strict rebuild witnesses. This is storage/candidate substrate, not semantic-attention evidence. |
 | Frozen schema-2 child, bounded direct/divisor/adjacent-spin candidate union, and exact address-to-payload value view | `IMPLEMENTED_SUBSTRATE` | The fixed #952 contrasts naturally expose both targets below the ceiling of eight, with exact direct rows absent and no target injection or truncation. Candidate reachability is not attention selection. |
-| Reusable order-sensitive route summary and recursive attention scorer | `A1R_RETAIN_STATE_ONLY_A1P_BLOCKS_A1Q` | #967 repaired ordered state and passed its structural contracts, but shortest Cayley distance mapped distinct candidate-relative states to equal energy on 6/6 queries. #970 owns candidate-relative readout/placement and blocks #969; no full attention or generation claim follows. |
+| Reusable order-sensitive route summary and recursive attention scorer | `A1P_RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q_PENDING_PROTECTED_MERGE` | #967 repaired ordered state but shortest Cayley distance mapped distinct states to equal energy on 6/6 queries. The corrected local #970 probe exhaustively bound 14,400 paired-H4 witnesses to 120 relative roots and 45 exact R4 heatmaps; its 36 exercised decisions formed 14 classes with 10/12 validation coverage, 10/12 oracle ceiling, 0/6 transfer, and eight incompatible classes. This is a readout-identifiability negative only. #970 remains active and #969 blocked until protected merge; no full-attention or generation claim follows. |
 | Layer-29 caller, equal-budget controls, no-Ollama product probe, and teacher comparison | `NOT_YET_IMPLEMENTED` | No deployed or product capability follows from the substrate. |
 | Binding one-worker/four-worker release canary with positive work on every worker and measured four-worker compile-stage improvement | `PASS_SUBSTRATE_SCOPE` | The frozen schema-2 report records 32/32 exact artifact/kappa matches, all four workers active, and 1.498x median compile-stage speedup. Any later semantic-input or workload-shape change must re-establish this bounded evidence. |
 

--- a/docs/candidate_relative_identifiability_a1p_970.md
+++ b/docs/candidate_relative_identifiability_a1p_970.md
@@ -1,0 +1,256 @@
+# A1P paired-H4 R4-heatmap identifiability — issue #970
+
+## Status and decision
+
+**Terminal bounded result:**
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`.
+
+The corrected public contract evaluates both exact H4 operands
+
+```text
+X(H,c) = C(H,c)
+Y(P_c,c) = C(P_c,c)
+D(H,c) = X(H,c) * Y(P_c,c)^-1
+```
+
+and runs the binary translation against the exact signed R4 heatmap derived
+from `D`. It does not score one H4 operand, an opaque table offset, a digest, or
+a fitted sign/threshold. The paired heatmap remains useful structural state,
+but its exact classes alias incompatible candidate outcomes on the frozen
+construction/validation envelope. The predeclared hard gate therefore stopped
+before scalar search, selector compilation, validation selection, control-arm
+execution, or placement intervention.
+
+This is a bounded readout-identifiability negative. It is not evidence that
+H4×H4, the exact R4 heatmap, fixed-zeta phases, ordered n-lets, or golden radial
+transport have no value. It establishes no attention, inference, generation,
+correctness, reasoning, or product readiness.
+
+## Bound identities
+
+| Artifact | Identity | Status |
+|---|---|---|
+| #952 partition | `blake3:d008b82eda9b16b102cf4c7ffa4a47a40ad514b30f0763ed3f46c0ebae3e277b` | reproduced |
+| Construction artifact | `blake3:2b70588d654c8e8bb2d8ab063f41853d45a21487d742ff7567f93a42cfb9011b` | reproduced |
+| Embedded schema-2 manifest | `blake3:1c77c4103732964af6776f1dfcabc8b2a9191eea875a8ba205c36ebbf5618a99` | reproduced |
+| Inherited #967 report | `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881` | reproduced |
+| `A1P-CONSTRUCTION-1` | `blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652` | reproduced |
+| `A1P-VALIDATION-1` | `blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602` | reproduced |
+| Paired-H4/R4 heatmap contract | `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98` | reproduced |
+| Complete 120×120 pair census | `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796` | reproduced twice |
+| Corrected #970 report | `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f` | reproduced twice, byte-identical |
+
+The former local single-`D` report κ
+`blake3:0359b08da5318b737379d4b5f1e2cbf1782b01960682b6defe308c46bd868eef`
+is a superseded scope diagnostic. It is not terminal evidence and is not used
+as the result identity.
+
+## Exact heatmap contract
+
+For
+
+```text
+D = (q0 + q1 i + q2 j + q3 k) / 2,
+qk = ak + bk*phi in Z[phi],
+```
+
+the frozen oriented `(1,i)` chart is
+
+```text
+sin        = q0 / 2
+cos        = q1 / 2
+activation = sin^2 = q0^2 / 4
+chirality  = sign(sin)
+polarity   = sign(cos).
+```
+
+All values remain exact in `Z[phi]`; no float or rounding enters the class
+key. `q2` and `q3` remain in the full `D` witness but are not scorer-key fields.
+When both `q0` and `q1` are zero, the chart is a typed-null abstention.
+
+The geometric endpoint bit is:
+
+| Heatmap endpoint | Activation bit | Retained orientation |
+|---|---:|---|
+| `sin=+1, cos=0` | 1 | positive chirality |
+| `sin=-1, cos=0` | 1 | negative chirality |
+| `sin=0, cos=+1` | 0 | positive cosine polarity |
+| `sin=0, cos=-1` | 0 | negative cosine polarity |
+
+The activation bit is not a candidate label. `SELECT`/`REJECT` is compiled
+only when a complete exact construction heatmap class is pure. Non-landmark
+roots retain their exact class; unseen, impure, and typed-null classes abstain.
+
+The same immutable contract binds the fixed zeta grid κ
+`blake3:512243ed9e2c1deef0691515caf02ca25e3d5c7990184cd804f6d65c1cc8d94c`,
+ordered multiplicity-preserving prime n-lets, and the exact golden shell maps
+
+```text
+(a,b)*phi    = (b,a+b)
+(a,b)*phi^-1 = (b-a,a).
+```
+
+It also retains the typed cross-chart marker
+`Euclidean sqrt(2) <-> complex 2i <-> Riemannian [0,2]`. These are typed
+representatives; units, orientation, normalization, and error must be supplied
+by an adapter rather than treating the raw values as ordinary scalar equality.
+No zeta/n-let-to-`phi` shell-exponent rule was supplied or established, so the
+binding is truthfully
+`STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`. Raw zeta identity,
+n-let identity, and radial magnitude are excluded from the scorer.
+
+## Complete paired structural universe
+
+The probe enumerated the entire frozen ordered pair domain before inspecting
+any fixture labels:
+
+| Measure | Result |
+|---|---:|
+| Exact H4 operands | 120 |
+| Ordered `(X,Y)` pairs | 14,400 / 14,400 |
+| Exact relative `D=X*Y^-1` image | 120 / 120 |
+| Pair multiplicity per relative image row | 120 |
+| Exact signed `(1,i)` heatmap classes | 45 |
+| Pairs projecting to typed-null heatmap rows | 480 |
+| Integer-only, no rounding | yes |
+| Target/label input | none |
+
+The report stores the complete ordered-pair census κ plus the 120 unique
+relative-image heatmap rows. This is equivalent to serializing 14,400 repeated
+rows because every exact relative row has multiplicity 120; the focused test
+independently re-enumerates that multiplicity from the frozen multiplication
+and inverse tables.
+
+## Independent fixtures and anti-recall boundary
+
+The three populations remain separate:
+
+| Population | Histories | Candidate decisions | History suffix | Role |
+|---|---:|---:|---|---|
+| Inherited A1R regression | 6 | 12 | `cc qq` | falsification/root-cause only |
+| `A1P-CONSTRUCTION-1` | 6 | 12 | `dd qq` | derives the sign-rule orientation |
+| `A1P-VALIDATION-1` | 6 | 12 | `bb qq` | held-out anti-recall transfer |
+
+All 18 exact histories are disjoint. The S4 parity for every construction and
+validation row is derived by inversion count from the exact history and frozen
+role order `[aa,bb,cc,dd]`; the serialized parity literal must reproduce it.
+Malformed or duplicate-role histories fail closed.
+
+Construction and validation geometry/support are prepared from a type that has
+no observed-next field. Both full populations are complete before the separate
+label ledgers are joined for class purity and ceiling calculation. Permuting
+validation labels therefore cannot change any preparation input.
+
+Every population preserves:
+
+- natural admitted candidates `{ll,rr}` on 6/6 queries;
+- 7 row reads/query, 42 total;
+- 2 candidate entries examined/query, 12 total;
+- candidate-entry ceiling 56/query and candidate ceiling 8;
+- maximum two admitted candidates;
+- 12/12 exact payload inversions;
+- direct/exact and divisor misses on 6/6 queries;
+- adjacent-spin-only support;
+- no target injection, future event, admission truncation, or support drift; and
+- support-denominator κ
+  `blake3:7b17bdc7f3686fd734c1770a4d6c5cc1a0590accbe8ceaa4e143ec1cd3369777`.
+
+## Paired-H4 R4-heatmap identifiability
+
+| Measure | Result |
+|---|---:|
+| Exact classes across 36 decisions | 14 |
+| Inherited classes | 9 |
+| Construction classes | 10 |
+| Validation classes | 7 |
+| Construction coverage | 12 / 12 |
+| Impure construction classes | 0 |
+| Validation decisions covered by construction | 10 / 12 |
+| No-class-splitting validation oracle ceiling | 10 / 12 |
+| Construction-transfer strict-selection ceiling | 0 / 6 |
+| Incompatible exact heatmap classes | 8 |
+
+The original decisive same-candidate alias survives in exact heatmap class
+`R4-HEATMAP-004`:
+
+- `A1R-R05 / ll / SELECT`, relative root offset 70;
+- `A1R-R06 / ll / REJECT`, relative root offset 70; and
+- `A1P-C04 / ll / SELECT`, relative root offset 70.
+
+Its exact heatmap is `sin=0`, `cos=1/2`, activation `0`, zero chirality,
+positive cosine polarity. The same complete heatmap class would have to select
+and reject `ll`.
+
+The binary landmarks themselves also demonstrate why the geometric activation
+bit cannot be mistaken for a label:
+
+- `R4-HEATMAP-005` has `sin=0`, `cos=+1`, activation bit `0`, yet contains
+  both `SELECT` and `REJECT` outcomes;
+- `R4-HEATMAP-014` has `sin=+1`, `cos=0`, activation bit `1`, yet likewise
+  contains incompatible candidate outcomes.
+
+Independently, no validation query receives both a construction-derived pure
+positive class for its intended candidate and a pure negative class for the
+alternative. The strict transfer ceiling is therefore 0/6 even though the
+exact heatmap improves class coverage from the superseded single-`D` diagnostic
+to 10/12 validation decisions.
+
+## Existing-additive comparator
+
+The unchanged exact class compiler was also applied to
+`(A*(H),A*(c),A*(P_c))`. `A*` is the existing non-digest additive projection
+with spelling, position/occurrence identifiers, lexical-unit ID, prime and
+factor identity, address/boundary/chain identity, κ/digests, and provenance
+absent by construction.
+
+| Measure | Result |
+|---|---:|
+| Exact classes across 36 decisions | 2 |
+| Construction coverage | 12 / 12 |
+| Impure construction classes | 2 / 2 |
+| Validation decisions covered by construction | 12 / 12 |
+| No-class-splitting validation oracle ceiling | 6 / 12 |
+| Construction-transfer strict-selection ceiling | 0 / 6 |
+| Incompatible retained classes | 2 / 2 |
+
+The additive comparator cannot compile a pure construction scorer. It is not
+relabeled as a tied or weaker exercised selection arm.
+
+## Downstream controls and claim boundary
+
+The identifiability failure is the predeclared hard stop. The exact frozen rows
+are `full-paired-h4-r4-heatmap`, `current-only`,
+`additive-summary-compiled-scorer`, `factor-count-only`,
+`deterministic-geometry-permutation`, `candidate-relabeling`,
+`prime-assignment-permutation`, `hierarchy-disabled`, `exact-recall-only`, and
+the optional `placement-intervention`.
+
+Every row is `NOT_RUN_IDENTIFIABILITY_HARD_STOP` with zero selection, tie,
+abstention, exact-hit, validation-query, candidate-decision, and row-read work.
+`NOT_RUN` is not PASS. No scalar was searched, no readout artifact was compiled,
+and no placement intervention was authorized.
+
+Source weights opened, teacher forwards, transformer calls, MoE calls, learned
+router calls, dense-intelligence-matrix calls, Ollama calls, hosted-provider
+calls, external/corpus population scans, #969 fixtures consumed, and generated
+lexical units were all zero.
+
+## Reproduction and run record
+
+The binding focused command is:
+
+```text
+cargo test -p uor-r4-core --offline \
+  --test recursive_geometric_attention_970 -- --nocapture
+```
+
+It executes the complete corrected probe twice, compares the reports and
+canonical bytes, and pins both result identities. Binding result after
+precomputing the 120 exact relative-state heatmap rows: **1 passed, 0 failed**,
+115.43 seconds (test runtime; compilation excluded).
+
+An earlier representation-only attempt serialized all 14,400 repeated pair
+rows directly. It was interrupted before any result after about eight minutes
+(`ABORTED_PRE_RESULT_REPRESENTATION_COST`, exit 130). The final form preserves
+the exhaustive enumeration through its census κ and 120 multiplicity-bound
+relative rows; no metric, class, or decision was changed to reduce cost.

--- a/docs/explainers/ELI5.md
+++ b/docs/explainers/ELI5.md
@@ -34,8 +34,29 @@ forgot earlier order. #967 repaired that memory and produced different shapes
 for the two possible next pieces, but its one-number ruler assigned both the
 same distance in all six trials. It therefore kept the state without claiming
 attention. #967 established only that the one-number ruler failed; it did not
-establish a placement defect. #970 owns the broader readout/placement check and
-repair. #969 must then prove that the full geometry, not a memorized answer, actually changes what the system
+establish a placement defect. #970 then kept a paired-H4 witness—both H4 shapes
+for each candidate—combined them in their fixed order, and read an exact R4
+heatmap instead of inventing another ruler. Its complete check covered all
+14,400 ordered shape
+pairs: 120 relative shapes became 45 heatmap kinds, including 480 typed-null
+pairs that must abstain. On the 36 fixed candidate decisions, eight of 14
+heatmap classes still meant conflicting answers and no construction rule made a
+strict choice on any of the six validation histories. The result therefore
+retains the paired shape and stops before readout or placement. This says only
+that this exact heatmap cannot identify the frozen answer rule; it does not say
+the geometry is useless.
+
+The heatmap keeps exact golden-number arithmetic: `sin=+1` or `-1` with
+`cos=0` maps to bit 1, while `sin=0` with `cos=+1` or `-1` maps to bit 0, and
+the sign remains attached. Histories and candidate support are prepared before
+answers are attached, and even/odd order is recomputed from each history. Zeta
+phases, ordered prime groups, golden-radius moves, and typed chart conversion
+remain structural ingredients; the project has not supplied a rule turning a
+zeta/prime group into a golden-shell exponent.
+
+#970 remains active until this corrected result lands through the protected
+merge path, so #969 is still blocked. After that delivery, #969 must prove that
+multiple channels, not a memorized answer, actually change what the system
 attends to. Only after that does #953 build the bounded source-free next-word
 loop; durable chat belongs to #962. Correct answers (#954) and multi-step
 reasoning (#955) come later. A pretty route or a readable stored sentence does

--- a/docs/explainers/UNDERGRADUATE.md
+++ b/docs/explainers/UNDERGRADUATE.md
@@ -36,9 +36,32 @@ The sequence is capability-ordered: #961 supplied reversible lexical geometry
 and complete hierarchy state; #952 exposed an order-erasing reusable summary;
 A1R/#967 repaired that representation but terminated `RETAIN_STATE_ONLY` when
 shortest Cayley distance mapped distinct candidate-relative states to equal
-energy on 6/6 queries; A1P/#970 now owns candidate-relative readout/placement;
-and A1Q/#969 must then establish recursive
-geometric attention at every scope under anti-recall matched controls. #953 can
+energy on 6/6 queries. The corrected A1P/#970 probe retains the ordered pair
+`X=C(H,c)`, `Y=C(P_c,c)` and forms `D=X*Y^-1`. For
+`D=(q0+q1 i+q2 j+q3 k)/2`, it keys equality by the exact signed R4 heatmap
+`(q0/2, q1/2, q0^2/4, chirality, cosine polarity, chart status)` in `Z[phi]`,
+not by one H4 operand or an opaque table offset. The endpoint translation is
+`sin=+/-1, cos=0 -> 1` and `sin=0, cos=+/-1 -> 0`, with orientation retained;
+non-landmarks remain exact and `q0=q1=0` is a typed-null abstention.
+
+The exhaustive target-free structural census covered 14,400/14,400 ordered
+pairs, all 120 relative roots, 45 heatmap classes, and 480 typed-null pairs. The
+36 fixture decisions produced 14 classes: construction covered 12/12, validation
+coverage was 10/12, the no-class-splitting ceiling was 10/12, strict transfer
+was 0/6, and eight classes carried incompatible outcomes. S4 parity was derived
+from each history before labels were joined. Contract, universe, and report
+kappas are respectively
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and
+`blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+
+This is a readout-identifiability negative only. Fixed-zeta phases, ordered
+n-lets, golden `phi` radial maps, and the typed Euclidean/complex/Riemannian
+adapter remain structurally bound, but no zeta/n-let-to-`phi` shell-exponent
+rule is established. #970 remains active until protected merge and #969 remains
+blocked until then. After delivery, A1Q/#969 must establish recursive geometric
+attention at every scope under anti-recall matched controls. #953 can
 then build provider-free grammatical generation from only A1Q-qualified
 semantic terms; #954 measures correctness and typed abstention; #955 begins
 reasoning. #958 is retained storage/recall foundation, not proof of attention.

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -19,12 +19,16 @@ probe whose possible outcomes cause different next actions.
 Lexical ingestion, canonical serialization, registered-address membership,
 and rebuild witnesses are prerequisite plumbing, not inference. The delivery
 sequence is fixed: A1R/#967 repaired ordered state but retained it as state only;
-A1P/#970 now falsifies and replaces the shortest-Cayley scalar readout within
-its broader candidate-relative readout/placement scope; A1Q/#969 then
-qualifies complete recursive attention across local, sentence, paragraph,
-conversation, and global scopes; inference/generation follows only after #969;
-correctness with abstention is third; bounded reasoning is fourth. #970 blocks
-#969, and #969 natively blocks #953.
+A1P/#970 has a corrected local paired-H4/R4-heatmap identifiability result of
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` before scalar design because
+eight retained heatmap classes aliased outcomes and construction transfer was
+0/6. This is a readout-identifiability negative only; paired H4 and its exact R4
+heatmap remain structural/control state. #970 remains active until protected
+merge, and A1Q/#969 remains blocked until then. After delivery, #969 may test
+complete recursive attention across local,
+sentence, paragraph, conversation, and global scopes; inference/generation
+follows only after #969; correctness with abstention is third; bounded reasoning
+is fourth. #969 natively blocks #953.
 
 A negative result remains evidence about its declared mechanism and
 distribution. It does not erase a separately established storage, identity,
@@ -45,16 +49,24 @@ The stages are ordered because each later claim depends on the earlier one:
    realizes the project shorthand `E8 = H4 × H4` as `H4 ⊕ φH4`. Their presence
    in the structural/storage representation does not qualify them for scoring;
    A1Q/#969 must establish the causal value of each term it promotes.
-2. **Inference/generation** — the real decoder uses only A1Q-qualified semantic
-   scoring terms from the completed hierarchy to produce decodable next tokens,
-   update state without future-route input, and run provider-free through the
-   evaluated CLI/HTTP/chat path. Required storage fields that remain
-   unqualified cannot influence ranking.
-3. **Correctness/abstention** — answers satisfy an independent oracle or
-   constraint, and typed abstentions are reported explicitly.
-4. **Reasoning** — novel multi-step tasks expose typed intermediate transitions,
+2. **Inference/generation (#953)** — the real decoder uses only A1Q-qualified
+   semantic scoring terms from the completed hierarchy to produce decodable next
+   tokens, update state without future-route input, and run provider-free through
+   the evaluated library/CLI path. Required storage fields that remain
+   unqualified cannot influence ranking. Durable HTTP/chat integration belongs
+   to #962.
+3. **Correctness/abstention (#954)** — the accepted #969-qualified terms through
+   the accepted #953 generator satisfy an independent oracle or constraint, and
+   typed abstentions are reported explicitly. #954 does not consume #952 as
+   qualified attention.
+4. **Reasoning (#955)** — every step invokes the accepted #969/#953/#954
+   consumer; novel multi-step tasks expose typed intermediate transitions,
    constraint preservation, alternative/counterfactual comparison, and a
-   checkable result.
+   checkable result. #952 is not the reasoning consumer.
+
+#962 later integrates #969-qualified attention and the accepted #953 generator
+into product chat/memory. #964 binds the inserted #970 → #969 stages in the
+serving contract, and #965 qualifies only that exact release path.
 
 Passing an earlier stage never promotes a later claim. Codec coverage is not
 attention; exact recall is not geometric attention; partial local/sentence
@@ -144,8 +156,11 @@ changed the same-candidate relative state in 5/6 paired comparisons. The scalar
 shortest-Cayley-distance readout nevertheless mapped both candidates to energy
 2 and tied on all 6/6 queries. The terminal verdict is `RETAIN_STATE_ONLY`:
 ordered state is retained, but attention, generation, correctness, and reasoning
-remain unestablished. A1P/#970 owns the readout/placement redesign and blocks
-A1Q/#969.
+remain unestablished. The corrected local A1P/#970 probe subsequently found
+eight incompatible exact paired-H4-derived R4-heatmap classes and stopped before
+readout or placement. This narrows only the frozen heatmap readout; it does not
+reject paired H4 or the other declared channels. #970 remains active and #969
+blocked pending protected merge.
 
 The legacy additive state was bound and remained equal, but its ranking arm is
 `NOT_EXERCISED`: no additive candidate scorer was predeclared. The exact-recall
@@ -154,6 +169,216 @@ address order reported `rr` as a diagnostic tie-break token for the full arm;
 it never converted a tie into a selection. The verdict does not depend on the
 unavailable additive arm: the report binds the 6/6 full tie and
 `any_exercised_control_not_weaker = true` separately.
+
+### A1P/#970 corrected construction/validation contract
+
+#970 is an identifiability decision before it is a metric decision. The six
+visible A1R labels remain an unchanged regression/root-cause fixture. Passing
+those six labels with a replacement scalar can never establish semantic value,
+and they cannot train, orient, or select the new readout. Their #952 partition
+kappa remains
+`blake3:d008b82eda9b16b102cf4c7ffa4a47a40ad514b30f0763ed3f46c0ebae3e277b`;
+their historical result remains bound by #967 report kappa
+`blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.
+The old denominator remains three contrasts/six queries, and the frozen
+shortest-Cayley outcome remains 0/6 selections, 6/6 ties, and 6/6 abstentions.
+
+The independent pre-evidence fixtures are:
+
+| Fixture | ID | Kappa | Histories / intended observations |
+|---|---|---|---|
+| Construction | `A1P-CONSTRUCTION-1` | `blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652` | `aa bb cc dd qq -> ll`; `aa cc bb dd qq -> rr`; `bb aa cc dd qq -> rr`; `bb cc aa dd qq -> ll`; `cc aa bb dd qq -> ll`; `cc bb aa dd qq -> rr` |
+| Sealed validation | `A1P-VALIDATION-1` | `blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602` | `aa cc dd bb qq -> ll`; `aa dd cc bb qq -> rr`; `cc aa dd bb qq -> rr`; `cc dd aa bb qq -> ll`; `dd aa cc bb qq -> ll`; `dd cc aa bb qq -> rr` |
+
+Construction, validation, and regression end in `dd qq`, `bb qq`, and `cc qq`,
+respectively; all exact five-unit histories differ. The natural candidate set is
+always `{ll, rr}`, with construction predecessors `P_ll = uu` and `P_rr = vv`.
+Observation continuations are a separate kappa-bound ledger and are not compiled
+into the schema-2 candidate manifest. Direct/exact or divisor continuation hits,
+target injection, future events, or a candidate union other than natural
+`{ll, rr}` invalidates the contract.
+
+Construction observations determine the rule rather than attaching targets to
+unrelated histories. The predeclared family is the two-element abelianization of
+permutations on ordered roles `[aa, bb, cc, dd]`: construction may select only
+the trivial map or the sign homomorphism `S4 -> C2`. The first construction
+observation rejects the trivial map and fixes candidate orientation; the
+remaining five must confirm `even -> ll` and `odd -> rr`. At validation time the
+scorer receives only exact construction-derived state classes, never role
+names, parity, token spelling or IDs, prime/address order, or labels. Validation
+labels are public for the
+identifiability ceiling; validation scorer outputs remain sealed until the
+construction-to-readout compiler is frozen. No #969 sentence, paragraph,
+conversation, or global fixture may be consumed, inspected, or exposed.
+
+Parity is not trusted from the fixture literal: it is derived by inversion count
+from each exact history and frozen role order `[aa,bb,cc,dd]`, then checked
+against the serialized literal. Construction and validation geometry and
+natural support are prepared through a target-free input with no observed-next
+field; both populations are complete before their separate label ledgers are
+joined for purity and ceiling calculations.
+
+The corrected public contract retains the complete ordered witness
+
+```text
+X(H,c) = C(H,c)
+Y(P_c,c) = C(P_c,c)
+D(H,c) = X(H,c) * Y(P_c,c)^-1.
+```
+
+Writing `D=(q0+q1 i+q2 j+q3 k)/2`, with every coordinate in exact `Z[phi]`,
+the scorer key is the signed `(1,i)` R4 heatmap
+`(sin=q0/2, cos=q1/2, activation=q0^2/4, chirality, cosine polarity, chart
+status)`. The full `D` witness retains `q2/q3`; neither operand is discarded or
+made label-bearing. The exact endpoint mapping is `sin=+1,cos=0 -> 1`,
+`sin=-1,cos=0 -> 1`, `sin=0,cos=+1 -> 0`, and `sin=0,cos=-1 -> 0`, with signed
+orientation retained. Non-landmarks remain exact classes, while `q0=q1=0` is a
+typed-null abstention. There is no float, fitted threshold, or Q1.30 shortcut.
+
+The same contract carries the immutable fixed-zeta identity, ordered
+multiplicity-preserving prime n-lets, golden radial maps
+`(a,b)*phi=(b,a+b)` and `(a,b)*phi^-1=(b-a,a)`, and the typed
+`Euclidean sqrt(2) <-> complex 2i <-> Riemannian [0,2]` adapter. These are
+structural bindings, not scorer shortcuts. No zeta/n-let-to-`phi` shell-exponent
+rule has been supplied or established.
+
+Before choosing a scalar or opening validation scorer output, enumerate all
+120×120 ordered `(X,Y)` pairs and the exact heatmap classes for every
+inherited-regression, construction, and validation candidate decision. Keep all
+three fixture denominators separate and keep the structural universe independent
+of the 36 exercised decisions. Report:
+
+1. construction class coverage and per-class binary candidate-outcome purity;
+2. validation candidate-class coverage;
+3. the no-class-splitting oracle ceiling,
+   `sum_E max_y count_validation(E,y) / 12`;
+4. the construction-transfer selection ceiling: validation queries on which the
+   construction class map makes the intended candidate uniquely positive and
+   the alternative uniquely negative, divided by six, with unseen classes
+   abstaining; and
+5. the same coverage, purity, aliasing, and ceilings for the additive comparator
+   class `(A*(H), A*(c), A*(P_c))`, using the existing additive non-digest
+   summary and excluding spelling, occurrence/position identifiers, lexical-unit
+   ID, prime, address index, boundary/chain identity, kappa/digests, and
+   provenance.
+
+If any retained exact class requires incompatible outcomes, construction is
+impure, or construction observations define no rule that transfers to
+validation, stop immediately as
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`. Do not search another metric,
+add fields, enlarge H4, expand the corpus, or execute downstream selection arms.
+The inherited/new union gate is binding even if another scalar could fit the six
+visible regression labels.
+
+Only an identifiable union authorizes exactly one deterministic bounded readout
+compiled from construction observations using exact integer and finite-table
+operations. Freeze its algorithm and serialized artifact before opening
+validation outputs. Apply the same class-to-outcome compiler to the additive
+comparator. Preserve candidate rows, support, admission, payload inversion,
+source partition, row/candidate ceilings, causality, and work. Expose only an
+API-neutral serializable `select_or_abstain` result and minimal trace. Report the
+old-six regression, construction, and validation separately, and execute the
+final authorized probe twice with byte-identical inputs, report, and kappa.
+
+The required #970 arms are the full paired-H4-derived exact R4 heatmap,
+current-only, additive with its compiled scorer, factor/count-only,
+deterministic geometry permutation,
+candidate relabeling, prime-assignment permutation, hierarchy-disabled, and
+exact-recall-only. A placement arm exists only if identifiability proves
+placement is the isolated defect; readout and placement may not both be tuned.
+Candidate relabeling applies `rho = (ll rr)(uu vv)` to construction evidence,
+predecessors, and validation labels before recompilation. Prime-assignment
+permutation is `pi_p = (aa bb cc dd gg qq)(ll rr uu vv)` with
+`leaf_pi(t) = leaf(pi_p(t))`; it changes only H4 leaf binding after the unchanged
+natural candidate/support path. Geometry permutation conjugates construction and
+validation by the existing A1R first-noncentral conjugator under root-table kappa
+`blake3:8d33d62a239fb8001fea2bd14a9a5ec7321d0f07d81c74a5715eaeb3df53aa76`.
+These are equivariance audits: the compiled result must follow transformed
+construction evidence exactly.
+
+Each fixture has six histories, twelve candidate decisions, seven row reads per
+query / 42 total, candidate-entry ceiling 56/query, candidate ceiling eight, and
+maximum two admitted candidates. The complete preflight is bounded to 18 fixed
+histories and 36 candidate decisions plus one target-free exhaustive structural
+census of 14,400 ordered pairs, its complete 120-root relative image, 45 exact
+heatmap classes, and 480 typed-null pairs. Every authorized arm reports
+selections, ties, abstentions, exact hits, support
+equality, work, and explicit status. `NOT_EXERCISED`, `NOT_RUN`, `UNAVAILABLE`,
+and `INVALID` are not passes. A hard-gate stop records downstream arms as
+`NOT_RUN_IDENTIFIABILITY_HARD_STOP`; that is a valid bounded
+readout-identifiability negative, not unavailable evidence or a claim that the
+underlying structures have no value.
+
+The terminal decisions are exact:
+
+- `PROMOTE_H4_READOUT_CANDIDATE_TO_A1Q` admits only the paired-H4-derived exact
+  R4-heatmap candidate term to #969 after strict 6/6 sealed validation, all
+  required controls, strict
+  superiority to every matched baseline, candidate/prime/geometry equivariance,
+  equal support/admission/payload/causality/work, and deterministic selector and
+  trace bytes. It establishes neither attention nor generation.
+- `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` closes this exact heatmap
+  readout search after aliasing, no transferable rule, a held-out
+  miss/tie/abstention, an inert
+  readout, or failure to beat an exercised comparator. Both H4 operands and the
+  derived heatmap remain structural, provenance, diagnostic, or control state;
+  after protected delivery, #969 may advance to its other predeclared
+  candidate-relative trajectory/harmonic channels. Do not create another
+  paired-heatmap scalar-readout chain.
+- `UNAVAILABLE_NO_INDEPENDENT_HOLDOUT` or `INVALID_CONTRACT` leaves #970 open
+  and #969 blocked with the exact blocker published.
+
+Both valid outcomes expose only #969 after protected delivery. Until the
+corrected result merges, #970 remains active and #969 remains blocked. #953
+remains blocked until #969 itself qualifies full attention.
+
+### Observed #970 outcome
+
+The corrected local preflight reached the valid negative without a scalar
+search. Its structural universe is independent of the fixture decisions:
+
+| Structural measure | Result |
+|---|---:|
+| Ordered paired-H4 witnesses | 14,400 / 14,400 |
+| Exact relative `D=X*Y^-1` image | 120 / 120 |
+| Pair multiplicity per relative row | 120 |
+| Exact signed R4 heatmap classes | 45 |
+| Typed-null ordered pairs | 480 |
+
+| Measure | Paired-H4-derived exact R4 heatmap | Existing additive comparator |
+|---|---:|---:|
+| Exact classes across 36 decisions | 14 | 2 |
+| Construction decisions | 12 / 12 pure | 12 / 12 across 2 impure classes |
+| Validation coverage by construction | 10 / 12 | 12 / 12 |
+| No-class-splitting ceiling | 10 / 12 | 6 / 12 |
+| Strict construction-transfer ceiling | 0 / 6 | 0 / 6 |
+| Incompatible retained classes | 8 | 2 |
+
+No readout was compiled and every downstream arm is
+`NOT_RUN_IDENTIFIABILITY_HARD_STOP`. The exact contract, complete pair-universe
+census, and byte-identical double-run report kappas are respectively
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and
+`blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+This is only a bounded readout-identifiability negative. #970 remains active
+until protected merge, and #969 remains blocked until that delivery.
+See the [append-only A1P record](candidate_relative_identifiability_a1p_970.md).
+
+### A1Q/#969 Gate 0 composition instrument
+
+After the corrected #970 result is delivered through protected merge, #969 may
+begin with one bounded 2–8 lexical-unit end-to-end instrument:
+
+```text
+bytes -> lexical routes -> admitted candidates -> frozen select/abstain
+      -> payload decode -> incremental state update
+```
+
+It stops before sentence/paragraph/conversation/global expansion if matched
+prompts emit identical continuations, the qualified-state intervention is inert,
+decoding fails, a period-1–4 cycle appears, termination is nondeterministic, or
+support changes. Those later fixtures remain sealed and disjoint from #970.
 
 ## 4. Matched controls
 
@@ -326,6 +551,18 @@ Use these outcomes literally:
 - `UNAVAILABLE` — a required fixture, provider, oracle, or platform was absent.
 - `NOT_EXERCISED` — the run completed but the named branch received zero valid
   opportunities.
+- `PROMOTE_H4_READOUT_CANDIDATE_TO_A1Q` — #970's independent construction and
+  sealed validation contract passed; only the paired-H4-derived exact R4
+  heatmap term advances to #969 after protected delivery.
+- `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` — the corrected local #970
+  probe produced a valid readout-identifiability negative; both H4 operands and
+  the derived heatmap
+  remain structural/control state, and #969 may advance to its other
+  predeclared channels only after protected delivery.
+- `UNAVAILABLE_NO_INDEPENDENT_HOLDOUT` — #970 cannot form the required
+  independent evidence; it remains open and #969 remains blocked.
+- `INVALID_CONTRACT` — the frozen #970 contract was violated; it remains open
+  and #969 remains blocked.
 
 Never convert a missing fixture, empty denominator, skipped test, or unrelated
 green suite into `PASS`. Every report preserves artifact kappas, partition CIDs,

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -95,9 +95,12 @@ shortest Cayley distance collapsed the distinct states to energy 2 and tied on
 This establishes ordered state only, not full attention or generation.
 See the [#967 A1R record](associative_ordered_route_summaries_a1r_967.md).
 
-New unassigned #970 owns A1P candidate-relative readout/placement. It follows
-protected #967 delivery and natively blocks #969. #969 owns A1Q full
-recursive-attention qualification and natively blocks #953. #953 continues to
+#970 now has a corrected local paired-H4-derived R4-heatmap identifiability
+result of `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`, pending protected
+delivery. It follows protected #967 delivery but does not yet expose #969: #970
+remains active and #969 remains blocked until the corrected result merges. #969
+continues to own A1Q multichannel full recursive-attention qualification and
+natively blocks #953. #953 continues to
 own source-free inference and language generation, but may consume only the
 semantic scoring terms qualified by A1Q. #962 separately owns product chat
 integration and persisted, identity-scoped hive memory.
@@ -300,6 +303,12 @@ serialized eight-dimensional state. The bridge must declare:
 - the fixed forward map and inverse/reconstruction witness;
 - collision and quantization behavior; and
 - a kappa-bound witness for every preserved invariant.
+
+#970 uses a distinct, explicitly bound ordered pair witness for its readout
+preflight: `X=C(H,c)`, `Y=C(P_c,c)`, followed by the relative projection
+`D=X*Y^-1` and exact signed R4 heatmap. This does not relabel the separately
+retained golden-coupled `H4 ⊕ phi H4` per-leaf serialization as another
+Cartesian root system. Both constructions remain typed and versioned.
 
 Structural presence does not authorize the paired coordinate as a semantic
 ranking feature. A1Q/#969 may qualify it only through candidate-relative,
@@ -523,8 +532,10 @@ rebuildable paired-H4 state.
 
 ### GI-2 / #952 → #967 A1R → #970 A1P → #969 A1Q — recursive geometric attention
 
-Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
-follows #967 and blocks #969; #969 A1Q blocked by #970**.
+Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; corrected
+local #970 A1P `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` pending protected
+merge; #970 remains active and #969 remains blocked until then; #969 remains
+the next A1Q stage and blocker of #953**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -548,15 +559,134 @@ and support invariants also held.
 The smallest joint history/candidate interaction produced distinct candidate
 relative states, including 5/6 same-candidate changes across paired histories,
 but shortest Cayley distance mapped both targets to energy 2 on all 6/6 queries.
-That readout degeneracy yielded `RETAIN_STATE_ONLY`. #970 now owns the A1P
-candidate-relative readout/placement redesign with the repaired fold, anchors,
-and support held fixed; it does not implement full recursive attention or
-promote #953.
-#969 owns the later full A1Q scorer and candidate-relative
-anti-recall qualification across sentence, paragraph, conversation, and global
-scope-isolating fixtures. Every selection carries the global-context coverage
-witness, with no future-route leakage, target injection, or external/unbounded
-corpus population scan.
+That readout degeneracy yielded `RETAIN_STATE_ONLY`.
+
+The corrected A1P/#970 contract does not assume that another scalar exists or
+that placement is defective. The inherited six A1R queries remain byte-identical
+regression/root-cause evidence, retain their 0/6 selections, 6/6 ties, and 6/6
+abstentions, and can never qualify semantic value. New evidence is separated as:
+
+- construction fixture `A1P-CONSTRUCTION-1`, kappa
+  `blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652`;
+  and
+- disjoint sealed anti-recall fixture `A1P-VALIDATION-1`, kappa
+  `blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602`.
+
+Both contain six fixed five-unit histories over the same natural `{ll, rr}`
+support. Construction ends in `dd qq`, validation ends in `bb qq`, and the old
+regression ends in `cc qq`; all exact histories are distinct. The candidate rule
+is not an arbitrary label assignment. Construction observations select the sign
+homomorphism from permutation parity on ordered roles `[aa, bb, cc, dd]`, with
+the first observation fixing orientation and the remaining five confirming
+`even -> ll` and `odd -> rr`. Parity is derived by inversion count from each
+exact history and frozen role order rather than trusted from the fixture
+literal. Construction and validation geometry/support are prepared without an
+observed-next field; both populations are complete before their label ledgers
+are joined for purity and ceilings. Validation labels are public for the
+ceiling, but validation scorer outputs remain sealed until a
+construction-to-readout compiler is frozen. No #969 sentence, paragraph,
+conversation, or global fixture may be consumed, inspected, or exposed by
+#970.
+
+Identifiability is a hard gate before metric design. The corrected contract
+retains both exact operands `X(H,c)=C(H,c)` and `Y(P_c,c)=C(P_c,c)`, with
+`D=X*Y^-1`. For `D=(q0+q1 i+q2 j+q3 k)/2`, it keys equality by the exact signed
+R4 heatmap `(q0/2, q1/2, q0^2/4, chirality, cosine polarity, chart status)` in
+`Z[phi]`; `q2/q3` remain in the full witness. The endpoint map is
+`sin=+/-1,cos=0 -> 1` and `sin=0,cos=+/-1 -> 0`, retaining signed orientation.
+Non-landmarks remain exact, and `q0=q1=0` is a typed-null abstention.
+
+The structural preflight independently enumerates all 120×120 ordered operand
+pairs and their 120-root relative image. For the union of inherited,
+construction, and validation candidate decisions, it enumerates complete exact
+heatmap classes and the existing additive-summary classes. It reports
+construction coverage and per-class binary outcome purity, validation class
+coverage, the no-class-splitting oracle ceiling, and the construction-transfer
+selection ceiling. Inherited and new denominators remain separate. If a
+retained class requires incompatible outcomes, construction is impure, or its
+class rule does not transfer, stop as
+`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`; do not search another metric,
+add fields, enlarge H4, or expand the corpus.
+
+The exact heatmap contract also binds the immutable fixed-zeta grid, ordered
+multiplicity-preserving prime n-lets, golden radial maps
+`(a,b)*phi=(b,a+b)` and `(a,b)*phi^-1=(b-a,a)`, and the typed
+`Euclidean sqrt(2) <-> complex 2i <-> Riemannian [0,2]` adapter. These channels
+are carried side-by-side as structural transport, not label-bearing scorer
+inputs. No zeta/n-let-to-`phi` shell-exponent rule has been supplied or
+established; the status remains
+`STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`.
+
+The corrected contract, exhaustive pair-universe census, and local double-run
+report are bound respectively by
+`blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
+`blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
+and
+`blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
+
+Only an identifiable union authorizes exactly one deterministic integer/
+finite-table readout compiled from construction observations. The same exact
+class-to-outcome compiler must exercise the additive comparator. Candidate rows,
+support, admission, payload inversion, source partition, ceilings, causality,
+and work remain unchanged. Candidate relabeling, prime-assignment permutation,
+and deterministic geometry permutation transform construction and validation,
+recompile from the transformed construction evidence, and require outputs to
+follow that evidence rather than literal spelling, token IDs, sequential primes,
+address order, diagnostic tie order, or a manually selected sign. A placement
+intervention is permitted only if the preflight isolates placement as the sole
+defect; readout and placement may not both be tuned. The old-six regression,
+construction result, and sealed validation result are reported separately, and
+the final authorized probe runs twice with byte-identical inputs, report, and
+kappa.
+
+The only valid #970 outcomes are:
+
+- `PROMOTE_H4_READOUT_CANDIDATE_TO_A1Q`, which admits only the
+  paired-H4-derived exact R4-heatmap term for #969 and establishes neither
+  attention nor generation; or
+- `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`, which closes this exact
+  heatmap readout search, retains both H4 operands and the derived heatmap as
+  structural/provenance/diagnostic/control state, and lets #969 test its other
+  already-declared candidate-relative trajectory/harmonic channels after
+  protected delivery.
+
+`UNAVAILABLE_NO_INDEPENDENT_HOLDOUT` or `INVALID_CONTRACT` leaves #970 open and
+#969 blocked. Both valid outcomes expose only #969 after protected delivery;
+neither exposes #953. Until this corrected result merges, #970 remains active
+and #969 remains blocked.
+
+The corrected local exact preflight selected the valid negative. Its independent
+structural census covered 14,400/14,400 ordered pairs, all 120 relative roots,
+45 exact signed heatmap classes, uniform pair multiplicity 120, and 480
+typed-null pairs. The 36 exercised decisions formed 14 heatmap classes.
+Construction was pure on 12/12 candidate decisions, validation coverage was
+10/12, the no-class-splitting ceiling was 10/12, strict construction transfer
+was 0/6, and eight heatmap classes carried incompatible outcomes. The additive
+comparator had two impure construction classes and 0/6 transfer. No scalar was
+searched, no readout was compiled, and every downstream control was
+`NOT_RUN_IDENTIFIABILITY_HARD_STOP`. This is a readout-identifiability negative
+only. The byte-identical local report kappa is
+`blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`;
+see the [#970 A1P record](candidate_relative_identifiability_a1p_970.md). #970
+remains active and #969 blocked until protected merge.
+
+After the corrected #970 result is delivered through protected merge, #969 may
+begin with Gate 0, a bounded 2–8 lexical-unit end-to-end composition instrument:
+
+```text
+bytes -> lexical routes -> admitted candidates -> frozen select/abstain
+      -> payload decode -> incremental state update
+```
+
+Gate 0 stops before expensive scope expansion if matched prompts emit identical
+continuations, the qualified-state intervention is inert, decoding fails, a
+period-1–4 cycle appears, termination is nondeterministic, or support changes.
+Its later sentence, paragraph, conversation, and global fixtures remain sealed
+and disjoint from #970. #969 then owns the full A1Q scorer and
+candidate-relative anti-recall qualification across those scope-isolating
+fixtures. Every selection carries the global-context coverage witness, with no
+future-route leakage, target injection, or external/unbounded corpus population
+scan.
 
 Anti-recall evidence is mandatory: exact-row hits are labeled separately;
 held-out histories cannot be exact stored continuations; real geometry shares
@@ -569,10 +699,10 @@ GI-2-qualified semantic scoring terms.
 
 GI-2 closes only when #969 shows full recursive attention is causally
 load-bearing and records `PROMOTE_TO_I1`. The #967 representation repair did
-not make A1Q reachable because its scalar readout tied; #970 must first falsify
-and replace that shortest-Cayley readout within its broader candidate-relative
-readout/placement scope. Neither stage promotes #953. GI-2 does not emit or
-score grammatical product text.
+not make A1Q reachable because its scalar readout tied. The corrected local
+#970 result is a valid paired-heatmap readout-identifiability negative, but it
+does not expose #969 until protected merge. That eventual delivery exposes
+#969, not #953. GI-2 does not emit or score grammatical product text.
 
 ### GI-3 / #953 — source-free grammatical inference and generation
 
@@ -587,6 +717,13 @@ learned router.
 The generator consumes only GI-2-qualified semantic scoring terms; mandatory
 storage fields and unqualified Hopf, H4, zeta, icosian, or SpiralCore controls
 cannot influence ranking merely because they are serialized.
+
+The existing source-free table-native R4G1/TLA continuation and candidate
+evidence may be reused as an offline substrate or comparator where appropriate;
+its replicated pointwise signal is not itself free-running generation. The
+#953 decision must show that a #969-qualified geometric intervention changes
+candidate choice relative to count-only, hierarchy-disabled, permuted, and
+exact-recall controls under equal support and work.
 
 #953 owns inference and language formation. Product CLI/HTTP chat integration,
 restart-persistent conversation state, and identity-scoped hive-memory lifecycle
@@ -603,11 +740,13 @@ inference/generation, not yet a claim that answers are correct.
 
 ### GI-4 / #954 — correctness and abstention
 
-After source-free generation exists, test whether the engine understands the
-input well enough to choose a correct answer. Use held-out questions with
-answerable, unanswerable, contradictory, and context-dependent cases. Score
-correctness, relevance, calibration/abstention, constraint coverage, and causal
-dependence on the required route levels.
+After source-free generation exists, test whether the accepted #969-qualified
+terms through the accepted #953 generator understand the input well enough to
+choose a correct answer. #954 does not consume #952 as qualified attention. Use
+held-out questions with answerable, unanswerable, contradictory, and
+context-dependent cases. Score correctness, relevance,
+calibration/abstention, constraint coverage, and causal dependence on the
+required route levels.
 
 An offline teacher may provide labels or a comparator only after the
 source-free arm has a frozen report. Teacher output is never substituted for
@@ -615,8 +754,9 @@ the product response.
 
 ### GI-5 / #955 — reasoning
 
-Reasoning begins only after correct one-step inference. Add bounded multi-step
-route composition with:
+Reasoning begins only after correct one-step inference. Every step invokes the
+accepted #969/#953/#954 consumer, not #952. Add bounded multi-step route
+composition with:
 
 - explicit goal and intermediate constraints;
 - branch creation and comparison;
@@ -630,9 +770,13 @@ intermediate constraints must change under the matched causal control.
 
 ### GI-6 / #962–#965 — product integration, serving purity, measured cost, and bounded release
 
-#962 integrates the accepted #953 generator into durable multi-turn CLI/HTTP
-chat, persistent conversation state, session and identity isolation, and
-load-bearing identity-scoped hive memory across turns and restarts. Later issues
+#962 integrates #969-qualified attention and the accepted #953 generator into
+durable multi-turn CLI/HTTP chat, persistent conversation state, session and
+identity isolation, and load-bearing identity-scoped hive memory across turns
+and restarts. #963 retains measured optimization. #964 freezes a serving
+contract that binds the inserted #970 → #969 qualification stages and the
+accepted #953 generator; #965 activates release evidence only for that exact
+path. These issues do not inherit an attention claim from #952. Later issues
 retain optimization, serving-kernel/formal closure, and release ownership.
 Freeze one accepted path and remove any remaining transitional serving
 dependency. The final serving census must show:

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,8 @@ enum Command {
     RecursiveAttentionA1Probe,
     /// Run the frozen A1R associative ordered-summary and candidate-relative probe.
     AssociativeOrderedSummaryA1rProbe,
+    /// Run the frozen A1P candidate-relative identifiability hard gate.
+    CandidateRelativeIdentifiabilityA1pProbe,
     /// List preserved compiler, serving, and certification commands.
     ResearchTools,
     /// Run the full artifact-discovering historical HTTP server.
@@ -1318,6 +1320,17 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             let rendered = serde_json::to_string_pretty(&report).map_err(|error| {
                 RunError::Command(format!(
                     "serialize associative ordered-summary A1R report: {error}"
+                ))
+            })?;
+            println!("{rendered}");
+            Ok(())
+        }
+        Some(Command::CandidateRelativeIdentifiabilityA1pProbe) => {
+            let report = uor_r4_core::recursive_geometric_attention::run_a1p_candidate_relative_identifiability_probe()
+                .map_err(|error| RunError::Command(error.to_string()))?;
+            let rendered = serde_json::to_string_pretty(&report).map_err(|error| {
+                RunError::Command(format!(
+                    "serialize candidate-relative A1P identifiability report: {error}"
                 ))
             })?;
             println!("{rendered}");


### PR DESCRIPTION
Closes #970

## Public contract correction

- Keeps the six visible A1R queries unchanged as regression/root-cause evidence only.
- Binds independent, disjoint, κ-pinned construction and sealed-validation fixtures before the replacement readout.
- Replaces the superseded single-`D` class key with the ordered paired-H4 witness `X=C(H,c)`, `Y=C(P_c,c)`, relative projection `D=X*Y^-1`, and exact signed `(1,i)` R4 heatmap in `Z[phi]`.
- Maps only exact endpoints `sin=+/-1, cos=0 -> activation 1` and `sin=0, cos=+/-1 -> activation 0`; the activation bit is not a candidate label. Nonlandmarks stay exact and typed-null rows abstain.
- Carries the immutable zeta grid, ordered multiplicity-preserving n-lets, exact golden radial maps, and the typed `sqrt(2) <-> 2i <-> [0,2]` marker as structural transport. It does not invent a zeta/n-let-to-phi exponent rule.

Contract κ: `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`.

## Bounded evidence

The target-free structural census enumerates all 120×120 ordered operand pairs:

- 14,400/14,400 pairs;
- 120/120 relative rows, multiplicity 120 each;
- 45 exact heatmap classes;
- 480 typed-null pairs;
- census κ `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`.

Fixture identities:

- construction `blake3:fb5f27fc1107f527d616f32affa8eba1746a2f60cfdb95ddbb21a0e493299652`;
- validation `blake3:ecbe8b404e7542d801ff4b4e66c91a41f90158d84efa484dc4edb53aff38b602`.

Across 36 candidate decisions, the paired heatmap yields 14 classes. Construction is 12/12 covered and pure; validation coverage and the no-class-splitting ceiling are 10/12; strict construction transfer is 0/6; eight classes require incompatible outcomes.

The unchanged old-six shortest-Cayley regression remains 0/6 strict selections, 6/6 ties, and 6/6 abstentions under inherited report κ `blake3:f0db7a5d5c81d51ebf3b4bf8a2715c4960ec16b14161e8bf7598d7b98c48c881`.

The existing-additive comparator forms two construction-impure classes, covers 12/12 validation decisions, has a 6/12 oracle ceiling, and transfers 0/6.

## Terminal result

`RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q`

The predeclared identifiability hard gate stopped before scalar search, scorer compilation, validation selection, downstream control execution, or placement. Every downstream row is `NOT_RUN_IDENTIFIABILITY_HARD_STOP`; `NOT_RUN` is not PASS. No selector or trace seam is emitted because no readout was authorized.

Corrected report κ: `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`, reproduced by byte-identical double execution.

This is a bounded exact-heatmap readout-identifiability negative. It does not negate paired H4, zeta phases, n-lets, golden radial transport, or typed geometry; it does not establish attention, inference, generation, correctness, reasoning, or product readiness. Protected delivery makes #969 the next unassigned multichannel A1Q stage; #953 remains blocked by #969.

## Focused verification

- `cargo test -p uor-r4-core --offline --test recursive_geometric_attention_970 -- --nocapture` — PASS, double execution, 115.43 s test runtime
- `cargo test -p uor-r4-core --lib a1p_contract_tests --offline` — PASS (2)
- `cargo test -p uor-r4-core --offline --test recursive_geometric_attention_967` — PASS (2)
- `cargo test -p uor-r4-model-source --lib exact_executor_contract_binds_complete_local_source_closure --offline` — PASS
- focused core/test and host CLI compilation — PASS
- WASM library check — PASS (existing target-specific warnings only)
- `cargo fmt --all --check` — PASS
- `git diff --check` — PASS
- `python3 scripts/check_claim_wording.py` — PASS

The broad workspace suite, corpus/model/teacher runs, generation canaries, and product QA were intentionally NOT_RUN; protected CI carries exhaustive integration.
