### PR TITLE
docs: add corpus-induced attention direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,22 @@ candidates, not candidate injection or a corpus broadcast. Call it harmonic
 only after its identity binds basis, mode order, coefficients, quantization,
 and transition law.
 
+Corpus scale follows mechanism qualification; it never substitutes for it.
+Within #973, after #953 and every required #973 scope qualify, a predeclared
+offline corpus ladder may compile causal prefix-to-observed-next-route examples,
+multiscale summaries, versioned placement overlays that preserve immutable
+route/payload identity, and operator statistics into the source-free artifact.
+Freeze the operator family/schema, objective, scope semantics, neighborhood
+contract, and induction rule; vary only declared parameter values under new
+artifact/operator identities, and rerun the bounded gate for every structural
+or placement epoch. Additional rows, hits, or trace activity are capacity/recall
+unless the real arm changes a held-out anti-recall choice and matched controls do
+not. A selector may provisionally append one candidate admitted from its cloned
+observed state, but actual future/target data never enter inference. Deeper
+hypothetical branches, rollback, and comparison belong to #955 after #954. Do
+not launch corpus expansion while the required scope gate is negative or
+blocked.
+
 Source weights are offline teachers/comparators only. The final serving path
 loads no source weights and contains no transformer/self-attention, dense
 matrix intelligence kernel, MoE, or sparse learned router. The learned

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,18 @@ active and #973 remains blocked)._
 > a new exact spin-relative relation or an explicit spin-to-H4 map; the existing
 > relative H4 witness is prime-derived route state.
 
+> **Corpus-induced attention direction:** within #973, once #953 is accepted
+> and every required #973 scope qualifies, a separately frozen offline corpus
+> ladder may compile causal prefix-to-observed-next-route examples, multiscale
+> route summaries, versioned placement overlays that preserve immutable
+> route/payload identity, and operator statistics. More rows, hits, or trace activity are
+> recall/capacity, not attention. Promotion requires a held-out anti-recall
+> candidate-relative effect under matched controls and requalification of every
+> structural or placement epoch. A
+> one-step hypothetical append of each admitted candidate is lawful selection;
+> actual future/target data are forbidden, and deeper branch lookahead remains
+> #955 work after #954.
+
 > The goal is frontier-like useful capability on ordinary local hardware, but
 > that remains an unproven research target. Spherical harmonics are the working
 > picture for overlapping spin-state storage and transport; R4/S3 compute and
@@ -174,15 +186,28 @@ Native GitHub relationships are the source of truth:
    cannot close #973; paragraph and conversation still require matched
    qualification or an explicit native scope revision. The operator is called
    harmonic only after its identity binds basis, mode order, coefficients,
-   quantization, and transition law.
+   quantization, and transition law. After all bounded #973 scope gates are
+   positive, #973 activates a separately predeclared corpus-induction ladder as
+   part of its terminal and handoff to #954. Freeze the operator family,
+   objective, scope semantics, neighborhood contract, and induction rule; vary
+   only declared corpus-derived parameters under a new artifact/operator kappa
+   per rung, and rerun the bounded gate for every structural or placement epoch.
+   Match support/work between controls within each rung, report support changes
+   across rungs separately, and stop if scale only raises exact/backoff recall or
+   table density.
 8. **GI-4 / #954 — correctness and abstention:** test held-out answer
    correctness, relevance, abstention, and causal use of required context only
-   through the accepted #969/#953/#973 path. Teacher weights may label or
-   compare offline only after the source-free report freezes.
+   through a frozen corpus-induced artifact that conforms to and binds the
+   accepted #969/#953/#973 identities. Teacher weights may label or compare
+   offline only after the source-free report freezes, and the #954 oracle cannot
+   tune the artifact.
 9. **GI-5 / #955 — reasoning:** invoke the accepted #969/#953/#973/#954 consumer at
-   every bounded goal-directed route-composition step, with branch comparison,
-   intermediate constraints, and closure/contradiction controls. #952 is not a
-   qualified-attention consumer.
+   every bounded goal-directed route-composition step. Compare cloned
+   hypothetical candidate states admitted anew by the accepted consumer at each
+   cloned branch node, under declared depth, width, rollback, and work ceilings,
+   with branch, intermediate-constraint, and
+   closure/contradiction controls. Actual future routes and targets remain
+   unavailable. #952 is not a qualified-attention consumer.
 10. **GI-6 / #962–#965 — product, cost, formal closure, and release:** integrate
    the accepted #969/#953/#973 path into durable
    multi-turn CLI/HTTP chat, persistence, isolation, and hive-memory (#962);

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -306,9 +306,16 @@ real overlay must change the intended candidate and exact decoded output, while
 the disabled and permuted arms do not reproduce that predeclared effect. A
 changed shared-result trace or stored state alone is not attention.
 
-No learned dense full-prefix Q/K projection, future-route input, all-prefix
-scan, or corpus scan belongs to this route hierarchy. A different transitional
-decoder component may still exist, but its work cannot be attributed to this
+For each already-admitted candidate `c`, the selector may clone the observed
+state, compute the deterministic provisional state
+`S_hat(t+1,c) = Update(S_t,c)`, and score that candidate-relative state. Only
+the selected candidate is committed. This one-step projection is part of causal
+selection and does not constitute a future read.
+
+No learned dense full-prefix Q/K projection, observed future event/route,
+target label, teacher continuation, provider text, all-prefix scan, or corpus
+scan belongs to this route hierarchy. A different transitional decoder
+component may still exist, but its work cannot be attributed to this
 geometric-attention mechanism.
 
 ## 6. Coverage witness
@@ -380,8 +387,15 @@ Delivery proceeds without skipping stages:
 4. in #973, qualify paragraph, conversation, and global influence through the
    accepted #953 loop, including the shared exact-spin operator overlay and
    its matched disabled/permuted controls;
-5. measure correctness and typed abstention in #954; and
-6. measure bounded reasoning through novel multi-step state transitions in
+5. within #973, after every required scope qualifies, activate a predeclared
+   offline corpus-induction ladder with a frozen operator family and induction
+   rule; assign every rung new artifact/operator identities and rerun the
+   bounded matched gate for every structural or placement epoch;
+6. measure correctness and typed abstention in #954 on the frozen induced
+   artifact that conforms to and binds the accepted #969/#953/#973 identities;
+   and
+7. measure bounded reasoning through novel multi-step hypothetical state
+   transitions in
    #955.
 
 No generation score can substitute for incomplete attention scopes, and no
@@ -395,9 +409,15 @@ reasoning claim can precede correctness evidence.
   recomputed at every node.
 - Exact recall remains useful and measurable without being mislabeled
   attention.
+- Corpus scale may compile the qualified receptive mechanism, but additional
+  rows, hits, and trace activity remain capacity/recall until held-out
+  candidate-relative causal controls establish attention.
 - Exact-state sharing can apply one bound harmonic operation to every matching
   address reference without mutating the immutable artifact or enumerating the
   corpus.
+- A one-step hypothetical append is causal candidate evaluation; actual future
+  observations and target data remain forbidden, while deeper bounded branch
+  comparison is deferred to reasoning.
 - Causal admission cannot be contaminated merely because an unrelated
   continuation occupies a coarse neighboring spin bucket.
 - Unknown addresses fail closed; unseen ordered combinations may still be

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -61,6 +61,14 @@ The stages are ordered because each later claim depends on the earlier one:
    constraint preservation, alternative/counterfactual comparison, and a
    checkable result. #952 is not the reasoning consumer.
 
+Within #973, after accepted #953 and every required #973 scope qualifies, or an
+explicit native revision changes that scope, run the separately frozen offline
+corpus-induction ladder and requalify its final artifact. The ladder is part of
+#973's terminal before #954; it is not a new serving-time corpus reader or a
+shortcut around the issue order. More rows, exact hits, or trace activity are
+capacity/recall results unless a candidate-relative effect transfers to the
+held-out anti-recall partition under matched controls.
+
 #962 later integrates the accepted #969/#953/#973 path into product chat/memory.
 #964 binds the #970 → #969 → #953 → #973 stages in the
 serving contract, and #965 qualifies only that exact release path.
@@ -562,8 +570,10 @@ same causal information and declared budget. At minimum report:
 
 - identical row types, row ceilings, candidate-entry ceilings, and output
   ceiling;
-- identical prefix, lexical coverage, hierarchy scopes, and absence of future
-  routes;
+- identical prefix, lexical coverage, hierarchy scopes, and absence of actual
+  future routes, events, target labels, teacher continuations, or provider text;
+- any one-step candidate projection derived deterministically from the same
+  observed state and already-admitted support;
 - identical compiler artifacts except for the named intervention;
 - candidate support before and after any common pre-geometric admission; and
 - work performed, not merely requested worker count.
@@ -639,6 +649,20 @@ admitted by an independent lawful row. That is an influence hypothesis, not
 candidate admission and not proof of anti-recall selection until the matched
 operator controls change the selected route and decoded output.
 
+Corpus scale receives the same treatment. A larger construction partition may
+compile more transition support, multiscale summaries, versioned placement
+overlays that preserve immutable route/payload identity, or operator statistics,
+but increased lookup density is not emergent attention.
+Construction may compile causal prefix-to-observed-next-route examples;
+validation/test continuations and runtime future data may not tune it.
+Within each corpus rung, real and control arms hold candidate support and work
+fixed: the real arm must change the predeclared route and decoded output, while
+scope-disabled, order-shuffled, and operator-permuted arms do not reproduce the
+effect. Coverage and support changes between rungs are reported separately as
+capacity/recall; an operator-only scale question freezes admission across all
+rungs. Exact recall, recombination, and anti-recall results remain separate at
+every corpus size.
+
 ## 6. Correctness and abstention
 
 Correctness requires an independent evaluator fixed before results are read:
@@ -682,6 +706,17 @@ if negative:              different next action
 if unavailable:           action without inventing a result
 stop conditions:          saturation, no reachability, bad ETA, errors, resource cap
 ```
+
+Corpus expansion uses a predeclared increasing, preferably log-spaced ladder
+rather than one immediate maximum-scale run. Document, conversation, and task
+splits freeze before route rows or operator statistics are constructed. The
+operator family/schema, basis and mode order, objective, quantization, scope
+semantics, neighborhood contract, and induction rule freeze before the ladder;
+only declared statistic/coefficient values vary under a new artifact/operator
+kappa per rung. A structural or placement-epoch change reruns the bounded #973
+qualification. The accepted small mechanism remains a regression at every rung,
+and expansion stops when the preceding rung cannot change the named decision or
+only improves exact/backoff coverage.
 
 Requested parallelism is not proven parallelism. Before a long run, a bounded
 canary must show positive assigned and completed work on every intended worker,

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -440,6 +440,41 @@ Attention is a recursive route lookup, not a Q/K dot-product approximation.
 At step `t`, only observed state and declared persistent memory may enter the
 query. The actual future route is never an input.
 
+### Corpus-induced attention hypothesis
+
+The programme hypothesis is that attention-like geometric routing can emerge
+from exposure to large construction corpora only after a causal,
+candidate-relative receptive mechanism exists. Offline corpus induction may
+compile lawful transition support, ordered multiscale route summaries, exact
+operator tables, finite angular-neighbor relations, and candidate-relative
+costs into the source-free artifact. Corpus volume by itself only increases
+coverage, capacity, and recall density. It is not attention and does not show
+that attention emerged.
+
+The existing seven-level contract gives typed inputs for the current/proposed
+candidate relation, previous route, last-two routes, accumulated sentence,
+paragraph, conversation, and bounded global state. The committed observed state
+must not contain the proposed candidate. If #973 adds a longer recent-route ring
+or distinct open/last-closed sentence or paragraph snapshots, those are new
+versioned fields; they do not silently reinterpret `R2`, `RS`, or `RP`. For each
+lawfully admitted candidate `c`, one deterministic hypothetical next state is
+permitted:
+
+```text
+H_t                 = committed observed hierarchy before candidate c
+c                   = one route in Admit(H_t)
+R0_t(c)             = CandidateRelativeLocal(H_t, c)
+H_hat(t+1, c)       = Update(H_t, c)
+candidate_cost_t(c) = QualifiedCost(H_t, R0_t(c), H_hat(t+1, c))
+```
+
+`H_hat(t+1, c)` is derived only from the observed prefix, declared persistent
+state, and `c`; only the selected candidate is committed. It is a
+counterfactual next-route evaluation, not access to an observed future event,
+target continuation, evaluation answer, teacher output, or provider text.
+Competing multi-step rollouts, rollback, and branch comparison belong to #955
+after correctness, not to the one-step attention selector.
+
 The first mechanism is deliberately concrete:
 
 ```text
@@ -882,13 +917,52 @@ A positive global subprobe cannot close #973. Paragraph and conversation still
 require their own matched load-bearing qualification through the accepted loop,
 or an explicit native revision of #973's scope and dependencies.
 
+#### #973 corpus-induction qualification and handoff to #954
+
+Within #973, only after #953 is accepted and every required #973 higher-scope
+intervention qualifies, or an explicit native revision changes that scope, may
+the programme activate controlled offline corpus induction. This ladder and its
+final requalification are part of #973's definition of done and terminal; #973
+cannot close and #954 cannot start without them. This does not authorize
+expansion of the active #953 experiment.
+
+Freeze the document/conversation/task partitions before compiling rows or
+operator statistics. Construction data may supply causal
+prefix-to-observed-next-route examples; validation/test continuations and
+runtime future data may not tune compilation or inference. Before the ladder,
+freeze the operator family and schema, basis/mode order, objective,
+quantization, scope semantics, neighborhood contract, and induction rule. Only
+the declared corpus-derived statistics and coefficient values may vary. Each
+rung receives new artifact and operator kappas while serving still performs no
+corpus scan and loads no source tensors.
+
+Current prime-derived H4 leaves and procedural spin classes remain exact
+identity coordinates, not established semantic placement. If corpus induction
+changes placement, it must create a versioned overlay or rebuilt artifact with
+an inverse/provenance witness; it may not silently reinterpret immutable route
+or payload identity. Every new placement epoch or structural operator revision
+invalidates inherited #973 evidence and reruns the bounded matched #973 gate
+before scale evidence is read.
+
+Within each rung, real, scope-disabled, order-shuffled, and operator-permuted
+arms have identical candidate support and work. Coverage and support changes
+between rungs are reported separately as capacity/recall; an operator-only
+scaling question freezes admission across all rungs. Expansion stops if it
+merely raises exact/backoff hit rate, table density, or trace activity.
+Promotion to #954 requires the real arm to change the predeclared selected
+route and decoded output on held-out anti-recall cases while the matched controls
+do not reproduce that effect.
+
 ### GI-4 / #954 — correctness and abstention
 
-After source-free generation and #973 higher-scope qualification exist, test
-whether the accepted #969/#953/#973 path understands the input well enough to
-choose a correct answer. #954 does not consume #952 as qualified attention. Use
-held-out questions with answerable, unanswerable, contradictory, and
-context-dependent cases. Score correctness, relevance,
+After source-free generation and #973's higher-scope plus corpus-induction
+terminal, test whether a frozen corpus-induced artifact conforming to and
+binding the accepted #969/#953/#973 identities understands the input well
+enough to choose a correct answer. #954 does not
+consume #952 as qualified attention, and its truth oracle or evaluation cases
+may not tune the compiled admission policy, placement, operator coefficients,
+or candidate costs. Use held-out questions with answerable, unanswerable,
+contradictory, and context-dependent cases. Score correctness, relevance,
 calibration/abstention, constraint coverage, and causal dependence on the
 required route levels.
 
@@ -903,11 +977,21 @@ accepted #969/#953/#973/#954 consumer, not #952. Add bounded multi-step route
 composition with:
 
 - explicit goal and intermediate constraints;
-- branch creation and comparison;
+- branch creation and comparison from cloned accepted state;
 - reversible state updates;
 - closure, contradiction, or abstention tests;
 - a trace showing which route operation produced each intermediate; and
 - controls that break one required premise or route.
+
+Each branch is a hypothetical append of an already-admitted candidate and may
+be expanded only after the accepted consumer admits that candidate from the
+branch node's cloned state, under predeclared depth, width, visited-node,
+rollback, and tie/abstention ceilings. Actual future events, target continuations, evaluation
+answers, teacher outputs, and provider text remain unavailable. A one-step
+candidate projection is inference/selection, not reasoning; #955 must show that
+deeper branch comparison preserves constraints and changes the independently
+checkable conclusion against matched greedy, no-lookahead, and permuted-branch
+controls.
 
 A fluent rationale is not reasoning evidence. The selected conclusion and its
 intermediate constraints must change under the matched causal control.

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -140,6 +140,26 @@ one another.
   the existing coarse adjacent-spin retrieval rows and remains unqualified
   until a matched real/disabled/permuted intervention changes selection and
   output.
+- **Corpus-induced geometric attention** — the programme hypothesis that a
+  previously qualified causal, candidate-relative receptive mechanism can be
+  parameterized offline from larger construction corpora into bounded
+  transition support, multiscale summaries, versioned placement overlays that
+  preserve immutable route/payload identity, and operator tables. The operator
+  family/schema and induction rule freeze before scaling; every rung receives a
+  new artifact/operator identity, and structural or placement changes rerun the
+  bounded qualification. More rows, exact/backoff hits, or trace activity
+  establish only coverage/capacity/recall. Attention is credited only when a held-out
+  anti-recall choice depends on the induced geometric term under matched causal
+  controls. The serving path loads the compiled artifact; it does not scan the
+  corpus or load source tensors.
+- **Hypothetical next-route state** — the deterministic provisional state
+  `Update(S_t,c)` formed from observed state and one already-admitted candidate
+  `c`. It may be scored before committing the unique winner and is not an
+  observed future read. Actual future events, target continuations, evaluation
+  answers, teacher outputs, and provider text are forbidden inputs. One-step
+  projection is selection/inference; deeper bounded branch rollout belongs to
+  reasoning, where the accepted consumer admits candidates anew from each
+  cloned branch-node state.
 - **Coverage witness** — a bounded replay record showing which lexical units
   had registered addresses; which hierarchy rows were consulted and physically
   present; which entries were examined, admitted, or used only as influence;
@@ -165,8 +185,10 @@ one another.
   serialization, and address membership are prerequisite plumbing. Delivery
   then proceeds in this order: one qualified local causal-path mechanism
   (#969); one bounded decoded generation loop with repaired admission (#953);
-  paragraph/conversation/global exact-spin operator qualification through that loop
-  (#973); correctness with abstention (#954); then bounded reasoning (#955).
+  paragraph/conversation/global exact-spin operator qualification through that
+  loop plus controlled corpus induction and final requalification (#973);
+  correctness with abstention (#954); then bounded hypothetical-branch reasoning
+  (#955).
   Evidence may not skip a stage or count prerequisite plumbing as inference.
 - **Correctness** — agreement with an independent task oracle, executable
   constraint, cited source, or other predeclared ground truth, reported with


### PR DESCRIPTION
## Summary

- define corpus-induced geometric attention as a programme hypothesis that can
  be tested only after a causal candidate-relative mechanism qualifies
- make the corpus ladder, per-rung identities, and final requalification an
  explicit part of #973 before #954
- distinguish lawful one-step candidate projection from forbidden future/target
  access and reserve deeper branch rollout for #955
- preserve immutable route/payload identity and require every structural or
  placement epoch to rerun the bounded matched #973 gate
- mirror the direction in the programme, roadmap, ADR, evaluation policy,
  glossary, and agent guidance

## Native roadmap

The existing `#953 -> #973 -> #954 -> #955` dependency chain, assignments, and
statuses are unchanged. The live #820/#953/#973/#954/#955 bodies and milestone
21 now mirror this direction.

References #820
References #953
References #973
References #954
References #955

## Verification

- `python3 scripts/check_claim_wording.py`
- `git diff --check`
- code, model, teacher, corpus-scale, and broad workspace tests: `NOT_RUN`
  (documentation-only programme direction)
