### PR TITLE
docs: separate route admission from exact-spin global influence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,12 @@ exact rank-preserving lexical relabel of #969 and terminated
 or qualify grammar. A separately frozen natural agreement revision then stopped
 before H4 selection because adjacent-spin fallback expanded the exact direct
 plus divisor support to five candidates. #953 remains active for the smallest
-tiered admission repair: direct plus divisor primary, adjacent-spin only when
-that tier is empty. #973 remains blocked, followed by #954–#955 → #962–#965.
+tiered admission repair: I1/I2/ordered-sentence plus divisor primary,
+adjacent-spin only when that tier is empty. Candidate admission and harmonic
+influence are separate contracts: spin similarity never widens non-empty
+primary support. #973 remains blocked and later owns a shared exact-spin global
+operator over already-admitted
+candidates, followed by #954–#955 → #962–#965.
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
@@ -47,7 +51,15 @@ transformers, MoE/sparse learned routing, or dense matrix intelligence. That is
 an aspirational research target, not a current capability claim. Spherical
 harmonics are the project-level model for overlapping spin-state storage and
 transport; R4/S3 and Hopf/S2 are the bounded compute/observation charts used to
-operate on that field.
+operate on that field. Exact operator sharing reuses the existing signed
+S3/Hopf/fiber/torsion `shared_class_kappa`; the current Hopf-octant/torsion
+`SpinSector` is only a coarse lookup bucket. Direction-sensitive relations use
+either a new exact `SpinTorsionState` relative relation or an explicitly bound
+spin-to-H4 map; the existing H4 relative witness is prime-derived route state.
+A versioned exact-spin global result is an immutable overlay over lawful
+candidates, not candidate injection or a corpus broadcast. Call it harmonic
+only after its identity binds basis, mode order, coefficients, quantization,
+and transition law.
 
 Source weights are offline teachers/comparators only. The final serving path
 loads no source weights and contains no transformer/self-attention, dense
@@ -228,6 +240,16 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   plumbing only; its relabelled smoke does not establish a natural grammar or
   sentence loop. Only a later accepted #953 result can expose #973, and only
   #973 may qualify paragraph, conversation, or global state.
+- Keep **candidate admission** separate from **harmonic influence**. In #953,
+  I1/I2/ordered-sentence plus divisor are the primary admission tier;
+  adjacent-spin rows remain visible in the trace but admit candidates only when
+  that tier is empty. Do not delete or disguise a physical adjacent-spin hit.
+  #973 may later apply one global-epoch/operator-bound result to every immutable
+  reference in the same exact signed-S3/Hopf/fiber/torsion class. Similar but
+  non-identical states require a separately frozen finite relative-angular
+  kernel built independently over exact classes. The existing adjacent-spin
+  rows remain retrieval fallback/diagnostics, not operator coefficients.
+  Neither operator mechanism may widen #953 support.
 - An exact kappa miss must not collapse unseen global history to a suffix-only
   default, but global ordered-state behavior is tested on an independently
   frozen global-snapshot permutation rather than by mutating session history.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,16 @@ active and #973 remains blocked)._
 > final serving path contains no transformer, dense matrix intelligence kernel,
 > MoE, or sparse learned router.
 
+> **Admission/influence split:** exact causal/index rows decide which routes are
+> lawful candidates. Harmonic/neighbor influence may transform the state used
+> to rank those candidates but never admits one; the existing adjacent-spin
+> retrieval row may admit only under the explicit empty-primary fallback. Exact
+> state sharing reuses the signed-S3/Hopf/fiber/torsion
+> `shared_class_kappa`—not the current coarse Hopf-octant/torsion bucket—and
+> remains an immutable operator overlay. A direction-sensitive query requires
+> a new exact spin-relative relation or an explicit spin-to-H4 map; the existing
+> relative H4 witness is prime-derived route state.
+
 > The goal is frontier-like useful capability on ordinary local hardware, but
 > that remains an unproven research target. Spherical harmonics are the working
 > picture for overlapping spin-state storage and transport; R4/S3 compute and
@@ -144,12 +154,27 @@ Native GitHub relationships are the source of truth:
    selection, but its support-only preflight admitted five candidates through
    adjacent-spin fallback instead of exact `{still}` then `{run,runs}`. H4 and
    all four generator arms were `NOT_RUN`. #953 remains active for the smallest
-   tiered admission repair: direct plus divisor primary, adjacent-spin only when
-   that tier is empty. See the
+   tiered admission repair: I1/I2/ordered-sentence plus divisor primary;
+   adjacent-spin traced but non-admitting when that tier is non-empty, and used
+   only as a bounded fallback when it is empty. Preserve PR #978's frozen
+   support witness and rerun that preflight before H4 selection. Harmonic
+   influence remains dormant in #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
 7. **GI-2 A1Q-H / #973 — higher-scope attention:** after accepted #969 and
    #953, test paragraph, conversation, and bounded global state through the
-   real decoded loop. Those scopes remain serialized but inert before #973.
+   real decoded loop. The first global mechanism is a deterministic exact-spin
+   operator prototype
+   overlay bound by global root/epoch kappa, operator and chart/table
+   identities, and the existing exact spin class. It acts
+   only on already-admitted candidate-relative state and is compared with
+   identity-disabled and deterministic class/operator-permuted controls under
+   identical support and work. Exact-class sharing comes first; a finite
+   orientation-aware angular-neighbor kernel is a later #973 subprobe. Those
+   scopes remain serialized but inert before #973. A global positive alone
+   cannot close #973; paragraph and conversation still require matched
+   qualification or an explicit native scope revision. The operator is called
+   harmonic only after its identity binds basis, mode order, coefficients,
+   quantization, and transition law.
 8. **GI-4 / #954 — correctness and abstention:** test held-out answer
    correctness, relevance, abstention, and causal use of required context only
    through the accepted #969/#953/#973 path. Teacher weights may label or
@@ -196,8 +221,12 @@ historical evidence and comparators.
   frozen agreement contrast found the direct `{still}` then `{run,runs}` rows,
   but unconditional adjacent-spin fallback expanded both unions to five
   candidates. Its four H4 arms were `NOT_RUN`; the next #953 action is the
-  smallest tiered admission repair—direct plus divisor primary, adjacent-spin
-  only when that tier is empty. See the
+  smallest tiered admission repair—I1/I2/ordered-sentence plus divisor primary,
+  adjacent-spin visible in the trace but non-admitting while that tier is
+  non-empty, and adjacent-spin fallback only when it is empty. The frozen
+  PR #978 support gate reruns before H4 selection. This repair addresses the
+  observed support contamination; it does not yet exercise harmonic influence
+  or qualify grammar. See the
   [#953 record](docs/local_geometric_generation_953.md).
 
 ## Landed

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -1,11 +1,15 @@
 # ADR-0004: Define a bounded geometric-intelligence route hierarchy
 
 - **Status:** Accepted as an architectural definition and evaluation boundary;
-  #967 A1R repaired ordered state but terminated `RETAIN_STATE_ONLY`; #970 A1P
-  candidate-relative readout/placement blocks #969 A1Q; and attention, inference,
-  correctness, and reasoning capability remain unproven and off the product
-  path. #969 blocks #953.
+  amended 2026-08-27 after #969 qualified one local causal-path mechanism and
+  #953's natural-agreement revision stopped at support admission. #953 remains
+  open for a tiered-admission repair; #973 remains blocked and later owns
+  paragraph, conversation, and global exact-spin operator qualification.
+  Harmonic qualification additionally requires a bound basis/mode contract.
+  Inference,
+  correctness, and reasoning capability remain unproven.
 - **Date:** 2026-08-26
+- **Last amended:** 2026-08-27
 - **Builds on:** [ADR-0003](0003-fixed-zeta-prime-route-attention.md)
 - **Evaluation:**
   [Geometric Intelligence Evaluation](../geometric_intelligence_evaluation.md)
@@ -54,8 +58,16 @@ number of rows at each enabled level; it never enumerates all descendant tokens
 or corpus records.
 
 Those fields are required structural/storage representation until evidence says
-otherwise. A1Q/#969 alone qualifies a subset as semantic scoring terms; #953
-may consume only that qualified subset.
+otherwise. #969 qualified one load-bearing identity-derived local path cost;
+#953 may consume only that qualified mechanism.
+
+Candidate admission and harmonic/neighbor influence are separate contracts.
+Exact causal/index evidence determines which routes are lawful candidates. An
+operator may then transform the state used to rank those already-admitted
+routes. Operator influence never admits a candidate; the existing coarse
+adjacent-spin retrieval row may do so only under the explicit empty-primary
+fallback policy. This separation is required by #953's observed support
+contamination and is the input boundary for #973.
 
 This ADR defines identities, boundaries, and evaluation. It does not promote a
 serving implementation.
@@ -88,6 +100,36 @@ envelope. The digest supplies equality and integrity, not geometric distance.
 Factor, phase, spin/Hopf, torsion, and radial fields supply declared structural
 coordinates and candidate locality hypotheses. They do not supply semantic
 ranking until qualified by A1Q/#969.
+
+**Definition:** an exact spin state class reuses the canonical
+`shared_class_kappa` already bound to the full signed S3 spin, checked Hopf
+observation, fiber, and torsion. The Hopf observation remains a witness, not a
+standalone class identity: `q` and `-q` stay distinct, and a shared Hopf octant
+or adjacent torsion bin is not an exact-state match. Lexical atom and payload
+identity remain outside this angular class so multiple immutable address
+references can share one operator evaluation. Radial shell, provenance, and
+other address-specific terms remain separately bound where required. If an
+operator depends on angular direction, #973 must bind either a new exact
+`SpinTorsionState` relative relation or an explicit spin-to-H4 map. The existing
+full relative H4 quaternion is prime-derived and remains a separate route
+witness; it is not automatically the relative orientation of two stored spin
+states.
+
+**Definition:** a versioned exact-spin global operator prototype is an
+immutable overlay bound by
+`(global_root_or_epoch_kappa, operator_kappa, chart/table identities,
+shared_class_kappa)`.
+It computes one deterministic class result and makes every reference in that
+exact class observe the result without rewriting canonical address, route, or
+payload bytes. The final candidate score remains query-specific because causal
+path and candidate-relative direction remain query-specific; only the class
+operator result is shared.
+Similar but non-identical states may interact only through an artifact-declared,
+bounded relative-angular neighbor kernel. Such a kernel is influence over
+lawful candidates, not an all-to-all broadcast or candidate-discovery rule.
+The prototype is described as a harmonic operator only after its kappa also
+binds the harmonic basis, mode order, coefficients, quantization, and transition
+law.
 
 The bridge mode is exact identity data. The project seam is
 `exp(i*pi)+pi^0 =_bridge 0^0`. In `ContinuousNull`, the typed transition
@@ -160,7 +202,7 @@ lexical codec.
 | **Sentence** | Ordered local route identities within one detected sentence | Increment while open; close at a codec-bound sentence boundary | Sentence continuation plus transported sentence trajectory/harmonic overlap | A sentence-key hit is recall; grammatical output is not correctness. |
 | **Paragraph** | Ordered closed sentence-route identities | Close at a codec-bound paragraph boundary | Cross-sentence support using shared factors, projection energy, resonance, winding, and Hopf phase | No paragraph capability exists until held-out cross-sentence effects are measured. |
 | **Conversation** | Ordered turns and paragraph-route identities for one session | Update only after an observed turn/paragraph; session identity isolates state | Session hypersphere trajectory, prior commitments, and bounded conversational memory | Conversation state must not leak across identity scopes; continuity is not reasoning. |
-| **Global** | Versioned project/knowledge snapshot entries selected and compiled offline | Immutable during one inference session; changed only by a new content-addressed epoch | Bounded shared background candidates through harmonic/trajectory locality and provenance | “Global” never means an unbounded corpus scan, implicit internet access, or universal knowledge. |
+| **Global** | Versioned project/knowledge snapshot entries selected and compiled offline | Immutable during one inference session; changed only by a new content-addressed epoch | A bound exact-spin operator overlay over already-admitted candidates, plus separately qualified bounded neighbor influence | “Global” never means candidate injection, an unbounded corpus scan, implicit internet access, or universal knowledge. |
 
 Each enabled scope declares maximum open children, rows per query, candidates
 per row, retained candidates after admission, and patch/epoch depth. Exceeding a
@@ -202,40 +244,50 @@ operator-table kappa.
 
 The paired coordinate is required in canonical hierarchy storage, address
 reconstruction, and the inverse witness. That architectural requirement does
-not make it a semantic scoring term. A1Q/#969 may qualify it only through an
-equal-budget intervention against factor-only and basis/shell-permuted controls
-on candidate-relative anti-recall inputs. If it does not qualify, the field
-remains valid structural/storage state, a diagnostic, or a control and may not
-influence #953 ranking.
+not make it a semantic scoring term. #969 closed without qualifying it. The
+field remains valid structural/storage state, a diagnostic, or a control and
+may not influence #953 ranking unless a later separately scoped, equal-budget
+intervention qualifies it.
 
 ## 5. Retrieval, admission, and attention
 
-Each query forms a bounded union from declared rows such as:
+Each query distinguishes bounded admission rows from later influence channels.
+The current local primary-admission rows are:
 
 ```text
 local:last-one
 local:last-two
 sentence:ordered-route
-paragraph:ordered-sentence-route
-conversation:ordered-turn-route
-global:versioned-summary-route
 divisor-overlap
+```
+
+Later or fallback channels include:
+
+```text
 adjacent-spin/torsion sectors
 transported-trajectory/harmonic overlap
 paired-H4/E8 sectors
+paragraph:ordered-sentence-route
+conversation:ordered-turn-route
+global:versioned-summary-route
 ```
 
-An implementation may apply a common geometry-independent support-admission
-rule, for example source breadth followed by total observed count and canonical
-address, when the union exceeds the artifact ceiling. That rule and the number
-excluded are part of the coverage witness.
+For #953, I1/last-one, I2/last-two, ordered-sentence, and divisor rows form the
+primary tier. When that tier is non-empty, adjacent-spin rows may be consulted
+and traced but cannot widen admitted support. Only an empty primary tier may
+activate bounded adjacent-spin fallback. The policy identity, each row slot and
+key, whether the row existed, entries examined, and entries admitted are part
+of the coverage witness. A later issue may qualify another admission source,
+but cannot silently change this precedence.
 
-When exact hierarchy kappas miss, bounded fallback uses overlapping
+When primary rows are empty, a bounded fallback may use overlapping
 trajectory/harmonic locality rather than digest distance. Candidate terms
 include shared-prime factors, projection energy, cosine resonance,
 winding/window compatibility, accumulated Hopf phase, trigonometric
-chart/quarter-turn transport, and paired-H4/E8 coordinates; only the
-A1Q-qualified subset may affect semantic candidate support or ranking.
+chart/quarter-turn transport, and paired-H4/E8 coordinates. Only a term
+qualified for admission may create fallback support. A term qualified only for
+influence may affect ranking of support admitted elsewhere but cannot create a
+route.
 
 **Definition:** geometric recall returns a continuation because an exact or
 declared backoff identity was stored. **Definition:** geometric attention ranks
@@ -244,6 +296,15 @@ and its qualified semantic terms are load-bearing against matched controls.
 Consequently,
 “least energy” means least energy among admitted candidates unless an artifact
 explicitly scores the entire bounded union before admission.
+
+#969 qualified only its retained local S3 path cost. #953 continues to use that
+cost while repairing admission and keeps paragraph, conversation, global, and
+shared higher-scope operator action inert. After an accepted #953 loop, #973
+may qualify a global exact-spin overlay only under identical admitted support and work across
+real, identity-disabled, and deterministic class/operator-permuted arms. The
+real overlay must change the intended candidate and exact decoded output, while
+the disabled and permuted arms do not reproduce that predeclared effect. A
+changed shared-result trace or stored state alone is not attention.
 
 No learned dense full-prefix Q/K projection, future-route input, all-prefix
 scan, or corpus scan belongs to this route hierarchy. A different transitional
@@ -257,8 +318,10 @@ coverage witness containing:
 
 - lexical codec, manifest, hierarchy, operator, and control identities;
 - observed route membership result and identity scope;
-- each row key read, scope/source, hit/miss, and entries examined;
-- union size, pre-geometric admission policy, admitted and excluded support;
+- each row slot/key, scope/source, whether it was consulted and physically
+  present, entries examined, fallback state, and entries admitted;
+- primary and fallback union sizes, admission-policy identity, and admitted and
+  excluded support;
 - per-candidate source counts, qualified semantic energy components, and
   separately labeled unqualified structural/diagnostic fields;
 - transported-trajectory fields: session hypersphere vector, winding/window,
@@ -266,6 +329,10 @@ coverage witness containing:
   and paired-H4/E8 coordinate;
 - active trigonometric chart, activation/chirality/polarity, any signed
   quarter-turn phase/torsion shift, and cross-domain cost-profile identity;
+- where exact-spin global action is active, global root/epoch kappa,
+  operator/chart/table
+  identities, exact `shared_class_kappa`, full signed candidate-relative
+  direction, class result and reuse count, and before/after candidate state;
 - deterministic tie-break stages and geometry source under controls;
 - selected route or typed abstention; and
 - fixed work ceilings and observed work.
@@ -305,18 +372,17 @@ rebuild witnesses are prerequisite plumbing. They are not inference.
 
 Delivery proceeds without skipping stages:
 
-1. retain the associative noncommutative ordered state delivered by A1R/#967
-   without claiming full attention;
-2. falsify and replace the shortest-Cayley scalar readout in A1P/#970, within
-   its broader candidate-relative readout/placement scope and with that state,
-   anchors, and support fixed;
-3. qualify full recursive attention in A1Q/#969 through local, sentence,
-   paragraph, conversation, and global scopes, including exact-key misses served by
-   transported harmonic/trajectory locality and matched controls;
-4. implement provider-free inference and coherent generation in #953 over only
-   the qualified hierarchy terms;
-5. measure correctness and typed abstention against independent oracles; and
-6. measure bounded reasoning through novel multi-step state transitions.
+1. retain the ordered state from #967 and paired-H4 structural state from #970
+   at their measured claim boundaries;
+2. retain the local causal R4/S3 path mechanism qualified by #969;
+3. in #953, repair tiered admission, rerun the frozen support gate, and only
+   then rerun the bounded decoded natural-generation contract;
+4. in #973, qualify paragraph, conversation, and global influence through the
+   accepted #953 loop, including the shared exact-spin operator overlay and
+   its matched disabled/permuted controls;
+5. measure correctness and typed abstention in #954; and
+6. measure bounded reasoning through novel multi-step state transitions in
+   #955.
 
 No generation score can substitute for incomplete attention scopes, and no
 reasoning claim can precede correctness evidence.
@@ -329,6 +395,11 @@ reasoning claim can precede correctness evidence.
   recomputed at every node.
 - Exact recall remains useful and measurable without being mislabeled
   attention.
+- Exact-state sharing can apply one bound harmonic operation to every matching
+  address reference without mutating the immutable artifact or enumerating the
+  corpus.
+- Causal admission cannot be contaminated merely because an unrelated
+  continuation occupies a coarse neighboring spin bucket.
 - Unknown addresses fail closed; unseen ordered combinations may still be
   evaluated through bounded geometric backoff.
 - The target realizes the conceptual `E8 = H4 × H4` identity through the

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -31,7 +31,8 @@ decoded-loop path, but its first smoke was an exact rank-preserving lexical
 relabel of #969 and terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen
 natural agreement follow-up stopped at support admission before H4 selection
 because adjacent-spin fallback expanded exact direct-plus-divisor support to
-five candidates. #953 remains active and #973 remains blocked; paragraph,
+five candidates. Protected PR #978 preserved that hard stop. #953 remains
+active for a tiered-admission repair, and #973 remains blocked; paragraph,
 conversation, global, correctness, and reasoning qualification remain
 downstream.
 
@@ -433,6 +434,16 @@ nondeterminism, a short cycle, or exceeding the eight-unit state bound. Do not
 respond with a comparator expansion, metric/weight sweep, larger fixture, or a
 new issue. Repair the exact seam directly within #953.
 
+The current repair has one frozen admission policy. I1/last-one, I2/last-two,
+ordered-sentence, and divisor rows form the primary tier. With non-empty primary
+support, adjacent-spin rows may be consulted and their physical entries counted
+but admit zero candidates. Only an empty primary tier activates bounded
+adjacent-spin fallback. The trace MUST bind the policy identity and distinguish
+row slot/key, consulted, physical-row-present, entries examined, fallback
+activated, and entries admitted. Preserve PR #978's frozen construction,
+surfaces, ordering, route placement, identities, expected support, and work;
+rerun only its selection-blind support preflight before exposing H4 selection.
+
 The frozen terminals are:
 
 - `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION` — the full
@@ -485,6 +496,65 @@ H4 path costs, selector outputs, and all four generator arms are
 direct-plus-divisor admission tier with adjacent-spin rows used only when that
 primary tier is empty.
 
+### A1Q-H/#973 exact-spin global operator prototype
+
+#973 owns paragraph, conversation, and bounded-global influence after #953
+qualifies the decoded loop. Operator influence consumes #953-admitted support;
+it does not participate in admission. The existing adjacent-spin retrieval rows
+remain fallback/diagnostic data, not operator coefficients; any neighbor
+operator is compiled independently over exact classes and admitted candidates.
+
+The first global decision reuses one existing exact `shared_class_kappa` over
+full signed S3 orientation, checked Hopf observation, fiber, and torsion.
+Hopf/S2 is not class identity by itself, and `q`/`-q` remain distinct. The
+fixture contains enough ordered global state to produce a witnessed
+non-identity transition, at least two immutable address references in the same
+exact class, and one different `shared_class_kappa` intentionally occupying the
+same current `SpinSector`. The operator
+result is bound by global root/epoch kappa, operator kappa, chart/table
+identities, and exact class and is reused without changing route, payload, or
+kappa identity.
+The final candidate score remains query-specific. If angular direction enters
+the dynamic relation, #973 binds either a new exact `SpinTorsionState` relative
+relation or an explicit spin-to-H4 map. The existing prime-derived relative H4
+quaternion remains a separate route witness.
+
+Compare exactly matched real, identity-disabled, and deterministic
+class/operator-permuted arms. Row reads, admitted candidate addresses, payloads,
+lower-scope state, candidate/operator ceilings, and observed work MUST be
+byte-identical. The report separately records base local cost, exact class,
+operator input/result, operator contribution, transformed candidate-relative
+cost, reuse count, selection or abstention, and exact decoded output. The real
+arm must change the predeclared candidate and decoded output, while the
+identity-disabled and class/operator-permuted arms do not reproduce that effect
+under identical support and work. Distinct stored state, a reuse hit, or a
+non-zero trace alone is insufficient.
+
+Before freezing a scalar readout, enumerate the transformed candidate-state
+classes and stop if any retained class requires incompatible outcomes. One
+fan-out witness MUST show one class-operator evaluation reused by multiple
+references with byte-identical overlay state. Share or precompute only that
+class result; do not share the query-specific candidate score. The current H4 leaf is assigned
+from the prime rather than `SpinTorsionState`, so the report must bind the
+spin/operator-to-candidate relation. The existing prime-derived H4 relative
+witness does not establish stored-spin direction without an explicit
+spin-to-H4 map.
+
+Only after that exact-class decision may #973 freeze a finite,
+orientation-aware relative-angular neighbor kernel. It may influence already
+admitted candidates but cannot inject candidates, collapse antipodal states via
+Hopf projection, or enumerate the corpus. Current procedural spin placement
+remains a threat to semantic interpretation and is exercised by the
+class/operator permutation control. H4 group action is not by itself evidence
+of a spherical-harmonic field. The operator kappa must bind basis, mode order,
+coefficients, quantization, and transition law before the prototype is called
+harmonic. #973 will freeze its own terminal literal before running this
+contract.
+
+A positive global subprobe cannot close #973. Paragraph and conversation still
+require their own matched load-bearing qualification through the accepted loop,
+or an explicit native revision of #973's scope and dependencies.
+
 ## 4. Matched controls
 
 An attention, inference, or reasoning comparison MUST use controls with the
@@ -509,6 +579,13 @@ For #953, run exactly the full-path and state-disabled arms with identical
 natural support and work. Do not carry #969's last-only arm or the obsolete
 six-comparator I1 matrix forward. A single grammar-disabled diagnostic is
 allowed only to localize an already observed output defect.
+
+For #973's global exact-spin operator decision, run real, identity-disabled, and
+deterministic class/operator-permuted arms with identical admission and work.
+At least two references share one exact class so reuse is exercised; a different
+exact class in the same current `SpinSector` checks that the operator is not
+aliasing the coarse Hopf-octant/torsion bucket. A one-unit registration-only
+global snapshot or an identity transition cannot qualify the operator.
 
 A working decoded intervention records
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. This establishes only a
@@ -556,6 +633,11 @@ recover locality. Report unqualified terms as storage fields, diagnostics, or
 controls rather than folding them into a winning aggregate score. A candidate
 found only through digest equality is recall and does not satisfy this
 requirement.
+
+A harmonic-neighbor channel may change the state or cost of a candidate already
+admitted by an independent lawful row. That is an influence hypothesis, not
+candidate admission and not proof of anti-recall selection until the matched
+operator controls change the selected route and decoded output.
 
 ## 6. Correctness and abstention
 

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -29,16 +29,24 @@ The central invariant is:
 
 > **The geometry is the route, and the route is the data location.**
 
+Two typed stages preserve that invariant: **admission determines which
+continuations are lawful; operator/harmonic influence determines how the state
+of lawful candidates is transformed.** The existing adjacent-spin retrieval
+row remains a separate empty-primary fallback.
+
 Text is not made intelligent by its cryptographic digest or by putting token
 IDs in a table. A canonical lexical payload is assigned a factorable location;
 the ordered route through those locations carries causal context; local
 spin/torsion changes move the state; and a bounded least-cost lookup chooses the
 next route. The route must remain reconstructable and causally falsifiable.
 
-The programme is sequenced by capability: lexically reversible geometry first,
-then recursive attention, then source-free inference/generation, then measured
-correctness, and only then multi-step reasoning. Attention must exist before an
-output can be credited to geometric inference.
+The programme is sequenced by capability: lexically reversible geometry first;
+one load-bearing local route-attention mechanism (#969); one bounded decoded
+loop with repaired admission (#953); paragraph, conversation, and global
+qualification through that loop (#973); then measured correctness and only then
+multi-step reasoning. A qualified local attention mechanism must exist before
+an output can be credited to geometric inference; later higher scopes remain
+separate claims.
 
 Optimization, broad QA, formalization, and release certification follow a
 working decision-bearing product slice. They do not replace it.
@@ -104,9 +112,13 @@ exact rank-preserving lexical relabel of #969 and terminated
 `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement follow-up stopped
 at support admission before H4 selection because adjacent-spin fallback
 expanded exact direct-plus-divisor support to five candidates. #953 remains
-active; #973 remains blocked and later owns paragraph, conversation, and global
-qualification through an accepted #953 loop. #962 separately owns product chat
-integration and persisted, identity-scoped hive memory.
+active after protected PR #978 for the smallest tiered-admission repair: direct
+I1/I2/ordered-sentence plus divisor form the primary tier, and adjacent-spin is
+an admitted fallback only when that tier is empty. #973 remains blocked and
+later owns paragraph, conversation, and global exact-spin operator
+qualification through an accepted #953 loop. Calling that operator harmonic
+additionally requires an artifact-bound basis/mode contract. #962 separately
+owns product chat integration and persisted, identity-scoped hive memory.
 
 ## Architecture invariants
 
@@ -153,6 +165,17 @@ not recompute the absolute geometry of the entire history.
 Spherical-harmonic or fixed-zeta coefficients may provide the multichannel
 spectral field. A four-coordinate state is a selected local chart of that
 field, not a claim that the full harmonic population is only four numbers.
+
+For shared exact-spin operator action, exact state reuses the existing
+`shared_class_kappa` over full signed S3 spin, checked Hopf observation, fiber,
+and torsion. Hopf/S2 cannot define the class by itself: antipodal `q` and `-q`
+states remain distinct, and the current Hopf-octant/torsion-bin lookup is only
+a coarse neighborhood index. When angular direction matters, #973 must bind
+either a new exact `SpinTorsionState` relative relation or an explicit
+spin-to-H4 map. The existing relative H4 quaternion is prime-derived route
+state, not automatically the relative orientation of two stored spin states. A
+bounded neighbor relation must use an artifact-declared exact relative state
+and orientation.
 
 ### 3. Prime experts and ordered Hamiltonian context
 
@@ -399,8 +422,12 @@ trajectory summary, session hypersphere vector, winding/window state, window
 projection energy, accumulated Hopf phase, route topology, payload identity,
 lexical provenance, and reconstruction evidence needed to recover the same
 object. Like spin states may share a canonical operator/chart entry, so a
-single bound state transition can update all references to that state without
-duplicating the calculation.
+single result bound by global root/epoch kappa, operator kappa, chart/table
+identities, and the existing exact `shared_class_kappa` can be reused by all references to
+that state without duplicating the calculation.
+This is an immutable overlay: it does not rewrite address, payload, route, or
+kappa identity. Address-specific radial and provenance terms remain separately
+bound where required.
 
 An offline source model may later label examples, propose candidate rankings,
 or act as a quality comparator. Those observations must be converted into
@@ -445,9 +472,12 @@ trajectory/harmonic structural summaries. #969 consumes only the local retained
 ordered-S3 path. Paragraph, conversation, and global state remain serialized
 and incrementally updated but inert for selection until #973.
 
-The prototype candidate set is the unchanged bounded schema-2 natural row union.
-Admission bounds are explicit; exact path-cost ranking runs only over the
-admitted set.
+The next #953 revision uses typed admission precedence rather than one flat row
+union. I1/last-one, I2/last-two, ordered-sentence, and divisor rows form the
+primary tier. If that tier is non-empty, adjacent-spin rows may be consulted
+and reported but admit nothing. Only an empty primary tier activates bounded
+adjacent-spin fallback. Admission bounds and policy identity are explicit;
+exact path-cost ranking runs only over the admitted set.
 
 An exact kappa miss is not permission to treat a digest as semantic distance.
 The first mechanism does not combine an omnibus list of stored channels. Its
@@ -459,6 +489,22 @@ Required structural/storage representation and qualified semantic scoring are
 separate contracts. Unqualified Hopf, H4, zeta, icosian, SpiralCore,
 trajectory, or harmonic fields remain storage fields, diagnostics, or controls
 even when present in every canonical envelope.
+
+Prospective harmonic action is likewise separate from admission. After #953,
+#973 may bind one deterministic operator result to
+`(global_root_or_epoch_kappa, operator_kappa, chart/table identities,
+shared_class_kappa)` and apply it to the candidate-relative state of
+already-admitted routes. Every reference in the same exact class observes that
+result. Similar but non-identical states may interact only through a separately
+frozen, finite angular-neighbor kernel; the
+kernel cannot inject candidates or trigger an unbounded corpus broadcast.
+The final candidate score is not shared because the causal path, route, and
+relative direction remain query-specific.
+
+The existing adjacent-spin rows remain retrieval fallback and diagnostics.
+They are compiled from coarse current-sector to historically observed-next
+support and are not operator coefficients. Any #973 neighbor operator is built
+independently over exact classes and already-admitted candidates.
 
 No learned dense Q/K projection, softmax over a full prefix, all-corpus scan,
 MoE gate, or sparse learned router is permitted in the promoted serving path.
@@ -778,8 +824,14 @@ motivated agreement contrast was frozen before selection. Its support preflight
 found the intended direct candidates but an adjacent-spin fallback row expanded
 both steps to five candidates, so H4 selection and all four generator arms were
 `NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP`. #953 remains open for the smallest
-tiered admission repair: direct plus divisor primary, adjacent-spin only when
-that tier is empty. #973 remains blocked.
+tiered admission repair: I1/I2/ordered-sentence plus divisor primary,
+adjacent-spin only when that tier is empty. The repaired trace must distinguish
+row consulted, physical row present, entries examined, fallback activation, and
+entries admitted. It must preserve the frozen corpus, surfaces, route placement,
+artifact identity,
+expected support, and work budget, then rerun the support-only preflight before
+any H4 selection. Harmonic ranking remains dormant in #953. #973 remains
+blocked.
 
 ### GI-2 A1Q-H / #973 — paragraph, conversation, and global attention
 
@@ -787,6 +839,48 @@ After accepted #969 and accepted #953, qualify paragraph, conversation, and
 bounded global state through the real decoded autoregressive loop. Before #973,
 those scopes may remain serialized and incrementally updated but cannot
 influence selection. #973 blocks #954.
+
+Global qualification begins with one exact-spin global operator prototype, not
+a larger channel census. Freeze a construction-independent global snapshot with
+enough ordered state to produce a witnessed non-identity transition, at least
+two immutable references in one exact spin class, and one different
+`shared_class_kappa` intentionally occupying the same current `SpinSector`.
+Bind the result to global root/epoch kappa,
+operator kappa, chart/table identities, and the existing `shared_class_kappa`;
+reuse it across exact-class references without changing their address or
+payload identity; and apply it only to candidates admitted by the accepted
+#953 policy.
+
+Compare real, identity-disabled, and deterministic class/operator-permuted arms
+with byte-identical row reads, admitted support, payloads, lower-scope state,
+ceilings, and work. The trace separates the base local cost, exact class,
+operator contribution, transformed cost, selection or abstention, and reuse
+count. The real operator must change the predeclared candidate and exact decoded
+output, while the identity-disabled and class/operator-permuted arms do not
+reproduce that effect under the same support and work. A changed shared-result
+trace or serialized field alone is not attention. Only after that exact-class
+decision may a finite, orientation-aware angular-neighbor kernel be frozen as a
+separate subprobe.
+
+Before choosing a scalar readout, enumerate the transformed
+candidate-relative classes and stop if one retained class requires incompatible
+outcomes. The causal path, route, and final candidate score remain
+query-specific; share or precompute only the exact-class result. The current H4
+route leaf is assigned from the prime rather
+than from `SpinTorsionState`; the existing relative H4 quaternion remains a
+route witness unless #973 binds an explicit spin-to-H4 map. Otherwise direction
+requires a new exact `SpinTorsionState` relative relation.
+
+This direction is intended to remove #953's observed support contamination and
+to give #973 a causal locus for global influence. It does not establish that
+the current procedural spin placement is semantic, nor does it establish broad
+grammar, coherence, correctness, or reasoning. H4 group action alone is not a
+qualified spherical-harmonic field; fixed channels/modes and their transition
+law must be artifact-bound before that stronger description is earned.
+
+A positive global subprobe cannot close #973. Paragraph and conversation still
+require their own matched load-bearing qualification through the accepted loop,
+or an explicit native revision of #973's scope and dependencies.
 
 ### GI-4 / #954 — correctness and abstention
 

--- a/docs/local_geometric_generation_953.md
+++ b/docs/local_geometric_generation_953.md
@@ -346,3 +346,38 @@ Gate C, kappa reproduction, audit, fuzz, formal proof, conformance, product QA,
 and release qualification were `NOT_RUN`. Repository-required checks remain
 transport acknowledgements while product QA is dormant; they are not test or
 release evidence.
+
+## Programme direction addendum — 2026-08-27
+
+This addendum records the accepted next design boundary; it adds no measurement
+and does not change the hard-stop evidence above.
+
+#953 will separate candidate admission from harmonic influence. Its primary
+tier is I1/I2/ordered-sentence plus divisor. When that tier is non-empty, the
+physically present adjacent-spin row remains visible as consulted/present in the
+trace but contributes zero admitted entries. When the primary tier is empty,
+the same bounded row may activate under an explicit fallback policy. The frozen
+support preflight reruns before any H4 selection or generator arm.
+
+The adjacent-spin rows are retained rather than discarded, but only as traced
+retrieval fallback and diagnostic data. They map a coarse current sector to
+historically observed next candidates; they are not operator coefficients or
+exact-class relations. #973 must build any neighbor operator independently over
+exact classes and routes already admitted by #953.
+
+That later operator prototype may reuse the existing full
+signed-S3/Hopf/fiber/torsion `shared_class_kappa`, not a Hopf octant. A
+direction-sensitive relation requires either a new exact `SpinTorsionState`
+relative relation or an explicitly bound spin-to-H4 map; the existing relative
+H4 witness is prime-derived route state. Similar non-identical states require a
+separately frozen finite relative-angular kernel. Neither operator path may
+inject candidates, rewrite immutable addresses, or broadcast across the
+corpus.
+
+This direction is intended to address the observed support contamination and
+to create a causal location for a higher-scope exact-spin operator prototype.
+Calling that operator harmonic additionally requires a bound basis, mode order,
+coefficients, quantization, and transition law. It does not
+establish grammar, coherence, semantic spin placement, correctness, or
+reasoning. #953 remains open at `REVISE_I1_GENERATOR_IN_PLACE`, and #973 remains
+blocked.

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -51,6 +51,14 @@ one another.
   Hopf map from `S3`. It is a many-to-one observable or heatmap coordinate.
   The observation cannot reconstruct the full `S3` state without retained
   fiber information.
+- **Exact spin class** — the existing `shared_class_kappa` exact-class
+  lookup/grouping key that may key future operator sharing. It binds the full
+  signed canonical S3 spin, checked Hopf observation, fiber, and torsion.
+  Hopf/S2 is not a standalone class identity and the current
+  Hopf-octant/torsion-bin `SpinSector` is only a coarse lookup bucket. Antipodal
+  `q` and `-q` states remain distinct. A direction-sensitive operator requires
+  a new exact `SpinTorsionState` relative relation or an explicitly bound
+  spin-to-H4 map; the existing relative H4 witness is prime-derived route state.
 - **Torsion** — the retained, quantized fiber/transport phase associated with
   a route state and its transition. It distinguishes states that share a Hopf
   observation. Here “torsion” is architectural transport metadata, not a claim
@@ -110,10 +118,34 @@ one another.
   winding/window and accumulated Hopf phase retain path/phase context. These
   summaries must be bounded and kappa-bound, but kappa equality itself is not
   the locality metric.
+- **Causal admission versus harmonic influence** — two typed stages of a
+  query. Admission uses declared causal/index rows to decide which routes are
+  lawful candidates. Harmonic/neighbor influence transforms or ranks the state
+  of those candidates and never admits one. In the current #953 repair,
+  I1/I2/ordered-sentence/divisor are the primary tier; the existing coarse
+  adjacent-spin retrieval row may admit only when that tier is empty.
+- **Exact-spin global operator overlay** — a prospective harmonic mechanism:
+  one deterministic result bound by global
+  root/epoch kappa, operator kappa, chart/table identities, and exact spin
+  class, reused by every immutable address reference in that class. The overlay
+  may influence candidate-relative state only after admission; it does not
+  mutate route/payload bytes or scan the corpus. The final candidate score
+  remains query-specific. The operator is called harmonic only after its
+  identity binds basis, mode order, coefficients, quantization, and transition
+  law.
+- **Bounded angular neighbor** — a finite, artifact-declared relation between
+  non-identical exact spin classes using their exact relative orientation and
+  transport state. It is not equivalence by Hopf octant, an all-to-all
+  broadcast, or authority to inject candidates. It is built independently from
+  the existing coarse adjacent-spin retrieval rows and remains unqualified
+  until a matched real/disabled/permuted intervention changes selection and
+  output.
 - **Coverage witness** — a bounded replay record showing which lexical units
-  had registered addresses, which hierarchy rows were read, which rows hit or
-  missed, candidate support before/after admission, the selected route or
-  abstention, and all artifact/control identities. Coverage proves only that a
+  had registered addresses; which hierarchy rows were consulted and physically
+  present; which entries were examined, admitted, or used only as influence;
+  fallback activation; candidate support before/after admission; exact spin
+  class and operator/epoch identities where active; the selected route or
+  abstention; and all artifact/control identities. Coverage proves only that a
   mechanism was reached; it does not prove attention, correctness, or
   reasoning.
 - **Geometric recall** — exact or backed-off retrieval of a stored continuation
@@ -131,10 +163,11 @@ one another.
   inference; it is not coherent generation by itself.
 - **Geometric-intelligence sequence** — lexical ingestion, canonical
   serialization, and address membership are prerequisite plumbing. Delivery
-  then proceeds in this order: complete recursive attention across local,
-  sentence, paragraph, conversation, and global scopes; inference/generation;
-  correctness with abstention; then bounded reasoning. Evidence may not skip a
-  stage or count prerequisite plumbing as inference.
+  then proceeds in this order: one qualified local causal-path mechanism
+  (#969); one bounded decoded generation loop with repaired admission (#953);
+  paragraph/conversation/global exact-spin operator qualification through that loop
+  (#973); correctness with abstention (#954); then bounded reasoning (#955).
+  Evidence may not skip a stage or count prerequisite plumbing as inference.
 - **Correctness** — agreement with an independent task oracle, executable
   constraint, cited source, or other predeclared ground truth, reported with
   coverage and abstention. Teacher agreement, grammatical output, and exact


### PR DESCRIPTION
## Direction

- separate lawful candidate admission from operator/harmonic influence
- keep #953 bounded to tiered I1/I2/ordered-sentence/divisor admission, with adjacent-spin only as an empty-primary fallback
- direct #973 to reuse the existing exact `shared_class_kappa` as an immutable global operator overlay over already-admitted candidates
- require an explicit spin-relative relation or spin-to-H4 map, matched disabled/permuted controls, and a bound harmonic basis/mode contract before calling the prototype harmonic
- preserve paragraph/conversation/global, correctness, and reasoning as separate downstream claims

This direction may remove the support contamination recorded by PR #978 and gives global state a causal selection locus. It does not establish grammar, coherence, semantic spin placement, correctness, knowledge, or reasoning.

## Verification

- `python3 scripts/check_claim_wording.py`
- `git diff --check`

Docs-only; broad product and research QA remain dormant.

References #953.
References #973.