### PR TITLE
research: hard-stop #953 local context placement preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,14 @@ non-empty. The preflight recovered exact `{still}` then `{run,runs}` support
 under equal work. One permitted four-arm run produced left/full `still run`,
 right/full `still run`, and both state-disabled arms `still runs`, with
 deterministic replay, so the terminal remains `REVISE_I1_GENERATOR_IN_PLACE`.
-The remaining bounded defect is candidate-relative representation/scoring, not
-admission or state starvation. #953 remains open for local corpus-induced
-same-object, order-sensitive candidate-relative compatibility/placement; do
-not jump directly to Poincare/Hopf/harmonic machinery. #973 and #954 remain
-blocked, followed by #955 → #962–#965.
+The first frozen local same-object, order-sensitive candidate-placement
+preflight then reproduced 7/7 construction prototypes with zero class
+collisions, but real placement selected 0/2 intended candidates while the
+same-artifact placement-permuted control selected 2/2. Generation and replay
+were `NOT_RUN`. #953 awaits a newly frozen maintainer plan; do not add a second
+representation under the failed contract or jump directly to
+Poincare/Hopf/harmonic machinery. #973 and #954 remain blocked, followed by
+#955 → #962–#965.
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
@@ -67,7 +70,8 @@ and transition law.
 
 Corpus scale follows mechanism qualification; it never substitutes for it.
 Within #973, after #953 and every required #973 scope qualify, a predeclared
-offline corpus ladder may compile causal prefix-to-observed-next-route examples,
+higher-scope/corpus-scale offline ladder may compile causal
+prefix-to-observed-next-route examples,
 multiscale summaries, versioned placement overlays that preserve immutable
 route/payload identity, and operator statistics into the source-free artifact.
 Freeze the operator family/schema, objective, scope semantics, neighborhood
@@ -239,9 +243,12 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   for both state-disabled prompts, with deterministic replay. The terminal
   therefore remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to
   candidate-relative representation/scoring rather than admission or state
-  starvation. #953 stays open for a bounded local corpus-induced same-object,
-  order-sensitive compatibility/placement revision; #973 and #954 remain
-  blocked. #954 and #955 own correctness and reasoning respectively.
+  starvation. The first frozen local candidate-placement preflight then
+  reproduced 7/7 construction prototypes with zero class collisions, but real
+  placement selected 0/2 intended candidates while its same-artifact cyclic
+  placement control selected 2/2; generation and replay were `NOT_RUN`. #953
+  awaits a newly frozen maintainer plan, while #973 and #954 remain blocked.
+  #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
 - Sequence strictly: lexical/address plumbing → local route attention →
@@ -282,10 +289,21 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   and state-disabled. #953's repaired natural agreement run carried full path
   and state-disabled arms under equal support/work: both full-path prompts chose
   `still run`, while both disabled prompts chose `still runs`. That deterministic
-  negative localizes the next revision to candidate-relative
-  representation/scoring; it does not qualify incompatible natural choices.
-  Do not add a construction/validation split, channel census, weight sweep,
-  control matrix, or higher-scope fixture to either bounded decision.
+  negative localized the next revision to candidate-relative
+  representation/scoring; it did not qualify incompatible natural choices.
+  Do not retroactively add a broad construction/validation programme, channel
+  census, weight sweep, control matrix, or higher-scope fixture to the completed
+  #969 smoke or #981 tiered-admission decision. The frozen #953 placement
+  revision permitted exactly one tiny pre-frozen construction/evaluation
+  separation: construction-only observed transitions compiled the overlay and
+  a label-free, selection-blind raw relation census froze before expected
+  continuations were attached; frozen evaluation labels could not tune it.
+  Full-history disjointness did not supply operative-representation anti-recall:
+  the decisive suffixes exactly recalled shorter construction subhistories. Its
+  exact preflight selected the opposite candidate on both prompts while the
+  placement-permuted control selected both intended candidates, so it stopped
+  before decoded generation or replay. That failure does not authorize a second
+  representation, a wider split, or broader scope under the same contract.
 - Teacher output may label or compare only after a source-free report freezes.
   It is never substituted for the product response.
 - Once #973 activates higher scopes, every hierarchy selection emits a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,14 @@ The experiment must be able to change the next programme decision:
   remained non-admitting until the primary tier was empty. The one permitted
   four-arm run produced `still run` for both full-path prompts
   and `still runs` for both state-disabled prompts, with deterministic replay.
-  The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to
-  candidate-relative representation/scoring rather than admission or state
-  starvation. #953 remains open for a bounded local corpus-induced same-object,
-  order-sensitive compatibility/placement revision; A1Q-H/#973 and GI-4/#954
-  remain blocked, with GI-5/#955 downstream. Do not promote the #953 plumbing
-  into their claims or jump directly to Poincare/Hopf/harmonic machinery.
+  The first frozen local same-object, order-sensitive candidate-placement
+  preflight then reproduced 7/7 construction prototypes with zero class
+  collisions, but real placement selected 0/2 intended candidates while the
+  same-artifact placement-permuted control selected 2/2. Generation and replay
+  were `NOT_RUN`; the terminal remains `REVISE_I1_GENERATOR_IN_PLACE`. #953
+  awaits a newly frozen maintainer plan, and the failed contract does not
+  authorize a second representation or immediate Poincare/Hopf/harmonic
+  machinery. A1Q-H/#973 and GI-4/#954 remain blocked, with GI-5/#955 downstream.
 - **Exercise the real route path.** Geometry must run before token choice and
   emit its admitted support and energy trace. Add a global-context coverage
   witness when the active issue, beginning with #973, activates higher scopes.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > repaired the frozen agreement admission to exact `{still}` then `{run,runs}`
 > support under equal work, but the one permitted four-arm run chose `still run`
 > for both full-path prompts and `still runs` for both state-disabled prompts.
-> Deterministic replay preserved `REVISE_I1_GENERATOR_IN_PLACE`: the remaining
-> defect is candidate-relative representation/scoring, not admission or state
-> starvation. #953 remains open; #973 and #954 remain blocked.
+> The frozen `LocalSameObjectContextPlacementV1` preflight then reproduced 7/7
+> construction prototypes with zero class collisions and zero
+> padding-identity aliases, but real placement selected 0/2 intended candidates
+> while the same-artifact placement-permuted and order-shuffled controls selected
+> 2/2 and 1/2. Generation and replay were `NOT_RUN`; the terminal remains
+> `REVISE_I1_GENERATOR_IN_PLACE`. #953 awaits a newly frozen maintainer plan;
+> #973 and #954 remain blocked.
 > Higher-scope attention, correct answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
@@ -171,10 +175,12 @@ and truthfully tracing adjacent-spin rows, which remained non-admitting until
 the primary tier was empty. The one permitted four-arm run produced `still run`
 for both full-path prompts and `still runs`
 for both state-disabled prompts, with deterministic replay. The terminal
-remains `REVISE_I1_GENERATOR_IN_PLACE`; the next bounded #953 action is local
-corpus-induced same-object, order-sensitive candidate-relative
-compatibility/placement, not immediate Poincare/Hopf/harmonic machinery. #953
-remains open; #973 and #954 remain blocked.
+remains `REVISE_I1_GENERATOR_IN_PLACE`. The first frozen local same-object,
+order-sensitive candidate-placement preflight then failed before generation or
+replay: real placement selected 0/2 intended candidates while its same-artifact cyclic
+placement control selected 2/2. #953 now awaits a newly frozen maintainer plan,
+not immediate Poincare/Hopf/harmonic machinery; #973 and #954 remain blocked.
+See the [append-only #953 record](docs/local_geometric_generation_953.md).
 Stored H4/Hopf/zeta/icosian and related route fields remain
 structural state, diagnostics, or controls unless the owning stage qualifies a
 specific term.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,12 @@ terminated `REVISE_I1_GENERATOR_IN_PLACE`. Its
 support, but the one permitted four-arm run chose `still run` for both full
 paths and `still runs` for both state-disabled paths under equal work and
 deterministic replay. The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`;
-#953 remains open and #973/#954 remain blocked)._
+#953's frozen `LocalSameObjectContextPlacementV1` preflight then reproduced all
+seven construction prototypes in the online frame with zero class collisions,
+but real placement resolved the two decisive candidates as `run/runs` (0/2
+intended) while the placement-permuted control resolved `runs/run` (2/2).
+Decoded generation and replay were `NOT_RUN`; #953 awaits a newly frozen
+maintainer plan and #973/#954 remain blocked)._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -42,11 +47,15 @@ deterministic replay. The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`;
 > a new exact spin-relative relation or an explicit spin-to-H4 map; the existing
 > relative H4 witness is prime-derived route state.
 
-> **Corpus-induced attention direction:** the next #953 revision is a bounded
-> local corpus-induced same-object, order-sensitive candidate-relative
-> compatibility/placement mechanism; it does not activate Poincare, Hopf, or
-> harmonic machinery. Once #953 is accepted and every required #973 scope
-> qualifies, a separately frozen offline corpus
+> **Corpus-induced attention direction:** #953's first bounded local
+> corpus-induced same-object, order-sensitive candidate-placement preflight
+> failed before decoded generation or replay because its cyclic
+> placement-permuted control outperformed real placement. The result retains
+> this direction only as an unqualified hypothesis; it does not activate
+> Poincare, Hopf, or harmonic
+> machinery or authorize a second representation under the frozen contract.
+> Once #953 is accepted and every required #973 scope
+> qualifies, a separately frozen higher-scope/corpus-scale offline induction
 > ladder may compile causal prefix-to-observed-next-route examples, multiscale
 > route summaries, versioned placement overlays that preserve immutable
 > route/payload identity, and operator statistics. More rows, hits, or trace activity are
@@ -178,10 +187,12 @@ Native GitHub relationships are the source of truth:
    four-arm run produced left/full `still run`, right/full `still run`, and both
    state-disabled arms `still runs`, with deterministic replay. The terminal
    remains `REVISE_I1_GENERATOR_IN_PLACE`, now localized to candidate-relative
-   representation/scoring rather than admission or state starvation. #953
-   remains open for a bounded local corpus-induced same-object, order-sensitive
-   compatibility/placement revision. Harmonic influence remains dormant in
-   #953. See the
+   representation/scoring rather than admission or state starvation. The first
+   frozen construction-induced placement overlay reproduced its exact classes,
+   but real placement chose `run/runs` (0/2 intended) while the cyclic
+   placement-permuted control chose `runs/run` (2/2); generation therefore
+   remained `NOT_RUN`. #953 awaits a newly frozen maintainer plan inside its
+   existing scope. Harmonic influence remains dormant in #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
 7. **GI-2 A1Q-H / #973 — higher-scope attention:** after accepted #969 and
    #953, test paragraph, conversation, and bounded global state through the
@@ -198,11 +209,12 @@ Native GitHub relationships are the source of truth:
    qualification or an explicit native scope revision. The operator is called
    harmonic only after its identity binds basis, mode order, coefficients,
    quantization, and transition law. After all bounded #973 scope gates are
-   positive, #973 activates a separately predeclared corpus-induction ladder as
-   part of its terminal and handoff to #954. Freeze the operator family,
-   objective, scope semantics, neighborhood contract, and induction rule; vary
-   only declared corpus-derived parameters under a new artifact/operator kappa
-   per rung, and rerun the bounded gate for every structural or placement epoch.
+   positive, #973 activates a separately predeclared higher-scope/corpus-scale
+   induction ladder as part of its terminal and handoff to #954. Freeze the
+   operator family, objective, scope semantics, neighborhood contract, and
+   induction rule; vary only declared corpus-derived parameters under a new
+   artifact/operator kappa per rung, and rerun the bounded gate for every
+   structural or placement epoch.
    Match support/work between controls within each rung, report support changes
    across rungs separately, and stop if scale only raises exact/backoff recall or
    table density.
@@ -234,10 +246,11 @@ protected PR #972 with its bounded heatmap-readout negative. #969's
 mechanism-first prototype reached its positive bounded terminal. #953's loop
 plumbing is implemented and tiered admission passed the frozen preflight, but
 the repaired natural agreement four-arm run made the same full-path choice for
-both prompts and preserved `REVISE_I1_GENERATOR_IN_PLACE`. #953 remains open
-for bounded local same-object, order-sensitive candidate-relative
-compatibility/placement induction; #973 and #954 remain blocked. The live chain
-is closed #970 → closed #969 → open #953 →
+both prompts and preserved `REVISE_I1_GENERATOR_IN_PLACE`. #953 awaits a newly
+frozen maintainer plan after its first bounded same-object placement preflight
+chose `run/runs` under real placement and `runs/run` under the cyclic
+placement-permuted control, so generation and replay stayed `NOT_RUN`; #973 and
+#954 remain blocked. The live chain is closed #970 → closed #969 → open #953 →
 blocked #973 → blocked #954 → #955 → #962–#965.
 Legacy tracker #949 is closed as
 superseded; #958 is retained directly under programme root #820 as GI-0
@@ -265,10 +278,15 @@ historical evidence and comparators.
   permitted four-arm run produced `still run` for both full-path prompts and
   `still runs` for both state-disabled prompts, with deterministic replay. The
   defect is now candidate-relative representation/scoring rather than
-  admission or state starvation. The next #953 action is a bounded local
-  corpus-induced same-object, order-sensitive candidate-relative
-  compatibility/placement revision, not immediate Poincare/Hopf/harmonic
-  machinery. #953 remains open; #973 and #954 remain blocked. See the
+  admission or state starvation. The frozen
+  `LocalSameObjectContextPlacementV1` census then reproduced seven of seven
+  construction prototypes with zero class collisions, but real placement chose
+  the opposite continuation on both decisive prompts while the cyclic
+  placement-permuted control chose both intended continuations. The hard gate
+  stopped before decoded generation or replay and does not authorize a second
+  representation under the same contract. #953 awaits a newly frozen maintainer
+  plan; Poincare/Hopf/harmonic machinery stays dormant, and #973/#954
+  remain blocked. See the
   [#953 record](docs/local_geometric_generation_953.md).
 
 ## Landed
@@ -388,8 +406,10 @@ historical evidence and comparators.
   implemented its decoded-loop plumbing while the tiered policy passed its
   frozen preflight. The repaired natural agreement run still made the same
   full-path choice for both prompts, so `REVISE_I1_GENERATOR_IN_PLACE` remains
-  active and #953 moves to a bounded local same-object, order-sensitive
-  candidate-relative compatibility/placement induction.
+  active. Its first bounded construction-induced placement preflight then
+  failed at a frozen-contract real-placement ceiling of 0/2 while the cyclic
+  placement-permuted control reached 2/2; generation and replay were `NOT_RUN`,
+  and #953 awaits a newly frozen maintainer plan.
   #973 and #954 are still blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a

--- a/crates/uor-r4-core/src/prime_route_geometric_attention.rs
+++ b/crates/uor-r4-core/src/prime_route_geometric_attention.rs
@@ -37,6 +37,15 @@ pub const ATTENTION_MAX_CANDIDATE_ENTRIES_PER_QUERY: usize =
     ATTENTION_ROWS_PER_QUERY * MANIFEST_MAX_CANDIDATES_PER_ROW as usize;
 pub const PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY: &str =
     "uor-r4.attention-query-policy/primary-then-adjacent-spin-fallback-v1";
+pub const LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY: &str =
+    "uor-r4.local-same-object-context-placement/1";
+pub const RECENT_SUFFIX_ORDERED_H4_TRAJECTORY_V1_IDENTITY: &str =
+    "uor-r4.recent-suffix-ordered-h4-trajectory/1";
+pub const EXACT_RECENT_SUFFIX_H4_SHELL_VECTOR_V1_IDENTITY: &str =
+    "uor-r4.exact-recent-suffix-h4-shell-vector/1";
+pub const LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH: &str = "UNAVAILABLE_FRAME_MISMATCH";
+pub const LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH: usize = 4;
+pub const LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE: usize = 4;
 /// #969's first local attention mechanism is deliberately bounded to the
 /// 2--8 lexical-unit loop named by the issue. The state keeps exact prefix
 /// products rather than a digest so every earlier route can participate in
@@ -344,6 +353,118 @@ pub struct PathLeaseAttentionTrace {
     pub tie: bool,
     pub abstained: bool,
     pub selected: Option<PathLeaseCandidateTrace>,
+}
+
+/// Frozen controls for #953's construction-only local context placement.
+/// Every control retains the admitted candidate set and the total number of
+/// prototype/trajectory comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalContextPlacementControl {
+    RealPlacement,
+    PlacementPermuted,
+    OrderShuffled,
+}
+
+/// Four exact recent-suffix folds in the frozen comparison order: suffix
+/// lengths one through four. Missing older construction slots are the typed H4
+/// identity. `fold_states` are opaque table addresses; coordinates are exposed
+/// for an auditable, integer-only representation inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextTrajectory {
+    fold_states: [OrderedH4FoldState; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    /// True when the corresponding suffix length exists in the observed
+    /// history. The shell-vector contract still evaluates identity padding as
+    /// H4 identity; selection-blind callers retain this mask so a coincident
+    /// padded/populated relation can be detected and rejected as an alias.
+    pub populated: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    pub suffix_states: [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+}
+
+/// One causal construction predecessor bound to the candidate observed
+/// immediately after it. The order-shuffled trajectory reverses the exact same
+/// predecessor multiset before applying the same encoder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextPrototype {
+    pub sentence_id: String,
+    pub transition_ordinal: usize,
+    pub predecessor_history: Vec<GeometricAddress>,
+    pub predecessor_history_kappa: String,
+    pub trajectory: LocalContextTrajectory,
+    pub order_shuffled_trajectory: LocalContextTrajectory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextCandidatePrototypeSet {
+    pub candidate: GeometricAddress,
+    pub prototypes: Vec<LocalContextPrototype>,
+}
+
+/// Exact lexicographic vector. Array ordering is the comparison contract: the
+/// most recent one-unit suffix is compared first, then lengths two, three, and
+/// four. No scalar sum or learned threshold is formed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct LocalContextPlacementCost {
+    pub suffix_shells: [H4S3AngularShell; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextPrototypeRelation {
+    pub sentence_id: String,
+    pub transition_ordinal: usize,
+    pub predecessor_history_kappa: String,
+    pub prototype_trajectory: LocalContextTrajectory,
+    pub relative_states: [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    pub cost: LocalContextPlacementCost,
+}
+
+/// Selection-blind relation inventory for one already-admitted candidate. It
+/// has no minimum, winner, address tiebreak, payload, or decoded-selection
+/// field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextCandidateRelation {
+    pub candidate: GeometricAddress,
+    pub source_counts: AttentionSourceCounts,
+    pub prototype_source_candidate: GeometricAddress,
+    pub prototype_count: usize,
+    pub prototype_relations: Vec<LocalContextPrototypeRelation>,
+}
+
+/// Cheap #953 preflight instrument. It inventories same-frame relations and
+/// bounded work without choosing or decoding any candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalContextPlacementRelationCensus {
+    pub manifest_kappa: String,
+    pub policy_identity: String,
+    pub policy_kappa: String,
+    pub overlay_kappa: String,
+    pub control: LocalContextPlacementControl,
+    pub live_trajectory: LocalContextTrajectory,
+    pub support: AttentionSupportTrace,
+    pub complete_candidate_membership: bool,
+    pub prototype_evaluations: usize,
+    pub trajectory_slot_comparisons: usize,
+    pub candidates: Vec<LocalContextCandidateRelation>,
+}
+
+/// Construction-only, same-frame candidate-conditioned placement overlay. It
+/// owns no admission rows and can compare only candidates already admitted by
+/// the caller's bound [`GeometricAttentionArtifact`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalSameObjectContextPlacementV1 {
+    schema: u32,
+    manifest_kappa: String,
+    tokenizer_cid: String,
+    corpus_cid: String,
+    compiler_cid: String,
+    cost_profile_cid: String,
+    h4_root_table_kappa: String,
+    multiplication_table_kappa: String,
+    policy_kappa: String,
+    overlay_kappa: String,
+    source_witnesses: usize,
+    source_transitions: usize,
+    prototype_sets: Vec<LocalContextCandidatePrototypeSet>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1534,6 +1655,642 @@ impl GeometricAttentionArtifact {
             ))
         })
     }
+}
+
+impl LocalSameObjectContextPlacementV1 {
+    /// Compile the frozen construction-only candidate placement from the
+    /// manifest's bounded sentence witnesses. A predecessor never crosses a
+    /// witness boundary and never includes the candidate observed after it.
+    pub fn compile_from_manifest_witnesses(
+        manifest: &CompiledSpinManifest,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, GeometricAttentionError> {
+        manifest.canonical_bytes()?;
+        validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+        if manifest.rebuild_witnesses.len() > MANIFEST_MAX_REBUILD_WITNESSES {
+            return Err(GeometricAttentionError::Invalid(
+                "rebuild witness count exceeds the local placement ceiling".to_owned(),
+            ));
+        }
+
+        let mut grouped = BTreeMap::<GeometricAddress, Vec<LocalContextPrototype>>::new();
+        let mut source_transitions = 0usize;
+        for witness in &manifest.rebuild_witnesses {
+            for transition_ordinal in 1..witness.address_indices.len() {
+                if transition_ordinal > LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH {
+                    return Err(GeometricAttentionError::Invalid(
+                        LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH.to_owned(),
+                    ));
+                }
+                let predecessor_history = witness.address_indices[..transition_ordinal]
+                    .iter()
+                    .map(|index| {
+                        manifest
+                            .addresses
+                            .get(usize::from(*index))
+                            .cloned()
+                            .ok_or_else(|| {
+                                GeometricAttentionError::Invalid(
+                                    "local placement predecessor index is out of range".to_owned(),
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let candidate = manifest
+                    .addresses
+                    .get(usize::from(witness.address_indices[transition_ordinal]))
+                    .cloned()
+                    .ok_or_else(|| {
+                        GeometricAttentionError::Invalid(
+                            "local placement candidate index is out of range".to_owned(),
+                        )
+                    })?;
+                let trajectory = encode_recent_suffix_trajectory(&predecessor_history, table)?;
+                let mut reversed_history = predecessor_history.clone();
+                reversed_history.reverse();
+                let order_shuffled_trajectory =
+                    encode_recent_suffix_trajectory(&reversed_history, table)?;
+                let predecessor_history_kappa = local_context_history_kappa(
+                    &witness.sentence_id,
+                    transition_ordinal,
+                    &predecessor_history,
+                )?;
+                let prototypes = grouped.entry(candidate).or_default();
+                prototypes.push(LocalContextPrototype {
+                    sentence_id: witness.sentence_id.clone(),
+                    transition_ordinal,
+                    predecessor_history,
+                    predecessor_history_kappa,
+                    trajectory,
+                    order_shuffled_trajectory,
+                });
+                if prototypes.len() > LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE {
+                    return Err(GeometricAttentionError::Invalid(format!(
+                        "local placement candidate exceeds its {}-prototype cap",
+                        LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE
+                    )));
+                }
+                source_transitions = source_transitions
+                    .checked_add(1)
+                    .ok_or(GeometricAttentionError::ArithmeticOverflow)?;
+            }
+        }
+        if grouped.is_empty() {
+            return Err(GeometricAttentionError::Invalid(
+                "local placement requires at least one witnessed transition".to_owned(),
+            ));
+        }
+
+        let prototype_sets = grouped
+            .into_iter()
+            .map(|(candidate, mut prototypes)| {
+                prototypes.sort_by(|left, right| {
+                    (
+                        left.sentence_id.as_str(),
+                        left.transition_ordinal,
+                        left.predecessor_history_kappa.as_str(),
+                    )
+                        .cmp(&(
+                            right.sentence_id.as_str(),
+                            right.transition_ordinal,
+                            right.predecessor_history_kappa.as_str(),
+                        ))
+                });
+                LocalContextCandidatePrototypeSet {
+                    candidate,
+                    prototypes,
+                }
+            })
+            .collect::<Vec<_>>();
+        let policy_kappa = format!(
+            "blake3:{}",
+            blake3::hash(LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY.as_bytes()).to_hex()
+        );
+        let mut overlay = Self {
+            schema: 1,
+            manifest_kappa: manifest.manifest_kappa.clone(),
+            tokenizer_cid: manifest.provenance.tokenizer_cid.clone(),
+            corpus_cid: manifest.provenance.corpus_cid.clone(),
+            compiler_cid: manifest.provenance.compiler_cid.clone(),
+            cost_profile_cid: manifest.provenance.cost_profile_cid.clone(),
+            h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+            multiplication_table_kappa: table.multiplication_table_kappa.clone(),
+            policy_kappa,
+            overlay_kappa: String::new(),
+            source_witnesses: manifest.rebuild_witnesses.len(),
+            source_transitions,
+            prototype_sets,
+        };
+        let reproduced = overlay.reproduce_overlay_kappa()?;
+        overlay.overlay_kappa = reproduced;
+        Ok(overlay)
+    }
+
+    pub const fn schema(&self) -> u32 {
+        self.schema
+    }
+
+    pub const fn policy_identity(&self) -> &'static str {
+        LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY
+    }
+
+    pub const fn encoder_identity(&self) -> &'static str {
+        RECENT_SUFFIX_ORDERED_H4_TRAJECTORY_V1_IDENTITY
+    }
+
+    pub const fn quantization_identity(&self) -> &'static str {
+        EXACT_RECENT_SUFFIX_H4_SHELL_VECTOR_V1_IDENTITY
+    }
+
+    pub fn policy_kappa(&self) -> &str {
+        &self.policy_kappa
+    }
+
+    pub fn overlay_kappa(&self) -> &str {
+        &self.overlay_kappa
+    }
+
+    pub fn manifest_kappa(&self) -> &str {
+        &self.manifest_kappa
+    }
+
+    pub fn h4_root_table_kappa(&self) -> &str {
+        &self.h4_root_table_kappa
+    }
+
+    pub fn multiplication_table_kappa(&self) -> &str {
+        &self.multiplication_table_kappa
+    }
+
+    pub fn prototype_sets(&self) -> &[LocalContextCandidatePrototypeSet] {
+        &self.prototype_sets
+    }
+
+    pub fn retained_prototypes(&self) -> usize {
+        self.prototype_sets
+            .iter()
+            .map(|set| set.prototypes.len())
+            .sum()
+    }
+
+    pub const fn source_witnesses(&self) -> usize {
+        self.source_witnesses
+    }
+
+    pub const fn source_transitions(&self) -> usize {
+        self.source_transitions
+    }
+
+    /// Canonical overlay bytes bind the final self-cleared kappa as well as
+    /// the full construction provenance and exact trajectory inventory.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, GeometricAttentionError> {
+        local_context_json(&self.overlay_wire(
+            self.overlay_kappa.clone(),
+            self.source_witnesses,
+            self.source_transitions,
+        )?)
+    }
+
+    pub fn reproduce_overlay_kappa(&self) -> Result<String, GeometricAttentionError> {
+        self.reproduce_overlay_kappa_with_counts(self.source_witnesses, self.source_transitions)
+    }
+
+    /// Encode an observed-only query history in exactly the construction
+    /// frame. This API consults no continuation row, payload, label, or future
+    /// route.
+    pub fn encode_query_history(
+        &self,
+        attention: &GeometricAttentionArtifact,
+        history: &[GeometricAddress],
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<LocalContextTrajectory, GeometricAttentionError> {
+        self.validate_frame_binding(attention, table)?;
+        if history.is_empty() || history.len() > LOCAL_PATH_ATTENTION_MAX_UNITS {
+            return Err(GeometricAttentionError::Invalid(format!(
+                "local context placement requires 1--{LOCAL_PATH_ATTENTION_MAX_UNITS} observed routes"
+            )));
+        }
+        // Reuse the production observed-address and manifest membership check;
+        // the resulting causal state is intentionally not retained here.
+        attention.causal_state_from_history(history)?;
+        encode_recent_suffix_trajectory(history, table)
+    }
+
+    /// Inventory exact candidate-relative relations over the unchanged
+    /// support-only union. It reports bounded costs but performs no selection,
+    /// payload inversion, append, rendering, or decoded generation.
+    pub fn relation_census_for_history(
+        &self,
+        attention: &GeometricAttentionArtifact,
+        history: &[GeometricAddress],
+        table: &H4BinaryIcosahedralClosure,
+        control: LocalContextPlacementControl,
+    ) -> Result<LocalContextPlacementRelationCensus, GeometricAttentionError> {
+        let live_trajectory = self.encode_query_history(attention, history, table)?;
+        let causal = attention.causal_state_from_history(history)?;
+        let support = attention.query_support_only(&causal)?;
+        if support.manifest_kappa != self.manifest_kappa
+            || support.query_policy.identity() != PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+            || support.query_policy_kappa != support.query_policy.identity_kappa()
+        {
+            return Err(GeometricAttentionError::Invalid(
+                LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH.to_owned(),
+            ));
+        }
+
+        let mut admitted = support.candidates.clone();
+        admitted.sort_by(|left, right| left.next.cmp(&right.next));
+        if admitted.is_empty() {
+            return Err(GeometricAttentionError::Invalid(
+                "local context placement requires nonempty admitted support".to_owned(),
+            ));
+        }
+        let mut prototype_evaluations = 0usize;
+        let mut candidates = Vec::with_capacity(admitted.len());
+        for (candidate_index, candidate) in admitted.iter().enumerate() {
+            let prototype_source_candidate = match control {
+                LocalContextPlacementControl::PlacementPermuted => admitted
+                    [(candidate_index + 1) % admitted.len()]
+                .next
+                .clone(),
+                LocalContextPlacementControl::RealPlacement
+                | LocalContextPlacementControl::OrderShuffled => candidate.next.clone(),
+            };
+            let prototype_set =
+                self.prototype_set(&prototype_source_candidate)
+                    .ok_or_else(|| {
+                        GeometricAttentionError::Invalid(
+                            "admitted candidate has no bounded local context prototype".to_owned(),
+                        )
+                    })?;
+            let mut prototype_relations = Vec::new();
+            for prototype in &prototype_set.prototypes {
+                let prototype_trajectory = match control {
+                    LocalContextPlacementControl::OrderShuffled => {
+                        &prototype.order_shuffled_trajectory
+                    }
+                    LocalContextPlacementControl::RealPlacement
+                    | LocalContextPlacementControl::PlacementPermuted => &prototype.trajectory,
+                };
+                let (relative_states, cost) =
+                    local_context_relation(prototype_trajectory, &live_trajectory, table)?;
+                prototype_relations.push(LocalContextPrototypeRelation {
+                    sentence_id: prototype.sentence_id.clone(),
+                    transition_ordinal: prototype.transition_ordinal,
+                    predecessor_history_kappa: prototype.predecessor_history_kappa.clone(),
+                    prototype_trajectory: prototype_trajectory.clone(),
+                    relative_states,
+                    cost,
+                });
+                prototype_evaluations = prototype_evaluations
+                    .checked_add(1)
+                    .ok_or(GeometricAttentionError::ArithmeticOverflow)?;
+            }
+            candidates.push(LocalContextCandidateRelation {
+                candidate: candidate.next.clone(),
+                source_counts: candidate.source_counts,
+                prototype_source_candidate,
+                prototype_count: prototype_relations.len(),
+                prototype_relations,
+            });
+        }
+        let trajectory_slot_comparisons = prototype_evaluations
+            .checked_mul(LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH)
+            .ok_or(GeometricAttentionError::ArithmeticOverflow)?;
+        Ok(LocalContextPlacementRelationCensus {
+            manifest_kappa: self.manifest_kappa.clone(),
+            policy_identity: LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY.to_owned(),
+            policy_kappa: self.policy_kappa.clone(),
+            overlay_kappa: self.overlay_kappa.clone(),
+            control,
+            live_trajectory,
+            support,
+            complete_candidate_membership: true,
+            prototype_evaluations,
+            trajectory_slot_comparisons,
+            candidates,
+        })
+    }
+
+    fn validate_frame_binding(
+        &self,
+        attention: &GeometricAttentionArtifact,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<(), GeometricAttentionError> {
+        if attention.manifest_kappa() != self.manifest_kappa
+            || table.h4_root_table_kappa != self.h4_root_table_kappa
+            || table.multiplication_table_kappa != self.multiplication_table_kappa
+        {
+            return Err(GeometricAttentionError::Invalid(
+                LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH.to_owned(),
+            ));
+        }
+        validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)
+    }
+
+    fn prototype_set(
+        &self,
+        candidate: &GeometricAddress,
+    ) -> Option<&LocalContextCandidatePrototypeSet> {
+        self.prototype_sets
+            .binary_search_by(|set| set.candidate.cmp(candidate))
+            .ok()
+            .and_then(|index| self.prototype_sets.get(index))
+    }
+
+    fn reproduce_overlay_kappa_with_counts(
+        &self,
+        source_witnesses: usize,
+        source_transitions: usize,
+    ) -> Result<String, GeometricAttentionError> {
+        let wire = self.overlay_wire(String::new(), source_witnesses, source_transitions)?;
+        let bytes = local_context_json(&wire)?;
+        Ok(format!("blake3:{}", blake3::hash(&bytes).to_hex()))
+    }
+
+    fn overlay_wire(
+        &self,
+        overlay_kappa: String,
+        source_witnesses: usize,
+        source_transitions: usize,
+    ) -> Result<LocalContextOverlayWire, GeometricAttentionError> {
+        let source_witnesses = u16::try_from(source_witnesses).map_err(|_| {
+            GeometricAttentionError::Invalid(
+                "local context source-witness count exceeds its wire width".to_owned(),
+            )
+        })?;
+        let source_transitions = u32::try_from(source_transitions).map_err(|_| {
+            GeometricAttentionError::Invalid(
+                "local context source-transition count exceeds its wire width".to_owned(),
+            )
+        })?;
+        let retained_candidates = u16::try_from(self.prototype_sets.len()).map_err(|_| {
+            GeometricAttentionError::Invalid(
+                "local context candidate count exceeds its wire width".to_owned(),
+            )
+        })?;
+        let retained_prototypes = u32::try_from(self.retained_prototypes()).map_err(|_| {
+            GeometricAttentionError::Invalid(
+                "local context prototype count exceeds its wire width".to_owned(),
+            )
+        })?;
+        let prototype_sets = self
+            .prototype_sets
+            .iter()
+            .map(|set| {
+                let candidate_address_kappa = set.candidate.canonical_kappa()?;
+                let prototypes = set
+                    .prototypes
+                    .iter()
+                    .map(|prototype| {
+                        let predecessor_address_kappas = prototype
+                            .predecessor_history
+                            .iter()
+                            .map(GeometricAddress::canonical_kappa)
+                            .collect::<Result<Vec<_>, _>>()?;
+                        Ok(LocalContextPrototypeWire {
+                            sentence_id: prototype.sentence_id.clone(),
+                            transition_ordinal: u16::try_from(prototype.transition_ordinal)
+                                .map_err(|_| {
+                                    PrimeRouteError::Invalid(
+                                        "local context transition ordinal exceeds its wire width"
+                                            .to_owned(),
+                                    )
+                                })?,
+                            predecessor_length: u8::try_from(prototype.predecessor_history.len())
+                                .map_err(|_| {
+                                PrimeRouteError::Invalid(
+                                    "local context predecessor length exceeds its wire width"
+                                        .to_owned(),
+                                )
+                            })?,
+                            predecessor_history_kappa: prototype.predecessor_history_kappa.clone(),
+                            predecessor_address_kappas,
+                            trajectory: LocalContextTrajectoryWire::from(&prototype.trajectory),
+                            order_shuffled_trajectory: LocalContextTrajectoryWire::from(
+                                &prototype.order_shuffled_trajectory,
+                            ),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, PrimeRouteError>>()?;
+                Ok(LocalContextPrototypeSetWire {
+                    candidate_address_kappa,
+                    prototypes,
+                })
+            })
+            .collect::<Result<Vec<_>, PrimeRouteError>>()?;
+        Ok(LocalContextOverlayWire {
+            schema: self.schema,
+            domain: LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY.to_owned(),
+            policy_identity: LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY.to_owned(),
+            policy_kappa: self.policy_kappa.clone(),
+            admission_policy_identity: PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY.to_owned(),
+            admission_policy_kappa: AttentionQueryPolicy::PrimaryThenAdjacentSpinFallbackV1
+                .identity_kappa(),
+            encoder_identity: RECENT_SUFFIX_ORDERED_H4_TRAJECTORY_V1_IDENTITY.to_owned(),
+            quantization_identity: EXACT_RECENT_SUFFIX_H4_SHELL_VECTOR_V1_IDENTITY.to_owned(),
+            manifest_kappa: self.manifest_kappa.clone(),
+            tokenizer_cid: self.tokenizer_cid.clone(),
+            corpus_cid: self.corpus_cid.clone(),
+            compiler_cid: self.compiler_cid.clone(),
+            cost_profile_cid: self.cost_profile_cid.clone(),
+            h4_root_table_kappa: self.h4_root_table_kappa.clone(),
+            multiplication_table_kappa: self.multiplication_table_kappa.clone(),
+            frame_width: LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH as u8,
+            padding_contract: "typed-h4-identity-with-explicit-population-mask".to_owned(),
+            slot_order: "recent-suffix-lengths-1-2-3-4".to_owned(),
+            comparison_order: "lexicographic-shortest-suffix-first".to_owned(),
+            prototype_cap_per_candidate: LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE as u8,
+            source_witnesses,
+            source_transitions,
+            retained_candidates,
+            retained_prototypes,
+            prototype_sets,
+            overlay_kappa,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct LocalContextHistoryWire {
+    domain: String,
+    sentence_id: String,
+    transition_ordinal: u16,
+    predecessor_address_kappas: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct LocalContextTrajectoryWire {
+    populated: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    suffix_states: [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+}
+
+impl From<&LocalContextTrajectory> for LocalContextTrajectoryWire {
+    fn from(trajectory: &LocalContextTrajectory) -> Self {
+        Self {
+            populated: trajectory.populated,
+            suffix_states: trajectory.suffix_states,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LocalContextPrototypeWire {
+    sentence_id: String,
+    transition_ordinal: u16,
+    predecessor_length: u8,
+    predecessor_history_kappa: String,
+    predecessor_address_kappas: Vec<String>,
+    trajectory: LocalContextTrajectoryWire,
+    order_shuffled_trajectory: LocalContextTrajectoryWire,
+}
+
+#[derive(Serialize)]
+struct LocalContextPrototypeSetWire {
+    candidate_address_kappa: String,
+    prototypes: Vec<LocalContextPrototypeWire>,
+}
+
+#[derive(Serialize)]
+struct LocalContextOverlayWire {
+    schema: u32,
+    domain: String,
+    policy_identity: String,
+    policy_kappa: String,
+    admission_policy_identity: String,
+    admission_policy_kappa: String,
+    encoder_identity: String,
+    quantization_identity: String,
+    manifest_kappa: String,
+    tokenizer_cid: String,
+    corpus_cid: String,
+    compiler_cid: String,
+    cost_profile_cid: String,
+    h4_root_table_kappa: String,
+    multiplication_table_kappa: String,
+    frame_width: u8,
+    padding_contract: String,
+    slot_order: String,
+    comparison_order: String,
+    prototype_cap_per_candidate: u8,
+    source_witnesses: u16,
+    source_transitions: u32,
+    retained_candidates: u16,
+    retained_prototypes: u32,
+    prototype_sets: Vec<LocalContextPrototypeSetWire>,
+    overlay_kappa: String,
+}
+
+fn local_context_json<T: Serialize>(value: &T) -> Result<Vec<u8>, GeometricAttentionError> {
+    serde_json::to_vec(value).map_err(|error| {
+        GeometricAttentionError::Invalid(format!(
+            "local context placement serialization failed: {error}"
+        ))
+    })
+}
+
+fn local_context_history_kappa(
+    sentence_id: &str,
+    transition_ordinal: usize,
+    predecessor_history: &[GeometricAddress],
+) -> Result<String, GeometricAttentionError> {
+    let predecessor_address_kappas = predecessor_history
+        .iter()
+        .map(GeometricAddress::canonical_kappa)
+        .collect::<Result<Vec<_>, _>>()?;
+    let wire = LocalContextHistoryWire {
+        domain: "uor-r4.local-context-construction-predecessor/1".to_owned(),
+        sentence_id: sentence_id.to_owned(),
+        transition_ordinal: u16::try_from(transition_ordinal).map_err(|_| {
+            GeometricAttentionError::Invalid(
+                "local context transition ordinal exceeds its wire width".to_owned(),
+            )
+        })?,
+        predecessor_address_kappas,
+    };
+    let bytes = local_context_json(&wire)?;
+    Ok(format!("blake3:{}", blake3::hash(&bytes).to_hex()))
+}
+
+fn encode_recent_suffix_trajectory(
+    history: &[GeometricAddress],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<LocalContextTrajectory, GeometricAttentionError> {
+    validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+    let identity = OrderedH4FoldState::identity(table).map_err(ordered_h4_error)?;
+    let mut fold_states = Vec::with_capacity(LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH);
+    let mut suffix_states = Vec::with_capacity(LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH);
+    let mut populated = [false; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH];
+    for (suffix_offset, slot_populated) in populated.iter_mut().enumerate() {
+        let suffix_length = suffix_offset + 1;
+        let fold = if history.len() >= suffix_length {
+            *slot_populated = true;
+            history[history.len() - suffix_length..].iter().try_fold(
+                identity,
+                |fold, address| {
+                    let leaf =
+                        h4_leaf_state_for_address(address, table).map_err(ordered_h4_error)?;
+                    fold.compose(leaf, table).map_err(ordered_h4_error)
+                },
+            )?
+        } else {
+            identity
+        };
+        fold_states.push(fold);
+        suffix_states.push(fold.root_coordinate(table).map_err(ordered_h4_error)?);
+    }
+    let fold_states = fold_states.try_into().map_err(|_| {
+        GeometricAttentionError::Invalid(
+            "local context trajectory did not fill its frozen frame".to_owned(),
+        )
+    })?;
+    let suffix_states = suffix_states.try_into().map_err(|_| {
+        GeometricAttentionError::Invalid(
+            "local context trajectory coordinate frame is incomplete".to_owned(),
+        )
+    })?;
+    Ok(LocalContextTrajectory {
+        fold_states,
+        populated,
+        suffix_states,
+    })
+}
+
+fn local_context_relation(
+    prototype: &LocalContextTrajectory,
+    live: &LocalContextTrajectory,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<
+    (
+        [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+        LocalContextPlacementCost,
+    ),
+    GeometricAttentionError,
+> {
+    validate_ordered_h4_table_exact(table).map_err(ordered_h4_error)?;
+    let mut relative_states = Vec::with_capacity(LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH);
+    let mut suffix_shells = Vec::with_capacity(LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH);
+    for slot in 0..LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH {
+        let inverse = prototype.fold_states[slot]
+            .inverse(table)
+            .map_err(ordered_h4_error)?;
+        let relative = inverse
+            .compose(live.fold_states[slot], table)
+            .map_err(ordered_h4_error)?;
+        relative_states.push(relative.root_coordinate(table).map_err(ordered_h4_error)?);
+        suffix_shells.push(h4_s3_angular_shell(relative, table)?);
+    }
+    let relative_states = relative_states.try_into().map_err(|_| {
+        GeometricAttentionError::Invalid(
+            "local context relative-state frame is incomplete".to_owned(),
+        )
+    })?;
+    let suffix_shells = suffix_shells.try_into().map_err(|_| {
+        GeometricAttentionError::Invalid(
+            "local context shell-vector frame is incomplete".to_owned(),
+        )
+    })?;
+    Ok((relative_states, LocalContextPlacementCost { suffix_shells }))
 }
 
 /// Exact monotone class of the S3 great-circle distance from the identity.

--- a/crates/uor-r4-core/tests/local_geometric_generation_953_natural_grammar.rs
+++ b/crates/uor-r4-core/tests/local_geometric_generation_953_natural_grammar.rs
@@ -1,10 +1,10 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
 use uor_r4_core::canonical_lexical_ingestion::{
-    canonical_global_epoch, CanonicalLexicalCodec, CanonicalRouteArtifact, ConversationInput,
-    ParagraphInput, TurnInput,
+    canonical_global_epoch, validate_h4_binary_icosahedral_closure, CanonicalLexicalCodec,
+    CanonicalRouteArtifact, ConversationInput, H4RootCoordinate, ParagraphInput, TurnInput,
 };
 use uor_r4_core::local_geometric_generation::{
     LocalGenerationControl, LocalGenerationSourceCounts, LocalGenerationStopReason,
@@ -13,8 +13,14 @@ use uor_r4_core::local_geometric_generation::{
 use uor_r4_core::prime_route_attention::GeometricAddress;
 use uor_r4_core::prime_route_geometric_attention::{
     AttentionQueryPolicy, AttentionRowKey, AttentionRowSource, AttentionSourceCounts,
-    AttentionSupportTrace, GeometricAttentionArtifact,
+    AttentionSupportTrace, GeometricAttentionArtifact, H4S3AngularShell,
+    LocalContextPlacementControl, LocalContextPlacementCost, LocalContextPlacementRelationCensus,
+    LocalContextTrajectory, LocalSameObjectContextPlacementV1,
+    EXACT_RECENT_SUFFIX_H4_SHELL_VECTOR_V1_IDENTITY, LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH,
+    LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH, LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE,
+    LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY,
     PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY,
+    RECENT_SUFFIX_ORDERED_H4_TRAJECTORY_V1_IDENTITY,
 };
 
 const IDENTITY_SCOPE: &str = "issue-953/natural-agreement-v1";
@@ -66,6 +72,30 @@ const FIXTURE_IDENTITY_BYTES: &[u8] = b"uor-r4.local-geometric-natural-agreement
 \ntermination=cap\
 \ncycle=period-1-through-4-requires-three-equal-trailing-periods";
 
+// Unlike FIXTURE_IDENTITY_BYTES, this selection-blind input identity contains
+// no expected continuation or terminal that could attach a held-out label to
+// construction, support, trajectory encoding, or relation enumeration.
+const LOCAL_CONTEXT_PREFLIGHT_INPUT_BYTES: &[u8] =
+    b"uor-r4.local-context-placement-preflight-input/1\
+\nidentity_scope=issue-953/natural-agreement-v1\
+\nturn_id=turn-0001\
+\nglobal_snapshot=near\
+\nconstruction_0001=athletes generally still run\
+\nconstruction_0002=one athlete generally still runs\
+\nregistered_surfaces=athlete|athletes|generally|near|one|run|runs|still\
+\nleft_prompt=one athlete near athletes generally\
+\nright_prompt=athletes near one athlete generally\
+\nadmission_policy=uor-r4.attention-query-policy/primary-then-adjacent-spin-fallback-v1\
+\nplacement_policy=uor-r4.local-same-object-context-placement/1\
+\nencoder=uor-r4.recent-suffix-ordered-h4-trajectory/1\
+\nrelation=uor-r4.exact-recent-suffix-h4-shell-vector/1\
+\ncontrols=real-placement|placement-permuted|order-shuffled\
+\nframe_width=4\
+\npadding=typed-h4-identity-with-explicit-population-mask\
+\nslot_order=recent-suffix-lengths-1-2-3-4\
+\ncomparison_order=lexicographic-shortest-suffix-first\
+\nprototype_cap_per_candidate=4";
+
 // These five identities are filled only from the pre-selection freeze test,
 // before the ignored four-arm selector witness is ever executed.
 const FIXTURE_KAPPA: &str =
@@ -83,6 +113,20 @@ const QUERY_POLICY_KAPPA: &str =
     "blake3:18c514b74b7d3e0e8796d9834c74d84745f0eddc88be0ef87236474f97a83820";
 const REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA: &str =
     "blake3:aab38fc513521cdd495bad74cc4a87754ec43ecdef5cb6e098b101412d3d7fe9";
+
+// These #953 placement identities are frozen from the selection-blind
+// relation census before its vectors are attached to the held-out expected
+// continuations. The decoded generator is not invoked by either preflight.
+const LOCAL_CONTEXT_PLACEMENT_POLICY_KAPPA: Option<&str> =
+    Some("blake3:e09af2db10f41efaf02b24e075a97fe42dc966834c43566689579763ba95b49c");
+const LOCAL_CONTEXT_PLACEMENT_OVERLAY_KAPPA: Option<&str> =
+    Some("blake3:2be03c8acc1e97d1ba830805653ec1b16745065127ee1e00cb431b933a173ee1");
+const LOCAL_CONTEXT_PREFLIGHT_INPUT_KAPPA: Option<&str> =
+    Some("blake3:ce5430048c3789e85e18ed17a80f10f79d317a66769ad8be0fd28224668eb72e");
+const LOCAL_CONTEXT_RELATION_CENSUS_KAPPA: Option<&str> =
+    Some("blake3:50e67c087e1ec5e04aa47cf09d42e9b0857c15e4cafa07b1363d67faf96c6aeb");
+const LOCAL_CONTEXT_PREFLIGHT_OUTCOME_KAPPA: Option<&str> =
+    Some("blake3:d5e2f3614c8f1d3c6c629e2261ec42dc970fa5484982b2a86cb4f4b06b06a372");
 
 // A post-run evidence binding, never an input to selection. This was `None` at
 // the pre-selection checkpoint and was replaced only after the single
@@ -133,17 +177,15 @@ fn fixture_kappa() -> String {
     format!("blake3:{}", blake3::hash(FIXTURE_IDENTITY_BYTES).to_hex())
 }
 
-fn address_for_surface(bundle: &FrozenBundle, surface: &[u8]) -> GeometricAddress {
-    let encoded = bundle.codec.encode(0, 0, surface).unwrap();
-    assert_eq!(bundle.codec.decode(&encoded).unwrap(), surface);
-    assert_eq!(encoded.units.len(), 1);
-    assert!(encoded.units[0].leading_bytes.is_empty());
-    assert!(encoded.trailing_bytes.is_empty());
-    bundle
-        .artifact
-        .lexical_route_address(encoded.units[0].unit_id)
-        .unwrap()
-        .unwrap()
+fn local_context_preflight_input_kappa() -> String {
+    format!(
+        "blake3:{}",
+        blake3::hash(LOCAL_CONTEXT_PREFLIGHT_INPUT_BYTES).to_hex()
+    )
+}
+
+fn local_context_placement_generation_authorized() -> bool {
+    false
 }
 
 fn history_for_prompt(bundle: &FrozenBundle, prompt: &[u8]) -> Vec<GeometricAddress> {
@@ -390,26 +432,44 @@ fn preflight_step(
     }
 }
 
-fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> RepairedPreflightArm {
-    let history = history_for_prompt(bundle, prompt);
+fn decisive_history_from_singleton_support(
+    bundle: &FrozenBundle,
+    prompt: &[u8],
+) -> (Vec<GeometricAddress>, AttentionSupportTrace) {
+    let mut history = history_for_prompt(bundle, prompt);
     assert_eq!(history.len(), 5);
-    let mut state = bundle
+    let state = bundle
         .attention
         .causal_state_from_history(&history)
+        .unwrap();
+    let support = bundle.attention.query_support_only(&state).unwrap();
+    assert_eq!(support.candidates.len(), 1);
+    let observed = support.candidates[0].next.clone();
+    // This is an audit of the construction-derived singleton output, never a
+    // literal candidate supplied to the causal history.
+    assert_eq!(payload_for_address(bundle, &observed), b"still");
+    history.push(observed);
+    (history, support)
+}
+
+fn preflight_arm(bundle: &FrozenBundle, prompt: &[u8]) -> RepairedPreflightArm {
+    let (history, first_support) = decisive_history_from_singleton_support(bundle, prompt);
+    let prompt_history = &history[..history.len() - 1];
+    let mut state = bundle
+        .attention
+        .causal_state_from_history(prompt_history)
         .unwrap();
 
     // This method has no H4 table, state, cost, or selection input. The
     // projection records only bounded lookup keys, tier state, and support.
-    let first = preflight_step(
-        bundle,
-        history.len(),
-        bundle.attention.query_support_only(&state).unwrap(),
-    );
-    let still = address_for_surface(bundle, b"still");
-    bundle.attention.observe(&mut state, still).unwrap();
+    let first = preflight_step(bundle, prompt_history.len(), first_support);
+    bundle
+        .attention
+        .observe(&mut state, history.last().unwrap().clone())
+        .unwrap();
     let second = preflight_step(
         bundle,
-        history.len() + 1,
+        history.len(),
         bundle.attention.query_support_only(&state).unwrap(),
     );
     RepairedPreflightArm {
@@ -720,6 +780,1070 @@ fn natural_agreement_support_preflight_qualifies_tiered_admission() {
     assert_eq!(record_kappa, REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA);
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementTrajectoryRecord {
+    populated: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    suffix_states: [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+}
+
+impl From<&LocalContextTrajectory> for PlacementTrajectoryRecord {
+    fn from(trajectory: &LocalContextTrajectory) -> Self {
+        Self {
+            populated: trajectory.populated,
+            suffix_states: trajectory.suffix_states,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementPrototypeRecord {
+    candidate_payload_bytes: Vec<u8>,
+    candidate_address_kappa: String,
+    sentence_id: String,
+    transition_ordinal: usize,
+    predecessor_length: usize,
+    predecessor_history_kappa: String,
+    predecessor_address_kappas: Vec<String>,
+    trajectory: PlacementTrajectoryRecord,
+    order_shuffled_trajectory: PlacementTrajectoryRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementPrototypeRelationRecord {
+    sentence_id: String,
+    transition_ordinal: usize,
+    predecessor_history_kappa: String,
+    prototype_trajectory: PlacementTrajectoryRecord,
+    population_match: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    padding_identity_alias: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    exact_slot_match: [bool; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    relative_states: [H4RootCoordinate; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH],
+    cost: LocalContextPlacementCost,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementCandidateRelationRecord {
+    candidate_payload_bytes: Vec<u8>,
+    candidate_address_kappa: String,
+    source_counts: [u32; 5],
+    prototype_source_payload_bytes: Option<Vec<u8>>,
+    prototype_source_address_kappa: Option<String>,
+    prototype_count: usize,
+    prototype_relations: Vec<PlacementPrototypeRelationRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementControlRecord {
+    control: LocalContextPlacementControl,
+    manifest_kappa: String,
+    placement_policy: String,
+    placement_policy_kappa: String,
+    overlay_kappa: String,
+    live_trajectory: PlacementTrajectoryRecord,
+    query_policy: String,
+    query_policy_kappa: String,
+    fallback_active: bool,
+    support_rows: usize,
+    candidate_entries_available: usize,
+    candidate_entries_examined: usize,
+    candidate_entries_admitted: usize,
+    candidate_entry_ceiling: usize,
+    unique_candidates_before_ceiling: usize,
+    candidate_ceiling: usize,
+    candidate_union: Vec<Vec<u8>>,
+    inherited_path_keys_per_candidate: usize,
+    inherited_path_comparisons: usize,
+    complete_candidate_membership: bool,
+    prototype_evaluations: usize,
+    trajectory_slot_comparisons: usize,
+    candidates: Vec<PlacementCandidateRelationRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PlacementPromptRelationRecord {
+    prompt_bytes: Vec<u8>,
+    decisive_observed_routes: usize,
+    real: PlacementControlRecord,
+    placement_permuted: PlacementControlRecord,
+    order_shuffled: PlacementControlRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct LocalContextRelationCensusRecord {
+    schema: u32,
+    preflight_input_kappa: String,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    construction_artifact_kappa: String,
+    attention_manifest_kappa: String,
+    query_policy: String,
+    query_policy_kappa: String,
+    overlay_schema: u32,
+    overlay_policy: String,
+    overlay_policy_kappa: String,
+    encoder_identity: String,
+    quantization_identity: String,
+    overlay_kappa: String,
+    h4_root_table_kappa: String,
+    multiplication_table_kappa: String,
+    frame_width: usize,
+    padding_contract: String,
+    slot_order: String,
+    comparison_order: String,
+    prototype_cap_per_candidate: usize,
+    source_witnesses: usize,
+    source_transitions: usize,
+    retained_candidates: usize,
+    retained_prototypes: usize,
+    prototypes: Vec<PlacementPrototypeRecord>,
+    compiler_query_reproductions: usize,
+    exact_self_matches: usize,
+    construction_class_collisions: usize,
+    padding_identity_aliases: usize,
+    decisive_order_shuffled_prototypes_distinct: usize,
+    held_out_full_histories_absent_from_construction: bool,
+    expected_continuation_inputs: usize,
+    held_out_label_inputs: usize,
+    future_route_inputs: usize,
+    source_tensor_reads: usize,
+    teacher_forwards: usize,
+    provider_calls: usize,
+    causal_singleton_support_observations: usize,
+    selector_candidate_append_inputs: usize,
+    frame_mismatch_terminal: String,
+    left_support: RepairedPreflightArm,
+    right_support: RepairedPreflightArm,
+    left_relations: PlacementPromptRelationRecord,
+    right_relations: PlacementPromptRelationRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct StrictMinimumRecord {
+    winner_payload_bytes: Option<Vec<u8>>,
+    tie: bool,
+    unavailable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct LocalContextPreflightOutcomeRecord {
+    schema: u32,
+    fixture_kappa: String,
+    repaired_support_record_kappa: String,
+    relation_census_kappa: String,
+    frozen_left_expected: Vec<u8>,
+    frozen_right_expected: Vec<u8>,
+    left_real: StrictMinimumRecord,
+    right_real: StrictMinimumRecord,
+    left_placement_permuted: StrictMinimumRecord,
+    right_placement_permuted: StrictMinimumRecord,
+    left_order_shuffled: StrictMinimumRecord,
+    right_order_shuffled: StrictMinimumRecord,
+    real_intended_matches: usize,
+    placement_permuted_intended_matches: usize,
+    order_shuffled_intended_matches: usize,
+    strict_selection_ceiling_numerator: usize,
+    strict_selection_ceiling_denominator: usize,
+    tie_rule: String,
+    pass_local_context_placement_preflight: String,
+    decoded_generation: String,
+    failure: String,
+    terminal: String,
+}
+
+fn trajectory_record(trajectory: &LocalContextTrajectory) -> PlacementTrajectoryRecord {
+    trajectory.into()
+}
+
+fn placement_control_record(
+    bundle: &FrozenBundle,
+    history_len: usize,
+    census: LocalContextPlacementRelationCensus,
+) -> PlacementControlRecord {
+    let LocalContextPlacementRelationCensus {
+        manifest_kappa,
+        policy_identity,
+        policy_kappa,
+        overlay_kappa,
+        control,
+        live_trajectory,
+        support,
+        complete_candidate_membership,
+        prototype_evaluations,
+        trajectory_slot_comparisons,
+        candidates: census_candidates,
+    } = census;
+    assert_eq!(manifest_kappa, support.manifest_kappa);
+    let mut candidate_union = support
+        .candidates
+        .iter()
+        .map(|candidate| payload_for_address(bundle, &candidate.next))
+        .collect::<Vec<_>>();
+    candidate_union.sort();
+    let candidates = census_candidates
+        .into_iter()
+        .map(|candidate| {
+            let prototype_source_payload_bytes = Some(payload_for_address(
+                bundle,
+                &candidate.prototype_source_candidate,
+            ));
+            let prototype_source_address_kappa = Some(
+                candidate
+                    .prototype_source_candidate
+                    .canonical_kappa()
+                    .unwrap(),
+            );
+            let prototype_relations = candidate
+                .prototype_relations
+                .into_iter()
+                .map(|relation| {
+                    let population_match = [0usize, 1, 2, 3].map(|slot| {
+                        relation.prototype_trajectory.populated[slot]
+                            == live_trajectory.populated[slot]
+                    });
+                    let padding_identity_alias = [0usize, 1, 2, 3].map(|slot| {
+                        !population_match[slot]
+                            && relation.cost.suffix_shells[slot] == H4S3AngularShell::Coincident
+                    });
+                    let exact_slot_match = [0usize, 1, 2, 3].map(|slot| {
+                        population_match[slot]
+                            && relation.prototype_trajectory.suffix_states[slot]
+                                == live_trajectory.suffix_states[slot]
+                    });
+                    PlacementPrototypeRelationRecord {
+                        sentence_id: relation.sentence_id,
+                        transition_ordinal: relation.transition_ordinal,
+                        predecessor_history_kappa: relation.predecessor_history_kappa,
+                        prototype_trajectory: trajectory_record(&relation.prototype_trajectory),
+                        population_match,
+                        padding_identity_alias,
+                        exact_slot_match,
+                        relative_states: relation.relative_states,
+                        cost: relation.cost,
+                    }
+                })
+                .collect::<Vec<_>>();
+            PlacementCandidateRelationRecord {
+                candidate_payload_bytes: payload_for_address(bundle, &candidate.candidate),
+                candidate_address_kappa: candidate.candidate.canonical_kappa().unwrap(),
+                source_counts: count_array(candidate.source_counts),
+                prototype_source_payload_bytes,
+                prototype_source_address_kappa,
+                prototype_count: candidate.prototype_count,
+                prototype_relations,
+            }
+        })
+        .collect::<Vec<_>>();
+    PlacementControlRecord {
+        control,
+        manifest_kappa,
+        placement_policy: policy_identity,
+        placement_policy_kappa: policy_kappa,
+        overlay_kappa,
+        live_trajectory: trajectory_record(&live_trajectory),
+        query_policy: support.query_policy.identity().to_owned(),
+        query_policy_kappa: support.query_policy_kappa,
+        fallback_active: support.fallback_active,
+        support_rows: support.rows_read.len(),
+        candidate_entries_available: support.candidate_entries_available,
+        candidate_entries_examined: support.candidate_entries_examined,
+        candidate_entries_admitted: support.candidate_entries_admitted,
+        candidate_entry_ceiling: support.candidate_entry_ceiling,
+        unique_candidates_before_ceiling: support.unique_candidates_before_ceiling,
+        candidate_ceiling: support.candidate_ceiling,
+        candidate_union,
+        inherited_path_keys_per_candidate: history_len,
+        inherited_path_comparisons: history_len * candidates.len(),
+        complete_candidate_membership,
+        prototype_evaluations,
+        trajectory_slot_comparisons,
+        candidates,
+    }
+}
+
+fn placement_prompt_record(
+    bundle: &FrozenBundle,
+    prompt: &[u8],
+    overlay: &LocalSameObjectContextPlacementV1,
+    table: &uor_r4_core::canonical_lexical_ingestion::H4BinaryIcosahedralClosure,
+) -> PlacementPromptRelationRecord {
+    let (history, _) = decisive_history_from_singleton_support(bundle, prompt);
+    let history_len = history.len();
+    let real = placement_control_record(
+        bundle,
+        history_len,
+        overlay
+            .relation_census_for_history(
+                &bundle.attention,
+                &history,
+                table,
+                LocalContextPlacementControl::RealPlacement,
+            )
+            .unwrap(),
+    );
+    let placement_permuted = placement_control_record(
+        bundle,
+        history_len,
+        overlay
+            .relation_census_for_history(
+                &bundle.attention,
+                &history,
+                table,
+                LocalContextPlacementControl::PlacementPermuted,
+            )
+            .unwrap(),
+    );
+    let order_shuffled = placement_control_record(
+        bundle,
+        history_len,
+        overlay
+            .relation_census_for_history(
+                &bundle.attention,
+                &history,
+                table,
+                LocalContextPlacementControl::OrderShuffled,
+            )
+            .unwrap(),
+    );
+    for control in [&placement_permuted, &order_shuffled] {
+        assert_eq!(control.manifest_kappa, real.manifest_kappa);
+        assert_eq!(control.placement_policy, real.placement_policy);
+        assert_eq!(control.placement_policy_kappa, real.placement_policy_kappa);
+        assert_eq!(control.overlay_kappa, real.overlay_kappa);
+        assert_eq!(control.query_policy, real.query_policy);
+        assert_eq!(control.query_policy_kappa, real.query_policy_kappa);
+        assert_eq!(control.fallback_active, real.fallback_active);
+        assert_eq!(control.support_rows, real.support_rows);
+        assert_eq!(
+            control.candidate_entries_available,
+            real.candidate_entries_available
+        );
+        assert_eq!(
+            control.candidate_entries_examined,
+            real.candidate_entries_examined
+        );
+        assert_eq!(
+            control.candidate_entries_admitted,
+            real.candidate_entries_admitted
+        );
+        assert_eq!(
+            control.candidate_entry_ceiling,
+            real.candidate_entry_ceiling
+        );
+        assert_eq!(
+            control.unique_candidates_before_ceiling,
+            real.unique_candidates_before_ceiling
+        );
+        assert_eq!(control.candidate_ceiling, real.candidate_ceiling);
+        assert_eq!(control.candidate_union, real.candidate_union);
+        assert_eq!(
+            control.inherited_path_keys_per_candidate,
+            real.inherited_path_keys_per_candidate
+        );
+        assert_eq!(
+            control.inherited_path_comparisons,
+            real.inherited_path_comparisons
+        );
+    }
+    PlacementPromptRelationRecord {
+        prompt_bytes: prompt.to_vec(),
+        decisive_observed_routes: history_len,
+        real,
+        placement_permuted,
+        order_shuffled,
+    }
+}
+
+fn strict_minimum(control: &PlacementControlRecord) -> StrictMinimumRecord {
+    if !control.complete_candidate_membership
+        || control.candidates.is_empty()
+        || control
+            .candidates
+            .iter()
+            .any(|candidate| candidate.prototype_relations.is_empty())
+    {
+        return StrictMinimumRecord {
+            winner_payload_bytes: None,
+            tie: false,
+            unavailable: true,
+        };
+    }
+    let minimum = control
+        .candidates
+        .iter()
+        .filter_map(candidate_minimum_cost)
+        .min()
+        .unwrap();
+    let winners = control
+        .candidates
+        .iter()
+        .filter(|candidate| candidate_minimum_cost(candidate) == Some(minimum))
+        .collect::<Vec<_>>();
+    if winners.len() == 1 {
+        StrictMinimumRecord {
+            winner_payload_bytes: Some(winners[0].candidate_payload_bytes.clone()),
+            tie: false,
+            unavailable: false,
+        }
+    } else {
+        StrictMinimumRecord {
+            winner_payload_bytes: None,
+            tie: true,
+            unavailable: false,
+        }
+    }
+}
+
+fn candidate_minimum_cost(
+    candidate: &PlacementCandidateRelationRecord,
+) -> Option<LocalContextPlacementCost> {
+    candidate
+        .prototype_relations
+        .iter()
+        .map(|relation| relation.cost)
+        .min()
+}
+
+fn placement_candidate<'a>(
+    control: &'a PlacementControlRecord,
+    payload: &[u8],
+) -> &'a PlacementCandidateRelationRecord {
+    control
+        .candidates
+        .iter()
+        .find(|candidate| candidate.candidate_payload_bytes == payload)
+        .unwrap()
+}
+
+fn padding_identity_aliases(record: &PlacementPromptRelationRecord) -> usize {
+    [
+        &record.real,
+        &record.placement_permuted,
+        &record.order_shuffled,
+    ]
+    .into_iter()
+    .flat_map(|control| &control.candidates)
+    .flat_map(|candidate| &candidate.prototype_relations)
+    .map(|relation| {
+        relation
+            .padding_identity_alias
+            .iter()
+            .filter(|alias| **alias)
+            .count()
+    })
+    .sum()
+}
+
+fn relation_census_record(bundle: &FrozenBundle) -> LocalContextRelationCensusRecord {
+    let manifest = bundle.artifact.embedded_spin_manifest().unwrap();
+    let table = validate_h4_binary_icosahedral_closure().unwrap();
+    let overlay =
+        LocalSameObjectContextPlacementV1::compile_from_manifest_witnesses(&manifest, &table)
+            .unwrap();
+    let replay =
+        LocalSameObjectContextPlacementV1::compile_from_manifest_witnesses(&manifest, &table)
+            .unwrap();
+    assert_eq!(overlay, replay);
+    assert_eq!(
+        overlay.canonical_bytes().unwrap(),
+        replay.canonical_bytes().unwrap()
+    );
+    assert_eq!(
+        overlay.overlay_kappa(),
+        overlay.reproduce_overlay_kappa().unwrap()
+    );
+
+    let prototypes = overlay
+        .prototype_sets()
+        .iter()
+        .flat_map(|set| {
+            set.prototypes
+                .iter()
+                .map(|prototype| PlacementPrototypeRecord {
+                    candidate_payload_bytes: payload_for_address(bundle, &set.candidate),
+                    candidate_address_kappa: set.candidate.canonical_kappa().unwrap(),
+                    sentence_id: prototype.sentence_id.clone(),
+                    transition_ordinal: prototype.transition_ordinal,
+                    predecessor_length: prototype.predecessor_history.len(),
+                    predecessor_history_kappa: prototype.predecessor_history_kappa.clone(),
+                    predecessor_address_kappas: prototype
+                        .predecessor_history
+                        .iter()
+                        .map(GeometricAddress::canonical_kappa)
+                        .collect::<Result<Vec<_>, _>>()
+                        .unwrap(),
+                    trajectory: trajectory_record(&prototype.trajectory),
+                    order_shuffled_trajectory: trajectory_record(
+                        &prototype.order_shuffled_trajectory,
+                    ),
+                })
+        })
+        .collect::<Vec<_>>();
+
+    let compiler_query_reproductions = overlay
+        .prototype_sets()
+        .iter()
+        .flat_map(|set| &set.prototypes)
+        .filter(|prototype| {
+            overlay
+                .encode_query_history(&bundle.attention, &prototype.predecessor_history, &table)
+                .is_ok_and(|trajectory| trajectory == prototype.trajectory)
+        })
+        .count();
+    let all_prototypes = overlay.retained_prototypes();
+    assert_eq!(compiler_query_reproductions, all_prototypes);
+    for prototype in overlay
+        .prototype_sets()
+        .iter()
+        .flat_map(|set| &set.prototypes)
+    {
+        let mut reversed_history = prototype.predecessor_history.clone();
+        reversed_history.reverse();
+        let mut original_multiset = prototype
+            .predecessor_history
+            .iter()
+            .map(GeometricAddress::canonical_kappa)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let mut reversed_multiset = reversed_history
+            .iter()
+            .map(GeometricAddress::canonical_kappa)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        original_multiset.sort();
+        reversed_multiset.sort();
+        assert_eq!(original_multiset, reversed_multiset);
+        assert_eq!(
+            overlay
+                .encode_query_history(&bundle.attention, &reversed_history, &table)
+                .unwrap(),
+            prototype.order_shuffled_trajectory
+        );
+    }
+
+    let exact_self_matches = overlay
+        .prototype_sets()
+        .iter()
+        .flat_map(|set| {
+            set.prototypes.iter().map(|prototype| {
+                let census = overlay
+                    .relation_census_for_history(
+                        &bundle.attention,
+                        &prototype.predecessor_history,
+                        &table,
+                        LocalContextPlacementControl::RealPlacement,
+                    )
+                    .unwrap();
+                census
+                    .candidates
+                    .iter()
+                    .find(|candidate| candidate.candidate == set.candidate)
+                    .and_then(|candidate| {
+                        candidate
+                            .prototype_relations
+                            .iter()
+                            .map(|relation| relation.cost)
+                            .min()
+                    })
+                    .is_some_and(|cost| {
+                        cost.suffix_shells
+                            == [H4S3AngularShell::Coincident; LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH]
+                    })
+            })
+        })
+        .filter(|matched| *matched)
+        .count();
+
+    let mut construction_classes = BTreeMap::<Vec<u8>, BTreeSet<Vec<u8>>>::new();
+    for prototype in &prototypes {
+        construction_classes
+            .entry(serde_json::to_vec(&prototype.trajectory).unwrap())
+            .or_default()
+            .insert(prototype.candidate_payload_bytes.clone());
+    }
+    let construction_class_collisions = construction_classes
+        .values()
+        .filter(|candidates| candidates.len() > 1)
+        .count();
+
+    let decisive_order_shuffled_prototypes_distinct = prototypes
+        .iter()
+        .filter(|prototype| {
+            [b"run".as_slice(), b"runs".as_slice()]
+                .contains(&prototype.candidate_payload_bytes.as_slice())
+                && prototype.trajectory != prototype.order_shuffled_trajectory
+        })
+        .count();
+    let (left_decisive_history, _) = decisive_history_from_singleton_support(bundle, LEFT_PROMPT);
+    let (right_decisive_history, _) = decisive_history_from_singleton_support(bundle, RIGHT_PROMPT);
+    let held_out_full_histories_absent_from_construction = overlay
+        .prototype_sets()
+        .iter()
+        .flat_map(|set| &set.prototypes)
+        .all(|prototype| {
+            prototype.predecessor_history != left_decisive_history
+                && prototype.predecessor_history != right_decisive_history
+        });
+
+    let mut mismatched_table = table.clone();
+    mismatched_table.h4_root_table_kappa =
+        "blake3:0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+    let mismatch = overlay
+        .encode_query_history(&bundle.attention, &left_decisive_history, &mismatched_table)
+        .unwrap_err();
+    assert!(mismatch
+        .to_string()
+        .ends_with(LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH));
+
+    let left_relations = placement_prompt_record(bundle, LEFT_PROMPT, &overlay, &table);
+    let right_relations = placement_prompt_record(bundle, RIGHT_PROMPT, &overlay, &table);
+    let padding_identity_aliases =
+        padding_identity_aliases(&left_relations) + padding_identity_aliases(&right_relations);
+
+    LocalContextRelationCensusRecord {
+        schema: 2,
+        preflight_input_kappa: local_context_preflight_input_kappa(),
+        codec_kappa: CODEC_KAPPA.to_owned(),
+        vocabulary_kappa: VOCABULARY_KAPPA.to_owned(),
+        construction_artifact_kappa: CONSTRUCTION_ARTIFACT_KAPPA.to_owned(),
+        attention_manifest_kappa: ATTENTION_MANIFEST_KAPPA.to_owned(),
+        query_policy: PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY.to_owned(),
+        query_policy_kappa: QUERY_POLICY_KAPPA.to_owned(),
+        overlay_schema: overlay.schema(),
+        overlay_policy: overlay.policy_identity().to_owned(),
+        overlay_policy_kappa: overlay.policy_kappa().to_owned(),
+        encoder_identity: overlay.encoder_identity().to_owned(),
+        quantization_identity: overlay.quantization_identity().to_owned(),
+        overlay_kappa: overlay.overlay_kappa().to_owned(),
+        h4_root_table_kappa: overlay.h4_root_table_kappa().to_owned(),
+        multiplication_table_kappa: overlay.multiplication_table_kappa().to_owned(),
+        frame_width: LOCAL_CONTEXT_PLACEMENT_FRAME_WIDTH,
+        padding_contract: "typed-h4-identity-with-explicit-population-mask".to_owned(),
+        slot_order: "recent-suffix-lengths-1-2-3-4".to_owned(),
+        comparison_order: "lexicographic-shortest-suffix-first".to_owned(),
+        prototype_cap_per_candidate: LOCAL_CONTEXT_PLACEMENT_MAX_PROTOTYPES_PER_CANDIDATE,
+        source_witnesses: overlay.source_witnesses(),
+        source_transitions: overlay.source_transitions(),
+        retained_candidates: overlay.prototype_sets().len(),
+        retained_prototypes: overlay.retained_prototypes(),
+        prototypes,
+        compiler_query_reproductions,
+        exact_self_matches,
+        construction_class_collisions,
+        padding_identity_aliases,
+        decisive_order_shuffled_prototypes_distinct,
+        held_out_full_histories_absent_from_construction,
+        expected_continuation_inputs: 0,
+        held_out_label_inputs: 0,
+        future_route_inputs: 0,
+        source_tensor_reads: 0,
+        teacher_forwards: 0,
+        provider_calls: 0,
+        causal_singleton_support_observations: 2,
+        selector_candidate_append_inputs: 0,
+        frame_mismatch_terminal: LOCAL_CONTEXT_PLACEMENT_FRAME_MISMATCH.to_owned(),
+        left_support: preflight_arm(bundle, LEFT_PROMPT),
+        right_support: preflight_arm(bundle, RIGHT_PROMPT),
+        left_relations,
+        right_relations,
+    }
+}
+
+#[test]
+fn freeze_local_context_placement_overlay_and_relation_census() {
+    let bundle = frozen_bundle();
+    let record = relation_census_record(&bundle);
+    let bytes = serde_json::to_vec(&record).unwrap();
+    let record_kappa = format!("blake3:{}", blake3::hash(&bytes).to_hex());
+    if let Some(expected) = LOCAL_CONTEXT_PREFLIGHT_INPUT_KAPPA {
+        assert_eq!(record.preflight_input_kappa, expected);
+    }
+    if let Some(expected) = LOCAL_CONTEXT_RELATION_CENSUS_KAPPA {
+        assert_eq!(record_kappa, expected);
+    }
+    assert_eq!(
+        record.overlay_policy,
+        LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY
+    );
+    assert_eq!(
+        record.encoder_identity,
+        RECENT_SUFFIX_ORDERED_H4_TRAJECTORY_V1_IDENTITY
+    );
+    assert_eq!(
+        record.quantization_identity,
+        EXACT_RECENT_SUFFIX_H4_SHELL_VECTOR_V1_IDENTITY
+    );
+    assert_eq!(record.frame_width, 4);
+    assert_eq!(record.prototype_cap_per_candidate, 4);
+    assert_eq!(
+        record.compiler_query_reproductions,
+        record.retained_prototypes
+    );
+    assert_eq!(record.exact_self_matches, record.retained_prototypes);
+    assert_eq!(record.construction_class_collisions, 0);
+    assert_eq!(record.padding_identity_aliases, 0);
+    assert_eq!(record.decisive_order_shuffled_prototypes_distinct, 2);
+    assert!(record.held_out_full_histories_absent_from_construction);
+    let prototype = |payload: &[u8]| {
+        record
+            .prototypes
+            .iter()
+            .find(|prototype| prototype.candidate_payload_bytes == payload)
+            .unwrap()
+    };
+    assert_eq!(prototype(b"run").predecessor_length, 3);
+    assert_eq!(
+        prototype(b"run").trajectory.populated,
+        [true, true, true, false]
+    );
+    assert_eq!(prototype(b"runs").predecessor_length, 4);
+    assert_eq!(
+        prototype(b"runs").trajectory.populated,
+        [true, true, true, true]
+    );
+    assert!(preflight_matches_frozen_contract(&record.left_support));
+    assert!(preflight_matches_frozen_contract(&record.right_support));
+    assert!(preflight_arms_have_equal_support_and_work(
+        &record.left_support,
+        &record.right_support
+    ));
+
+    for prompt in [&record.left_relations, &record.right_relations] {
+        for control in [
+            &prompt.real,
+            &prompt.placement_permuted,
+            &prompt.order_shuffled,
+        ] {
+            assert_eq!(control.candidate_union, [b"run".to_vec(), b"runs".to_vec()]);
+            assert_eq!(control.support_rows, 7);
+            assert_eq!(control.candidate_entries_available, 11);
+            assert_eq!(control.candidate_entries_examined, 6);
+            assert_eq!(control.candidate_entries_admitted, 6);
+            assert_eq!(control.manifest_kappa, ATTENTION_MANIFEST_KAPPA);
+            assert_eq!(
+                control.placement_policy,
+                LOCAL_SAME_OBJECT_CONTEXT_PLACEMENT_V1_IDENTITY
+            );
+            assert_eq!(control.placement_policy_kappa, record.overlay_policy_kappa);
+            assert_eq!(control.overlay_kappa, record.overlay_kappa);
+            assert_eq!(
+                control.query_policy,
+                PRIMARY_THEN_ADJACENT_SPIN_FALLBACK_V1_IDENTITY
+            );
+            assert_eq!(control.query_policy_kappa, QUERY_POLICY_KAPPA);
+            assert!(!control.fallback_active);
+            assert_eq!(control.candidate_entry_ceiling, 56);
+            assert_eq!(control.unique_candidates_before_ceiling, 2);
+            assert_eq!(control.candidate_ceiling, 8);
+            assert!(control.complete_candidate_membership);
+            assert_eq!(control.inherited_path_keys_per_candidate, 6);
+            assert_eq!(control.inherited_path_comparisons, 12);
+            assert_eq!(control.prototype_evaluations, 2);
+            assert_eq!(control.trajectory_slot_comparisons, 8);
+        }
+        assert_ne!(prompt.real.candidates, prompt.placement_permuted.candidates);
+        assert_ne!(prompt.real.candidates, prompt.order_shuffled.candidates);
+        assert_eq!(
+            prompt.real.candidates.len(),
+            prompt.placement_permuted.candidates.len()
+        );
+        for candidate_index in 0..prompt.real.candidates.len() {
+            let real_candidate = &prompt.real.candidates[candidate_index];
+            let permuted_candidate = &prompt.placement_permuted.candidates[candidate_index];
+            let shuffled_candidate = &prompt.order_shuffled.candidates[candidate_index];
+            let cyclic_source =
+                &prompt.real.candidates[(candidate_index + 1) % prompt.real.candidates.len()];
+            assert_eq!(
+                real_candidate.candidate_address_kappa,
+                permuted_candidate.candidate_address_kappa
+            );
+            assert_eq!(
+                real_candidate.candidate_address_kappa,
+                shuffled_candidate.candidate_address_kappa
+            );
+            assert_eq!(
+                real_candidate.prototype_source_address_kappa.as_ref(),
+                Some(&real_candidate.candidate_address_kappa)
+            );
+            assert_eq!(
+                permuted_candidate.prototype_source_address_kappa.as_ref(),
+                Some(&cyclic_source.candidate_address_kappa)
+            );
+            assert_eq!(
+                shuffled_candidate.prototype_source_address_kappa.as_ref(),
+                Some(&shuffled_candidate.candidate_address_kappa)
+            );
+        }
+        assert_ne!(
+            candidate_minimum_cost(&prompt.real.candidates[0]),
+            candidate_minimum_cost(&prompt.real.candidates[1])
+        );
+    }
+
+    println!(
+        "local_context_placement_policy_kappa={}",
+        record.overlay_policy_kappa
+    );
+    println!(
+        "local_context_placement_overlay_kappa={}",
+        record.overlay_kappa
+    );
+    println!(
+        "local_context_preflight_input_kappa={}",
+        record.preflight_input_kappa
+    );
+    println!("local_context_relation_census_kappa={record_kappa}");
+    println!(
+        "inventory=source_witnesses:{},source_transitions:{},retained_candidates:{},retained_prototypes:{},class_collisions:{},compiler_query_reproductions:{},self_matches:{}",
+        record.source_witnesses,
+        record.source_transitions,
+        record.retained_candidates,
+        record.retained_prototypes,
+        record.construction_class_collisions,
+        record.compiler_query_reproductions,
+        record.exact_self_matches,
+    );
+    for prototype in record.prototypes.iter().filter(|prototype| {
+        [b"run".as_slice(), b"runs".as_slice()]
+            .contains(&prototype.candidate_payload_bytes.as_slice())
+    }) {
+        println!(
+            "prototype={} predecessor_length={} populated={:?}",
+            String::from_utf8_lossy(&prototype.candidate_payload_bytes),
+            prototype.predecessor_length,
+            prototype.trajectory.populated,
+        );
+    }
+    for (prompt, control) in [
+        ("left", &record.left_relations.real),
+        ("right", &record.right_relations.real),
+    ] {
+        for candidate in &control.candidates {
+            println!(
+                "{prompt}_real_{}={:?}; exact_slot_match={:?}",
+                String::from_utf8_lossy(&candidate.candidate_payload_bytes),
+                candidate_minimum_cost(candidate).unwrap().suffix_shells,
+                candidate.prototype_relations[0].exact_slot_match,
+            );
+        }
+    }
+    if let Some(expected) = LOCAL_CONTEXT_PLACEMENT_POLICY_KAPPA {
+        assert_eq!(record.overlay_policy_kappa, expected);
+    }
+    if let Some(expected) = LOCAL_CONTEXT_PLACEMENT_OVERLAY_KAPPA {
+        assert_eq!(record.overlay_kappa, expected);
+    }
+}
+
+#[test]
+fn local_context_placement_preflight_hard_stops_before_generation() {
+    let bundle = frozen_bundle();
+    let record = relation_census_record(&bundle);
+    let relation_bytes = serde_json::to_vec(&record).unwrap();
+    let relation_census_kappa = format!("blake3:{}", blake3::hash(&relation_bytes).to_hex());
+    if let Some(expected) = LOCAL_CONTEXT_RELATION_CENSUS_KAPPA {
+        assert_eq!(relation_census_kappa, expected);
+    }
+    assert_eq!(record.padding_identity_aliases, 0);
+
+    // Selector semantics begin only after the raw relation census is hashed.
+    // Equal exact minima abstain; canonical address order never rescues a tie.
+    let mut tied = record.left_relations.real.clone();
+    let tied_cost = candidate_minimum_cost(&tied.candidates[0]).unwrap();
+    for relation in &mut tied.candidates[1].prototype_relations {
+        relation.cost = tied_cost;
+    }
+    let tie = strict_minimum(&tied);
+    assert!(tie.tie);
+    assert!(!tie.unavailable);
+    assert!(tie.winner_payload_bytes.is_none());
+
+    let left_real = strict_minimum(&record.left_relations.real);
+    let right_real = strict_minimum(&record.right_relations.real);
+    let left_placement_permuted = strict_minimum(&record.left_relations.placement_permuted);
+    let right_placement_permuted = strict_minimum(&record.right_relations.placement_permuted);
+    let left_order_shuffled = strict_minimum(&record.left_relations.order_shuffled);
+    let right_order_shuffled = strict_minimum(&record.right_relations.order_shuffled);
+    let frozen_left_expected = LEFT_EXPECTED[1].to_vec();
+    let frozen_right_expected = RIGHT_EXPECTED[1].to_vec();
+    let intended_matches = |left: &StrictMinimumRecord, right: &StrictMinimumRecord| {
+        usize::from(left.winner_payload_bytes.as_deref() == Some(frozen_left_expected.as_slice()))
+            + usize::from(
+                right.winner_payload_bytes.as_deref() == Some(frozen_right_expected.as_slice()),
+            )
+    };
+    let real_intended_matches = intended_matches(&left_real, &right_real);
+    let placement_permuted_intended_matches =
+        intended_matches(&left_placement_permuted, &right_placement_permuted);
+    let order_shuffled_intended_matches =
+        intended_matches(&left_order_shuffled, &right_order_shuffled);
+
+    assert_eq!(
+        left_real.winner_payload_bytes.as_deref(),
+        Some(b"run".as_slice())
+    );
+    assert_eq!(
+        right_real.winner_payload_bytes.as_deref(),
+        Some(b"runs".as_slice())
+    );
+    assert_eq!(
+        left_placement_permuted.winner_payload_bytes.as_deref(),
+        Some(b"runs".as_slice())
+    );
+    assert_eq!(
+        right_placement_permuted.winner_payload_bytes.as_deref(),
+        Some(b"run".as_slice())
+    );
+    assert_eq!(
+        left_order_shuffled.winner_payload_bytes.as_deref(),
+        Some(b"runs".as_slice())
+    );
+    assert_eq!(
+        right_order_shuffled.winner_payload_bytes.as_deref(),
+        Some(b"runs".as_slice())
+    );
+    let shells = |control: &PlacementControlRecord, payload: &[u8]| {
+        placement_candidate(control, payload).prototype_relations[0]
+            .cost
+            .suffix_shells
+    };
+    assert_eq!(
+        shells(&record.left_relations.real, b"run"),
+        [
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Degrees120,
+        ]
+    );
+    assert_eq!(
+        shells(&record.left_relations.real, b"runs"),
+        [
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Orthogonal,
+            H4S3AngularShell::Degrees120,
+        ]
+    );
+    assert_eq!(
+        shells(&record.right_relations.real, b"run"),
+        [
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Orthogonal,
+            H4S3AngularShell::Degrees108,
+        ]
+    );
+    assert_eq!(
+        shells(&record.right_relations.real, b"runs"),
+        [
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+            H4S3AngularShell::Coincident,
+        ]
+    );
+    assert_eq!(
+        shells(&record.left_relations.order_shuffled, b"run"),
+        [
+            H4S3AngularShell::Degrees144,
+            H4S3AngularShell::Degrees144,
+            H4S3AngularShell::Degrees60,
+            H4S3AngularShell::Degrees120,
+        ]
+    );
+    assert_eq!(
+        shells(&record.left_relations.order_shuffled, b"runs"),
+        [
+            H4S3AngularShell::Degrees60,
+            H4S3AngularShell::Degrees108,
+            H4S3AngularShell::Orthogonal,
+            H4S3AngularShell::Degrees120,
+        ]
+    );
+    assert_eq!(
+        shells(&record.right_relations.order_shuffled, b"run"),
+        [
+            H4S3AngularShell::Degrees144,
+            H4S3AngularShell::Degrees144,
+            H4S3AngularShell::Degrees120,
+            H4S3AngularShell::Degrees108,
+        ]
+    );
+    assert_eq!(
+        shells(&record.right_relations.order_shuffled, b"runs"),
+        [
+            H4S3AngularShell::Degrees60,
+            H4S3AngularShell::Degrees108,
+            H4S3AngularShell::Orthogonal,
+            H4S3AngularShell::Degrees60,
+        ]
+    );
+    assert_eq!(
+        placement_candidate(&record.left_relations.real, b"run").prototype_relations[0]
+            .exact_slot_match,
+        [true, true, true, false]
+    );
+    assert_eq!(
+        placement_candidate(&record.left_relations.real, b"runs").prototype_relations[0]
+            .exact_slot_match,
+        [true, true, false, false]
+    );
+    assert_eq!(
+        placement_candidate(&record.right_relations.real, b"run").prototype_relations[0]
+            .exact_slot_match,
+        [true, true, false, false]
+    );
+    assert_eq!(
+        placement_candidate(&record.right_relations.real, b"runs").prototype_relations[0]
+            .exact_slot_match,
+        [true, true, true, true]
+    );
+    assert_eq!(real_intended_matches, 0);
+    assert_eq!(placement_permuted_intended_matches, 2);
+    assert_eq!(order_shuffled_intended_matches, 1);
+
+    let outcome = LocalContextPreflightOutcomeRecord {
+        schema: 2,
+        fixture_kappa: FIXTURE_KAPPA.to_owned(),
+        repaired_support_record_kappa: REPAIRED_SUPPORT_PREFLIGHT_RECORD_KAPPA.to_owned(),
+        relation_census_kappa,
+        frozen_left_expected,
+        frozen_right_expected,
+        left_real,
+        right_real,
+        left_placement_permuted,
+        right_placement_permuted,
+        left_order_shuffled,
+        right_order_shuffled,
+        real_intended_matches,
+        placement_permuted_intended_matches,
+        order_shuffled_intended_matches,
+        strict_selection_ceiling_numerator: 0,
+        strict_selection_ceiling_denominator: 2,
+        tie_rule: "equal-exact-candidate-vectors-abstain".to_owned(),
+        pass_local_context_placement_preflight: "UNAVAILABLE".to_owned(),
+        decoded_generation: "NOT_RUN".to_owned(),
+        failure: "REAL_PLACEMENT_INVERTED_AND_PERMUTED_CONTROL_OUTPERFORMED".to_owned(),
+        terminal: REVISION_TERMINAL.to_owned(),
+    };
+    let outcome_bytes = serde_json::to_vec(&outcome).unwrap();
+    let outcome_kappa = format!("blake3:{}", blake3::hash(&outcome_bytes).to_hex());
+    println!("local_context_preflight_outcome_kappa={outcome_kappa}");
+    println!("PASS_LOCAL_CONTEXT_PLACEMENT_PREFLIGHT=UNAVAILABLE");
+    println!("strict_selection_ceiling=0/2");
+    println!("decoded_generation=NOT_RUN");
+    println!("terminal={REVISION_TERMINAL}");
+    if let Some(expected) = LOCAL_CONTEXT_PREFLIGHT_OUTCOME_KAPPA {
+        assert_eq!(outcome_kappa, expected);
+    }
+}
+
+#[test]
+fn failed_local_context_preflight_quarantines_historical_four_arm_generator() {
+    assert!(LOCAL_CONTEXT_PREFLIGHT_OUTCOME_KAPPA.is_some());
+    assert!(!local_context_placement_generation_authorized());
+}
+
 fn emitted_payloads(report: &LocalGeometricGenerationReport) -> Vec<Vec<u8>> {
     report
         .steps
@@ -894,8 +2018,9 @@ fn natural_agreement_four_arm_witness() {
     let bundle = frozen_bundle();
 
     // Fail closed before constructing the generator or opening any H4 path.
-    // An explicit ignored-test invocation cannot bypass the published support
-    // gate merely because the freeze and negative record now exist.
+    // An explicit ignored-test invocation cannot bypass either the published
+    // support gate or the later placement-preflight hard stop merely because
+    // the historical four-arm record remains append-only below.
     let left_preflight = preflight_arm(&bundle, LEFT_PROMPT);
     let right_preflight = preflight_arm(&bundle, RIGHT_PROMPT);
     assert!(
@@ -903,6 +2028,10 @@ fn natural_agreement_four_arm_witness() {
             && preflight_matches_frozen_contract(&right_preflight)
             && preflight_arms_have_equal_support_and_work(&left_preflight, &right_preflight),
         "NOT_RUN_SUPPORT_PREFLIGHT_HARD_STOP"
+    );
+    assert!(
+        local_context_placement_generation_authorized(),
+        "NOT_RUN_LOCAL_CONTEXT_PLACEMENT_PREFLIGHT_HARD_STOP"
     );
 
     let artifact_bytes = bundle.artifact.canonical_bytes().unwrap();

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -28,10 +28,20 @@ universe, and report kappas are
 `blake3:2daacf538c022fab9580d1e124af6c18d0b06da04604fbc962a01bda57f08a98`,
 `blake3:dca725c0ec6060166bcd0023df956e1ff029661b5fa7800ccb9f20808712b796`,
 and `blake3:5f9239150dea8c0c27c4dfa6ad2e4d0068bc3d18afc127b315c0ec358ceddb3f`.
-#969 becomes the next A1Q multichannel full recursive-attention qualification
-only after protected #970 merge; #953 remains blocked by #969 and owns bounded
-library/CLI inference and generation using only A1Q-qualified semantic scoring
-terms. #962 separately owns durable
+#970 closed through protected PR #972. #969 then qualified one bounded causal
+R4/S3 path selector. #953 implemented the first decoded library/CLI loop and
+`PrimaryThenAdjacentSpinFallbackV1`; exact `{still}` then `{run,runs}` support
+was restored under equal work, but both full-path prompts selected `still run`
+while both state-disabled prompts selected `still runs`. The terminal remains
+`REVISE_I1_GENERATOR_IN_PLACE`. #953's tiny construction-only, same-frame
+`LocalSameObjectContextPlacementV1` overlay reproduced 7/7 construction
+prototypes with zero class collisions and zero padding-identity aliases, but
+real placement resolved `run/runs` (0/2 intended) while the
+placement-permuted control resolved `runs/run` (2/2). The preflight stopped
+before decoded generation or replay, so #953 has not qualified local
+construction-induced placement and awaits a newly frozen maintainer plan.
+Corpus-scale and higher-scope induction remain blocked in #973; #954 remains
+blocked downstream. #962 separately owns durable
 multi-turn CLI/HTTP chat, persisted conversation state, session/identity
 isolation, and identity-scoped hive memory.
 
@@ -49,8 +59,9 @@ canonical text/corpus
     -> incremental local/sentence/paragraph/conversation/global state
     -> associative noncommutative ordered-summary repair (#967, state only)
     -> paired-H4-derived exact R4-heatmap readout hard stop (#970, bounded negative)
-    -> complete recursive geometric-attention qualification (GI-2/#969)
-    -> bounded source-free library/CLI inference and generation (#953)
+    -> qualified local causal R4/S3 path mechanism (#969)
+    -> bounded decoded loop + tiered admission + failed local-placement preflight (#953)
+    -> higher-scope attention and corpus-scale induction (#973)
     -> correctness + typed abstention (#954)
     -> bounded reasoning (#955)
     -> durable isolated CLI/HTTP chat + persisted hive memory (#962)
@@ -62,8 +73,9 @@ addresses, spin/harmonic state, transported trajectory summaries, recursive
 scope identities, and rebuild witnesses. Corpus observations populate routes;
 they do not become serving weights. Kappa binds canonical identity and
 provenance. Factor/spin/harmonic coordinates provide structural/storage state
-and locality hypotheses; only terms qualified by A1Q/#969 may affect #953
-semantic ranking.
+and locality hypotheses. Only terms frozen by the active issue's pre-evidence
+contract may affect its experimental ranking; only positively qualified terms
+may pass downstream.
 
 The #952 A1.0 record is a representation-level negative result, not a failure
 of lexical inversion, candidate admission, H4 closure, Hopf state, or the value
@@ -79,8 +91,10 @@ the full `D` witness but are not scorer-key fields. Fixed-zeta phases,
 ordered n-lets, exact `phi` radial transport, and typed
 `sqrt(2) <-> 2i <-> [0,2]` adapters remain structural under
 `STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`, not semantic scorer
-inputs. #969 becomes the next multichannel qualification only after protected
-#970 merge.
+inputs. #970 and #969 are closed at their bounded claim scopes; neither result
+establishes semantics, and #953 remains the active generation issue after its
+first construction-induced placement preflight failed before generation or
+replay. Any next attempt requires a newly frozen maintainer plan.
 See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
 
@@ -1371,17 +1385,18 @@ Passing `--cover` reuses the measured cover. It may be omitted to re-induce
 the default cover deterministically during scoring. For experiments, `cover`
 also accepts `--depths`, `--k0`, `--regions-budget`, and `--memory-budget`.
 
-**Current production boundary pending #962 after #969 and #953–#955.**
-#970 has bounded paired-H4-derived exact R4-heatmap readout evidence awaiting
-protected merge; #969 becomes the next multichannel full recursive-attention
-qualification only after that merge. #953 owns the
-bounded source-free library/CLI inference and generation engine; #962 owns its
-integration into durable multi-turn CLI/HTTP chat, persisted conversation
-state, session/identity isolation, and identity-scoped hive memory. Until that
-product stage, the public `ask`, `chat`, HTTP, library, and WASM production facades use
-`R4G1Runtime` as their sole ranked-candidate and token authority. D4 remains a
-token-free permit/widen/abstain policy. A production bundle must carry a
-schema-2 `release-bundle.json` and a content-bound, full-census
+**Current production boundary pending accepted #953 → #973 → #954 → #955
+before #962.** #970 and #969 are closed at their bounded claim scopes. #953 owns
+the bounded source-free library/CLI inference and generation engine, but has not
+qualified local construction-induced placement and awaits a newly frozen
+maintainer plan; #973 and #954 remain blocked.
+#962 owns integration into durable multi-turn CLI/HTTP chat, persisted
+conversation state, session/identity isolation, and
+identity-scoped hive memory. Until that product stage, the public `ask`, `chat`,
+HTTP, library, and WASM production facades use `R4G1Runtime` as their sole
+ranked-candidate and token authority. D4 remains a token-free
+permit/widen/abstain policy. A production bundle must carry a schema-2
+`release-bundle.json` and a content-bound, full-census
 `graph/deployed_quality_report.json`; legacy, missing, sampled, mismatched, or
 off-serving evidence is available only to explicitly named research loaders.
 There is no silent TLA/TLS1 fallback under the production profile.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -31,9 +31,13 @@ assumptions, or objectives rather than measured results.
 > stopped at support admission under the old flat union. The versioned tiered
 > repair then restored exact `{still}` and `{run,runs}` primary support, but the
 > single four-arm run selected `still run` for both prompt orders instead of
-> the required incompatible choices. #953 remains active for a bounded
-> same-object, order-sensitive candidate-relative representation repair; #973
-> and #954 remain blocked. Legacy
+> the required incompatible choices. The frozen
+> `LocalSameObjectContextPlacementV1` preflight then reproduced 7/7 construction
+> prototypes with zero class collisions and zero padding-identity aliases, but
+> real placement selected 0/2 intended candidates while the same-artifact
+> placement-permuted and order-shuffled controls selected 2/2 and 1/2.
+> Generation and replay were `NOT_RUN`. #953 awaits a newly frozen maintainer
+> plan; #973 and #954 remain blocked. Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
 > current-summary corrections remain important: **#784** found
@@ -207,6 +211,30 @@ assumptions, or objectives rather than measured results.
 > disabled, same-artifact placement-permuted, and order-shuffled controls.
 > Generic fixed Hopf or spectral proxy activity is not decoded causal evidence.
 > No second tuned experiment was run; #973 and #954 remain blocked.
+>
+> **#953 `LocalSameObjectContextPlacementV1` preflight hard stop,
+> 2026-08-27.** Each decisive history obtained `still` from the live causal
+> singleton-support query and appended that observed route; `still` was not
+> injected as a selector candidate. The label-free preflight input is
+> `blake3:ce5430048c3789e85e18ed17a80f10f79d317a66769ad8be0fd28224668eb72e`.
+> Its raw relation census was both label-free and selection-blind and froze as
+> `blake3:50e67c087e1ec5e04aa47cf09d42e9b0857c15e4cafa07b1363d67faf96c6aeb`
+> before expected continuations were attached. Every control reused the same
+> overlay artifact, repaired support, prompt history, and work budget; only the
+> predeclared placement or construction order changed. All 7/7 construction
+> trajectories reproduced online, with zero cross-candidate class collisions
+> and zero padding-identity aliases.
+>
+> Complete held-out histories were absent from construction, but the operative
+> retained suffixes exactly recalled shorter construction subhistories, so that
+> absence was not operative-representation anti-recall. After the raw census
+> froze, the label-attached outcome
+> `blake3:d5e2f3614c8f1d3c6c629e2261ec42dc970fa5484982b2a86cb4f4b06b06a372`
+> recorded real placement at 0/2 intended candidates, the cyclic
+> placement-permuted control at 2/2, and reversed construction order at 1/2.
+> Generator execution and replay were `NOT_RUN`. The terminal remains
+> `REVISE_I1_GENERATOR_IN_PLACE`; #953 awaits a newly frozen maintainer plan,
+> while #973 and #954 remain blocked.
 
 The current quality-baseline reconciliation is recorded by #933 and the
 [append-only #934 genealogy](canonical_quality_baseline_934.md). The historical
@@ -446,9 +474,12 @@ one causal ordered-S3 least-cost path mechanism with a matched two-unit decoded
 intervention. #953 now drives that selector through decoded-loop plumbing, but
 its relabel smoke did not qualify a natural grammar result. Tiered admission
 then restored the frozen agreement support, but the full path chose the same
-decisive candidate for both prompt orders. #953 remains active for a bounded
-same-object/order-sensitive candidate-relative representation repair and #973
-remains blocked. Dependable coherent text remains unestablished.
+decisive candidate for both prompt orders. The first frozen local
+candidate-placement preflight then reproduced its construction classes but
+selected 0/2 intended candidates under real placement while its same-artifact
+cyclic placement control selected 2/2; generator execution and replay were
+`NOT_RUN`. #953 awaits a newly frozen maintainer plan, and #973 remains blocked.
+Dependable coherent text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
 point remains allowed for witnessed chart construction; serving arithmetic is
@@ -993,9 +1024,12 @@ loop but records `REVISE_I1_GENERATOR_IN_PLACE` because the initial smoke is an
 exact lexical relabel of #969 rather than an incompatible natural contrast. Its
 next frozen agreement contrast first stopped at admission under the old flat
 union. Tiered admission subsequently restored its exact support, but the single
-four-arm selector run chose `still run` for both full-path prompt orders. #953
-remains open for bounded same-object, order-sensitive candidate-relative
-representation; #973 remains blocked by #953 and continues to block #954.
+four-arm selector run chose `still run` for both full-path prompt orders. The
+first frozen `LocalSameObjectContextPlacementV1` preflight then selected 0/2
+intended candidates under real placement, while its same-artifact
+placement-permuted and order-shuffled controls selected 2/2 and 1/2; generator
+execution and replay were `NOT_RUN`. #953 awaits a newly frozen maintainer plan;
+#973 remains blocked by #953 and continues to block #954.
 #955 invokes the eventual accepted
 #969/#953/#973/#954 path; #962 integrates that path into product chat with
 persisted identity-scoped hive memory. #963 retains measured cost; #964 binds

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -382,15 +382,21 @@ Delivery proceeds without skipping stages:
 1. retain the ordered state from #967 and paired-H4 structural state from #970
    at their measured claim boundaries;
 2. retain the local causal R4/S3 path mechanism qualified by #969;
-3. in #953, repair tiered admission, rerun the frozen support gate, and only
-   then rerun the bounded decoded natural-generation contract;
+3. in #953, retain #981's tiered-admission policy and the completed tiny
+   construction-only, same-frame, candidate-conditioned context-placement
+   overlay's selection-blind hard stop under the same artifact, support, and
+   work: real placement resolved 0/2 intended candidates while the
+   placement-permuted and order-shuffled controls resolved 2/2 and 1/2.
+   Generation and replay were not run. Any later #953 attempt requires a newly
+   frozen native contract rather than a metric tweak or second representation
+   under this result;
 4. in #973, qualify paragraph, conversation, and global influence through the
    accepted #953 loop, including the shared exact-spin operator overlay and
    its matched disabled/permuted controls;
 5. within #973, after every required scope qualifies, activate a predeclared
-   offline corpus-induction ladder with a frozen operator family and induction
-   rule; assign every rung new artifact/operator identities and rerun the
-   bounded matched gate for every structural or placement epoch;
+   higher-scope/corpus-scale offline induction ladder with a frozen operator
+   family and induction rule; assign every rung new artifact/operator identities
+   and rerun the bounded matched gate for every structural or placement epoch;
 6. measure correctness and typed abstention in #954 on the frozen induced
    artifact that conforms to and binds the accepted #969/#953/#973 identities;
    and

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -65,12 +65,13 @@ The stages are ordered because each later claim depends on the earlier one:
    checkable result. #952 is not the reasoning consumer.
 
 Within #973, after accepted #953 and every required #973 scope qualifies, or an
-explicit native revision changes that scope, run the separately frozen offline
-corpus-induction ladder and requalify its final artifact. The ladder is part of
-#973's terminal before #954; it is not a new serving-time corpus reader or a
-shortcut around the issue order. More rows, exact hits, or trace activity are
-capacity/recall results unless a candidate-relative effect transfers to the
-held-out anti-recall partition under matched controls.
+explicit native revision changes that scope, run the separately frozen
+higher-scope/corpus-scale offline induction ladder and requalify its final
+artifact. The ladder is part of #973's terminal before #954; it is not a new
+serving-time corpus reader or a shortcut around the issue order. More rows,
+exact hits, or trace activity are capacity/recall results unless a
+candidate-relative effect transfers to the held-out anti-recall partition under
+matched controls.
 
 #962 later integrates the accepted #969/#953/#973 path into product chat/memory.
 #964 binds the #970 → #969 → #953 → #973 stages in the
@@ -526,16 +527,21 @@ not distinct. Record:
 `blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
 The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`.
 
-The next bounded in-place hypothesis changes only the compared representation:
-compile construction-only ordered predecessor histories with the same
-versioned noncommutative encoder as the live history, induce a candidate-
-conditioned exact placement/prototype, and rank already-admitted candidates in
-that same frame. Freeze admission/work and require a same-frame anti-vacuity
-guard, state-disabled, same-artifact placement-permuted, order-shuffled, and
-held-out anti-recall controls with ties abstaining. Historical self-match and
-corpus-placement records motivate operand comparability only; they do not
-establish this decoded effect. Generic fixed Hopf or spectral proxy activity is
-not the immediate mechanism. #953 remains open and #973 remains blocked.
+That next hypothesis was frozen and executed as
+`LocalSameObjectContextPlacementV1`. Each decisive history obtained `still`
+from causal singleton support before the `{run,runs}` query; no candidate was
+appended as an inference input. All controls reused the same overlay artifact,
+prompt support, admission, and work. The label-free, selection-blind raw census
+reproduced 7/7 construction trajectories with zero class collisions and zero
+padding-identity aliases. Real placement selected 0/2 intended candidates,
+while the placement-permuted and order-shuffled controls selected 2/2 and 1/2.
+Complete held-out histories were absent from construction, but the operative
+suffixes exactly recalled shorter construction subhistories, so the partition
+was not operative-representation anti-recall. Generator execution and replay
+were `NOT_RUN`. The corrected label-free input, raw-census, and label-attached
+outcome identities are bound in the
+[#953 record](local_geometric_generation_953.md). #953 awaits a newly frozen
+maintainer plan; #973 and downstream #954 remain blocked.
 
 ### A1Q-H/#973 exact-spin global operator prototype
 

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -118,10 +118,15 @@ run nevertheless chose `still run` for both full-path prompt orders; disabled
 selection chose `still runs` for both. Deterministic replay and the bounded
 runtime invariants passed, but the required incompatible full-path choices did
 not. #953 therefore remains at `REVISE_I1_GENERATOR_IN_PLACE`; the localized
-next hypothesis is bounded same-object, order-sensitive corpus-induced
-candidate-relative compatibility/placement within #953. #973 remains blocked
-and later owns paragraph, conversation, and global exact-spin operator
-qualification only through an accepted #953 loop. Calling that operator
+same-object, order-sensitive corpus-induced candidate-placement hypothesis was
+then frozen as `LocalSameObjectContextPlacementV1`. Its exact preflight
+reproduced all construction prototypes with zero class collisions, but real
+placement chose `run/runs` (0/2 intended) while the placement-permuted control
+chose `runs/run` (2/2). Generator execution and replay were `NOT_RUN`, so it did
+not qualify the placement hypothesis. #953 awaits a newly frozen maintainer
+plan; #973 remains blocked and later owns paragraph, conversation, and global
+exact-spin operator qualification only through an accepted #953 loop. Calling
+that operator
 harmonic additionally requires an artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive
 memory.
@@ -622,9 +627,11 @@ Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
 `RETAIN_H4_STATE_ONLY_ADVANCE_MULTICHANNEL_A1Q` closed through protected PR
 #972; #969 positive bounded mechanism result
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #953 loop plumbing and tiered
-admission implemented, but the natural selector remains at
-`REVISE_I1_GENERATOR_IN_PLACE`; #953 is active for candidate-relative
-same-object/order-sensitive representation and #973 remains blocked**.
+admission implemented; its first frozen candidate-placement preflight then
+selected 0/2 intended candidates under real placement while the same-artifact
+placement-permuted control selected 2/2, and generator execution/replay were
+`NOT_RUN`. #953 remains at `REVISE_I1_GENERATOR_IN_PLACE` and awaits a newly
+frozen maintainer plan; #973 remains blocked**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -884,12 +891,16 @@ source/provider closure, support/work equality, and byte-identical replay
 passed. The right full-path arm was correct, the left was wrong, and the two
 full-path decisive choices were not distinct. The record is
 `blake3:dfe03d4c56f7e5e9cf48d524f2f0b10482c4b3b85fae152dd29c64543caa0b79`.
-#953 remains `REVISE_I1_GENERATOR_IN_PLACE`; admission is repaired and the
-next bounded in-place hypothesis is a construction-only, same-object,
-order-sensitive candidate-relative compatibility/placement overlay under
-disabled, placement-permuted, and order-shuffled controls. Generic fixed Hopf
-or spectral proxy activity is not the missing decoded decision. Harmonic
-ranking and higher-scope work remain dormant; #973 remains blocked.
+#953 remains `REVISE_I1_GENERATOR_IN_PLACE`; admission is repaired. The frozen
+construction-only, same-object, order-sensitive candidate-placement overlay
+then reproduced 7/7 construction prototypes with zero class collisions and zero
+padding-identity aliases. Real placement selected 0/2 intended candidates,
+while the same-artifact placement-permuted and order-shuffled controls selected
+2/2 and 1/2. Full-history absence was not operative-representation anti-recall
+because decisive retained suffixes exactly recalled construction subhistories.
+Generator execution and replay were `NOT_RUN`. #953 awaits a newly frozen
+maintainer plan; harmonic ranking and higher-scope work remain dormant, and
+#973 remains blocked.
 
 ### GI-2 A1Q-H / #973 — paragraph, conversation, and global attention
 
@@ -941,14 +952,21 @@ A positive global subprobe cannot close #973. Paragraph and conversation still
 require their own matched load-bearing qualification through the accepted loop,
 or an explicit native revision of #973's scope and dependencies.
 
-#### #973 corpus-induction qualification and handoff to #954
+#### #973 higher-scope/corpus-scale induction qualification and handoff to #954
 
 Within #973, only after #953 is accepted and every required #973 higher-scope
 intervention qualifies, or an explicit native revision changes that scope, may
-the programme activate controlled offline corpus induction. This ladder and its
-final requalification are part of #973's definition of done and terminal; #973
-cannot close and #954 cannot start without them. This does not authorize
-expansion of the active #953 experiment.
+the programme activate controlled higher-scope/corpus-scale offline induction.
+This ladder and its final requalification are part of #973's definition of done
+and terminal; #973 cannot close and #954 cannot start without them. The one
+separation permitted inside #953 was a tiny construction-only, same-frame,
+candidate-conditioned context-placement overlay over already-admitted
+candidates followed by frozen label attachment. Its label-free,
+selection-blind raw census froze before expected continuations were attached.
+That first attempt failed before decoded generation or replay, and exact
+shorter-suffix recall showed that full-history disjointness was not
+operative-representation anti-recall. The result does not authorize broad
+corpus expansion, a metric sweep, or higher-scope induction inside #953.
 
 Freeze the document/conversation/task partitions before compiling rows or
 operator statistics. Construction data may supply causal
@@ -961,12 +979,13 @@ rung receives new artifact and operator kappas while serving still performs no
 corpus scan and loads no source tensors.
 
 Current prime-derived H4 leaves and procedural spin classes remain exact
-identity coordinates, not established semantic placement. If corpus induction
-changes placement, it must create a versioned overlay or rebuilt artifact with
-an inverse/provenance witness; it may not silently reinterpret immutable route
-or payload identity. Every new placement epoch or structural operator revision
-invalidates inherited #973 evidence and reruns the bounded matched #973 gate
-before scale evidence is read.
+identity coordinates, not established semantic placement. Any corpus-induced
+placement change, including #953's bounded local overlay and #973's later
+corpus-scale ladder, must create a versioned overlay or rebuilt artifact with an
+inverse/provenance witness; it may not silently reinterpret immutable route or
+payload identity. Every new placement epoch or structural operator revision
+invalidates inherited evidence at its owning gate and reruns that bounded
+matched gate before downstream evidence is read.
 
 Within each rung, real, scope-disabled, order-shuffled, and operator-permuted
 arms have identical candidate support and work. Coverage and support changes
@@ -979,7 +998,7 @@ do not reproduce that effect.
 
 ### GI-4 / #954 — correctness and abstention
 
-After source-free generation and #973's higher-scope plus corpus-induction
+After source-free generation and #973's higher-scope plus corpus-scale induction
 terminal, test whether a frozen corpus-induced artifact conforming to and
 binding the accepted #969/#953/#973 identities understands the input well
 enough to choose a correct answer. #954 does not

--- a/docs/local_geometric_generation_953.md
+++ b/docs/local_geometric_generation_953.md
@@ -551,3 +551,139 @@ fuzz, formal proof, conformance, product QA, performance measurement, and
 release qualification were `NOT_RUN`. The protected merge queue remains the
 binding integration transport; its checks are not local product or research
 qualification evidence.
+
+## `LocalSameObjectContextPlacementV1` preflight hard stop — 2026-08-27
+
+This append-only revision executed the next frozen #953 mechanism contract. It
+did not modify `PrimaryThenAdjacentSpinFallbackV1`, the five frozen natural
+fixture identities, the repaired support record, the historical four-arm
+record, the #969 selector, or the schema-2 decoded generator. It added only a
+construction-derived overlay, a label-free preflight input, and a raw relation
+census that was both label-free and selection-blind.
+
+The frozen identities are:
+
+| Object | Identity / kappa |
+|---|---|
+| Placement policy | `uor-r4.local-same-object-context-placement/1` |
+| Placement-policy kappa | `blake3:e09af2db10f41efaf02b24e075a97fe42dc966834c43566689579763ba95b49c` |
+| Ordered encoder | `uor-r4.recent-suffix-ordered-h4-trajectory/1` |
+| Exact relation vector | `uor-r4.exact-recent-suffix-h4-shell-vector/1` |
+| Overlay artifact | `blake3:2be03c8acc1e97d1ba830805653ec1b16745065127ee1e00cb431b933a173ee1` |
+| Label-free preflight input | `blake3:ce5430048c3789e85e18ed17a80f10f79d317a66769ad8be0fd28224668eb72e` |
+| Raw label-free, selection-blind relation census | `blake3:50e67c087e1ec5e04aa47cf09d42e9b0857c15e4cafa07b1363d67faf96c6aeb` |
+| Label-attached preflight outcome | `blake3:d5e2f3614c8f1d3c6c629e2261ec42dc970fa5484982b2a86cb4f4b06b06a372` |
+
+The overlay binds schema, the placement and repaired-admission policies,
+manifest kappa and all four provenance CIDs, H4 root and multiplication-table
+kappas, width and occupancy-aware identity padding, suffix/comparison order,
+the four-prototype cap, exact candidate membership, causal witness provenance,
+and prototype coordinates. Its compiler consumed three artifact-bound rebuild
+witnesses containing seven within-witness predecessor-to-observed-next
+transitions. Those yielded five candidate classes and seven retained
+prototypes; the decisive `run` and `runs` candidates each had one prototype.
+All seven compiler trajectories reproduced through the online query encoder,
+all seven exact self-matches were coincident, and the complete typed
+construction inventory had zero cross-candidate class collisions and zero
+padding-identity aliases.
+
+The fixed carrier is the exact left-to-right ordered-H4 fold of recent suffix
+lengths 1, 2, 3, and 4, compared in that lexicographic order. The `run`
+predecessor has length three and occupancy `[true,true,true,false]`; its fourth
+slot is typed H4-identity padding with an explicit occupancy bit. The `runs`
+predecessor has length four and occupancy `[true,true,true,true]`. Live query
+histories use the same encoder and table. A manifest/table mismatch returns
+`UNAVAILABLE_FRAME_MISMATCH`.
+
+For each prompt, the preflight first ran the live repaired support query over
+the prompt history. Its causal singleton support supplied the observed `still`
+route, which was appended before the decisive `{run,runs}` query. `still` was
+not injected as a selector candidate: the raw census records two causal
+singleton-support observations and zero selector candidate-append inputs.
+
+The repaired admission contract remained exact on both prompt orders:
+
+| Step | Rows | Available | Examined/admitted | Union | Source counts `(I1,I2,IS,D,AS)` | Historical path work |
+|---:|---:|---:|---:|---|---|---:|
+| prompt to `still` | 7 | 8 | 3 / 3 | `{still}` | `(2,1,0,2,0)` | 5 keys / 5 comparisons |
+| after observed `still` | 7 | 11 | 6 / 6 | `{run,runs}` | each `(1,1,0,1,0)` | 6 keys / 12 comparisons |
+
+Every decisive placement arm performed two prototype evaluations and eight
+slot comparisons. Within each prompt, real, placement-permuted, and
+order-shuffled controls reused the same overlay artifact, causal history,
+support, admission, and work; only the predeclared prototype placement or
+construction order changed.
+
+The frozen real-placement inventory was:
+
+| Prompt | Candidate | Exact shell vector, suffix lengths 1→4 | Exact-slot mask |
+|---|---|---|---|
+| left | `run` | `Coincident, Coincident, Coincident, Degrees120` | `true,true,true,false` |
+| left | `runs` | `Coincident, Coincident, Orthogonal, Degrees120` | `true,true,false,false` |
+| right | `run` | `Coincident, Coincident, Orthogonal, Degrees108` | `true,true,false,false` |
+| right | `runs` | `Coincident, Coincident, Coincident, Coincident` | `true,true,true,true` |
+
+Both candidates tie on suffix lengths one (`still`) and two (`generally
+still`). The shortest-to-longest lexicographic contract therefore decides at
+length three: the left retained suffix exactly recalls `athletes generally
+still` and points to construction candidate `run`, while the right retained
+suffix exactly recalls `athlete generally still` and points to construction
+candidate `runs`. The controlling earlier subject is outside the decisive
+width. No complete six-route held-out history equals a construction
+predecessor, but that full-history anti-recall check is insufficient: the
+operative retained representation contains these exact shorter construction
+subhistories.
+
+Attaching the already-frozen expected continuations only after the relation
+census produced:
+
+| Placement/control | Left decisive relation | Right decisive relation | Intended matches |
+|---|---|---|---:|
+| real | `run` | `runs` | 0 / 2 |
+| canonical cyclic placement permutation | `runs` | `run` | 2 / 2 |
+| reversed construction order | `runs` | `runs` | 1 / 2 |
+
+This is clean separability with the wrong causal orientation, not an H4 class
+collision. The same-artifact placement-permuted control exactly reproduces the
+desired pair and therefore outperforms the real mechanism. The strict
+frozen-contract real-placement `strict_selection_ceiling` is `0/2`;
+`PASS_LOCAL_CONTEXT_PLACEMENT_PREFLIGHT` is `UNAVAILABLE`. Per the frozen
+contract, no selector or report-schema change was added; decoded generation and
+decoded replay were `NOT_RUN`, and no scalar,
+cost order, width, fixture, prototype cap, or second representation was tried.
+The terminal remains `REVISE_I1_GENERATOR_IN_PLACE`.
+
+The overlay, label-free preflight input, and raw selection-blind census use only
+canonical construction witnesses, immutable addresses, exact H4 tables, and
+observed query history. Expected-continuation, held-out-label,
+actual-future-route, source-tensor, teacher, provider, and candidate-append
+inputs are all zero. Canonical overlay bytes and the complete raw census
+reproduced byte-for-byte before expected continuations were attached to produce
+the separate label-attached outcome.
+
+Focused verification for this revision:
+
+- the exact raw relation-census freeze passed at
+  `blake3:50e67c087e1ec5e04aa47cf09d42e9b0857c15e4cafa07b1363d67faf96c6aeb`;
+- the exact label-attached hard-stop outcome passed at
+  `blake3:d5e2f3614c8f1d3c6c629e2261ec42dc970fa5484982b2a86cb4f4b06b06a372`;
+- the explicit historical-generator quarantine passed without constructing or
+  running the generator;
+- the focused #969 causal-path decoded regression retained record
+  `blake3:60360a9e22a56ea4af363e43f7103bb8104d015d58feb582d921fc17afaf207f`;
+- focused core/test compilation and changed-mechanism clippy passed after
+  excluding unchanged `origin/main` lint categories;
+- the exported WASM library check passed with existing warnings outside this
+  revision; and
+- formatting, claim wording, and diff-whitespace checks passed.
+
+Decoded #953 generation/replay, workspace-wide tests/clippy, no-std ladders,
+corpus/model/teacher work, generation canaries, BDD, Gate C, kappa
+reproduction, audit, fuzz, formal proof, conformance, product QA, performance,
+and release qualification were `NOT_RUN`.
+
+This result does not establish grammar, coherent generation, semantic
+placement, correctness, higher-scope attention, reasoning, performance
+advantage, formal closure, product readiness, or release readiness. #953 awaits
+a newly frozen maintainer plan inside its existing scope; #973 and #954 remain
+blocked, and no downstream issue is activated.

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -184,9 +184,13 @@ one another.
 - **Geometric-intelligence sequence** — lexical ingestion, canonical
   serialization, and address membership are prerequisite plumbing. Delivery
   then proceeds in this order: one qualified local causal-path mechanism
-  (#969); one bounded decoded generation loop with repaired admission (#953);
-  paragraph/conversation/global exact-spin operator qualification through that
-  loop plus controlled corpus induction and final requalification (#973);
+  (#969); one bounded decoded generation loop with repaired admission plus an
+  accepted local construction-induced candidate-placement mechanism (#953).
+  The first frozen placement preflight failed, so #953 awaits a newly frozen
+  plan;
+  paragraph, conversation, and global exact-spin operator qualification through
+  that loop plus controlled higher-scope/corpus-scale induction and final
+  requalification (#973);
   correctness with abstention (#954); then bounded hypothetical-branch reasoning
   (#955).
   Evidence may not skip a stage or count prerequisite plumbing as inference.


### PR DESCRIPTION
## Outcome

Implements and records exactly the frozen #953 `LocalSameObjectContextPlacementV1` selection-blind preflight from live `main`.

The raw census is label-free and selection-blind: each decisive `still` route is observed from causal singleton support; candidate minima, tie semantics, and held-out continuation labels are applied only after the raw census is frozen.

Frozen identities:

- placement policy: `blake3:e09af2db10f41efaf02b24e075a97fe42dc966834c43566689579763ba95b49c`
- overlay: `blake3:2be03c8acc1e97d1ba830805653ec1b16745065127ee1e00cb431b933a173ee1`
- label-free input: `blake3:ce5430048c3789e85e18ed17a80f10f79d317a66769ad8be0fd28224668eb72e`
- raw relation census: `blake3:50e67c087e1ec5e04aa47cf09d42e9b0857c15e4cafa07b1363d67faf96c6aeb`
- label-attached outcome: `blake3:d5e2f3614c8f1d3c6c629e2261ec42dc970fa5484982b2a86cb4f4b06b06a372`

Inventory: 7/7 compiler/query reproductions, zero cross-candidate class collisions, zero padded/populated identity aliases, and identical artifact/support/work bindings across real, placement-permuted, and order-shuffled controls.

Outcome:

- real placement: `run/runs` = 0/2 intended
- cyclic placement-permuted: `runs/run` = 2/2
- reversed construction order: `runs/runs` = 1/2
- `PASS_LOCAL_CONTEXT_PLACEMENT_PREFLIGHT=UNAVAILABLE`
- frozen-contract real-placement ceiling: 0/2
- decoded generation and replay: `NOT_RUN`
- terminal: `REVISE_I1_GENERATOR_IN_PLACE`

The historical generator is mechanically quarantined. #953 remains open for a newly frozen maintainer plan; #973 and #954 remain blocked. This does not establish grammar, coherence, semantic placement, correctness, reasoning, product quality, or release readiness.

## Focused verification

- exact raw census freeze: passed
- exact label-attached hard-stop outcome: passed
- historical-generator quarantine: passed without generator construction
- focused #969 causal-path decoded regression: passed
- focused changed-mechanism clippy: passed with unchanged `origin/main` lint categories excluded
- exported WASM library check: passed with existing unrelated warnings
- format, claim wording, and diff whitespace: passed

Workspace-wide tests/clippy, no-std ladders, corpus/model/teacher work, BDD, Gate C, kappa reproduction, audit, fuzz, formal proof, conformance, product QA, performance, and release qualification were `NOT_RUN`.

References #953