### PR TITLE
#953: tier candidate admission and record selector result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,15 +17,19 @@ route-attention mechanism and one matched two-unit decoded smoke at
 bounded provider-free decode/render/append loop, but its initial smoke was an
 exact rank-preserving lexical relabel of #969 and terminated
 `REVISE_I1_GENERATOR_IN_PLACE`: it did not supply incompatible natural choices
-or qualify grammar. A separately frozen natural agreement revision then stopped
-before H4 selection because adjacent-spin fallback expanded the exact direct
-plus divisor support to five candidates. #953 remains active for the smallest
-tiered admission repair: I1/I2/ordered-sentence plus divisor primary,
-adjacent-spin only when that tier is empty. Candidate admission and harmonic
-influence are separate contracts: spin similarity never widens non-empty
-primary support. #973 remains blocked and later owns a shared exact-spin global
-operator over already-admitted
-candidates, followed by #954–#955 → #962–#965.
+or qualify grammar. `PrimaryThenAdjacentSpinFallbackV1` then repaired the
+separately frozen natural agreement admission: I1/I2/ordered-sentence plus
+divisor form the primary tier; adjacent-spin rows are always consulted and
+report physical presence truthfully, but do not admit while primary support is
+non-empty. The preflight recovered exact `{still}` then `{run,runs}` support
+under equal work. One permitted four-arm run produced left/full `still run`,
+right/full `still run`, and both state-disabled arms `still runs`, with
+deterministic replay, so the terminal remains `REVISE_I1_GENERATOR_IN_PLACE`.
+The remaining bounded defect is candidate-relative representation/scoring, not
+admission or state starvation. #953 remains open for local corpus-induced
+same-object, order-sensitive candidate-relative compatibility/placement; do
+not jump directly to Poincare/Hopf/harmonic machinery. #973 and #954 remain
+blocked, followed by #955 → #962–#965.
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
@@ -226,15 +230,18 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   promote attention or generation. #970 closed through protected PR #972.
   #969 then delivered one causal R4/S3 least-cost route-attention mechanism and
   one matched decoded smoke. #953 has implemented a bounded source-free
-  library/CLI decode/render/append loop, but its rank-preserving relabel smoke
-  terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its next frozen natural agreement
-  contrast stopped at support preflight when broad adjacent-spin fallback
-  contaminated non-empty direct-plus-divisor support; H4 selection was
-  `NOT_RUN`. #953 owns
-  the smallest tiered admission repair—direct plus divisor primary,
-  adjacent-spin only on an empty primary tier; #973 remains blocked and later
-  owns paragraph/conversation/global qualification. #954 and #955 own
-  correctness and reasoning.
+  library/CLI decode/render/append loop. Its rank-preserving relabel smoke
+  terminated `REVISE_I1_GENERATOR_IN_PLACE`; the later
+  `PrimaryThenAdjacentSpinFallbackV1` repair recovered exact `{still}` then
+  `{run,runs}` primary support under equal work while still consulting and
+  truthfully tracing non-admitting adjacent-spin rows. The one permitted
+  four-arm run produced `still run` for both full-path prompts and `still runs`
+  for both state-disabled prompts, with deterministic replay. The terminal
+  therefore remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to
+  candidate-relative representation/scoring rather than admission or state
+  starvation. #953 stays open for a bounded local corpus-induced same-object,
+  order-sensitive compatibility/placement revision; #973 and #954 remain
+  blocked. #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
 - Sequence strictly: lexical/address plumbing → local route attention →
@@ -253,13 +260,15 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   shared-factor, and resonance terms remain storage fields, diagnostics, or
   future hypotheses. #969 establishes only its local ordered-S3 path mechanism
   as load-bearing. #953's current code establishes reusable decoded-loop
-  plumbing only; its relabelled smoke does not establish a natural grammar or
-  sentence loop. Only a later accepted #953 result can expose #973, and only
-  #973 may qualify paragraph, conversation, or global state.
+  plumbing and tiered admission on the frozen preflight only; the unchanged
+  full-path choice does not establish a natural grammar or sentence loop. Only
+  a later accepted #953 result can expose #973, and only #973 may qualify
+  paragraph, conversation, or global state.
 - Keep **candidate admission** separate from **harmonic influence**. In #953,
-  I1/I2/ordered-sentence plus divisor are the primary admission tier;
-  adjacent-spin rows remain visible in the trace but admit candidates only when
-  that tier is empty. Do not delete or disguise a physical adjacent-spin hit.
+  `PrimaryThenAdjacentSpinFallbackV1` uses I1/I2/ordered-sentence plus divisor
+  as the primary admission tier. Adjacent-spin rows are always consulted and
+  report physical presence truthfully, but admit candidates only when that tier
+  is empty. Do not delete or disguise a physical adjacent-spin hit.
   #973 may later apply one global-epoch/operator-bound result to every immutable
   reference in the same exact signed-S3/Hopf/fiber/torsion class. Similar but
   non-identical states require a separately frozen finite relative-angular
@@ -270,11 +279,13 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   default, but global ordered-state behavior is tested on an independently
   frozen global-snapshot permutation rather than by mutating session history.
 - The completed #969 evidence compares exactly full retained path, last-only,
-  and state-disabled. #953's revision smoke carried forward full path and
-  state-disabled under identical support/work, but its exact rank-preserving
-  lexical relabel cannot qualify incompatible natural choices. Do not add a
-  construction/validation split, channel census, weight sweep, control matrix,
-  or higher-scope fixture to either bounded decision.
+  and state-disabled. #953's repaired natural agreement run carried full path
+  and state-disabled arms under equal support/work: both full-path prompts chose
+  `still run`, while both disabled prompts chose `still runs`. That deterministic
+  negative localizes the next revision to candidate-relative
+  representation/scoring; it does not qualify incompatible natural choices.
+  Do not add a construction/validation split, channel census, weight sweep,
+  control matrix, or higher-scope fixture to either bounded decision.
 - Teacher output may label or compare only after a source-free report freezes.
   It is never substituted for the product response.
 - Once #973 activates higher scopes, every hierarchy selection emits a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,12 +107,19 @@ The experiment must be able to change the next programme decision:
   structural. A1Q-L/#969 subsequently qualified one local causal R4/S3 path
   selector. GI-3/#953 implemented bounded provider-free library/CLI loop
   plumbing, but its rank-preserving relabel smoke terminated
-  `REVISE_I1_GENERATOR_IN_PLACE`. A frozen natural agreement follow-up stopped
-  before H4 selection because adjacent-spin fallback contaminated non-empty
-  direct-plus-divisor support. #953 remains active for a tiered admission repair
-  that uses adjacent-spin only when the primary tier is empty, and A1Q-H/#973
-  remains blocked; GI-4/#954 and GI-5/#955 remain
-  downstream. Do not promote the #953 plumbing into their claims.
+  `REVISE_I1_GENERATOR_IN_PLACE`. `PrimaryThenAdjacentSpinFallbackV1` repaired
+  the later natural agreement admission: I1/I2/ordered-sentence plus divisor
+  recovered exact `{still}` then `{run,runs}` support under equal work, while
+  adjacent-spin stayed consulted, truthfully reported physical presence, and
+  remained non-admitting until the primary tier was empty. The one permitted
+  four-arm run produced `still run` for both full-path prompts
+  and `still runs` for both state-disabled prompts, with deterministic replay.
+  The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to
+  candidate-relative representation/scoring rather than admission or state
+  starvation. #953 remains open for a bounded local corpus-induced same-object,
+  order-sensitive compatibility/placement revision; A1Q-H/#973 and GI-4/#954
+  remain blocked, with GI-5/#955 downstream. Do not promote the #953 plumbing
+  into their claims or jump directly to Poincare/Hopf/harmonic machinery.
 - **Exercise the real route path.** Geometry must run before token choice and
   emit its admitted support and energy trace. Add a global-context coverage
   witness when the active issue, beginning with #973, activates higher scopes.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > **Honest status:** the geometric storage/identity foundation, one bounded
 > causal R4/S3 path selector, and reusable provider-free decode/render/append
 > plumbing exist. The first #953 smoke was an exact lexical relabel of #969, so
-> it did not qualify a natural grammar loop. A frozen agreement follow-up then
-> stopped before H4 selection because broad fallback rows contaminated its exact
-> direct-plus-divisor support; #953 remains at direct revision.
+> it did not qualify a natural grammar loop. `PrimaryThenAdjacentSpinFallbackV1`
+> repaired the frozen agreement admission to exact `{still}` then `{run,runs}`
+> support under equal work, but the one permitted four-arm run chose `still run`
+> for both full-path prompts and `still runs` for both state-disabled prompts.
+> Deterministic replay preserved `REVISE_I1_GENERATOR_IN_PLACE`: the remaining
+> defect is candidate-relative representation/scoring, not admission or state
+> starvation. #953 remains open; #973 and #954 remain blocked.
 > Higher-scope attention, correct answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
@@ -124,8 +128,9 @@ phases, ordered n-lets, exact `phi` radial transport, and the typed
 scorer inputs. It does not establish attention or generation, and #969 becomes
 the next stage only after protected #970 merge. #969 has since delivered one
 bounded causal path selector. #953 has driven it through real decoded-loop
-plumbing, but its first smoke was a rank-preserving relabel of #969 and did not
-qualify a natural grammar result.
+plumbing and tiered admission on the frozen preflight, but the natural agreement
+run made the same full-path choice for both prompts and did not qualify a
+natural grammar result.
 
 The ingestion witness maps two turns of text through the pinned lexical codec,
 prime/spin route state, canonical hierarchy manifest, strict reload, and exact
@@ -160,9 +165,16 @@ corrected paired-H4-derived exact R4-heatmap gate stopped at bounded readout
 identifiability without searching another scalar. #969 then qualified one local
 causal path selector, and #953 implemented the first bounded decoded
 library/CLI plumbing. Its relabelled smoke terminated
-`REVISE_I1_GENERATOR_IN_PLACE`; its frozen agreement follow-up stopped at
-support admission before H4 selection. #953 remains open and #973 remains
-blocked.
+`REVISE_I1_GENERATOR_IN_PLACE`. `PrimaryThenAdjacentSpinFallbackV1` then
+recovered exact `{still}` then `{run,runs}` primary support while consulting
+and truthfully tracing adjacent-spin rows, which remained non-admitting until
+the primary tier was empty. The one permitted four-arm run produced `still run`
+for both full-path prompts and `still runs`
+for both state-disabled prompts, with deterministic replay. The terminal
+remains `REVISE_I1_GENERATOR_IN_PLACE`; the next bounded #953 action is local
+corpus-induced same-object, order-sensitive candidate-relative
+compatibility/placement, not immediate Poincare/Hopf/harmonic machinery. #953
+remains open; #973 and #954 remain blocked.
 Stored H4/Hopf/zeta/icosian and related route fields remain
 structural state, diagnostics, or controls unless the owning stage qualifies a
 specific term.
@@ -254,8 +266,8 @@ complete.
 The active dependency chain is tracked in
 [#820](https://github.com/UOR-Foundation/uor-r4/issues/820). The immediate
 implementation stage is
-[#953](https://github.com/UOR-Foundation/uor-r4/issues/953); #973 remains
-blocked until #953 qualifies a genuinely natural decoded grammar loop.
+[#953](https://github.com/UOR-Foundation/uor-r4/issues/953). #973 and #954
+remain blocked downstream of #953; #954 also depends on #973.
 
 ## Find your way around
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,9 +15,12 @@ PR #972; #969 delivered one causal R4/S3 least-cost route-attention mechanism
 and matched two-unit decoded smoke at
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #953 implemented the first
 bounded provider-free loop, but its exact rank-preserving relabel smoke
-terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement
-follow-up then stopped at support admission before H4 selection; #953 remains
-active and #973 remains blocked)._
+terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its
+`PrimaryThenAdjacentSpinFallbackV1` repair recovered exact natural agreement
+support, but the one permitted four-arm run chose `still run` for both full
+paths and `still runs` for both state-disabled paths under equal work and
+deterministic replay. The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`;
+#953 remains open and #973/#954 remain blocked)._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -39,8 +42,11 @@ active and #973 remains blocked)._
 > a new exact spin-relative relation or an explicit spin-to-H4 map; the existing
 > relative H4 witness is prime-derived route state.
 
-> **Corpus-induced attention direction:** within #973, once #953 is accepted
-> and every required #973 scope qualifies, a separately frozen offline corpus
+> **Corpus-induced attention direction:** the next #953 revision is a bounded
+> local corpus-induced same-object, order-sensitive candidate-relative
+> compatibility/placement mechanism; it does not activate Poincare, Hopf, or
+> harmonic machinery. Once #953 is accepted and every required #973 scope
+> qualifies, a separately frozen offline corpus
 > ladder may compile causal prefix-to-observed-next-route examples, multiscale
 > route summaries, versioned placement overlays that preserve immutable
 > route/payload identity, and operator statistics. More rows, hits, or trace activity are
@@ -163,14 +169,19 @@ Native GitHub relationships are the source of truth:
    terminates `REVISE_I1_GENERATOR_IN_PLACE` at
    `blake3:f8738ae16585b5817108ad6c8bc1ec7aee93f9d5a6cacffaa3aa084bb643cf72`.
    The next independently motivated agreement contrast was frozen before
-   selection, but its support-only preflight admitted five candidates through
-   adjacent-spin fallback instead of exact `{still}` then `{run,runs}`. H4 and
-   all four generator arms were `NOT_RUN`. #953 remains active for the smallest
-   tiered admission repair: I1/I2/ordered-sentence plus divisor primary;
-   adjacent-spin traced but non-admitting when that tier is non-empty, and used
-   only as a bounded fallback when it is empty. Preserve PR #978's frozen
-   support witness and rerun that preflight before H4 selection. Harmonic
-   influence remains dormant in #953. See the
+   selection after unconditional adjacent-spin fallback expanded its support.
+   `PrimaryThenAdjacentSpinFallbackV1` repaired that admission:
+   I1/I2/ordered-sentence plus divisor form the primary tier; adjacent-spin is
+   always consulted and reports physical presence truthfully, but is
+   non-admitting when primary support is non-empty. The preflight recovered
+   exact `{still}` then `{run,runs}` support under equal work. The one permitted
+   four-arm run produced left/full `still run`, right/full `still run`, and both
+   state-disabled arms `still runs`, with deterministic replay. The terminal
+   remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to candidate-relative
+   representation/scoring rather than admission or state starvation. #953
+   remains open for a bounded local corpus-induced same-object, order-sensitive
+   compatibility/placement revision. Harmonic influence remains dormant in
+   #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
 7. **GI-2 A1Q-H / #973 — higher-scope attention:** after accepted #969 and
    #953, test paragraph, conversation, and bounded global state through the
@@ -221,11 +232,13 @@ is closed. #952's terminal negative evidence is preserved in
 #967 is at terminal A1R delivery with `RETAIN_STATE_ONLY`. #970 closed through
 protected PR #972 with its bounded heatmap-readout negative. #969's
 mechanism-first prototype reached its positive bounded terminal. #953's loop
-plumbing is implemented, but its first smoke terminated
-`REVISE_I1_GENERATOR_IN_PLACE` and its frozen agreement follow-up stopped at
-support admission before H4 selection; #953 remains open and #973 remains
-blocked. The live chain is closed #970 → closed #969 → open #953 → blocked #973
-→ blocked #954 → #955 → #962–#965.
+plumbing is implemented and tiered admission passed the frozen preflight, but
+the repaired natural agreement four-arm run made the same full-path choice for
+both prompts and preserved `REVISE_I1_GENERATOR_IN_PLACE`. #953 remains open
+for bounded local same-object, order-sensitive candidate-relative
+compatibility/placement induction; #973 and #954 remain blocked. The live chain
+is closed #970 → closed #969 → open #953 →
+blocked #973 → blocked #954 → #955 → #962–#965.
 Legacy tracker #949 is closed as
 superseded; #958 is retained directly under programme root #820 as GI-0
 foundation.
@@ -243,15 +256,19 @@ historical evidence and comparators.
   short cycle, and deterministic replay. Its natural surfaces are nonetheless
   an exact rank-preserving relabel of #969, so it supplies no incompatible
   linguistic requirement and cannot qualify grammar or expose #973. The next
-  frozen agreement contrast found the direct `{still}` then `{run,runs}` rows,
-  but unconditional adjacent-spin fallback expanded both unions to five
-  candidates. Its four H4 arms were `NOT_RUN`; the next #953 action is the
-  smallest tiered admission repair—I1/I2/ordered-sentence plus divisor primary,
-  adjacent-spin visible in the trace but non-admitting while that tier is
-  non-empty, and adjacent-spin fallback only when it is empty. The frozen
-  PR #978 support gate reruns before H4 selection. This repair addresses the
-  observed support contamination; it does not yet exercise harmonic influence
-  or qualify grammar. See the
+  frozen agreement contrast first found direct `{still}` then `{run,runs}` rows
+  but was contaminated by unconditional adjacent-spin fallback.
+  `PrimaryThenAdjacentSpinFallbackV1` repaired the preflight exactly:
+  I1/I2/ordered-sentence plus divisor form the primary tier, while adjacent-spin
+  is always consulted and truthfully reports physical presence but remains
+  non-admitting until that tier is empty. Under equal support/work, the one
+  permitted four-arm run produced `still run` for both full-path prompts and
+  `still runs` for both state-disabled prompts, with deterministic replay. The
+  defect is now candidate-relative representation/scoring rather than
+  admission or state starvation. The next #953 action is a bounded local
+  corpus-induced same-object, order-sensitive candidate-relative
+  compatibility/placement revision, not immediate Poincare/Hopf/harmonic
+  machinery. #953 remains open; #973 and #954 remain blocked. See the
   [#953 record](docs/local_geometric_generation_953.md).
 
 ## Landed
@@ -368,9 +385,12 @@ historical evidence and comparators.
   repaired that representation but retained it as state only; #970 then found
   the bounded paired-H4-derived exact R4-heatmap readout non-identifiable on its
   frozen union. #969 then qualified one local causal selector, and #953 has
-  implemented its decoded-loop plumbing. The first #953 natural smoke was an
-  exact lexical relabel; its frozen agreement follow-up stopped at admission
-  before H4 selection and remains at direct revision. #973 is still blocked.
+  implemented its decoded-loop plumbing while the tiered policy passed its
+  frozen preflight. The repaired natural agreement run still made the same
+  full-path choice for both prompts, so `REVISE_I1_GENERATOR_IN_PLACE` remains
+  active and #953 moves to a bounded local same-object, order-sensitive
+  candidate-relative compatibility/placement induction.
+  #973 and #954 are still blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See

--- a/crates/uor-r4-core/src/local_geometric_generation.rs
+++ b/crates/uor-r4-core/src/local_geometric_generation.rs
@@ -15,14 +15,15 @@ use crate::canonical_lexical_ingestion::{
 };
 use crate::prime_route_attention::{GeometricAddress, PrimeRouteError};
 use crate::prime_route_geometric_attention::{
-    AttentionRowKey, AttentionRowRead, AttentionRowSource, AttentionSourceCounts,
-    AttentionSupportAdmission, GeometricAttentionArtifact, GeometricAttentionError,
-    PathLeaseAttentionTrace, PathLeaseControl, PathLeaseCost, LOCAL_PATH_ATTENTION_MAX_UNITS,
+    AttentionQueryPolicy, AttentionRowKey, AttentionRowRead, AttentionRowSource,
+    AttentionSourceCounts, AttentionSupportAdmission, GeometricAttentionArtifact,
+    GeometricAttentionError, PathLeaseAttentionTrace, PathLeaseControl, PathLeaseCost,
+    LOCAL_PATH_ATTENTION_MAX_UNITS,
 };
 
-pub const LOCAL_GEOMETRIC_GENERATION_REPORT_SCHEMA: u32 = 1;
+pub const LOCAL_GEOMETRIC_GENERATION_REPORT_SCHEMA: u32 = 2;
 pub const LOCAL_GEOMETRIC_GENERATION_REPORT_DOMAIN: &str =
-    "uor-r4.local-geometric-generation-report/1";
+    "uor-r4.local-geometric-generation-report/2";
 pub const LOCAL_GEOMETRIC_GENERATION_MIN_PROMPT_UNITS: usize = 2;
 
 #[derive(Debug)]
@@ -151,10 +152,15 @@ pub enum LocalGenerationRowKey {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LocalGenerationRowTrace {
+    pub slot_index: usize,
     pub source: LocalGenerationRowSource,
     pub key: LocalGenerationRowKey,
-    pub hit: bool,
+    pub consulted: bool,
+    pub physical_row_present: bool,
+    pub fallback_active: bool,
+    pub candidate_entries_available: usize,
     pub candidate_entries_examined: usize,
+    pub candidate_entries_admitted: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
@@ -220,9 +226,14 @@ pub struct LocalGenerationSelectionTrace {
 pub struct LocalGenerationStepTrace {
     pub step_index: usize,
     pub observed_routes_before: usize,
+    pub query_policy: String,
+    pub query_policy_kappa: String,
+    pub fallback_active: bool,
     pub support_admission: String,
     pub support_rows: Vec<LocalGenerationRowTrace>,
+    pub candidate_entries_available: usize,
     pub candidate_entries_examined: usize,
+    pub candidate_entries_admitted: usize,
     pub candidate_entry_ceiling: usize,
     pub unique_candidates_before_ceiling: usize,
     pub candidate_ceiling: usize,
@@ -274,6 +285,8 @@ pub struct LocalGeometricGenerationReport {
     pub codec_kappa: String,
     pub vocabulary_kappa: String,
     pub attention_manifest_kappa: String,
+    pub query_policy: String,
+    pub query_policy_kappa: String,
     pub h4_root_table_kappa: String,
     pub h4_multiplication_table_kappa: String,
     pub source_boundary: LocalGenerationSourceBoundary,
@@ -466,7 +479,9 @@ impl LocalGeometricGenerator {
                 })
                 .collect::<Result<Vec<_>, LocalGeometricGenerationError>>()?;
 
+            let candidate_entries_available = path_trace.support.candidate_entries_available;
             let candidate_entries_examined = path_trace.support.candidate_entries_examined;
+            let candidate_entries_admitted = path_trace.support.candidate_entries_admitted;
             let candidate_entry_ceiling = path_trace.support.candidate_entry_ceiling;
             let unique_candidates_before_ceiling =
                 path_trace.support.unique_candidates_before_ceiling;
@@ -522,7 +537,9 @@ impl LocalGeometricGenerator {
                 observed_routes_before,
                 &path_trace,
                 support_rows,
+                candidate_entries_available,
                 candidate_entries_examined,
+                candidate_entries_admitted,
                 candidate_entry_ceiling,
                 unique_candidates_before_ceiling,
                 candidate_ceiling,
@@ -559,6 +576,11 @@ impl LocalGeometricGenerator {
             codec_kappa: self.codec.codec_kappa().to_owned(),
             vocabulary_kappa: self.codec.vocabulary_kappa().to_owned(),
             attention_manifest_kappa: self.attention.manifest_kappa().to_owned(),
+            query_policy: query_policy_contract(
+                AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1,
+            ),
+            query_policy_kappa:
+                AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1.identity_kappa(),
             h4_root_table_kappa: self.h4_table.h4_root_table_kappa.clone(),
             h4_multiplication_table_kappa: self.h4_table.multiplication_table_kappa.clone(),
             source_boundary: LocalGenerationSourceBoundary {
@@ -680,10 +702,15 @@ fn row_trace(
         },
     };
     Ok(LocalGenerationRowTrace {
+        slot_index: row.slot_index,
         source: row.source.into(),
         key,
-        hit: row.hit,
+        consulted: row.consulted,
+        physical_row_present: row.physical_row_present,
+        fallback_active: row.fallback_active,
+        candidate_entries_available: row.candidate_entries_available,
         candidate_entries_examined: row.candidate_entries_examined,
+        candidate_entries_admitted: row.candidate_entries_admitted,
     })
 }
 
@@ -693,7 +720,9 @@ fn step_trace(
     observed_routes_before: usize,
     path_trace: &PathLeaseAttentionTrace,
     support_rows: Vec<LocalGenerationRowTrace>,
+    candidate_entries_available: usize,
     candidate_entries_examined: usize,
+    candidate_entries_admitted: usize,
     candidate_entry_ceiling: usize,
     unique_candidates_before_ceiling: usize,
     candidate_ceiling: usize,
@@ -711,9 +740,14 @@ fn step_trace(
     LocalGenerationStepTrace {
         step_index,
         observed_routes_before,
+        query_policy: query_policy_contract(path_trace.support.query_policy),
+        query_policy_kappa: path_trace.support.query_policy_kappa.clone(),
+        fallback_active: path_trace.support.fallback_active,
         support_admission: support_admission_contract(path_trace.support.support_admission),
         support_rows,
+        candidate_entries_available,
         candidate_entries_examined,
+        candidate_entries_admitted,
         candidate_entry_ceiling,
         unique_candidates_before_ceiling,
         candidate_ceiling,
@@ -807,6 +841,10 @@ fn support_admission_contract(admission: AttentionSupportAdmission) -> String {
             "source-breadth-then-total-count-then-canonical-address".to_owned()
         }
     }
+}
+
+fn query_policy_contract(policy: AttentionQueryPolicy) -> String {
+    policy.identity().to_owned()
 }
 
 /// Match the existing project gate: a period of one through four units is a

--- a/crates/uor-r4-core/src/prime_route_geometric_attention.rs
+++ b/crates/uor-r4-core/src/prime_route_geometric_attention.rs
@@ -35,6 +35,8 @@ pub const ATTENTION_MAX_SPIN_ROWS: usize = 8 * ATTENTION_TORSION_BINS as usize;
 pub const ATTENTION_MAX_PHASE_ATOMS: usize = MANIFEST_MAX_ADDRESSES;
 pub const ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY: usize =
     ATTENTION_ROWS_PER_QUERY * MANIFEST_MAX_CANDIDATES_PER_ROW as usize;
+pub const PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY: &str =
+    "uor-r4.attention-query-policy/primary-then-adjacent-spin-fallback-v1";
 /// #969's first local attention mechanism is deliberately bounded to the
 /// 2--8 lexical-unit loop named by the issue. The state keeps exact prefix
 /// products rather than a digest so every earlier route can participate in
@@ -122,10 +124,22 @@ pub enum AttentionRowKey {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttentionRowRead {
+    pub slot_index: usize,
     pub source: AttentionRowSource,
     pub key: AttentionRowKey,
+    /// The declared key/slot was consulted, even when its candidate entries
+    /// were not examined under the active tier policy.
+    pub consulted: bool,
+    /// Backward-compatible physical-presence signal. This is never cleared to
+    /// represent an inactive fallback.
     pub hit: bool,
+    pub physical_row_present: bool,
+    /// This row participated as an active fallback row for this query.
+    pub fallback_active: bool,
+    /// Bounded physical entries in the row, whether active or not.
+    pub candidate_entries_available: usize,
     pub candidate_entries_examined: usize,
+    pub candidate_entries_admitted: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -227,8 +241,13 @@ pub struct AttentionSupportCandidateTrace {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttentionSupportTrace {
     pub manifest_kappa: String,
+    pub query_policy: AttentionQueryPolicy,
+    pub query_policy_kappa: String,
+    pub fallback_active: bool,
     pub rows_read: Vec<AttentionRowRead>,
+    pub candidate_entries_available: usize,
     pub candidate_entries_examined: usize,
+    pub candidate_entries_admitted: usize,
     pub candidate_entry_ceiling: usize,
     pub unique_candidates_before_ceiling: usize,
     pub candidate_ceiling: usize,
@@ -241,8 +260,13 @@ pub struct GeometricAttentionTrace {
     pub manifest_kappa: String,
     pub control: AttentionControl,
     pub geometry_intervention: AttentionGeometryIntervention,
+    pub query_policy: AttentionQueryPolicy,
+    pub query_policy_kappa: String,
+    pub fallback_active: bool,
     pub rows_read: Vec<AttentionRowRead>,
+    pub candidate_entries_available: usize,
     pub candidate_entries_examined: usize,
+    pub candidate_entries_admitted: usize,
     pub candidate_entry_ceiling: usize,
     pub unique_candidates_before_ceiling: usize,
     pub candidate_ceiling: usize,
@@ -336,6 +360,32 @@ pub struct GeometricAttentionLookupBounds {
     pub rows_per_query: usize,
     pub candidate_entries_per_query: usize,
     pub unique_candidates_after_ceiling: usize,
+}
+
+/// Versioned selection of the active candidate-support tier. This identity is
+/// independent of [`AttentionSupportAdmission`], which orders/truncates the
+/// candidates only after the active tier has been chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttentionQueryPolicy {
+    PrimaryThenAdjacentSpinFallbackV1,
+}
+
+impl AttentionQueryPolicy {
+    pub const fn identity(self) -> &'static str {
+        match self {
+            Self::PrimaryThenAdjacentSpinFallbackV1 => {
+                PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+            }
+        }
+    }
+
+    pub fn identity_kappa(self) -> String {
+        format!(
+            "blake3:{}",
+            blake3::hash(self.identity().as_bytes()).to_hex()
+        )
+    }
 }
 
 /// The common, geometry-independent admission rule applied when the bounded
@@ -849,10 +899,12 @@ impl GeometricAttentionArtifact {
 
     // BEGIN GEOMETRIC_ATTENTION_BOUNDED_LOOKUP
     /// Read and admit the bounded natural candidate support without evaluating
-    /// candidate energy or H4 path geometry. The frozen row keys, including
-    /// adjacent-spin admission rows, are still queried but only row/count data
-    /// is returned. This is the common support seam for geometric queries,
-    /// path-lease selection, and support-only preflight inspection.
+    /// candidate energy or H4 path geometry. I1, I2, ordered-sentence, and
+    /// divisor rows form the primary tier. All adjacent-spin keys remain
+    /// consulted and physically accounted for, but their entries are examined
+    /// and admitted only when the primary tier is empty. This is the common
+    /// support seam for geometric queries, path-lease selection, and
+    /// support-only preflight inspection.
     pub fn query_support_only(
         &self,
         state: &CausalAttentionState,
@@ -865,9 +917,11 @@ impl GeometricAttentionArtifact {
         let sentence_key = state.sentence_key()?;
 
         self.read_direct_row(
+            0,
             AttentionRowSource::LastOne,
             AttentionRowKey::LastOne(state.last.clone()),
             self.direct_indexes.last_one(&state.last),
+            true,
             &mut merged,
             &mut rows_read,
         )?;
@@ -883,34 +937,48 @@ impl GeometricAttentionArtifact {
             None => AttentionRowKey::LastTwoUnavailable,
         };
         self.read_direct_row(
+            1,
             AttentionRowSource::LastTwo,
             last_two_key,
             last_two_row,
+            state.previous.is_some(),
             &mut merged,
             &mut rows_read,
         )?;
         self.read_direct_row(
+            2,
             AttentionRowSource::OrderedSentence,
             AttentionRowKey::OrderedSentence(sentence_key.as_str().to_owned()),
             self.direct_indexes.sentence_precomputed(sentence_key),
+            true,
             &mut merged,
             &mut rows_read,
         )?;
 
         let divisor_row = self.divisor_rows.get(&state.last.atom);
         self.read_attention_row(
+            3,
             AttentionRowSource::Divisor,
             AttentionRowKey::Divisor(state.last.atom),
             divisor_row,
+            true,
+            false,
             &mut merged,
             &mut rows_read,
         )?;
 
-        for sector in adjacent_spin_sectors(spin_sector(&state.last)) {
+        let fallback_active = merged.is_empty();
+        for (offset, sector) in adjacent_spin_sectors(spin_sector(&state.last))
+            .into_iter()
+            .enumerate()
+        {
             self.read_attention_row(
+                4 + offset,
                 AttentionRowSource::AdjacentSpin,
                 AttentionRowKey::AdjacentSpin(sector),
                 self.spin_rows.get(&sector),
+                fallback_active,
+                fallback_active,
                 &mut merged,
                 &mut rows_read,
             )?;
@@ -921,14 +989,19 @@ impl GeometricAttentionArtifact {
                 "bounded lookup did not account for every declared row".to_owned(),
             ));
         }
-        let candidate_entries_examined = rows_read.iter().try_fold(0usize, |total, row| {
-            total
-                .checked_add(row.candidate_entries_examined)
-                .ok_or(GeometricAttentionError::ArithmeticOverflow)
-        })?;
+        let candidate_entries_available =
+            sum_row_entries(&rows_read, |row| row.candidate_entries_available)?;
+        let candidate_entries_examined =
+            sum_row_entries(&rows_read, |row| row.candidate_entries_examined)?;
+        let candidate_entries_admitted =
+            sum_row_entries(&rows_read, |row| row.candidate_entries_admitted)?;
         let bounds = self.lookup_bounds();
-        if candidate_entries_examined > bounds.candidate_entries_per_query
+        if candidate_entries_available > bounds.candidate_entries_per_query
+            || candidate_entries_examined > bounds.candidate_entries_per_query
+            || candidate_entries_admitted > bounds.candidate_entries_per_query
+            || candidate_entries_available > ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY
             || candidate_entries_examined > ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY
+            || candidate_entries_admitted > ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY
         {
             return Err(GeometricAttentionError::Invalid(
                 "lookup exceeded its declared candidate-entry ceiling".to_owned(),
@@ -959,8 +1032,14 @@ impl GeometricAttentionArtifact {
 
         Ok(AttentionSupportTrace {
             manifest_kappa: self.manifest_kappa.clone(),
+            query_policy: AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1,
+            query_policy_kappa: AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1
+                .identity_kappa(),
+            fallback_active,
             rows_read,
+            candidate_entries_available,
             candidate_entries_examined,
+            candidate_entries_admitted,
             candidate_entry_ceiling: bounds.candidate_entries_per_query,
             unique_candidates_before_ceiling,
             candidate_ceiling: bounds.unique_candidates_after_ceiling,
@@ -994,8 +1073,13 @@ impl GeometricAttentionArtifact {
     ) -> Result<GeometricAttentionTrace, GeometricAttentionError> {
         let AttentionSupportTrace {
             manifest_kappa,
+            query_policy,
+            query_policy_kappa,
+            fallback_active,
             rows_read,
+            candidate_entries_available,
             candidate_entries_examined,
+            candidate_entries_admitted,
             candidate_entry_ceiling,
             unique_candidates_before_ceiling,
             candidate_ceiling,
@@ -1051,8 +1135,13 @@ impl GeometricAttentionArtifact {
             manifest_kappa,
             control,
             geometry_intervention: intervention,
+            query_policy,
+            query_policy_kappa,
+            fallback_active,
             rows_read,
+            candidate_entries_available,
             candidate_entries_examined,
+            candidate_entries_admitted,
             candidate_entry_ceiling,
             unique_candidates_before_ceiling,
             candidate_ceiling,
@@ -1274,50 +1363,75 @@ impl GeometricAttentionArtifact {
 
     fn read_direct_row(
         &self,
+        slot_index: usize,
         source: AttentionRowSource,
         key: AttentionRowKey,
         row: Option<&CandidateRow>,
+        consulted: bool,
         merged: &mut BTreeMap<GeometricAddress, AttentionSourceCounts>,
         trace: &mut Vec<AttentionRowRead>,
     ) -> Result<(), GeometricAttentionError> {
         let entries = row.map_or(&[][..], CandidateRow::candidates);
         self.validate_row_entries(entries.len())?;
-        for candidate in entries {
-            merged
-                .entry(candidate.next.clone())
-                .or_default()
-                .add(source, candidate.count)?;
+        if consulted {
+            for candidate in entries {
+                merged
+                    .entry(candidate.next.clone())
+                    .or_default()
+                    .add(source, candidate.count)?;
+            }
         }
+        let candidate_entries_examined = if consulted { entries.len() } else { 0 };
+        let physical_row_present = row.is_some();
         trace.push(AttentionRowRead {
+            slot_index,
             source,
             key,
-            hit: row.is_some(),
-            candidate_entries_examined: entries.len(),
+            consulted,
+            hit: physical_row_present,
+            physical_row_present,
+            fallback_active: false,
+            candidate_entries_available: entries.len(),
+            candidate_entries_examined,
+            candidate_entries_admitted: candidate_entries_examined,
         });
         Ok(())
     }
 
     fn read_attention_row(
         &self,
+        slot_index: usize,
         source: AttentionRowSource,
         key: AttentionRowKey,
         row: Option<&AttentionRow>,
+        examine_and_admit: bool,
+        fallback_active: bool,
         merged: &mut BTreeMap<GeometricAddress, AttentionSourceCounts>,
         trace: &mut Vec<AttentionRowRead>,
     ) -> Result<(), GeometricAttentionError> {
         let entries = row.map_or(&[][..], |row| row.candidates.as_slice());
         self.validate_row_entries(entries.len())?;
-        for candidate in entries {
-            merged
-                .entry(candidate.next.clone())
-                .or_default()
-                .add(source, candidate.count)?;
+        if examine_and_admit {
+            for candidate in entries {
+                merged
+                    .entry(candidate.next.clone())
+                    .or_default()
+                    .add(source, candidate.count)?;
+            }
         }
+        let candidate_entries_examined = if examine_and_admit { entries.len() } else { 0 };
+        let physical_row_present = row.is_some();
         trace.push(AttentionRowRead {
+            slot_index,
             source,
             key,
-            hit: row.is_some(),
-            candidate_entries_examined: entries.len(),
+            consulted: true,
+            hit: physical_row_present,
+            physical_row_present,
+            fallback_active,
+            candidate_entries_available: entries.len(),
+            candidate_entries_examined,
+            candidate_entries_admitted: candidate_entries_examined,
         });
         Ok(())
     }
@@ -1457,6 +1571,17 @@ fn increment_count(count: &mut u32) -> Result<(), GeometricAttentionError> {
         .checked_add(1)
         .ok_or(GeometricAttentionError::ArithmeticOverflow)?;
     Ok(())
+}
+
+fn sum_row_entries(
+    rows: &[AttentionRowRead],
+    select: impl Fn(&AttentionRowRead) -> usize,
+) -> Result<usize, GeometricAttentionError> {
+    rows.iter().try_fold(0usize, |total, row| {
+        total
+            .checked_add(select(row))
+            .ok_or(GeometricAttentionError::ArithmeticOverflow)
+    })
 }
 
 fn finalize_rows<K: Ord>(

--- a/crates/uor-r4-core/tests/local_geometric_attention_969.rs
+++ b/crates/uor-r4-core/tests/local_geometric_attention_969.rs
@@ -6,8 +6,9 @@ use uor_r4_core::canonical_lexical_ingestion::{
 };
 use uor_r4_core::prime_route_attention::GeometricAddress;
 use uor_r4_core::prime_route_geometric_attention::{
-    AttentionSourceCounts, GeometricAttentionArtifact, H4S3AngularShell, PathLeaseAttentionTrace,
-    PathLeaseControl, PathLeaseCost,
+    AttentionQueryPolicy, AttentionRowKey, AttentionRowSource, AttentionSourceCounts,
+    GeometricAttentionArtifact, H4S3AngularShell, PathLeaseAttentionTrace, PathLeaseControl,
+    PathLeaseCost, ATTENTION_ADJACENT_SPIN_ROWS, ATTENTION_ROWS_PER_QUERY,
 };
 
 const REGISTERED_TOKENS: [&str; 10] = ["aa", "bb", "cc", "dd", "gg", "ll", "qq", "rr", "uu", "vv"];
@@ -156,6 +157,76 @@ fn support_signature(
     signature
 }
 
+fn assert_adjacent_spin_fallback_contract(trace: &PathLeaseAttentionTrace) {
+    let support = &trace.support;
+    let policy = AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1;
+    assert_eq!(support.query_policy, policy);
+    assert_eq!(support.query_policy_kappa, policy.identity_kappa());
+    assert!(support.fallback_active);
+    assert_eq!(support.rows_read.len(), ATTENTION_ROWS_PER_QUERY);
+    assert_eq!(
+        support
+            .rows_read
+            .iter()
+            .map(|row| row.slot_index)
+            .collect::<Vec<_>>(),
+        (0..ATTENTION_ROWS_PER_QUERY).collect::<Vec<_>>()
+    );
+
+    let primary_rows =
+        &support.rows_read[..ATTENTION_ROWS_PER_QUERY - ATTENTION_ADJACENT_SPIN_ROWS];
+    assert!(primary_rows.iter().all(|row| {
+        row.source != AttentionRowSource::AdjacentSpin
+            && row.consulted
+            && !row.fallback_active
+            && row.candidate_entries_available == 0
+            && row.candidate_entries_examined == 0
+            && row.candidate_entries_admitted == 0
+    }));
+
+    let adjacent_rows =
+        &support.rows_read[ATTENTION_ROWS_PER_QUERY - ATTENTION_ADJACENT_SPIN_ROWS..];
+    assert_eq!(adjacent_rows.len(), ATTENTION_ADJACENT_SPIN_ROWS);
+    assert!(adjacent_rows.iter().all(|row| {
+        row.source == AttentionRowSource::AdjacentSpin
+            && matches!(&row.key, AttentionRowKey::AdjacentSpin(_))
+            && row.consulted
+            && row.fallback_active
+    }));
+    assert!(support
+        .rows_read
+        .iter()
+        .all(|row| row.hit == row.physical_row_present));
+
+    assert_eq!(support.candidate_entries_available, 2);
+    assert_eq!(support.candidate_entries_examined, 2);
+    assert_eq!(support.candidate_entries_admitted, 2);
+    assert_eq!(
+        support
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_available)
+            .sum::<usize>(),
+        2
+    );
+    assert_eq!(
+        support
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_examined)
+            .sum::<usize>(),
+        2
+    );
+    assert_eq!(
+        support
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_admitted)
+            .sum::<usize>(),
+        2
+    );
+}
+
 fn exercise_incremental_hierarchy(
     codec: &CanonicalLexicalCodec,
     history: &[&str],
@@ -269,8 +340,7 @@ fn run_smoke() -> SmokeRun {
         &right_disabled,
     ] {
         assert_eq!(support_signature(&construction, trace), expected_support);
-        assert_eq!(trace.support.rows_read.len(), 7);
-        assert_eq!(trace.support.candidate_entries_examined, 2);
+        assert_adjacent_spin_fallback_contract(trace);
         assert_eq!(trace.support.unique_candidates_before_ceiling, 2);
         assert_eq!(trace.candidates.len(), 2);
         assert_eq!(trace.memory_keys_per_candidate, 4);
@@ -375,8 +445,7 @@ fn run_smoke() -> SmokeRun {
         .unwrap();
     for trace in [&left_second_trace, &right_second_trace] {
         assert_eq!(support_signature(&construction, trace), expected_support);
-        assert_eq!(trace.support.rows_read.len(), 7);
-        assert_eq!(trace.support.candidate_entries_examined, 2);
+        assert_adjacent_spin_fallback_contract(trace);
         assert_eq!(trace.support.unique_candidates_before_ceiling, 2);
         assert_eq!(trace.candidates.len(), 2);
         assert_eq!(trace.memory_keys_per_candidate, 5);

--- a/crates/uor-r4-core/tests/local_geometric_generation_953.rs
+++ b/crates/uor-r4-core/tests/local_geometric_generation_953.rs
@@ -7,9 +7,13 @@ use uor_r4_core::canonical_lexical_ingestion::{
 use uor_r4_core::local_geometric_generation::{
     LocalGenerationControl, LocalGenerationRowSource, LocalGenerationSourceCounts,
     LocalGenerationStepTrace, LocalGenerationStopReason, LocalGeometricGenerationReport,
-    LocalGeometricGenerator,
+    LocalGeometricGenerator, LOCAL_GEOMETRIC_GENERATION_REPORT_DOMAIN,
+    LOCAL_GEOMETRIC_GENERATION_REPORT_SCHEMA,
 };
-use uor_r4_core::prime_route_geometric_attention::{H4S3AngularShell, PathLeaseCost};
+use uor_r4_core::prime_route_geometric_attention::{
+    AttentionQueryPolicy, H4S3AngularShell, PathLeaseCost,
+    PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY,
+};
 
 const REGISTERED_UNITS: [&str; 10] = [
     "active",
@@ -48,8 +52,12 @@ const CONSTRUCTION_ARTIFACT_KAPPA: &str =
 const ATTENTION_MANIFEST_KAPPA: &str =
     "blake3:55465770d59b8e27cc232e09511c59654b4c93acd074ee3f26652e4a03eb76d2";
 const CODEC_KAPPA: &str = "blake3:71aa5e35465be4da1847bbfdbb7a836a4a21194f289fd638b79b4bfe576c8c09";
-const SMOKE_RECORD_KAPPA: &str =
+const PRIOR_SMOKE_RECORD_KAPPA: &str =
     "blake3:f8738ae16585b5817108ad6c8bc1ec7aee93f9d5a6cacffaa3aa084bb643cf72";
+const QUERY_POLICY_KAPPA: &str =
+    "blake3:18c514b74b7d3e0e8796d9834c74d84745f0eddc88be0ef87236474f97a83820";
+const TIERED_POLICY_SMOKE_RECORD_KAPPA: &str =
+    "blake3:b0248e715d4eab726588f47bef5dc4bb330580096b9d2e3bd3de9162d267081c";
 
 fn conversation_input(scope: &str, sentences: &[&[&str]]) -> ConversationInput {
     let global_snapshot_units = vec![b"brave".to_vec()];
@@ -208,6 +216,13 @@ fn assert_exact_inversion(
 }
 
 fn assert_bounded_source_free_report(report: &LocalGeometricGenerationReport) {
+    assert_eq!(report.schema, LOCAL_GEOMETRIC_GENERATION_REPORT_SCHEMA);
+    assert_eq!(report.domain, LOCAL_GEOMETRIC_GENERATION_REPORT_DOMAIN);
+    assert_eq!(
+        report.query_policy,
+        PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+    );
+    assert_eq!(report.query_policy_kappa, QUERY_POLICY_KAPPA);
     assert_eq!(report.prompt_routes.len(), 4);
     assert_eq!(report.steps.len(), 2);
     assert_eq!(report.emitted_lexical_unit_ids.len(), 2);
@@ -236,8 +251,16 @@ fn assert_bounded_source_free_report(report: &LocalGeometricGenerationReport) {
     );
 
     for (step_index, step) in report.steps.iter().enumerate() {
+        assert_eq!(
+            step.query_policy,
+            PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+        );
+        assert_eq!(step.query_policy_kappa, QUERY_POLICY_KAPPA);
+        assert!(step.fallback_active);
         assert_eq!(step.support_rows.len(), 7);
+        assert_eq!(step.candidate_entries_available, 2);
         assert_eq!(step.candidate_entries_examined, 2);
+        assert_eq!(step.candidate_entries_admitted, 2);
         assert_eq!(step.unique_candidates_before_ceiling, 2);
         assert_eq!(step.memory_keys_per_candidate, 4 + step_index);
         assert_eq!(step.path_geometry_evaluations, 8 + 2 * step_index);
@@ -257,9 +280,42 @@ fn assert_bounded_source_free_report(report: &LocalGeometricGenerationReport) {
                     | LocalGenerationRowSource::LastTwo
                     | LocalGenerationRowSource::OrderedSentence
             ) {
-                assert!(!row.hit, "no exact I1/I2/IS continuation row may serve");
+                assert!(
+                    !row.physical_row_present,
+                    "no exact I1/I2/IS continuation row may serve"
+                );
             }
         }
+        let adjacent_rows = step
+            .support_rows
+            .iter()
+            .filter(|row| row.source == LocalGenerationRowSource::AdjacentSpin)
+            .collect::<Vec<_>>();
+        assert_eq!(adjacent_rows.len(), 3);
+        assert!(adjacent_rows
+            .iter()
+            .all(|row| row.consulted && row.fallback_active));
+        assert_eq!(
+            adjacent_rows
+                .iter()
+                .map(|row| row.candidate_entries_available)
+                .sum::<usize>(),
+            2
+        );
+        assert_eq!(
+            adjacent_rows
+                .iter()
+                .map(|row| row.candidate_entries_examined)
+                .sum::<usize>(),
+            2
+        );
+        assert_eq!(
+            adjacent_rows
+                .iter()
+                .map(|row| row.candidate_entries_admitted)
+                .sum::<usize>(),
+            2
+        );
         assert_eq!(
             support_signature(step),
             vec![
@@ -291,6 +347,10 @@ fn relabelled_natural_smoke_requires_generator_revision() {
         ATTENTION_MANIFEST_KAPPA
     );
     assert_eq!(artifact.codec_kappa(), CODEC_KAPPA);
+    assert_eq!(
+        AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1.identity_kappa(),
+        QUERY_POLICY_KAPPA
+    );
     let artifact_bytes = artifact.canonical_bytes().unwrap();
     let generator = LocalGeometricGenerator::from_canonical_bytes(&artifact_bytes).unwrap();
 
@@ -524,7 +584,7 @@ fn relabelled_natural_smoke_requires_generator_revision() {
     }
 
     let record = SmokeRecord {
-        schema: 1,
+        schema: 2,
         fixture_kappa: SMOKE_FIXTURE_KAPPA,
         terminal: REVISION_TERMINAL,
         left_full: &left_full,
@@ -534,5 +594,7 @@ fn relabelled_natural_smoke_requires_generator_revision() {
     };
     let record_bytes = serde_json::to_vec(&record).unwrap();
     let record_kappa = format!("blake3:{}", blake3::hash(&record_bytes).to_hex());
-    assert_eq!(record_kappa, SMOKE_RECORD_KAPPA);
+    println!("tiered_policy_relabel_smoke_record_kappa={record_kappa}");
+    assert_ne!(record_kappa, PRIOR_SMOKE_RECORD_KAPPA);
+    assert_eq!(record_kappa, TIERED_POLICY_SMOKE_RECORD_KAPPA);
 }

--- a/crates/uor-r4-core/tests/local_geometric_generation_953_natural_grammar.rs
+++ b/crates/uor-r4-core/tests/local_geometric_generation_953_natural_grammar.rs
@@ -12,7 +12,9 @@ use uor_r4_core::local_geometric_generation::{
 };
 use uor_r4_core::prime_route_attention::GeometricAddress;
 use uor_r4_core::prime_route_geometric_attention::{
-    AttentionRowSource, AttentionSourceCounts, AttentionSupportTrace, GeometricAttentionArtifact,
+    AttentionQueryPolicy, AttentionRowKey, AttentionRowSource, AttentionSourceCounts,
+    AttentionSupportTrace, GeometricAttentionArtifact,
+    PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY,
 };
 
 const IDENTITY_SCOPE: &str = "issue-953/natural-agreement-v1";
@@ -75,13 +77,18 @@ const CONSTRUCTION_ARTIFACT_KAPPA: &str =
     "blake3:b222510ccc01ed3257c8b38b743ca771f5e60c87ebf12c565f92fadbbd00332d";
 const ATTENTION_MANIFEST_KAPPA: &str =
     "blake3:1c3baf432b9fdcf2f3d90014797a5cae5850c0acba2fda63e0d6b659d49562de";
-const SUPPORT_PREFLIGHT_RECORD_KAPPA: &str =
+const PRIOR_SUPPORT_PREFLIGHT_RECORD_KAPPA: &str =
     "blake3:70375921e267b5ceff2198f879356cfb42dd6907accc0c2b720fc8b89b59b271";
+const QUERY_POLICY_KAPPA: &str =
+    "blake3:18c514b74b7d3e0e8796d9834c74d84745f0eddc88be0ef87236474f97a83820";
+const REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA: &str =
+    "blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9";
 
-// A post-run evidence binding, never an input to selection. `None` is frozen
-// in the pre-selection checkpoint; the observed record kappa may replace it
-// after the single four-arm run and its byte-identical replay.
-const FOUR_ARM_RECORD_KAPPA: Option<&str> = None;
+// A post-run evidence binding, never an input to selection. This was `None` at
+// the pre-selection checkpoint and was replaced only after the single
+// four-arm run and its byte-identical replay.
+const FOUR_ARM_RECORD_KAPPA: Option<&str> =
+    Some("blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79");
 
 struct FrozenBundle {
     codec: CanonicalLexicalCodec,
@@ -182,7 +189,7 @@ struct PreflightCandidate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct PreflightStep {
+struct LegacyPreflightStep {
     observed_routes: usize,
     rows_queried: usize,
     candidate_entries: usize,
@@ -196,13 +203,13 @@ struct PreflightStep {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct PreflightArm {
+struct LegacyPreflightArm {
     prompt_bytes: Vec<u8>,
-    steps: Vec<PreflightStep>,
+    steps: Vec<LegacyPreflightStep>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct PreflightRecord {
+struct LegacyPreflightRecord {
     schema: u32,
     fixture_kappa: String,
     codec_kappa: String,
@@ -211,15 +218,150 @@ struct PreflightRecord {
     attention_manifest_kappa: String,
     registered_surfaces: usize,
     observed_routes_per_completed_arm: usize,
-    left: PreflightArm,
-    right: PreflightArm,
+    left: LegacyPreflightArm,
+    right: LegacyPreflightArm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PreflightRowSource {
+    LastOne,
+    LastTwo,
+    OrderedSentence,
+    Divisor,
+    AdjacentSpin,
+}
+
+impl From<AttentionRowSource> for PreflightRowSource {
+    fn from(source: AttentionRowSource) -> Self {
+        match source {
+            AttentionRowSource::LastOne => Self::LastOne,
+            AttentionRowSource::LastTwo => Self::LastTwo,
+            AttentionRowSource::OrderedSentence => Self::OrderedSentence,
+            AttentionRowSource::Divisor => Self::Divisor,
+            AttentionRowSource::AdjacentSpin => Self::AdjacentSpin,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum PreflightRowKey {
+    LastOne {
+        address_kappa: String,
+    },
+    LastTwo {
+        previous_address_kappa: String,
+        last_address_kappa: String,
+    },
+    LastTwoUnavailable,
+    OrderedSentence {
+        route_kappa: String,
+    },
+    Divisor {
+        prime: u32,
+    },
+    AdjacentSpin {
+        hopf_octant: u8,
+        torsion_bin: u8,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RepairedPreflightRow {
+    slot_index: usize,
+    source: PreflightRowSource,
+    key: PreflightRowKey,
+    consulted: bool,
+    physical_row_present: bool,
+    fallback_active: bool,
+    candidate_entries_available: usize,
+    candidate_entries_examined: usize,
+    candidate_entries_admitted: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RepairedPreflightStep {
+    observed_routes: usize,
+    query_policy: String,
+    query_policy_kappa: String,
+    fallback_active: bool,
+    rows: Vec<RepairedPreflightRow>,
+    candidate_entries_available: usize,
+    candidate_entries_examined: usize,
+    candidate_entries_admitted: usize,
+    candidate_entry_ceiling: usize,
+    unique_candidates_before_ceiling: usize,
+    candidate_ceiling: usize,
+    candidates: Vec<PreflightCandidate>,
+    keys_per_candidate: usize,
+    declared_h4_comparisons: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RepairedPreflightArm {
+    prompt_bytes: Vec<u8>,
+    steps: Vec<RepairedPreflightStep>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RepairedPreflightRecord {
+    schema: u32,
+    prior_support_record_kappa: String,
+    fixture_kappa: String,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    construction_artifact_kappa: String,
+    attention_manifest_kappa: String,
+    query_policy: String,
+    query_policy_kappa: String,
+    registered_surfaces: usize,
+    observed_routes_per_completed_arm: usize,
+    left: RepairedPreflightArm,
+    right: RepairedPreflightArm,
+}
+
+fn preflight_row(
+    row: &uor_r4_core::prime_route_geometric_attention::AttentionRowRead,
+) -> RepairedPreflightRow {
+    let key = match &row.key {
+        AttentionRowKey::LastOne(address) => PreflightRowKey::LastOne {
+            address_kappa: address.canonical_kappa().unwrap(),
+        },
+        AttentionRowKey::LastTwo { previous, last } => PreflightRowKey::LastTwo {
+            previous_address_kappa: previous.canonical_kappa().unwrap(),
+            last_address_kappa: last.canonical_kappa().unwrap(),
+        },
+        AttentionRowKey::LastTwoUnavailable => PreflightRowKey::LastTwoUnavailable,
+        AttentionRowKey::OrderedSentence(route_kappa) => PreflightRowKey::OrderedSentence {
+            route_kappa: route_kappa.clone(),
+        },
+        AttentionRowKey::Divisor(atom) => PreflightRowKey::Divisor {
+            prime: atom.value(),
+        },
+        AttentionRowKey::AdjacentSpin(sector) => PreflightRowKey::AdjacentSpin {
+            hopf_octant: sector.hopf_octant,
+            torsion_bin: sector.torsion_bin,
+        },
+    };
+    RepairedPreflightRow {
+        slot_index: row.slot_index,
+        source: row.source.into(),
+        key,
+        consulted: row.consulted,
+        physical_row_present: row.physical_row_present,
+        fallback_active: row.fallback_active,
+        candidate_entries_available: row.candidate_entries_available,
+        candidate_entries_examined: row.candidate_entries_examined,
+        candidate_entries_admitted: row.candidate_entries_admitted,
+    }
 }
 
 fn preflight_step(
     bundle: &FrozenBundle,
     observed_routes: usize,
     trace: AttentionSupportTrace,
-) -> PreflightStep {
+) -> RepairedPreflightStep {
     let mut candidates = trace
         .candidates
         .into_iter()
@@ -229,27 +371,26 @@ fn preflight_step(
         })
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| left.payload_bytes.cmp(&right.payload_bytes));
-    let adjacent_spin_rows_hit = trace
-        .rows_read
-        .iter()
-        .filter(|row| row.source == AttentionRowSource::AdjacentSpin && row.hit)
-        .count();
     let declared_h4_comparisons = candidates.len() * observed_routes;
-    PreflightStep {
+    RepairedPreflightStep {
         observed_routes,
-        rows_queried: trace.rows_read.len(),
-        candidate_entries: trace.candidate_entries_examined,
+        query_policy: trace.query_policy.identity().to_owned(),
+        query_policy_kappa: trace.query_policy_kappa,
+        fallback_active: trace.fallback_active,
+        rows: trace.rows_read.iter().map(preflight_row).collect(),
+        candidate_entries_available: trace.candidate_entries_available,
+        candidate_entries_examined: trace.candidate_entries_examined,
+        candidate_entries_admitted: trace.candidate_entries_admitted,
         candidate_entry_ceiling: trace.candidate_entry_ceiling,
         unique_candidates_before_ceiling: trace.unique_candidates_before_ceiling,
         candidate_ceiling: trace.candidate_ceiling,
         candidates,
-        adjacent_spin_rows_hit,
         keys_per_candidate: observed_routes,
         declared_h4_comparisons,
     }
 }
 
-fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> PreflightArm {
+fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> RepairedPreflightArm {
     let history = history_for_prompt(bundle, prompt);
     assert_eq!(history.len(), 5);
     let mut state = bundle
@@ -257,8 +398,8 @@ fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> PreflightArm {
         .causal_state_from_history(&history)
         .unwrap();
 
-    // This method has no H4 table/cost input. The preflight projection below
-    // reads only row source/hit/count data and never inspects or logs row keys.
+    // This method has no H4 table, state, cost, or selection input. The
+    // projection records only bounded lookup keys, tier state, and support.
     let first = preflight_step(
         bundle,
         history.len(),
@@ -271,25 +412,55 @@ fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> PreflightArm {
         history.len() + 1,
         bundle.attention.query_support_only(&state).unwrap(),
     );
-    PreflightArm {
+    RepairedPreflightArm {
         prompt_bytes: prompt.to_vec(),
         steps: vec![first, second],
     }
 }
 
-fn preflight_matches_frozen_contract(arm: &PreflightArm) -> bool {
+fn adjacent_rows(step: &RepairedPreflightStep) -> Vec<&RepairedPreflightRow> {
+    step.rows
+        .iter()
+        .filter(|row| row.source == PreflightRowSource::AdjacentSpin)
+        .collect()
+}
+
+fn preflight_matches_frozen_contract(arm: &RepairedPreflightArm) -> bool {
     let Some(first) = arm.steps.first() else {
         return false;
     };
     let Some(second) = arm.steps.get(1) else {
         return false;
     };
+    let first_adjacent = adjacent_rows(first);
+    let second_adjacent = adjacent_rows(second);
     arm.steps.len() == 2
         && first.observed_routes == 5
-        && first.rows_queried == 7
-        && first.candidate_entries == 3
+        && first.query_policy == PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+        && first.query_policy_kappa == QUERY_POLICY_KAPPA
+        && !first.fallback_active
+        && first.rows.len() == 7
+        && first.candidate_entries_available == 8
+        && first.candidate_entries_examined == 3
+        && first.candidate_entries_admitted == 3
         && first.unique_candidates_before_ceiling == 1
-        && first.adjacent_spin_rows_hit == 0
+        && first_adjacent.len() == 3
+        && first_adjacent
+            .iter()
+            .all(|row| row.consulted && !row.fallback_active)
+        && first_adjacent
+            .iter()
+            .filter(|row| row.physical_row_present)
+            .count()
+            == 1
+        && first_adjacent
+            .iter()
+            .map(|row| row.candidate_entries_available)
+            .sum::<usize>()
+            == 5
+        && first_adjacent
+            .iter()
+            .all(|row| row.candidate_entries_examined == 0 && row.candidate_entries_admitted == 0)
         && first.keys_per_candidate == 5
         && first.declared_h4_comparisons == 5
         && first.candidates
@@ -298,10 +469,31 @@ fn preflight_matches_frozen_contract(arm: &PreflightArm) -> bool {
                 source_counts: [2, 1, 0, 2, 0],
             }]
         && second.observed_routes == 6
-        && second.rows_queried == 7
-        && second.candidate_entries == 6
+        && second.query_policy == PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+        && second.query_policy_kappa == QUERY_POLICY_KAPPA
+        && !second.fallback_active
+        && second.rows.len() == 7
+        && second.candidate_entries_available == 11
+        && second.candidate_entries_examined == 6
+        && second.candidate_entries_admitted == 6
         && second.unique_candidates_before_ceiling == 2
-        && second.adjacent_spin_rows_hit == 0
+        && second_adjacent.len() == 3
+        && second_adjacent
+            .iter()
+            .all(|row| row.consulted && !row.fallback_active)
+        && second_adjacent
+            .iter()
+            .filter(|row| row.physical_row_present)
+            .count()
+            == 1
+        && second_adjacent
+            .iter()
+            .map(|row| row.candidate_entries_available)
+            .sum::<usize>()
+            == 5
+        && second_adjacent
+            .iter()
+            .all(|row| row.candidate_entries_examined == 0 && row.candidate_entries_admitted == 0)
         && second.keys_per_candidate == 6
         && second.declared_h4_comparisons == 12
         && second.candidates
@@ -317,77 +509,111 @@ fn preflight_matches_frozen_contract(arm: &PreflightArm) -> bool {
             ]
 }
 
-fn assert_observed_preflight(arm: &PreflightArm) {
-    assert_eq!(arm.steps.len(), 2);
-    let first = &arm.steps[0];
-    assert_eq!(first.observed_routes, 5);
-    assert_eq!(first.rows_queried, 7);
-    assert_eq!(first.candidate_entries, 8);
-    assert_eq!(first.unique_candidates_before_ceiling, 5);
-    assert_eq!(first.candidate_ceiling, 8);
-    assert_eq!(first.adjacent_spin_rows_hit, 1);
-    assert_eq!(first.keys_per_candidate, 5);
-    assert_eq!(first.declared_h4_comparisons, 25);
-    assert_eq!(
-        first.candidates,
-        vec![
-            PreflightCandidate {
-                payload_bytes: b"athlete".to_vec(),
-                source_counts: [0, 0, 0, 0, 1],
-            },
-            PreflightCandidate {
-                payload_bytes: b"generally".to_vec(),
-                source_counts: [0, 0, 0, 0, 2],
-            },
-            PreflightCandidate {
-                payload_bytes: b"run".to_vec(),
-                source_counts: [0, 0, 0, 0, 1],
-            },
-            PreflightCandidate {
-                payload_bytes: b"runs".to_vec(),
-                source_counts: [0, 0, 0, 0, 1],
-            },
-            PreflightCandidate {
-                payload_bytes: b"still".to_vec(),
-                source_counts: [2, 1, 0, 2, 2],
-            },
-        ]
-    );
+fn preflight_arms_have_equal_support_and_work(
+    left: &RepairedPreflightArm,
+    right: &RepairedPreflightArm,
+) -> bool {
+    left.steps.len() == right.steps.len()
+        && left.steps.iter().zip(&right.steps).all(|(left, right)| {
+            left.observed_routes == right.observed_routes
+                && left.query_policy == right.query_policy
+                && left.query_policy_kappa == right.query_policy_kappa
+                && left.fallback_active == right.fallback_active
+                && left.candidate_entries_available == right.candidate_entries_available
+                && left.candidate_entries_examined == right.candidate_entries_examined
+                && left.candidate_entries_admitted == right.candidate_entries_admitted
+                && left.candidate_entry_ceiling == right.candidate_entry_ceiling
+                && left.unique_candidates_before_ceiling == right.unique_candidates_before_ceiling
+                && left.candidate_ceiling == right.candidate_ceiling
+                && left.candidates == right.candidates
+                && left.keys_per_candidate == right.keys_per_candidate
+                && left.declared_h4_comparisons == right.declared_h4_comparisons
+                && left.rows.len() == right.rows.len()
+                && left.rows.iter().zip(&right.rows).all(|(left, right)| {
+                    left.slot_index == right.slot_index
+                        && left.source == right.source
+                        && left.consulted == right.consulted
+                        && left.physical_row_present == right.physical_row_present
+                        && left.fallback_active == right.fallback_active
+                        && left.candidate_entries_available == right.candidate_entries_available
+                        && left.candidate_entries_examined == right.candidate_entries_examined
+                        && left.candidate_entries_admitted == right.candidate_entries_admitted
+                })
+        })
+}
 
-    let second = &arm.steps[1];
-    assert_eq!(second.observed_routes, 6);
-    assert_eq!(second.rows_queried, 7);
-    assert_eq!(second.candidate_entries, 11);
-    assert_eq!(second.unique_candidates_before_ceiling, 5);
-    assert_eq!(second.candidate_ceiling, 8);
-    assert_eq!(second.adjacent_spin_rows_hit, 1);
-    assert_eq!(second.keys_per_candidate, 6);
-    assert_eq!(second.declared_h4_comparisons, 30);
-    assert_eq!(
-        second.candidates,
-        vec![
-            PreflightCandidate {
-                payload_bytes: b"athlete".to_vec(),
-                source_counts: [0, 0, 0, 0, 1],
+fn prior_support_preflight_arm(prompt: &[u8]) -> LegacyPreflightArm {
+    LegacyPreflightArm {
+        prompt_bytes: prompt.to_vec(),
+        steps: vec![
+            LegacyPreflightStep {
+                observed_routes: 5,
+                rows_queried: 7,
+                candidate_entries: 8,
+                candidate_entry_ceiling: 56,
+                unique_candidates_before_ceiling: 5,
+                candidate_ceiling: 8,
+                candidates: vec![
+                    PreflightCandidate {
+                        payload_bytes: b"athlete".to_vec(),
+                        source_counts: [0, 0, 0, 0, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"generally".to_vec(),
+                        source_counts: [0, 0, 0, 0, 2],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"run".to_vec(),
+                        source_counts: [0, 0, 0, 0, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"runs".to_vec(),
+                        source_counts: [0, 0, 0, 0, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"still".to_vec(),
+                        source_counts: [2, 1, 0, 2, 2],
+                    },
+                ],
+                adjacent_spin_rows_hit: 1,
+                keys_per_candidate: 5,
+                declared_h4_comparisons: 25,
             },
-            PreflightCandidate {
-                payload_bytes: b"generally".to_vec(),
-                source_counts: [0, 0, 0, 0, 2],
+            LegacyPreflightStep {
+                observed_routes: 6,
+                rows_queried: 7,
+                candidate_entries: 11,
+                candidate_entry_ceiling: 56,
+                unique_candidates_before_ceiling: 5,
+                candidate_ceiling: 8,
+                candidates: vec![
+                    PreflightCandidate {
+                        payload_bytes: b"athlete".to_vec(),
+                        source_counts: [0, 0, 0, 0, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"generally".to_vec(),
+                        source_counts: [0, 0, 0, 0, 2],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"run".to_vec(),
+                        source_counts: [1, 1, 0, 1, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"runs".to_vec(),
+                        source_counts: [1, 1, 0, 1, 1],
+                    },
+                    PreflightCandidate {
+                        payload_bytes: b"still".to_vec(),
+                        source_counts: [0, 0, 0, 0, 2],
+                    },
+                ],
+                adjacent_spin_rows_hit: 1,
+                keys_per_candidate: 6,
+                declared_h4_comparisons: 30,
             },
-            PreflightCandidate {
-                payload_bytes: b"run".to_vec(),
-                source_counts: [1, 1, 0, 1, 1],
-            },
-            PreflightCandidate {
-                payload_bytes: b"runs".to_vec(),
-                source_counts: [1, 1, 0, 1, 1],
-            },
-            PreflightCandidate {
-                payload_bytes: b"still".to_vec(),
-                source_counts: [0, 0, 0, 0, 2],
-            },
-        ]
-    );
+        ],
+    }
 }
 
 #[test]
@@ -424,20 +650,10 @@ fn freeze_natural_agreement_contract_and_identities() {
 }
 
 #[test]
-fn natural_agreement_support_preflight_records_admission_hard_stop() {
-    let bundle = frozen_bundle();
-    assert_eq!(fixture_kappa(), FIXTURE_KAPPA);
-    assert_eq!(bundle.codec.codec_kappa(), CODEC_KAPPA);
-    assert_eq!(bundle.codec.vocabulary_kappa(), VOCABULARY_KAPPA);
-    assert_eq!(
-        bundle.artifact.manifest_kappa(),
-        CONSTRUCTION_ARTIFACT_KAPPA
-    );
-    assert_eq!(bundle.attention.manifest_kappa(), ATTENTION_MANIFEST_KAPPA);
-
-    let left = preflight_arm(&bundle, LEFT_PROMPT);
-    let right = preflight_arm(&bundle, RIGHT_PROMPT);
-    let record = PreflightRecord {
+fn prior_natural_agreement_support_hard_stop_record_is_append_only() {
+    let left = prior_support_preflight_arm(LEFT_PROMPT);
+    let right = prior_support_preflight_arm(RIGHT_PROMPT);
+    let record = LegacyPreflightRecord {
         schema: 1,
         fixture_kappa: FIXTURE_KAPPA.to_owned(),
         codec_kappa: CODEC_KAPPA.to_owned(),
@@ -451,12 +667,57 @@ fn natural_agreement_support_preflight_records_admission_hard_stop() {
     };
     let bytes = serde_json::to_vec(&record).unwrap();
     let record_kappa = format!("blake3:{}", blake3::hash(&bytes).to_hex());
-    assert_eq!(record_kappa, SUPPORT_PREFLIGHT_RECORD_KAPPA);
-    assert!(!preflight_matches_frozen_contract(&record.left));
-    assert!(!preflight_matches_frozen_contract(&record.right));
-    assert_observed_preflight(&record.left);
-    assert_observed_preflight(&record.right);
+    assert_eq!(record_kappa, PRIOR_SUPPORT_PREFLIGHT_RECORD_KAPPA);
     assert_eq!(record.left.steps, record.right.steps);
+    assert_eq!(record.left.steps[0].candidate_entries, 8);
+    assert_eq!(record.left.steps[1].candidate_entries, 11);
+}
+
+#[test]
+fn natural_agreement_support_preflight_qualifies_tiered_admission() {
+    let bundle = frozen_bundle();
+    assert_eq!(fixture_kappa(), FIXTURE_KAPPA);
+    assert_eq!(bundle.codec.codec_kappa(), CODEC_KAPPA);
+    assert_eq!(bundle.codec.vocabulary_kappa(), VOCABULARY_KAPPA);
+    assert_eq!(
+        bundle.artifact.manifest_kappa(),
+        CONSTRUCTION_ARTIFACT_KAPPA
+    );
+    assert_eq!(bundle.attention.manifest_kappa(), ATTENTION_MANIFEST_KAPPA);
+
+    let left = preflight_arm(&bundle, LEFT_PROMPT);
+    let right = preflight_arm(&bundle, RIGHT_PROMPT);
+    assert_eq!(
+        AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1.identity(),
+        PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+    );
+    assert_eq!(
+        AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1.identity_kappa(),
+        QUERY_POLICY_KAPPA
+    );
+    assert!(preflight_matches_frozen_contract(&left));
+    assert!(preflight_matches_frozen_contract(&right));
+    assert!(preflight_arms_have_equal_support_and_work(&left, &right));
+
+    let record = RepairedPreflightRecord {
+        schema: 2,
+        prior_support_record_kappa: PRIOR_SUPPORT_PREFLIGHT_RECORD_KAPPA.to_owned(),
+        fixture_kappa: FIXTURE_KAPPA.to_owned(),
+        codec_kappa: CODEC_KAPPA.to_owned(),
+        vocabulary_kappa: VOCABULARY_KAPPA.to_owned(),
+        construction_artifact_kappa: CONSTRUCTION_ARTIFACT_KAPPA.to_owned(),
+        attention_manifest_kappa: ATTENTION_MANIFEST_KAPPA.to_owned(),
+        query_policy: PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY.to_owned(),
+        query_policy_kappa: QUERY_POLICY_KAPPA.to_owned(),
+        registered_surfaces: 8,
+        observed_routes_per_completed_arm: 7,
+        left,
+        right,
+    };
+    let bytes = serde_json::to_vec(&record).unwrap();
+    let record_kappa = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    println!("repaired_support_preflight_record_kappa={record_kappa}");
+    assert_eq!(record_kappa, REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA);
 }
 
 fn emitted_payloads(report: &LocalGeometricGenerationReport) -> Vec<Vec<u8>> {
@@ -471,10 +732,25 @@ fn emitted_payloads(report: &LocalGeometricGenerationReport) -> Vec<Vec<u8>> {
         .collect()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GenerationSupportSignature {
+    rows: usize,
+    query_policy: String,
+    query_policy_kappa: String,
+    fallback_active: bool,
+    candidate_entries_available: usize,
+    candidate_entries_examined: usize,
+    candidate_entries_admitted: usize,
+    unique_candidates_before_ceiling: usize,
+    memory_keys_per_candidate: usize,
+    path_geometry_evaluations: usize,
+    candidates: Vec<(Vec<u8>, [u32; 5])>,
+}
+
 fn support_signature(
     report: &LocalGeometricGenerationReport,
     step_index: usize,
-) -> Option<(usize, usize, usize, usize, usize, Vec<(Vec<u8>, [u32; 5])>)> {
+) -> Option<GenerationSupportSignature> {
     let step = report.steps.get(step_index)?;
     let mut candidates = step
         .candidates
@@ -494,14 +770,19 @@ fn support_signature(
         })
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| left.0.cmp(&right.0));
-    Some((
-        step.support_rows.len(),
-        step.candidate_entries_examined,
-        step.unique_candidates_before_ceiling,
-        step.memory_keys_per_candidate,
-        step.path_geometry_evaluations,
+    Some(GenerationSupportSignature {
+        rows: step.support_rows.len(),
+        query_policy: step.query_policy.clone(),
+        query_policy_kappa: step.query_policy_kappa.clone(),
+        fallback_active: step.fallback_active,
+        candidate_entries_available: step.candidate_entries_available,
+        candidate_entries_examined: step.candidate_entries_examined,
+        candidate_entries_admitted: step.candidate_entries_admitted,
+        unique_candidates_before_ceiling: step.unique_candidates_before_ceiling,
+        memory_keys_per_candidate: step.memory_keys_per_candidate,
+        path_geometry_evaluations: step.path_geometry_evaluations,
         candidates,
-    ))
+    })
 }
 
 fn exact_inversion_holds(
@@ -595,6 +876,9 @@ struct FourArmRecord<'a> {
     vocabulary_kappa: &'a str,
     construction_artifact_kappa: &'a str,
     attention_manifest_kappa: &'a str,
+    query_policy: &'a str,
+    query_policy_kappa: &'a str,
+    support_preflight_record_kappa: &'a str,
     frozen_left_expected: &'a [&'a [u8]],
     frozen_right_expected: &'a [&'a [u8]],
     terminal: &'a str,
@@ -605,7 +889,7 @@ struct FourArmRecord<'a> {
 }
 
 #[test]
-#[ignore = "NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP"]
+#[ignore = "explicit frozen four-arm evidence; excluded from routine QA"]
 fn natural_agreement_four_arm_witness() {
     let bundle = frozen_bundle();
 
@@ -617,7 +901,7 @@ fn natural_agreement_four_arm_witness() {
     assert!(
         preflight_matches_frozen_contract(&left_preflight)
             && preflight_matches_frozen_contract(&right_preflight)
-            && left_preflight.steps == right_preflight.steps,
+            && preflight_arms_have_equal_support_and_work(&left_preflight, &right_preflight),
         "NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP"
     );
 
@@ -744,13 +1028,30 @@ fn natural_agreement_four_arm_witness() {
         REVISION_TERMINAL
     };
 
+    // Freeze the observed negative branch. Admission is now exact, but the
+    // decisive full-path choice is still `run` for both prompt orders.
+    assert!(first_emissions_are_still);
+    assert!(!left_full_matches);
+    assert!(right_full_matches);
+    assert!(!full_choices_are_distinct);
+    assert!(disabled_prompt_inert);
+    assert!(support_and_work_match);
+    assert!(inversion_holds);
+    assert!(bounded_closure);
+    assert!(source_boundary);
+    assert!(replay_is_identical);
+    assert_eq!(terminal, REVISION_TERMINAL);
+
     let record = FourArmRecord {
-        schema: 1,
+        schema: 2,
         fixture_kappa: FIXTURE_KAPPA,
         codec_kappa: CODEC_KAPPA,
         vocabulary_kappa: VOCABULARY_KAPPA,
         construction_artifact_kappa: CONSTRUCTION_ARTIFACT_KAPPA,
         attention_manifest_kappa: ATTENTION_MANIFEST_KAPPA,
+        query_policy: PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY,
+        query_policy_kappa: QUERY_POLICY_KAPPA,
+        support_preflight_record_kappa: REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA,
         frozen_left_expected: LEFT_EXPECTED,
         frozen_right_expected: RIGHT_EXPECTED,
         terminal,

--- a/crates/uor-r4-core/tests/prime_route_geometric_attention_958.rs
+++ b/crates/uor-r4-core/tests/prime_route_geometric_attention_958.rs
@@ -2,14 +2,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU16, NonZeroUsize};
 
 use uor_r4_core::prime_route_attention::{
-    compile_spin_manifest, GeometricAddress, ManifestProvenance, PhaseQ29, PrimeAtom,
-    PrimeRegistry, RouteSentence, SemanticAtom, SpinTorsionState, UnitS3Q30, ZPhi, ZeroPowerBridge,
+    compile_spin_manifest, GeometricAddress, ManifestProvenance, PhaseQ29, PrimeRegistry,
+    RouteSentence, SemanticAtom, SpinTorsionState, UnitS3Q30, ZPhi, ZeroPowerBridge,
 };
 use uor_r4_core::prime_route_geometric_attention::{
-    AttentionCandidateTrace, AttentionControl, AttentionGeometryIntervention, AttentionRowKey,
-    AttentionRowSource, AttentionSupportAdmission, CausalAttentionState,
-    GeometricAttentionArtifact, ATTENTION_ADJACENT_SPIN_ROWS,
-    ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY, ATTENTION_ROWS_PER_QUERY, ATTENTION_ZETA_CHANNELS,
+    AttentionCandidateTrace, AttentionControl, AttentionGeometryIntervention, AttentionQueryPolicy,
+    AttentionRowKey, AttentionRowSource, CausalAttentionState, GeometricAttentionArtifact,
+    ATTENTION_ADJACENT_SPIN_ROWS, ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY,
+    ATTENTION_ROWS_PER_QUERY, ATTENTION_ZETA_CHANNELS,
 };
 
 fn label(seed: &str) -> String {
@@ -201,8 +201,20 @@ fn lookup_is_strictly_row_and_candidate_bounded() {
         .unwrap();
     let bounds = attention.lookup_bounds();
 
+    let policy = AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1;
+    assert_eq!(trace.query_policy, policy);
+    assert_eq!(trace.query_policy_kappa, policy.identity_kappa());
+    assert_eq!(trace.manifest_kappa, attention.manifest_kappa());
     assert_eq!(trace.rows_read.len(), ATTENTION_ROWS_PER_QUERY);
     assert_eq!(bounds.rows_per_query, ATTENTION_ROWS_PER_QUERY);
+    assert_eq!(
+        trace.candidate_entry_ceiling,
+        bounds.candidate_entries_per_query
+    );
+    assert_eq!(
+        trace.candidate_ceiling,
+        bounds.unique_candidates_after_ceiling
+    );
     assert_eq!(
         trace
             .rows_read
@@ -211,12 +223,43 @@ fn lookup_is_strictly_row_and_candidate_bounded() {
             .count(),
         ATTENTION_ADJACENT_SPIN_ROWS
     );
-    assert!(trace
-        .rows_read
-        .iter()
-        .all(|row| row.candidate_entries_examined <= 3));
+    assert!(trace.rows_read.iter().enumerate().all(|(slot_index, row)| {
+        row.slot_index == slot_index
+            && row.hit == row.physical_row_present
+            && row.candidate_entries_available <= 3
+            && row.candidate_entries_examined <= row.candidate_entries_available
+            && row.candidate_entries_admitted <= row.candidate_entries_examined
+    }));
+    assert_eq!(
+        trace.candidate_entries_available,
+        trace
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_available)
+            .sum::<usize>()
+    );
+    assert_eq!(
+        trace.candidate_entries_examined,
+        trace
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_examined)
+            .sum::<usize>()
+    );
+    assert_eq!(
+        trace.candidate_entries_admitted,
+        trace
+            .rows_read
+            .iter()
+            .map(|row| row.candidate_entries_admitted)
+            .sum::<usize>()
+    );
+    assert!(trace.candidate_entries_available <= bounds.candidate_entries_per_query);
     assert!(trace.candidate_entries_examined <= bounds.candidate_entries_per_query);
+    assert!(trace.candidate_entries_admitted <= bounds.candidate_entries_per_query);
+    assert!(trace.candidate_entries_available <= ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY);
     assert!(trace.candidate_entries_examined <= ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY);
+    assert!(trace.candidate_entries_admitted <= ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY);
     assert!(trace.candidates.len() <= bounds.unique_candidates_after_ceiling);
     assert_eq!(trace.geometry_evaluations, trace.candidates.len());
     assert_eq!(trace.selected.as_ref(), trace.candidates.first());
@@ -318,9 +361,9 @@ fn last_one_last_two_and_ordered_sentence_interventions_are_observable() {
         )
         .unwrap();
     assert!(candidate(&from_p, &routes.x).source_counts.last_one > 0);
-    assert_eq!(candidate(&from_p, &routes.y).source_counts.last_one, 0);
+    assert!(!support(&from_p).contains(&routes.y));
     assert!(candidate(&from_q, &routes.y).source_counts.last_one > 0);
-    assert_eq!(candidate(&from_q, &routes.x).source_counts.last_one, 0);
+    assert!(!support(&from_q).contains(&routes.x));
 
     let from_b_c = attention
         .query(

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -27,10 +27,13 @@ assumptions, or objectives rather than measured results.
 > `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. #953 then implemented the first
 > bounded provider-free decode/render/append loop, but its exact
 > rank-preserving lexical-relabel smoke terminated
-> `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement follow-up then
-> stopped at support admission before H4 selection because adjacent-spin
-> fallback expanded the exact direct-plus-divisor unions to five candidates.
-> #953 remains active; #973 and #954 remain blocked. Legacy
+> `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement follow-up first
+> stopped at support admission under the old flat union. The versioned tiered
+> repair then restored exact `{still}` and `{run,runs}` primary support, but the
+> single four-arm run selected `still run` for both prompt orders instead of
+> the required incompatible choices. #953 remains active for a bounded
+> same-object, order-sensitive candidate-relative representation repair; #973
+> and #954 remain blocked. Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
 > current-summary corrections remain important: **#784** found
@@ -179,6 +182,31 @@ assumptions, or objectives rather than measured results.
 > The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`; the localized next
 > hypothesis is a primary tier of direct plus divisor support, with
 > adjacent-spin rows only when that primary tier is empty.
+>
+> **#953 tiered admission and selector outcome, 2026-08-27.** The versioned
+> `PrimaryThenAdjacentSpinFallbackV1` policy preserved the five frozen fixture
+> identities and produced exact `{still}` then `{run,runs}` support. Seven rows
+> were consulted at each step; 8 then 11 entries were physically available,
+> while only 3 then 6 primary entries were examined and admitted. One adjacent
+> row remained physically present with five available entries, but fallback
+> was inactive and its examined/admitted counts were zero. Left/right support
+> and work matched. The repaired support record is
+> `blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9`;
+> #969's empty-primary adjacent fallback retained its prior record.
+>
+> The one permitted four-arm experiment decoded `still run` for both full-path
+> prompts and `still runs` for both state-disabled prompts. Exact inversion,
+> append, bounded termination, no short cycle, source/provider closure, equal
+> support/work, and byte-identical replay passed. The right full-path arm was
+> correct, the left was wrong, and the full-path decisive choices were equal.
+> Record kappa:
+> `blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
+> The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`; admission is repaired,
+> and the localized next hypothesis is a construction-only, same-object,
+> order-sensitive candidate-relative compatibility/placement overlay under
+> disabled, same-artifact placement-permuted, and order-shuffled controls.
+> Generic fixed Hopf or spectral proxy activity is not decoded causal evidence.
+> No second tuned experiment was run; #973 and #954 remain blocked.
 
 The current quality-baseline reconciliation is recorded by #933 and the
 [append-only #934 genealogy](canonical_quality_baseline_934.md). The historical
@@ -416,8 +444,11 @@ classes, so the gate stopped before scalar design. The old six labels remained
 diagnostic/falsification-only. #970 closed through PR #972. #969 then delivered
 one causal ordered-S3 least-cost path mechanism with a matched two-unit decoded
 intervention. #953 now drives that selector through decoded-loop plumbing, but
-its relabel smoke did not qualify a natural grammar result. #953 remains active
-and #973 remains blocked. Dependable coherent text remains unestablished.
+its relabel smoke did not qualify a natural grammar result. Tiered admission
+then restored the frozen agreement support, but the full path chose the same
+decisive candidate for both prompt orders. #953 remains active for a bounded
+same-object/order-sensitive candidate-relative representation repair and #973
+remains blocked. Dependable coherent text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
 point remains allowed for witnessed chart construction; serving arithmetic is
@@ -511,9 +542,10 @@ classes alias outcomes and that the construction-derived rule has a 0/6 strict
 transfer ceiling on the separate sealed validation fixture. It stopped without
 scalar search and closed through PR #972. #969 then built and smoke-tested the
 single local path mechanism; #953 now executes it in bounded source-free
-decode/render/append plumbing, while its natural grammar witness remains at
-direct revision. Structural presence does not qualify the other stored fields
-for ranking. Product chat and
+decode/render/append plumbing. Its tiered admission is exact on the frozen
+agreement witness, while its current identity-derived candidate placement still
+collapses the required order-sensitive choice. Structural presence does not
+qualify the other stored fields for ranking. Product chat and
 persisted hive memory remain GI-6/#962 responsibilities. The
 retained #951 negative
 checkpoint and exact population remain in
@@ -959,10 +991,11 @@ first choices using non-identity retained prefixes. It records
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. #953 has implemented its core
 loop but records `REVISE_I1_GENERATOR_IN_PLACE` because the initial smoke is an
 exact lexical relabel of #969 rather than an incompatible natural contrast. Its
-next frozen agreement contrast stopped at admission before H4 selection when
-adjacent-spin fallback expanded exact direct-plus-divisor support to five
-candidates. #953 remains open; #973 remains blocked by #953 and continues to
-block #954.
+next frozen agreement contrast first stopped at admission under the old flat
+union. Tiered admission subsequently restored its exact support, but the single
+four-arm selector run chose `still run` for both full-path prompt orders. #953
+remains open for bounded same-object, order-sensitive candidate-relative
+representation; #973 remains blocked by #953 and continues to block #954.
 #955 invokes the eventual accepted
 #969/#953/#973/#954 path; #962 integrates that path into product chat with
 persisted identity-scoped hive memory. #963 retains measured cost; #964 binds

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -29,10 +29,13 @@ route-attention mechanism and one matched two-unit decoded smoke at
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. #953 implemented a bounded
 decoded-loop path, but its first smoke was an exact rank-preserving lexical
 relabel of #969 and terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its frozen
-natural agreement follow-up stopped at support admission before H4 selection
-because adjacent-spin fallback expanded exact direct-plus-divisor support to
-five candidates. Protected PR #978 preserved that hard stop. #953 remains
-active for a tiered-admission repair, and #973 remains blocked; paragraph,
+natural agreement follow-up first stopped at support admission under the old
+flat union. The versioned tiered repair then produced exact `{still}` and
+`{run,runs}` support with matched work and preserved #969's empty-primary
+fallback. The single permitted four-arm run still selected `still run` for both
+full-path prompt orders; state-disabled selected `still runs` for both. #953
+remains `REVISE_I1_GENERATOR_IN_PLACE` for bounded same-object, order-sensitive
+candidate-relative representation, and #973 remains blocked; paragraph,
 conversation, global, correctness, and reasoning qualification remain
 downstream.
 
@@ -442,15 +445,15 @@ nondeterminism, a short cycle, or exceeding the eight-unit state bound. Do not
 respond with a comparator expansion, metric/weight sweep, larger fixture, or a
 new issue. Repair the exact seam directly within #953.
 
-The current repair has one frozen admission policy. I1/last-one, I2/last-two,
+The implemented repair has one frozen admission policy. I1/last-one, I2/last-two,
 ordered-sentence, and divisor rows form the primary tier. With non-empty primary
-support, adjacent-spin rows may be consulted and their physical entries counted
-but admit zero candidates. Only an empty primary tier activates bounded
-adjacent-spin fallback. The trace MUST bind the policy identity and distinguish
-row slot/key, consulted, physical-row-present, entries examined, fallback
-activated, and entries admitted. Preserve PR #978's frozen construction,
-surfaces, ordering, route placement, identities, expected support, and work;
-rerun only its selection-blind support preflight before exposing H4 selection.
+support, adjacent-spin rows are consulted and their physical entries counted
+but examined/admitted as zero. Only an empty primary tier activates bounded
+adjacent-spin fallback. The trace binds the policy identity and distinguishes
+row slot/key, consulted, physical-row-present, entries available/examined,
+fallback activated, and entries admitted. The repaired preflight preserved PR
+#978's frozen construction, surfaces, ordering, route placement, identities,
+expected support, and work before exposing H4 selection.
 
 The frozen terminals are:
 
@@ -502,7 +505,37 @@ to the same five candidates. The preflight record is
 H4 path costs, selector outputs, and all four generator arms are
 `NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP`; the localized repair is a primary
 direct-plus-divisor admission tier with adjacent-spin rows used only when that
-primary tier is empty.
+primary tier is empty. That statement remains the historical old-policy stop.
+
+The versioned `PrimaryThenAdjacentSpinFallbackV1` repair subsequently produced
+the exact frozen support. At the two steps, all seven slots were consulted; 8
+then 11 entries were physically available, while only 3 then 6 primary entries
+were examined and admitted. The physical adjacent row exposed five available
+entries at both steps but examined/admitted zero because fallback was inactive.
+The left/right candidate unions, source counts, keys, and comparison budgets
+matched. Repaired support record:
+`blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9`.
+The #969 regression also retained active adjacent fallback and its prior record.
+
+The one permitted four-arm run then decoded `still run` for both full-path
+prompts and `still runs` for both state-disabled prompts. Exact inversion,
+append, bounded termination, no short cycle, source/provider closure, matched
+support/work, and byte-identical replay passed. The right full-path arm matched
+its frozen continuation, the left did not, and the two full-path choices were
+not distinct. Record:
+`blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
+The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`.
+
+The next bounded in-place hypothesis changes only the compared representation:
+compile construction-only ordered predecessor histories with the same
+versioned noncommutative encoder as the live history, induce a candidate-
+conditioned exact placement/prototype, and rank already-admitted candidates in
+that same frame. Freeze admission/work and require a same-frame anti-vacuity
+guard, state-disabled, same-artifact placement-permuted, order-shuffled, and
+held-out anti-recall controls with ties abstaining. Historical self-match and
+corpus-placement records motivate operand comparability only; they do not
+establish this decoded effect. Generic fixed Hopf or spectral proxy activity is
+not the immediate mechanism. #953 remains open and #973 remains blocked.
 
 ### A1Q-H/#973 exact-spin global operator prototype
 

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -109,16 +109,22 @@ mechanism and a matched two-unit decoded smoke at
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. #953 implemented the first
 bounded provider-free decode/render/append loop, but its initial smoke was an
 exact rank-preserving lexical relabel of #969 and terminated
-`REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement follow-up stopped
-at support admission before H4 selection because adjacent-spin fallback
-expanded exact direct-plus-divisor support to five candidates. #953 remains
-active after protected PR #978 for the smallest tiered-admission repair: direct
-I1/I2/ordered-sentence plus divisor form the primary tier, and adjacent-spin is
-an admitted fallback only when that tier is empty. #973 remains blocked and
-later owns paragraph, conversation, and global exact-spin operator
-qualification through an accepted #953 loop. Calling that operator harmonic
-additionally requires an artifact-bound basis/mode contract. #962 separately
-owns product chat integration and persisted, identity-scoped hive memory.
+`REVISE_I1_GENERATOR_IN_PLACE`. Its frozen natural agreement follow-up first
+stopped at support admission under the old flat union. The versioned
+`PrimaryThenAdjacentSpinFallbackV1` repair now reproduces exact `{still}` then
+`{run,runs}` support with matched work while retaining truthful adjacent-row
+presence and the #969 empty-primary fallback. The single permitted four-arm
+run nevertheless chose `still run` for both full-path prompt orders; disabled
+selection chose `still runs` for both. Deterministic replay and the bounded
+runtime invariants passed, but the required incompatible full-path choices did
+not. #953 therefore remains at `REVISE_I1_GENERATOR_IN_PLACE`; the localized
+next hypothesis is bounded same-object, order-sensitive corpus-induced
+candidate-relative compatibility/placement within #953. #973 remains blocked
+and later owns paragraph, conversation, and global exact-spin operator
+qualification only through an accepted #953 loop. Calling that operator
+harmonic additionally requires an artifact-bound basis/mode contract. #962
+separately owns product chat integration and persisted, identity-scoped hive
+memory.
 
 ## Architecture invariants
 
@@ -507,12 +513,14 @@ trajectory/harmonic structural summaries. #969 consumes only the local retained
 ordered-S3 path. Paragraph, conversation, and global state remain serialized
 and incrementally updated but inert for selection until #973.
 
-The next #953 revision uses typed admission precedence rather than one flat row
-union. I1/last-one, I2/last-two, ordered-sentence, and divisor rows form the
-primary tier. If that tier is non-empty, adjacent-spin rows may be consulted
-and reported but admit nothing. Only an empty primary tier activates bounded
-adjacent-spin fallback. Admission bounds and policy identity are explicit;
-exact path-cost ranking runs only over the admitted set.
+The #953 query uses typed admission precedence rather than one flat row union.
+I1/last-one, I2/last-two, ordered-sentence, and divisor rows form the primary
+tier. If that tier is non-empty, adjacent-spin rows are consulted and their
+physical availability is reported, but they are not examined or admitted.
+Only an empty primary tier activates bounded adjacent-spin fallback. Admission
+bounds and the versioned policy identity are explicit; exact path-cost ranking
+runs only over the admitted set. The frozen agreement preflight and the #969
+fallback regression both satisfy this contract.
 
 An exact kappa miss is not permission to treat a digest as semantic distance.
 The first mechanism does not combine an omnibus list of stored channels. Its
@@ -613,9 +621,10 @@ rebuildable paired-H4 state.
 Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
 `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` closed through protected PR
 #972; #969 positive bounded mechanism result
-`PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #953 loop plumbing implemented
-but natural smoke at `REVISE_I1_GENERATOR_IN_PLACE`; #953 remains active and
-#973 remains blocked**.
+`PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #953 loop plumbing and tiered
+admission implemented, but the natural selector remains at
+`REVISE_I1_GENERATOR_IN_PLACE`; #953 is active for candidate-relative
+same-object/order-sensitive representation and #973 remains blocked**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -858,15 +867,29 @@ other, the smoke cannot qualify grammar. #953 therefore records
 motivated agreement contrast was frozen before selection. Its support preflight
 found the intended direct candidates but an adjacent-spin fallback row expanded
 both steps to five candidates, so H4 selection and all four generator arms were
-`NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP`. #953 remains open for the smallest
-tiered admission repair: I1/I2/ordered-sentence plus divisor primary,
-adjacent-spin only when that tier is empty. The repaired trace must distinguish
-row consulted, physical row present, entries examined, fallback activation, and
-entries admitted. It must preserve the frozen corpus, surfaces, route placement,
-artifact identity,
-expected support, and work budget, then rerun the support-only preflight before
-any H4 selection. Harmonic ranking remains dormant in #953. #973 remains
-blocked.
+`NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP` under the old flat-union policy.
+
+The versioned tiered repair then preserved every frozen fixture identity and
+produced exact `{still}` then `{run,runs}` primary support with 3 then 6
+examined/admitted entries and 5 then 12 declared comparisons. All adjacent
+slots remained consulted and truthful; the one physical adjacent row exposed
+five available entries at both steps but examined/admitted zero while fallback
+was inactive. The #969 empty-primary fallback regression retained its original
+decoded result and record identity.
+
+After that gate passed, the only permitted natural four-arm experiment decoded
+`still run` for both full-path prompts and `still runs` for both state-disabled
+prompts. Exact inversion, append, bounded termination, no short cycle,
+source/provider closure, support/work equality, and byte-identical replay
+passed. The right full-path arm was correct, the left was wrong, and the two
+full-path decisive choices were not distinct. The record is
+`blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
+#953 remains `REVISE_I1_GENERATOR_IN_PLACE`; admission is repaired and the
+next bounded in-place hypothesis is a construction-only, same-object,
+order-sensitive candidate-relative compatibility/placement overlay under
+disabled, placement-permuted, and order-shuffled controls. Generic fixed Hopf
+or spectral proxy activity is not the missing decoded decision. Harmonic
+ranking and higher-scope work remain dormant; #973 remains blocked.
 
 ### GI-2 A1Q-H / #973 — paragraph, conversation, and global attention
 
@@ -906,8 +929,9 @@ than from `SpinTorsionState`; the existing relative H4 quaternion remains a
 route witness unless #973 binds an explicit spin-to-H4 map. Otherwise direction
 requires a new exact `SpinTorsionState` relative relation.
 
-This direction is intended to remove #953's observed support contamination and
-to give #973 a causal locus for global influence. It does not establish that
+The tiered #953 policy has removed the measured support contamination. This
+later direction would give #973 a causal locus for global influence only after
+#953 qualifies its decoded loop. It does not establish that
 the current procedural spin placement is semantic, nor does it establish broad
 grammar, coherence, correctness, or reasoning. H4 group action alone is not a
 qualified spherical-harmonic field; fixed channels/modes and their transition

--- a/docs/local_geometric_generation_953.md
+++ b/docs/local_geometric_generation_953.md
@@ -381,3 +381,173 @@ coefficients, quantization, and transition law. It does not
 establish grammar, coherence, semantic spin placement, correctness, or
 reasoning. #953 remains open at `REVISE_I1_GENERATOR_IN_PLACE`, and #973 remains
 blocked.
+
+## Tiered-admission repair and frozen selector outcome — 2026-08-27
+
+This append-only revision implements the previously frozen admission seam as
+the versioned query policy
+`uor-r4.attention-query-policy/primary-then-adjacent-spin-fallback-v1`
+(`PrimaryThenAdjacentSpinFallbackV1`). Its policy kappa is
+`blake3:18c514b74b7d3e0e8796d9834c74d84745f0eddc88be0ef87236474f97a83820`.
+Within each active tier, selection remains
+`SourceBreadthThenTotalCountThenCanonicalAddress`; the admission policy and the
+within-tier ordering policy are separate identities.
+
+Slots 0–3 are the primary I1/last-one, I2/last-two, ordered-sentence, and
+divisor rows. Slots 4–6 are the adjacent-spin center, previous, and next rows.
+Every slot is consulted and reported in deterministic order. A non-empty
+primary tier leaves adjacent rows physically visible and reports their
+available entries, but marks fallback inactive and examines and admits zero of
+those entries. Only an empty primary tier activates adjacent-spin fallback.
+The schema-2 generation report and each row trace bind the query-policy
+identity and kappa, slot, source, key, consulted flag, physical-row presence,
+fallback state, and available/examined/admitted entry counts. The existing
+seven-row and candidate ceilings remain unchanged.
+
+The repair preserved all five frozen natural-agreement identities:
+
+| Frozen object | Kappa |
+|---|---|
+| Natural agreement fixture | `blake3:0e018c9bcd43a29ed6f043665b2646c9579dd31d881d331f198fb89543184259` |
+| Canonical lexical codec | `blake3:6db64540ef344562903e01adac102f7bcc96c65908d162b1deca9b83550b35ed` |
+| Canonical vocabulary | `blake3:3b74f7ace425c039b4eab751b400f2603d92baf4ccfc9f4b8ac9409446291b58` |
+| Natural construction artifact | `blake3:b222510ccc01ed3257c8b38b743ca771f5e60c87ebf12c565f92fadbbd00332d` |
+| Embedded/compiled attention manifest | `blake3:1c3baf432b9fdcf2f3d90014797a5cae5850c0acba2fda63e0d6b659d49562de` |
+
+The prior flat-union hard-stop record
+`blake3:70375921e267b5ceff2198f879356cfb42dd6907accc0c2b720fc8b89b59b271`
+remains historical evidence. The repaired selection-blind support record is
+`blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9`.
+
+| Step | Rows | Available | Examined/admitted | Candidate union | Per-candidate source counts `(I1,I2,IS,D,AS)` | Keys/candidate | Declared H4 comparisons |
+|---:|---:|---:|---:|---|---|---:|---:|
+| prompt to `still` | 7 | 8 | 3 / 3 | `{still}` | `still=(2,1,0,2,0)` | 5 | 5 |
+| after frozen append `still` | 7 | 11 | 6 / 6 | `{run,runs}` | each `(1,1,0,1,0)` | 6 | 12 |
+
+At both steps one adjacent-spin row was physically present with five available
+entries. All three adjacent slots were consulted, fallback was false, and their
+examined/admitted counts were zero. The two prompt orders had identical
+support and work after excluding the necessarily prompt-specific canonical row
+keys. Thus the repaired preflight passed exactly before H4 selection was
+opened.
+
+The directly implicated #969 empty-primary regression also passed. Its three
+adjacent rows activated under fallback, examined and admitted exactly two
+entries, preserved its causal decoded choices and counts, and retained record
+kappa
+`blake3:60360a9e22a56ea4af363e43f7103bb8104d015d58feb582d921fc17afaf207f`.
+
+The natural-agreement selector was then executed exactly once in the four
+frozen arms, followed only by the declared complete in-test replay:
+
+| Prompt/control | Decoded continuation |
+|---|---|
+| left / full path | `still run` |
+| right / full path | `still run` |
+| left / state disabled | `still runs` |
+| right / state disabled | `still runs` |
+
+Every arm emitted the shared first unit `still`. The right full-path arm matched
+its frozen continuation, but the left full-path arm did not; both full-path
+decisive choices were the same rather than incompatible. The disabled arms
+were prompt-inert. Support/work equality, exact address-to-payload inversion,
+append, two-unit cap termination, no period-1 through period-4 short cycle,
+source/provider closure, and byte-identical replay all passed. The frozen
+four-arm record kappa is
+`blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
+The separate schema-2 relabel regression is bound by
+`blake3:b0248e715d4eab726588f47bef5dc4bb330580096b9d2e3bd3de9162d267081c`;
+its earlier schema record
+`blake3:f8738ae16585b5817108ad6c8bc1ec7aee93f9d5a6cacffaa3aa084bb643cf72`
+remains historical.
+
+The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`. Admission is no longer the
+defect, and the prompt-inert disabled control rules out candidate starvation as
+the explanation for the observed full-path collapse. The localized defect is
+that the current candidate-relative representation/scorer does not distinguish
+the two required same-object, order-sensitive agreement outcomes. No second
+tuned natural experiment was run.
+
+The next in-place #953 hypothesis is a bounded construction-only,
+corpus-induced, same-object and order-sensitive candidate-relative
+compatibility or placement overlay. It must freeze its representation,
+placement, partitions, quantization, provenance, policy identity, and kappa
+before evaluation; preserve the repaired candidate union and work; and compare
+real, disabled, same-artifact placement-permuted, and order-shuffled controls on
+held-out anti-recall histories. Historical same-object tests support this only
+as a hypothesis: exact self-match is a sanity anchor, while corpus-derived
+placement has shown selective proxy alignment without a decoded causal choice.
+Generic fixed Hopf routing, broad sector occupancy, and Poincare low-mode
+alignment do not establish the missing decision and are not the immediate
+repair. The original Markov/trigram generator, larger model/corpus runs, and
+higher-scope operator work remain dormant.
+
+The immediate operand mismatch is concrete. The current selector composes the
+live ordered fold with a candidate leaf assigned from the candidate prime modulo
+the fixed 120-root table; that identity-derived leaf is not a construction-
+induced representation of histories in which the same candidate occurred.
+The proposed local overlay instead encodes construction-only predecessor
+histories with the same versioned ordered encoder used at query time and binds
+each already-admitted candidate to one exact prototype or bounded prototype
+set. Equal exact costs abstain. A compiler/query same-frame pair must reproduce
+the same exact H4 state or report `UNAVAILABLE_FRAME_MISMATCH` before any
+quality verdict.
+
+The historical #486 same-object audit explains the guard but does not supply a
+decoder score. Routing-query self-match was chance, whereas placing both sides
+in the same content frame yielded identity self-similarity/top-1 of 1.0 and a
+shipped-probe top-1 of 0.8. On the bounded retrieval probe, content-query
+placement improved top-1/MRR/recall@20 from
+`0.6240/0.7179/0.9720` to `0.7840/0.8542/0.9900`; the exact identity result is
+tautological and retrieval is not generation. #490 retained routing state and
+changed only the comparison operand. #502's later `W=0` simplification added
+only 0.032 top-1 and 0.022 MRR at unchanged recall, below its historical 0.05
+bar. The frame-consistency audit also records a false zero caused by comparing
+rotated frames; same-frame operands restored cosine 1.0 and 1.327 separation.
+Those values are anti-vacuity/representation evidence, not promotion
+thresholds.
+
+Archived geometric evidence reinforces the boundary. Generic fixed Hopf
+routing was indistinguishable from placement-permuted or randomly permuted
+controls, including validation perplexities 164.54 versus 164.41 in a
+transformer experiment. Corpus-derived PPMI placement and selected four-
+dimensional subspaces later produced selective routing and low-frequency proxy
+alignment, including roughly 40–48% task-margin low-frequency improvement
+across four seeds, but no decoded causal choice; one preregistered shell gate
+was degenerate rather than passed. These records justify testing a frozen local
+candidate-context placement, not inserting Hopf/Poincare machinery or claiming
+semantic attention.
+
+#953 therefore remains open and assigned. The positive-only handoff to #973 is
+not activated; #973 and #954 remain blocked. This result establishes a
+versioned bounded admission policy and one negative decoded-loop witness only.
+It does not establish grammar, coherent generation, semantic placement,
+correctness, higher-scope attention, reasoning, performance advantage, formal
+closure, product readiness, or release readiness.
+
+### Focused verification for this revision
+
+The decision-bearing checks executed locally were:
+
+- the frozen natural-agreement identity, historical hard-stop, and repaired
+  support-preflight tests: 3 passed, with the explicit four-arm evidence test
+  ignored during routine replay;
+- the explicit natural four-arm witness: one permitted run passed and performed
+  its complete byte-identical replay internally;
+- the existing #953 relabel regression: passed with its schema-2 record pinned;
+- the #969 empty-primary adjacent-fallback and causal-path regression: 1 passed,
+  retaining its prior record;
+- the #958 policy identity, truthful row trace, bounds, and attention
+  regressions: 8 passed;
+- focused `uor-r4-core` all-target compilation: passed;
+- the root WASM library check required by the exported core change: passed with
+  existing warnings outside this revision;
+- formatting, changed-document claim wording, and diff-whitespace checks:
+  passed.
+
+Workspace-wide tests, strict workspace clippy, no-std ladders, corpus/model/
+teacher work, generation canaries, BDD, Gate C, kappa reproduction, cargo audit,
+fuzz, formal proof, conformance, product QA, performance measurement, and
+release qualification were `NOT_RUN`. The protected merge queue remains the
+binding integration transport; its checks are not local product or research
+qualification evidence.


### PR DESCRIPTION
## Summary

- add versioned `PrimaryThenAdjacentSpinFallbackV1` admission: I1/I2/ordered-sentence/divisor primary; adjacent-spin always consulted and truthfully traced, but examined/admitted only on empty-primary fallback
- propagate policy identity plus physical availability/examined/admitted accounting through schema-2 generation reports without changing H4 cost or selection
- preserve the frozen natural-agreement fixture identities and historical support record; bind repaired support as `blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9`
- preserve the #969 empty-primary fallback and its record

## Frozen outcome

The support preflight now matches exactly under equal left/right work:

- step 1: 7 rows, 8 available, 3 examined/admitted, `{still}`, 5 keys, 5 comparisons
- step 2: 7 rows, 11 available, 6 examined/admitted, `{run,runs}`, 6 keys, 12 comparisons
- the physical adjacent row exposes 5 available entries at both steps, with fallback false and 0 examined/admitted

The one permitted four-arm run plus internal replay produced:

- left/full: `still run`
- right/full: `still run`
- left/state-disabled: `still runs`
- right/state-disabled: `still runs`

Record: `blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.

The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`: admission is repaired, but the identity-derived candidate representation/scorer does not distinguish the required same-object, order-sensitive choice. #953 stays open; #973 and #954 stay blocked. The next bounded in-place hypothesis is construction-only candidate-context placement under same-frame, disabled, placement-permuted, order-shuffled, and held-out anti-recall controls.

## Focused verification

- natural agreement freeze/historical support/repaired preflight: 3 passed, explicit four-arm evidence ignored in routine replay
- explicit natural four-arm evidence: passed once with complete byte-identical replay
- existing #953 relabel regression: passed
- #969 adjacent-only fallback and causal-path regression: passed
- #958 policy/trace/bounds regressions: 8 passed
- `cargo check -p uor-r4-core --all-targets --offline`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib`
- `cargo fmt --all -- --check`
- `python3 scripts/check_claim_wording.py`
- `git diff --check`

Workspace-wide tests/clippy, no-std ladders, corpus/model/teacher work, BDD, Gate C, kappa reproduction, audit, fuzz, formal proof, conformance, product QA, performance, and release qualification are `NOT_RUN`.

References #953