### PR TITLE
Certify #986 unavailable corpus/frame prerequisites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,17 +34,20 @@ three-family, six-decision population. Its usable construction classes were
 pure, but construction coverage and the sealed strict ceiling were both 0/6.
 It stopped `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before a deployed selector,
 payload inversion, or #953 generation. #983 is now closed as bounded negative
-evidence. Fresh native child #986 owns exactly one successor:
-`CorpusSignedTransportV1` first qualifies corpus-induced semantic placement and
-a static self-plus-six harmonic link-state field, then asks whether signed
-zero-sum Cl(0,6)/SpiralCore transport adds causal value beyond matched link/
-distance controls and a table-native semantic-value comparator. #953 remains parked,
-unassigned, untouched, and blocked by #986. Do not add a second representation
-under #983, reuse its population, or add Poincare/Hopf or other harmonic
-machinery beyond #986's exact frozen local contract. The current chain is
-closed #983 → #986 → #953 → #973 → #954,
-followed by #955 → #962–#965. The complete decision and nonclaim boundary is
-[`docs/corpus_induced_signed_transport_attention_plan_986.md`](docs/corpus_induced_signed_transport_attention_plan_986.md).
+evidence. #986 then executed the one frozen `CorpusSignedTransportV1`
+feasibility contract. The pinned raw corpus reproduced, but no exact
+corpus-scale codec/three-way pair commitment existed, and the exact SpiralCore
+control still supplied no complete same-frame lexical `O(x)` map or
+compiler/query frame identity. #986 therefore closed
+`UNAVAILABLE_FRAME_OR_POPULATION` before placement, diffusion, Gate 0, labels,
+selection, or #953. #953 remains parked, unassigned, and untouched; it is not
+eligible merely because its completed native blocker is now closed. Do not add
+a second representation under #983/#986, reuse their populations, or resume
+#953. A new local attempt first requires a freshly frozen population/frame
+successor issue. The completed evidence chain is #983 → #986; downstream
+#953 → #973 → #954 → #955 → #962–#965 remains parked. The complete #986 result
+and nonclaim boundary is
+[`docs/corpus_signed_transport_attention_986.md`](docs/corpus_signed_transport_attention_986.md).
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
@@ -65,13 +68,12 @@ canonical decode/render/append loop. H4 is an exact finite S3 codebook here;
 `H4 ⊕ phi H4` / E8 remains structural storage and control rather than the
 attention score.
 
-#986 does not assume that identity geometry is semantic geometry. Its
-construction-only corpus artifact supplies semantic placement/value over
-immutable route identities. Exact ordered H4/Cl(0,6)/SpiralCore state supplies
-causal transport. One candidate-relative signed zero-sum radial/angular
-contrast is the attention candidate, and a table-native value-only arm is the
-required comparator. If geometry adds no causal uplift, retain it as
-addressing/transport and advance the simpler value engine honestly.
+#986 did not assume that identity geometry was semantic geometry. It stopped
+before constructing either semantic placement or the signed transport readout:
+the population commitment and complete lexical SpiralCore operator frame were
+unavailable. Its exact finite algebra remains addressing/transport/control
+substrate only. No table-value or geometric arm ran, so neither may be promoted
+from #986.
 
 The intended destination is frontier-like useful local intelligence without
 transformers, MoE/sparse learned routing, or dense matrix intelligence. That is
@@ -89,8 +91,8 @@ only after its identity binds basis, mode order, coefficients, quantization,
 and transition law.
 
 Corpus scale follows mechanism qualification; it never substitutes for it.
-#986 is one bounded local placement/transport qualification on a frozen
-CID-disjoint split, not the corpus-scale ladder. Within #973, after #953 and
+#986 was one bounded local placement/transport qualification, but it stopped
+before freezing its CID-disjoint split. Within #973, after #953 and
 every required #973 scope qualify, a predeclared
 higher-scope/corpus-scale offline ladder may compile causal
 prefix-to-observed-next-route examples,
@@ -274,10 +276,12 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   transferred to 0/6 held-out decisions. #983 stopped
   `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before deployed selection, payload
   inversion, or #953 generation and is now closed as bounded negative evidence.
-  #986 owns the fresh `CorpusSignedTransportV1` semantic-placement, static
-  self-plus-six harmonic link-state, and signed-transport qualification. #953
-  stays parked, unassigned, untouched, and
-  blocked by #986, while #973 and #954 remain blocked.
+  #986 then stopped `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus
+  reproduced, but the exact population/codec commitment and a complete
+  same-frame lexical SpiralCore operator map were unavailable. Placement,
+  Gate 0, labels, selection, and #953 were `NOT_RUN`. #953 stays parked,
+  unassigned, and untouched pending a newly frozen population/frame successor;
+  #973 and #954 remain blocked.
   #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,13 +121,13 @@ The experiment must be able to change the next programme decision:
   were `NOT_RUN`; the terminal remains `REVISE_I1_GENERATOR_IN_PLACE`. A1Q-L2/
   #983 then formed pure construction classes on an independent population but
   transferred on 0/6 held-out decisions and closed
-  `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER`. A1Q-L3/#986 is now the only local
-  qualification: first test CID-disjoint corpus-induced semantic placement and
-  a static self-plus-six harmonic link-state field, then ask whether signed
-  zero-sum Cl(0,6)/SpiralCore transport adds causal value over matched link/
-  distance controls and a table-native semantic-value comparator. #953 remains
-  parked, unassigned, untouched, and blocked. A1Q-H/#973 and GI-4/#954 remain
-  blocked, with GI-5/#955 downstream.
+  `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER`. A1Q-L3/#986 then closed
+  `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus reproduced, but the exact
+  corpus-scale codec/pair commitment and complete same-frame lexical
+  Cl(0,6)/SpiralCore operator map were unavailable. Gate 0, labels, selection,
+  and #953 were `NOT_RUN`. #953 remains parked, unassigned, and untouched until
+  a freshly frozen population/frame successor independently qualifies. A1Q-H/
+  #973 and GI-4/#954 remain blocked, with GI-5/#955 downstream.
 - **Exercise the real route path.** Geometry must run before token choice and
   emit its admitted support and energy trace. Add a global-context coverage
   witness when the active issue, beginning with #973, activates higher scopes.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > 2/2 and 1/2. Generation and replay were `NOT_RUN`; the terminal remains
 > `REVISE_I1_GENERATOR_IN_PLACE`. Independent #983 then formed pure
 > construction classes but transferred to 0/6 held-out decisions and closed at
-> `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before selection. #986 now tests one
-> fresh `CorpusSignedTransportV1` contract: corpus-induced semantic placement
-> and a static self-plus-six harmonic link-state field first, then signed
-> zero-sum exact transport against link/distance controls and a table-native
-> value comparator. #953 remains parked, unassigned, untouched, and blocked; #973 and
-> #954 remain blocked.
+> `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before selection. #986 then closed
+> `UNAVAILABLE_FRAME_OR_POPULATION`: the pinned raw corpus reproduced, but its
+> exact #986 codec/pair commitment and a complete same-frame lexical SpiralCore
+> operator map were unavailable. Placement, diffusion, Gate 0, calibration,
+> sealed labels, selection, and #953 were `NOT_RUN`. #953 remains parked,
+> unassigned, and untouched pending a newly frozen population/frame successor;
+> #973 and #954 remain blocked.
 > Higher-scope attention, correct answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
@@ -185,13 +186,13 @@ remains `REVISE_I1_GENERATOR_IN_PLACE`. The first frozen local same-object,
 order-sensitive candidate-placement preflight then failed before generation or
 replay: real placement selected 0/2 intended candidates while its same-artifact cyclic
 placement control selected 2/2. #983's later independent construction-return
-classes then transferred to 0/6 held-out decisions. #986 is now the only local
-qualification: semantic placement must transfer before signed
-Cl(0,6)/SpiralCore transport may claim causal value over the matched
-table-native comparator. #953 remains untouched; #973 and #954 remain blocked.
+classes then transferred to 0/6 held-out decisions. #986's later local
+qualification stopped before geometry because neither its exact corpus/codec
+population nor a complete lexical Cl(0,6)/SpiralCore frame was available.
+#953 remains untouched; #973 and #954 remain blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
-See the [current #986 plan](docs/corpus_induced_signed_transport_attention_plan_986.md)
-for the selected mechanism, controls, and decision branches.
+See the [#986 evidence record](docs/corpus_signed_transport_attention_986.md)
+for the exact feasibility boundary and deliberately unrun stages.
 Stored H4/Hopf/zeta/icosian and related route fields remain
 structural state, diagnostics, or controls unless the owning stage qualifies a
 specific term.
@@ -282,11 +283,10 @@ sequence so each new mechanism can become visible before the final engine is
 complete.
 
 The active dependency chain is tracked in
-[#820](https://github.com/UOR-Foundation/uor-r4/issues/820). The immediate
-implementation stage is
-[#986](https://github.com/UOR-Foundation/uor-r4/issues/986). #953 is parked
-behind #986; #973 and #954 remain blocked downstream of #953, and #954 also
-depends on #973.
+[#820](https://github.com/UOR-Foundation/uor-r4/issues/820). #986 is closed at
+its pre-sealed unavailable terminal. There is no eligible local implementation
+stage until a fresh population/frame successor is frozen. #953 remains parked;
+#973 and #954 remain blocked downstream of #953, and #954 also depends on #973.
 
 ## Find your way around
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,10 +31,13 @@ six-decision population. Its binding label-free census found pure construction
 classes but zero construction-to-validation transfer; the sealed outcome is
 `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` at 0/6. The deployed selector,
 payload inversion, decoded generation, and #953 were `NOT_RUN`. #983 remains
-closed as negative evidence. #986 now owns one fresh
-`CorpusSignedTransportV1` qualification, including the static self-plus-six
-`HarmonicLinkState7` field, and blocks parked, unassigned, untouched #953;
-#953 continues to block #973 and #954._
+closed as negative evidence. A1Q-L3/#986 then stopped
+`UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but no exact
+corpus-scale codec/three-way pair commitment or complete same-frame lexical
+SpiralCore operator map was available. Placement, diffusion, Gate 0, labels,
+selection, and #953 were `NOT_RUN`. #986 is closed; parked, unassigned,
+untouched #953 remains ineligible pending a freshly frozen population/frame
+successor and continues to block #973 and #954._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -68,13 +71,12 @@ closed as negative evidence. #986 now owns one fresh
 > construction classes, all usable classes pure, but zero structural transfer
 > and a 0/6 strict ceiling. It stopped `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER`
 > before the deployed selector or payload inversion; #953 remained untouched.
-> That negative is now closed and preserved. #986 is the separate fresh
-> contract: corpus-induced placement/value must first transfer on a CID-disjoint
-> held-out split, then one signed zero-sum candidate-relative
-> Cl(0,6)/SpiralCore transport readout must beat matched placement, transport,
-> order, state, recall, and table-native value controls. If table value
-> transfers but geometry adds no causal uplift, geometry remains addressing and
-> transport rather than semantic scoring. Once #953 is accepted and every required #973 scope
+> That negative is now closed and preserved. #986 separately attempted the
+> frozen corpus-induced placement/value and signed-transport contract, but its
+> exact population and lexical SpiralCore frame were unavailable. It stopped
+> before placement or labels; no table or geometric arm transferred. A new
+> local attempt must freeze a population/frame successor rather than retry
+> #986. Once #953 is accepted and every required #973 scope
 > qualifies, a separately frozen higher-scope/corpus-scale offline induction
 > ladder may compile causal prefix-to-observed-next-route examples, multiscale
 > route summaries, versioned placement overlays that preserve immutable
@@ -105,10 +107,11 @@ closed as negative evidence. #986 now owns one fresh
 
 Native GitHub relationships are the source of truth:
 
-The current priority view is **Now:** #986 only; **Next:** #953 → #973 → #954;
-**Later:** #955 → #962 → #963 → #964 → #965. The full #986 mechanism,
-controls, thresholds, and branches are frozen in the
-[#986 plan](docs/corpus_induced_signed_transport_attention_plan_986.md).
+The current priority view is **Now:** freeze no implementation until a fresh
+population/frame successor is authored; **Parked:** #953 → #973 → #954;
+**Later:** #955 → #962 → #963 → #964 → #965. The completed #986 feasibility
+boundary is recorded in the
+[#986 evidence](docs/corpus_signed_transport_attention_986.md).
 
 1. **GI-0 — retain #958 foundation:** keep the schema-2 manifest, bounded route
    lookup, worker evidence, controls, and optional operator fixtures at their
@@ -229,7 +232,7 @@ controls, thresholds, and branches are frozen in the
    selector, payload inversion, decoded generation, and #953 were `NOT_RUN`.
    See the [#983 evidence record](docs/construction_causal_return_attention_983.md).
 7. **GI-2 A1Q-L3 / #986 — corpus-induced harmonic signed transport
-   qualification:** on a fresh document/CID-disjoint induction, calibration,
+   qualification (completed unavailable):** on a fresh document/CID-disjoint induction, calibration,
    and sealed-test split, compile deterministic causal co-occurrence/PPMI
    semantic placement over immutable lexical-route identities. Give each route
    one `HarmonicLinkState7` record—self plus up to six construction-derived PPMI
@@ -269,10 +272,21 @@ controls, thresholds, and branches are frozen in the
    No re-freeze, retry, or generation runs in #986. See the
    [#986 plan](docs/corpus_induced_signed_transport_attention_plan_986.md).
 
-   Downstream, **accepted local semantic selector** means either the full #986
-   mechanism after its positive terminal, or the separate table-value selector
-   after #986 takes that branch and its successor independently qualifies.
-   #983/#986 remain evidence provenance, not automatic serving consumers.
+   **Observed #986 result (2026-08-28):** raw corpus identity and the
+   3,000-document census reproduced, but no exact corpus-scale codec/three-way
+   pair commitment existed. The exact 64-state SpiralCore table also
+   reproduced, while cross-chart transport remained `NOT_ESTABLISHED` and no
+   lexical `O(x)` or compiler/query frame identity existed. The certificate
+   `blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`
+   therefore records `UNAVAILABLE_FRAME_OR_POPULATION`. Placement, diffusion,
+   Gate 0, calibration, sealed labels, all arms, replay, and #953 were
+   `NOT_RUN`. See the
+   [#986 evidence record](docs/corpus_signed_transport_attention_986.md).
+
+   Downstream, **accepted local semantic selector** now requires an independently
+   frozen successor that first repairs both population and frame availability
+   and then qualifies its own causal contract. #983/#986 remain evidence
+   provenance, not serving consumers.
 8. **GI-3 / #953 — bounded source-free geometric generation loop:** the
    accepted #969 path now drives reusable library/CLI plumbing from canonical
    prompt bytes through admission, exact inversion, rendering, append, and
@@ -297,9 +311,9 @@ controls, thresholds, and branches are frozen in the
    but real placement chose `run/runs` (0/2 intended) while the cyclic
    placement-permuted control chose `runs/run` (2/2); generation therefore
    remained `NOT_RUN`. #953 is now a parked, unassigned, untouched integration
-   regression. Only a full positive protected #986 terminal, or a separately
-   qualified table-value successor authorized by that branch, may be applied
-   there in a later session, unchanged and behind a new label-free preflight. Harmonic
+   regression. Only a newly frozen successor that independently qualifies a
+   local semantic selector may be applied there in a later session, unchanged
+   and behind a new label-free preflight. Harmonic
    influence remains dormant in #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
 9. **GI-2 A1Q-H / #973 — higher-scope attention:** after the accepted local
@@ -358,11 +372,12 @@ mechanism-first prototype reached its positive bounded terminal. #953's loop
 plumbing and tiered admission remain preserved, but its known placement
 population is quarantined after 0/2 real versus 2/2 placement-permuted and
 decoded generation/replay `NOT_RUN`. #983 is closed bounded negative evidence
-after its independent Gate 0 transferred on 0/6 decisions. Fresh, unassigned
-#986 is the only open local qualification and the native blocker of parked,
-unassigned #953. The live chain is closed #967/#970/#969/#983 → open #986 →
-parked #953 → blocked #973 → blocked #954 → #955 → #962–#965. #953 continues
-to block #973 and #954; #973 continues to block #954.
+after its independent Gate 0 transferred on 0/6 decisions. #986 is also closed
+at its pre-sealed population/frame unavailable terminal. No local
+implementation issue is eligible until a fresh successor is frozen. The live
+sequence is closed #967/#970/#969/#983/#986 → parked #953 → blocked #973 →
+blocked #954 → #955 → #962–#965. #953 continues to block #973 and #954; #973
+continues to block #954.
 Legacy tracker #949 is closed as
 superseded; #958 is retained directly under programme root #820 as GI-0
 foundation.
@@ -373,15 +388,18 @@ historical evidence and comparators.
 
 ## Now
 
-- [ ] **#986 A1Q-L3 corpus-induced signed transport qualification** — the one
-  open successor to closed-negative #983. First qualify corpus-induced semantic
-  placement/value on the frozen CID-disjoint split. Only then test whether the
-  signed candidate-relative exact transport arm causally beats the matched
-  table-native semantic-value comparator and required controls. #986 is
-  intentionally unassigned until execution begins. No generation, higher
-  scope, corpus scale, zeta-zero calculation, or runtime lowering is in scope.
+- [ ] **Fresh population/frame successor — not yet authored.** Before any local
+  semantic selector can run, a new issue must freeze a source-free corpus-scale
+  codec plus exact three-way pair commitment and a complete same-frame lexical
+  SpiralCore operator map. Do not resume #986 or #953 to invent either contract.
 
 ## Completed negative
+
+- [x] **#986 A1Q-L3 corpus-induced signed transport qualification** — closed
+  `UNAVAILABLE_FRAME_OR_POPULATION`. The source corpus and finite SpiralCore
+  control reproduced, but the exact #986 population/codec commitment and
+  lexical operator frame were unavailable. Gate 0, labels, all selection arms,
+  replay, and #953 were `NOT_RUN`.
 
 - [x] **#983 A1Q-L2 construction-transferred candidate-conditioned geometric
   attention** — closed at `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER`: pure usable
@@ -395,10 +413,10 @@ historical evidence and comparators.
 - [ ] **#953 bounded source-free geometric generation loop** — preserved at
   historical terminal `REVISE_I1_GENERATOR_IN_PLACE`, open and unassigned. Its
   fixture, placement overlay, decoded loop, and records remain untouched while
-  #986 is open. After a positive protected #986 terminal, or its explicit
-  table-value qualifier branch, a separate session may apply the accepted
-  algorithm unchanged to #953's preserved fixture, beginning with a new label-
-  free preflight. #953 continues to block #973 and #954.
+  no accepted semantic selector exists. Only a newly frozen successor that
+  independently qualifies a local semantic selector may later authorize a
+  separate #953 session beginning with a new label-free preflight. #953
+  continues to block #973 and #954.
 
 ## Landed
 
@@ -522,10 +540,10 @@ historical evidence and comparators.
   placement-permuted control reached 2/2; generation and replay were `NOT_RUN`.
   #983 then tested `ConstructionCausalReturnV1` on an independent natural
   population and stopped `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` at 0/6
-  before its deployed selector. Fresh #986 now owns the only local qualifier:
-  corpus-induced semantic value, a self-plus-six harmonic link-state field,
-  signed candidate-relative transport, and a table-native comparator on a new
-  matched sealed population. #953 remains an untouched parked integration
+  before its deployed selector. #986 then stopped
+  `UNAVAILABLE_FRAME_OR_POPULATION` before geometry because its exact
+  population/codec commitment and complete lexical SpiralCore frame were
+  unavailable. #953 remains an untouched parked integration
   regression; #973 and #954 are still blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a

--- a/crates/uor-r4-graph-certify/src/corpus_signed_transport_attention.rs
+++ b/crates/uor-r4-graph-certify/src/corpus_signed_transport_attention.rs
@@ -1,0 +1,579 @@
+//! Fail-closed pre-geometry feasibility certificate for issue #986.
+//!
+//! This module deliberately has no placement, diffusion, Gate 0, calibration,
+//! label, or route-map API. It records the observed corpus/codec/split state,
+//! revalidates the live exact SpiralCore control, and stops at the absent
+//! complete same-frame lexical `O(x)` binding.
+
+use serde::Serialize;
+use uor_r4_core::spiralcore_operator::{
+    cl06_finite_composition_table, validate_spiralcore_v63_operator, CANONICAL_SIX_PRIME_VALUES,
+    CHART_TRANSPORT_STATUS, CL06_FINITE_COMPOSITION_DOMAIN,
+    CL06_FINITE_COMPOSITION_KAPPA_REFERENCE, CL06_FINITE_GROUP_ORDER, OPERATOR_SEMANTIC_STATUS,
+    SIX_PRIME_CHART_DOMAIN, SPIRALCORE_OPERATOR_DOMAIN, SPIRALCORE_OPERATOR_KAPPA_REFERENCE,
+    SPIRALCORE_V63_REFERENCE_SHA256,
+};
+
+pub const PREFLIGHT_SCHEMA: u32 = 1;
+pub const PREFLIGHT_DOMAIN: &str = "uor-r4.corpus-signed-transport-pregeometry/1";
+pub const FROZEN_POLICY: &str = "CorpusSignedTransportV1";
+pub const UNAVAILABLE_FRAME_OR_POPULATION: &str = "UNAVAILABLE_FRAME_OR_POPULATION";
+pub const TERMINAL_PRECEDENCE: [&str; 5] = [
+    "INVALID_CONTRACT",
+    UNAVAILABLE_FRAME_OR_POPULATION,
+    "PROCEED_TO_I1_WITH_CORPUS_SIGNED_TRANSPORT_ATTENTION",
+    "RETAIN_GEOMETRY_AS_TRANSPORT_ADVANCE_TABLE_VALUE_QUALIFIER",
+    "REDESIGN_CORPUS_OBJECTIVE_OR_PLACEMENT",
+];
+
+const REQUIRED_CALIBRATION_PAIRS: u32 = 16;
+const REQUIRED_CALIBRATION_DECISIONS: u32 = 32;
+const REQUIRED_SEALED_TEST_PAIRS: u32 = 32;
+const REQUIRED_SEALED_TEST_DECISIONS: u32 = 64;
+const LEXICAL_BINDING_STATUS: &str = "ABSENT_NO_VERIFIABLE_COMPLETE_SAME_FRAME_LEXICAL_O_X_SURFACE";
+
+/// Label-free facts observed before any geometric work is allowed.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct ObservedCorpusCodecSplitReadiness {
+    pub audited_main_commit: String,
+    pub raw_manifest_bytes_cid: Option<String>,
+    pub declared_corpus_bytes_cid: Option<String>,
+    pub reproduced_corpus_bytes_cid: Option<String>,
+    pub codec_cid: Option<String>,
+    pub split_commitment_cid: Option<String>,
+    pub source_document_count: u64,
+    pub construction_document_count: u64,
+    pub held_out_document_count: u64,
+    pub construction_lexical_route_count: u64,
+    pub calibration_pair_count: u32,
+    pub calibration_decision_count: u32,
+    pub sealed_test_pair_count: u32,
+    pub sealed_test_decision_count: u32,
+    pub source_free_observation_corpus: bool,
+    pub canonical_codec_reproduces: bool,
+    pub document_cid_partition_verified: bool,
+    pub anti_recall_disjointness_verified: bool,
+    pub natural_candidate_rule_frozen: bool,
+    pub pair_selection_key_frozen: bool,
+}
+
+/// Live exact-algebra finding, separated from the missing lexical binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LiveSpiralCorePrerequisite {
+    pub reference_sha256: &'static str,
+    pub operator_domain: &'static str,
+    pub operator_kappa_reference: &'static str,
+    pub observed_operator_kappa: Option<String>,
+    pub composition_domain: &'static str,
+    pub composition_kappa_reference: &'static str,
+    pub observed_composition_kappa: Option<String>,
+    pub finite_group_order: u64,
+    pub composition_entries: u64,
+    pub associativity_checks: u64,
+    pub two_sided_inverses: u64,
+    pub noncommuting_ordered_pairs: u64,
+    pub exact_operator_and_table_reproduce: bool,
+    pub six_prime_chart_domain: &'static str,
+    pub canonical_six_prime_values: [u32; 6],
+    pub chart_transport_status: &'static str,
+    pub operator_semantic_status: &'static str,
+    pub cross_chart_transport_established: bool,
+    pub lexical_binding_status: &'static str,
+    pub lexical_binding_manifest_cid: Option<String>,
+    pub verified_bound_lexical_route_count: u64,
+    pub complete_same_frame_lexical_operator_binding: bool,
+    pub compiler_query_frame_identity_verified: bool,
+}
+
+/// Canonical, label-free prerequisite certificate for the current repository
+/// surface. Its only emitted terminal is the frozen pre-sealed failure branch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusSignedTransportPregeometryCertificate {
+    pub schema: u32,
+    pub domain: &'static str,
+    pub policy: &'static str,
+    pub terminal_precedence: [&'static str; 5],
+    pub required_calibration_pairs: u32,
+    pub required_calibration_decisions: u32,
+    pub required_sealed_test_pairs: u32,
+    pub required_sealed_test_decisions: u32,
+    pub observed: ObservedCorpusCodecSplitReadiness,
+    pub audited_main_commit_is_canonical: bool,
+    pub raw_manifest_bytes_cid_is_canonical: bool,
+    pub corpus_bytes_cid_reproduces: bool,
+    pub source_partition_counts_reproduce: bool,
+    pub codec_cid_is_canonical: bool,
+    pub split_commitment_is_canonical: bool,
+    pub exact_population_available: bool,
+    pub spiralcore: LiveSpiralCorePrerequisite,
+    pub placement_started: bool,
+    pub diffusion_started: bool,
+    pub gate0_started: bool,
+    pub calibration_started: bool,
+    pub sealed_label_path_started: bool,
+    pub terminal: &'static str,
+    pub unavailable_reasons: Vec<&'static str>,
+}
+
+impl CorpusSignedTransportPregeometryCertificate {
+    /// Schema-fixed JSON with declaration-order fields and deterministic
+    /// escaping. All identity-bearing inputs are also reported with their
+    /// canonical-syntax verdicts.
+    pub fn canonical_json_bytes(&self) -> Vec<u8> {
+        let mut json = JsonObject::new();
+        json.u64("schema", u64::from(self.schema));
+        json.string("domain", self.domain);
+        json.string("policy", self.policy);
+        json.strings("terminal_precedence", &self.terminal_precedence);
+        json.u64(
+            "required_calibration_pairs",
+            u64::from(self.required_calibration_pairs),
+        );
+        json.u64(
+            "required_calibration_decisions",
+            u64::from(self.required_calibration_decisions),
+        );
+        json.u64(
+            "required_sealed_test_pairs",
+            u64::from(self.required_sealed_test_pairs),
+        );
+        json.u64(
+            "required_sealed_test_decisions",
+            u64::from(self.required_sealed_test_decisions),
+        );
+        json.raw("observed", &observed_json(&self.observed));
+        json.boolean(
+            "audited_main_commit_is_canonical",
+            self.audited_main_commit_is_canonical,
+        );
+        json.boolean(
+            "raw_manifest_bytes_cid_is_canonical",
+            self.raw_manifest_bytes_cid_is_canonical,
+        );
+        json.boolean(
+            "corpus_bytes_cid_reproduces",
+            self.corpus_bytes_cid_reproduces,
+        );
+        json.boolean(
+            "source_partition_counts_reproduce",
+            self.source_partition_counts_reproduce,
+        );
+        json.boolean("codec_cid_is_canonical", self.codec_cid_is_canonical);
+        json.boolean(
+            "split_commitment_is_canonical",
+            self.split_commitment_is_canonical,
+        );
+        json.boolean(
+            "exact_population_available",
+            self.exact_population_available,
+        );
+        json.raw("spiralcore", &spiralcore_json(&self.spiralcore));
+        json.boolean("placement_started", self.placement_started);
+        json.boolean("diffusion_started", self.diffusion_started);
+        json.boolean("gate0_started", self.gate0_started);
+        json.boolean("calibration_started", self.calibration_started);
+        json.boolean("sealed_label_path_started", self.sealed_label_path_started);
+        json.string("terminal", self.terminal);
+        json.strings("unavailable_reasons", &self.unavailable_reasons);
+        json.finish().into_bytes()
+    }
+
+    pub fn cid(&self) -> String {
+        format!(
+            "blake3:{}",
+            blake3::hash(&self.canonical_json_bytes()).to_hex()
+        )
+    }
+}
+
+/// Revalidate the current prerequisite surface and emit its fail-closed
+/// certificate. Summary data cannot establish a route-by-route `O(x)` map, so
+/// the current version always records zero verified bindings rather than
+/// accepting a caller assertion or synthesizing a mapping.
+pub fn certify_corpus_signed_transport_pregeometry(
+    observed: ObservedCorpusCodecSplitReadiness,
+) -> CorpusSignedTransportPregeometryCertificate {
+    let audited_main_commit_is_canonical = is_git_revision(&observed.audited_main_commit);
+    let raw_manifest_bytes_cid_is_canonical = observed
+        .raw_manifest_bytes_cid
+        .as_deref()
+        .is_some_and(is_blake3_cid);
+    let corpus_bytes_cid_reproduces = observed
+        .declared_corpus_bytes_cid
+        .as_deref()
+        .is_some_and(is_blake3_cid)
+        && observed.declared_corpus_bytes_cid == observed.reproduced_corpus_bytes_cid;
+    let source_partition_counts_reproduce = observed.source_document_count > 0
+        && observed
+            .construction_document_count
+            .checked_add(observed.held_out_document_count)
+            == Some(observed.source_document_count);
+    let codec_cid_is_canonical = observed.codec_cid.as_deref().is_some_and(is_blake3_cid);
+    let split_commitment_is_canonical = observed
+        .split_commitment_cid
+        .as_deref()
+        .is_some_and(is_blake3_cid);
+    let exact_population_available = audited_main_commit_is_canonical
+        && raw_manifest_bytes_cid_is_canonical
+        && corpus_bytes_cid_reproduces
+        && source_partition_counts_reproduce
+        && codec_cid_is_canonical
+        && split_commitment_is_canonical
+        && observed.construction_lexical_route_count > 0
+        && observed.calibration_pair_count == REQUIRED_CALIBRATION_PAIRS
+        && observed.calibration_decision_count == REQUIRED_CALIBRATION_DECISIONS
+        && observed.sealed_test_pair_count == REQUIRED_SEALED_TEST_PAIRS
+        && observed.sealed_test_decision_count == REQUIRED_SEALED_TEST_DECISIONS
+        && observed.source_free_observation_corpus
+        && observed.canonical_codec_reproduces
+        && observed.document_cid_partition_verified
+        && observed.anti_recall_disjointness_verified
+        && observed.natural_candidate_rule_frozen
+        && observed.pair_selection_key_frozen;
+
+    let operator = validate_spiralcore_v63_operator().ok();
+    let composition = cl06_finite_composition_table()
+        .and_then(|table| table.validate())
+        .ok();
+    let exact_operator_and_table_reproduce = operator.as_ref().is_some_and(|value| {
+        value.operator_kappa == SPIRALCORE_OPERATOR_KAPPA_REFERENCE
+            && value.finite_group_size == CL06_FINITE_GROUP_ORDER
+    }) && composition.as_ref().is_some_and(|value| {
+        value.operator_kappa == SPIRALCORE_OPERATOR_KAPPA_REFERENCE
+            && value.composition_kappa == CL06_FINITE_COMPOSITION_KAPPA_REFERENCE
+            && value.unique_states == CL06_FINITE_GROUP_ORDER
+            && value.composition_entries == CL06_FINITE_GROUP_ORDER * CL06_FINITE_GROUP_ORDER
+            && value.associativity_checks
+                == CL06_FINITE_GROUP_ORDER * CL06_FINITE_GROUP_ORDER * CL06_FINITE_GROUP_ORDER
+            && value.two_sided_inverses == CL06_FINITE_GROUP_ORDER
+            && value.noncommuting_ordered_pairs > 0
+    });
+    let spiralcore = LiveSpiralCorePrerequisite {
+        reference_sha256: SPIRALCORE_V63_REFERENCE_SHA256,
+        operator_domain: SPIRALCORE_OPERATOR_DOMAIN,
+        operator_kappa_reference: SPIRALCORE_OPERATOR_KAPPA_REFERENCE,
+        observed_operator_kappa: operator.as_ref().map(|value| value.operator_kappa.clone()),
+        composition_domain: CL06_FINITE_COMPOSITION_DOMAIN,
+        composition_kappa_reference: CL06_FINITE_COMPOSITION_KAPPA_REFERENCE,
+        observed_composition_kappa: composition
+            .as_ref()
+            .map(|value| value.composition_kappa.clone()),
+        finite_group_order: operator
+            .as_ref()
+            .map_or(0, |value| value.finite_group_size as u64),
+        composition_entries: composition
+            .as_ref()
+            .map_or(0, |value| value.composition_entries as u64),
+        associativity_checks: composition
+            .as_ref()
+            .map_or(0, |value| value.associativity_checks as u64),
+        two_sided_inverses: composition
+            .as_ref()
+            .map_or(0, |value| value.two_sided_inverses as u64),
+        noncommuting_ordered_pairs: composition
+            .as_ref()
+            .map_or(0, |value| value.noncommuting_ordered_pairs as u64),
+        exact_operator_and_table_reproduce,
+        six_prime_chart_domain: SIX_PRIME_CHART_DOMAIN,
+        canonical_six_prime_values: CANONICAL_SIX_PRIME_VALUES,
+        chart_transport_status: CHART_TRANSPORT_STATUS,
+        operator_semantic_status: OPERATOR_SEMANTIC_STATUS,
+        cross_chart_transport_established: CHART_TRANSPORT_STATUS == "ESTABLISHED",
+        lexical_binding_status: LEXICAL_BINDING_STATUS,
+        lexical_binding_manifest_cid: None,
+        verified_bound_lexical_route_count: 0,
+        complete_same_frame_lexical_operator_binding: false,
+        compiler_query_frame_identity_verified: false,
+    };
+
+    let mut unavailable_reasons = Vec::new();
+    if !audited_main_commit_is_canonical {
+        unavailable_reasons.push("AUDITED_MAIN_COMMIT_UNBOUND");
+    }
+    if !exact_population_available {
+        unavailable_reasons.push("EXACT_CORPUS_CODEC_SPLIT_POPULATION_UNAVAILABLE");
+    }
+    if !exact_operator_and_table_reproduce {
+        unavailable_reasons.push("EXACT_SPIRALCORE_OPERATOR_UNAVAILABLE");
+    }
+    unavailable_reasons.push("COMPLETE_SAME_FRAME_LEXICAL_O_X_BINDING_UNAVAILABLE");
+
+    CorpusSignedTransportPregeometryCertificate {
+        schema: PREFLIGHT_SCHEMA,
+        domain: PREFLIGHT_DOMAIN,
+        policy: FROZEN_POLICY,
+        terminal_precedence: TERMINAL_PRECEDENCE,
+        required_calibration_pairs: REQUIRED_CALIBRATION_PAIRS,
+        required_calibration_decisions: REQUIRED_CALIBRATION_DECISIONS,
+        required_sealed_test_pairs: REQUIRED_SEALED_TEST_PAIRS,
+        required_sealed_test_decisions: REQUIRED_SEALED_TEST_DECISIONS,
+        observed,
+        audited_main_commit_is_canonical,
+        raw_manifest_bytes_cid_is_canonical,
+        corpus_bytes_cid_reproduces,
+        source_partition_counts_reproduce,
+        codec_cid_is_canonical,
+        split_commitment_is_canonical,
+        exact_population_available,
+        spiralcore,
+        placement_started: false,
+        diffusion_started: false,
+        gate0_started: false,
+        calibration_started: false,
+        sealed_label_path_started: false,
+        terminal: UNAVAILABLE_FRAME_OR_POPULATION,
+        unavailable_reasons,
+    }
+}
+
+fn is_blake3_cid(value: &str) -> bool {
+    value.strip_prefix("blake3:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn is_git_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn observed_json(value: &ObservedCorpusCodecSplitReadiness) -> String {
+    let mut json = JsonObject::new();
+    json.string("audited_main_commit", &value.audited_main_commit);
+    json.optional_string(
+        "raw_manifest_bytes_cid",
+        value.raw_manifest_bytes_cid.as_deref(),
+    );
+    json.optional_string(
+        "declared_corpus_bytes_cid",
+        value.declared_corpus_bytes_cid.as_deref(),
+    );
+    json.optional_string(
+        "reproduced_corpus_bytes_cid",
+        value.reproduced_corpus_bytes_cid.as_deref(),
+    );
+    json.optional_string("codec_cid", value.codec_cid.as_deref());
+    json.optional_string(
+        "split_commitment_cid",
+        value.split_commitment_cid.as_deref(),
+    );
+    json.u64("source_document_count", value.source_document_count);
+    json.u64(
+        "construction_document_count",
+        value.construction_document_count,
+    );
+    json.u64("held_out_document_count", value.held_out_document_count);
+    json.u64(
+        "construction_lexical_route_count",
+        value.construction_lexical_route_count,
+    );
+    json.u64(
+        "calibration_pair_count",
+        u64::from(value.calibration_pair_count),
+    );
+    json.u64(
+        "calibration_decision_count",
+        u64::from(value.calibration_decision_count),
+    );
+    json.u64(
+        "sealed_test_pair_count",
+        u64::from(value.sealed_test_pair_count),
+    );
+    json.u64(
+        "sealed_test_decision_count",
+        u64::from(value.sealed_test_decision_count),
+    );
+    json.boolean(
+        "source_free_observation_corpus",
+        value.source_free_observation_corpus,
+    );
+    json.boolean(
+        "canonical_codec_reproduces",
+        value.canonical_codec_reproduces,
+    );
+    json.boolean(
+        "document_cid_partition_verified",
+        value.document_cid_partition_verified,
+    );
+    json.boolean(
+        "anti_recall_disjointness_verified",
+        value.anti_recall_disjointness_verified,
+    );
+    json.boolean(
+        "natural_candidate_rule_frozen",
+        value.natural_candidate_rule_frozen,
+    );
+    json.boolean("pair_selection_key_frozen", value.pair_selection_key_frozen);
+    json.finish()
+}
+
+fn spiralcore_json(value: &LiveSpiralCorePrerequisite) -> String {
+    let mut json = JsonObject::new();
+    json.string("reference_sha256", value.reference_sha256);
+    json.string("operator_domain", value.operator_domain);
+    json.string("operator_kappa_reference", value.operator_kappa_reference);
+    json.optional_string(
+        "observed_operator_kappa",
+        value.observed_operator_kappa.as_deref(),
+    );
+    json.string("composition_domain", value.composition_domain);
+    json.string(
+        "composition_kappa_reference",
+        value.composition_kappa_reference,
+    );
+    json.optional_string(
+        "observed_composition_kappa",
+        value.observed_composition_kappa.as_deref(),
+    );
+    json.u64("finite_group_order", value.finite_group_order);
+    json.u64("composition_entries", value.composition_entries);
+    json.u64("associativity_checks", value.associativity_checks);
+    json.u64("two_sided_inverses", value.two_sided_inverses);
+    json.u64(
+        "noncommuting_ordered_pairs",
+        value.noncommuting_ordered_pairs,
+    );
+    json.boolean(
+        "exact_operator_and_table_reproduce",
+        value.exact_operator_and_table_reproduce,
+    );
+    json.string("six_prime_chart_domain", value.six_prime_chart_domain);
+    json.u32s(
+        "canonical_six_prime_values",
+        &value.canonical_six_prime_values,
+    );
+    json.string("chart_transport_status", value.chart_transport_status);
+    json.string("operator_semantic_status", value.operator_semantic_status);
+    json.boolean(
+        "cross_chart_transport_established",
+        value.cross_chart_transport_established,
+    );
+    json.string("lexical_binding_status", value.lexical_binding_status);
+    json.optional_string(
+        "lexical_binding_manifest_cid",
+        value.lexical_binding_manifest_cid.as_deref(),
+    );
+    json.u64(
+        "verified_bound_lexical_route_count",
+        value.verified_bound_lexical_route_count,
+    );
+    json.boolean(
+        "complete_same_frame_lexical_operator_binding",
+        value.complete_same_frame_lexical_operator_binding,
+    );
+    json.boolean(
+        "compiler_query_frame_identity_verified",
+        value.compiler_query_frame_identity_verified,
+    );
+    json.finish()
+}
+
+struct JsonObject {
+    text: String,
+    first: bool,
+}
+
+impl JsonObject {
+    fn new() -> Self {
+        Self {
+            text: "{".to_owned(),
+            first: true,
+        }
+    }
+
+    fn key(&mut self, key: &str) {
+        if !self.first {
+            self.text.push(',');
+        }
+        self.first = false;
+        push_json_string(&mut self.text, key);
+        self.text.push(':');
+    }
+
+    fn string(&mut self, key: &str, value: &str) {
+        self.key(key);
+        push_json_string(&mut self.text, value);
+    }
+
+    fn optional_string(&mut self, key: &str, value: Option<&str>) {
+        self.key(key);
+        if let Some(value) = value {
+            push_json_string(&mut self.text, value);
+        } else {
+            self.text.push_str("null");
+        }
+    }
+
+    fn boolean(&mut self, key: &str, value: bool) {
+        self.key(key);
+        self.text.push_str(if value { "true" } else { "false" });
+    }
+
+    fn u64(&mut self, key: &str, value: u64) {
+        self.key(key);
+        self.text.push_str(&value.to_string());
+    }
+
+    fn strings(&mut self, key: &str, values: &[&str]) {
+        self.key(key);
+        self.text.push('[');
+        for (index, value) in values.iter().enumerate() {
+            if index > 0 {
+                self.text.push(',');
+            }
+            push_json_string(&mut self.text, value);
+        }
+        self.text.push(']');
+    }
+
+    fn u32s(&mut self, key: &str, values: &[u32]) {
+        self.key(key);
+        self.text.push('[');
+        for (index, value) in values.iter().enumerate() {
+            if index > 0 {
+                self.text.push(',');
+            }
+            self.text.push_str(&value.to_string());
+        }
+        self.text.push(']');
+    }
+
+    fn raw(&mut self, key: &str, value: &str) {
+        self.key(key);
+        self.text.push_str(value);
+    }
+
+    fn finish(mut self) -> String {
+        self.text.push('}');
+        self.text
+    }
+}
+
+fn push_json_string(output: &mut String, value: &str) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    output.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\u{08}' => output.push_str("\\b"),
+            '\u{0c}' => output.push_str("\\f"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            character if character <= '\u{1f}' => {
+                let value = character as usize;
+                output.push_str("\\u00");
+                output.push(char::from(HEX[(value >> 4) & 0x0f]));
+                output.push(char::from(HEX[value & 0x0f]));
+            }
+            character => output.push(character),
+        }
+    }
+    output.push('"');
+}

--- a/crates/uor-r4-graph-certify/src/lib.rs
+++ b/crates/uor-r4-graph-certify/src/lib.rs
@@ -7,6 +7,8 @@ pub mod certify;
 pub mod compare;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod compiler_scaling;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod corpus_signed_transport_attention;
 #[cfg(feature = "fairness-provenance")]
 pub mod fairness_provenance;
 pub mod fmm;

--- a/crates/uor-r4-graph-certify/tests/corpus_signed_transport_attention_986.rs
+++ b/crates/uor-r4-graph-certify/tests/corpus_signed_transport_attention_986.rs
@@ -1,0 +1,138 @@
+use uor_r4_graph_certify::corpus_signed_transport_attention::{
+    certify_corpus_signed_transport_pregeometry, ObservedCorpusCodecSplitReadiness,
+    TERMINAL_PRECEDENCE, UNAVAILABLE_FRAME_OR_POPULATION,
+};
+
+const AUDITED_MAIN: &str = "5de08b7e21cdd100a89782f480dc129cef3cd04d";
+const RAW_MANIFEST_BYTES_CID: &str =
+    "blake3:bb5f446ce92df60f7824ed5a1f04ede385386e7a47b9c198ae83a5d0f907bab3";
+const CORPUS_BYTES_CID: &str =
+    "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf";
+
+fn cid(fill: char) -> String {
+    format!("blake3:{}", fill.to_string().repeat(64))
+}
+
+/// Structural control only: these synthetic CIDs are not #986 population
+/// evidence and cannot satisfy the independent lexical `O(x)` prerequisite.
+fn synthetic_population_ready_control() -> ObservedCorpusCodecSplitReadiness {
+    ObservedCorpusCodecSplitReadiness {
+        audited_main_commit: AUDITED_MAIN.to_owned(),
+        raw_manifest_bytes_cid: Some(cid('1')),
+        declared_corpus_bytes_cid: Some(cid('2')),
+        reproduced_corpus_bytes_cid: Some(cid('2')),
+        codec_cid: Some(cid('3')),
+        split_commitment_cid: Some(cid('4')),
+        source_document_count: 48,
+        construction_document_count: 32,
+        held_out_document_count: 16,
+        construction_lexical_route_count: 256,
+        calibration_pair_count: 16,
+        calibration_decision_count: 32,
+        sealed_test_pair_count: 32,
+        sealed_test_decision_count: 64,
+        source_free_observation_corpus: true,
+        canonical_codec_reproduces: true,
+        document_cid_partition_verified: true,
+        anti_recall_disjointness_verified: true,
+        natural_candidate_rule_frozen: true,
+        pair_selection_key_frozen: true,
+    }
+}
+
+fn observed_source_facts() -> ObservedCorpusCodecSplitReadiness {
+    ObservedCorpusCodecSplitReadiness {
+        audited_main_commit: AUDITED_MAIN.to_owned(),
+        raw_manifest_bytes_cid: Some(RAW_MANIFEST_BYTES_CID.to_owned()),
+        declared_corpus_bytes_cid: Some(CORPUS_BYTES_CID.to_owned()),
+        reproduced_corpus_bytes_cid: Some(CORPUS_BYTES_CID.to_owned()),
+        codec_cid: None,
+        split_commitment_cid: None,
+        source_document_count: 3_000,
+        construction_document_count: 2_404,
+        held_out_document_count: 596,
+        ..ObservedCorpusCodecSplitReadiness::default()
+    }
+}
+
+#[test]
+fn exact_spiralcore_control_does_not_fabricate_a_lexical_operator_map() {
+    let report = certify_corpus_signed_transport_pregeometry(synthetic_population_ready_control());
+
+    assert!(report.exact_population_available);
+    assert!(report.spiralcore.exact_operator_and_table_reproduce);
+    assert_eq!(report.spiralcore.chart_transport_status, "NOT_ESTABLISHED");
+    assert_eq!(
+        report.spiralcore.operator_semantic_status,
+        "OPTIONAL_CONTROL_PENDING"
+    );
+    assert!(!report.spiralcore.cross_chart_transport_established);
+    assert!(report.spiralcore.lexical_binding_manifest_cid.is_none());
+    assert_eq!(report.spiralcore.verified_bound_lexical_route_count, 0);
+    assert!(
+        !report
+            .spiralcore
+            .complete_same_frame_lexical_operator_binding
+    );
+    assert!(!report.spiralcore.compiler_query_frame_identity_verified);
+    assert_eq!(report.terminal, UNAVAILABLE_FRAME_OR_POPULATION);
+    assert_eq!(report.terminal_precedence, TERMINAL_PRECEDENCE);
+    assert_eq!(
+        report.unavailable_reasons,
+        ["COMPLETE_SAME_FRAME_LEXICAL_O_X_BINDING_UNAVAILABLE"]
+    );
+    assert!(!report.placement_started);
+    assert!(!report.diffusion_started);
+    assert!(!report.gate0_started);
+    assert!(!report.calibration_started);
+    assert!(!report.sealed_label_path_started);
+}
+
+#[test]
+fn observed_source_facts_stop_at_the_same_presealed_terminal() {
+    let report = certify_corpus_signed_transport_pregeometry(observed_source_facts());
+
+    assert!(!report.exact_population_available);
+    assert!(report.raw_manifest_bytes_cid_is_canonical);
+    assert!(report.corpus_bytes_cid_reproduces);
+    assert!(report.source_partition_counts_reproduce);
+    assert_eq!(report.observed.source_document_count, 3_000);
+    assert_eq!(report.observed.construction_document_count, 2_404);
+    assert_eq!(report.observed.held_out_document_count, 596);
+    assert!(report.observed.codec_cid.is_none());
+    assert!(report.observed.split_commitment_cid.is_none());
+    assert_eq!(report.terminal, UNAVAILABLE_FRAME_OR_POPULATION);
+    assert!(report
+        .unavailable_reasons
+        .contains(&"EXACT_CORPUS_CODEC_SPLIT_POPULATION_UNAVAILABLE"));
+    assert!(report
+        .unavailable_reasons
+        .contains(&"COMPLETE_SAME_FRAME_LEXICAL_O_X_BINDING_UNAVAILABLE"));
+}
+
+#[test]
+fn canonical_json_and_cid_replay_byte_identically() {
+    let observation = observed_source_facts();
+    let first = certify_corpus_signed_transport_pregeometry(observation.clone());
+    let second = certify_corpus_signed_transport_pregeometry(observation);
+
+    assert_eq!(first, second);
+    assert_eq!(first.canonical_json_bytes(), second.canonical_json_bytes());
+    assert_eq!(first.cid(), second.cid());
+    assert_eq!(
+        first.canonical_json_bytes(),
+        serde_json::to_vec(&first).expect("certificate serializes")
+    );
+
+    let decoded: serde_json::Value =
+        serde_json::from_slice(&first.canonical_json_bytes()).expect("canonical JSON parses");
+    assert_eq!(decoded["terminal"], UNAVAILABLE_FRAME_OR_POPULATION);
+    assert_eq!(decoded["placement_started"], false);
+    assert_eq!(decoded["sealed_label_path_started"], false);
+
+    assert_eq!(
+        first.cid(),
+        "blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337",
+        "the unavailable prerequisite certificate CID is pinned"
+    );
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -42,10 +42,11 @@ before decoded generation or replay, so #953 has not qualified local
 construction-induced placement. #983 then tested one independent
 `ConstructionCausalReturnV1` population: usable construction classes were
 pure, but structural coverage and the sealed strict ceiling were both 0/6. It
-closed `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before selection. #986 now owns
-the fresh CID-disjoint `CorpusSignedTransportV1` placement/value, static
-self-plus-six harmonic link-state, and signed-transport qualification; #953 is
-parked, unassigned, untouched, and blocked.
+closed `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before selection. #986 then
+closed `UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but its
+exact codec/pair commitment and complete same-frame lexical SpiralCore frame
+were unavailable. Placement, Gate 0, labels, and #953 were `NOT_RUN`; #953 is
+parked, unassigned, and untouched pending a freshly frozen successor.
 Corpus-scale and higher-scope induction remain blocked in #973; #954 remains
 blocked downstream. #962 separately owns durable
 multi-turn CLI/HTTP chat, persisted conversation state, session/identity
@@ -67,7 +68,8 @@ canonical text/corpus
     -> paired-H4-derived exact R4-heatmap readout hard stop (#970, bounded negative)
     -> qualified local causal R4/S3 path mechanism (#969)
     -> failed construction-return transfer (#983, bounded negative)
-    -> corpus-induced semantic placement + signed local transport qualification (#986)
+    -> unavailable corpus/frame feasibility boundary (#986, completed)
+    -> freshly frozen population/frame successor (not yet authored)
     -> bounded decoded loop + tiered admission + preserved failed preflights (#953)
     -> higher-scope attention and corpus-scale induction (#973)
     -> correctness + typed abstention (#954)
@@ -101,9 +103,9 @@ ordered n-lets, exact `phi` radial transport, and typed
 `STRUCTURAL_BINDING_ONLY_NO_ZETA_NLET_TO_PHI_EXPONENT_RULE`, not semantic scorer
 inputs. #970 and #969 are closed at their bounded claim scopes; neither result
 establishes semantics. #983's later construction-return representation also
-failed to transfer. #986, not #953, is the active qualification after those
-negative results; its complete frozen plan separates corpus value from exact
-transport. #953 remains the preserved integration regression.
+failed to transfer. #986 then stopped before geometry at its unavailable
+population/frame boundary. No active qualification now authorizes #953, which
+remains the preserved integration regression.
 See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
 
@@ -1395,11 +1397,10 @@ the default cover deterministically during scoring. For experiments, `cover`
 also accepts `--depths`, `--k0`, `--regions-budget`, and `--memory-budget`.
 
 **Current production boundary pending an accepted local semantic selector →
-#953 → #973 → #954 → #955 before #962.** That selector is either a full-
-positive #986 mechanism or a separately qualified table-value successor
-authorized by #986. #970, #969, and #983 are closed at their bounded claim
-scopes. #986 owns semantic-placement, harmonic link-state, and signed-transport
-qualification. #953
+#953 → #973 → #954 → #955 before #962.** #986 closed before producing such a
+selector; a freshly frozen population/frame successor must qualify one
+independently. #970, #969, #983, and #986 are closed at their bounded claim
+scopes. #953
 owns the preserved bounded source-free library/CLI inference and generation
 engine but remains untouched and blocked; #973 and #954 remain blocked.
 #962 owns integration into durable multi-turn CLI/HTTP chat, persisted

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -43,10 +43,12 @@ assumptions, or objectives rather than measured results.
 > pure but covered 0/6 held-out decisions; the sealed strict ceiling was also
 > 0/6. It stopped `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before any deployed
 > selector or payload inversion and is now closed bounded negative evidence.
-> #986 owns the fresh CID-disjoint `CorpusSignedTransportV1` semantic-placement,
-> self-plus-six harmonic link-state, and signed-transport qualification and
-> blocks parked, unassigned, untouched
-> #953; #953 continues to block #973 and #954; and #973 continues to block #954.
+> #986 then closed `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus
+> reproduced, but the exact corpus-scale codec/pair commitment and complete
+> same-frame lexical SpiralCore frame were unavailable. Placement, Gate 0,
+> labels, all arms, and #953 were `NOT_RUN`. Parked, unassigned, untouched #953
+> now awaits a freshly frozen population/frame successor; #953 continues to
+> block #973 and #954; and #973 continues to block #954.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -289,8 +291,8 @@ assumptions, or objectives rather than measured results.
 > **Post-A1Q-L2 decision — A1Q-L3/#986, 2026-08-28.** #983 is closed as
 > completed bounded negative evidence. Its failed representation, population,
 > identities, and `NOT_RUN` selector/generation boundary remain unchanged.
-> Fresh #986 is the only open local qualification and now blocks untouched
-> #953.
+> #986 subsequently completed at its pre-sealed population/frame unavailable
+> terminal; untouched #953 remains parked.
 >
 > `CorpusSignedTransportV1` separates the missing semantic layer from exact
 > geometry. A source-free observation corpus induces a canonical causal
@@ -335,6 +337,18 @@ assumptions, or objectives rather than measured results.
 > algebra are permitted for qualification; base-256/integer/LUT lowering is
 > deferred until causal transfer. See the
 > [#986 plan](corpus_induced_signed_transport_attention_plan_986.md).
+>
+> **Observed A1Q-L3 result.** The raw corpus bytes and 3,000-document D3 census
+> reproduced, but no source-free corpus-scale codec or exact three-way pair
+> commitment existed. The finite 64-state SpiralCore table reproduced at
+> control scope, while cross-chart transport remained `NOT_ESTABLISHED` and no
+> complete lexical `O(x)` or compiler/query frame identity existed. Certificate
+> `blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`
+> records `UNAVAILABLE_FRAME_OR_POPULATION`. Placement, link state, diffusion,
+> Gate 0, calibration, sealed labels, full/table/control arms, payload replay,
+> and #953 were `NOT_RUN`. See the
+> [#986 evidence record](corpus_signed_transport_attention_986.md). Any repair
+> is a newly frozen successor, not a #986 retry.
 
 The current quality-baseline reconciliation is recorded by #933 and the
 [append-only #934 genealogy](canonical_quality_baseline_934.md). The historical
@@ -583,8 +597,8 @@ candidate-conditioned mechanism on a separate natural population. Its pure
 construction classes transferred to 0/6 held-out decisions and stopped
 `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before deployed selection or payload
 decode. #953 remains an untouched parked integration regression while #983
-holds closed negative evidence. #986 now owns the fresh semantic-placement and
-signed-transport decision and blocks #953; #973 remains blocked. Dependable
+holds closed negative evidence. #986 then closed at its unavailable population/
+frame boundary before geometry; #953 and #973 remain parked/blocked. Dependable
 coherent text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
@@ -1145,11 +1159,11 @@ population. Its usable construction classes were pure, but structural coverage
 and the sealed strict ceiling were both 0/6. It stopped
 `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before deployed selection, payload
 inversion, or #953 generation and is now closed bounded negative evidence.
-#986 owns the fresh `CorpusSignedTransportV1` qualifier and blocks parked,
-unassigned, untouched #953; #953 continues to block
-#973/#954; #973 continues to block #954. The eventual accepted local semantic
-selector is either a full-positive #986 mechanism or a separately qualified
-table-value successor authorized by #986. #955 invokes that accepted selector/
+#986 also closed at `UNAVAILABLE_FRAME_OR_POPULATION` before placement, labels,
+or selection. Parked, unassigned, untouched #953 awaits a freshly frozen
+population/frame successor; #953 continues to block #973/#954, and #973
+continues to block #954. Any eventual accepted local semantic selector must be
+independently qualified by that successor. #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains
 measured cost; #964 binds evidence provenance #970 → #969 → #983 → #986 plus

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -2,10 +2,10 @@
 
 - **Status:** Accepted as an architectural definition and evaluation boundary;
   amended 2026-08-28 after #953's repaired admission and placement preflight,
-  and #983's independent 0/6 construction-transfer negative. #986 now owns one
-  fresh corpus-induced semantic-placement, self-plus-six harmonic link-state,
-  and signed-transport qualification;
-  #953 remains parked and blocked. #973 remains blocked and later owns
+  #983's independent 0/6 construction-transfer negative, and #986's
+  `UNAVAILABLE_FRAME_OR_POPULATION` feasibility terminal. #986 produced no
+  placement, link state, or selector; #953 remains parked pending a freshly
+  frozen population/frame successor. #973 remains blocked and later owns
   paragraph, conversation, global exact-spin, and corpus-scale qualification.
   Harmonic qualification additionally requires a bound basis/mode contract.
   Inference,
@@ -386,12 +386,11 @@ Delivery proceeds without skipping stages:
 2. retain the local causal R4/S3 path mechanism qualified by #969;
 3. retain closed #983 at `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER`; its pure
    construction classes covered 0/6 held-out decisions and no selector ran;
-4. in #986, first qualify construction-only corpus-induced semantic placement
-   and a static self-plus-six harmonic link-state field on a document/CID-
-   disjoint split, then test one candidate-relative signed zero-sum exact-
-   transport arm against matched link/distance/causal controls and a table-
-   native semantic-value comparator. A table-preferred result retains geometry
-   as addressing/transport rather than forcing it into semantic scoring;
+4. retain closed #986 at `UNAVAILABLE_FRAME_OR_POPULATION`: its pinned raw
+   corpus and finite SpiralCore control reproduced, but no exact three-way
+   population/codec commitment or complete same-frame lexical operator map
+   existed. Gate 0, labels, table/geometric arms, and #953 were not run. Any
+   replacement must be a freshly frozen population/frame successor;
 5. in #953, retain #981's tiered-admission policy and the completed tiny
    construction-only, same-frame, candidate-conditioned context-placement
    overlay's selection-blind hard stop under the same artifact, support, and
@@ -399,9 +398,8 @@ Delivery proceeds without skipping stages:
    placement-permuted and order-shuffled controls resolved 2/2 and 1/2.
    Generation and replay were not run. Any later #953 attempt requires a newly
    frozen native contract rather than a metric tweak or second representation
-   under this result. Apply only a full-positive #986 mechanism, or its
-   separately qualified table-value successor, unchanged after a fresh label-
-   free preflight;
+   under this result. Apply only a newly qualified successor mechanism,
+   unchanged after a fresh label-free preflight;
 6. in #973, qualify paragraph, conversation, and global influence through the
    accepted #953 loop, including the shared exact-spin operator overlay and
    its matched disabled/permuted controls;

--- a/docs/corpus_induced_signed_transport_attention_plan_986.md
+++ b/docs/corpus_induced_signed_transport_attention_plan_986.md
@@ -1,7 +1,7 @@
 # Corpus-Induced Harmonic Signed Transport Attention Plan
 
-- **Status:** adopted direction; implementation and qualification are owned by
-  [#986](https://github.com/UOR-Foundation/uor-r4/issues/986)
+- **Status:** executed; [#986](https://github.com/UOR-Foundation/uor-r4/issues/986)
+  closed `UNAVAILABLE_FRAME_OR_POPULATION` before placement
 - **Programme authority:**
   [#820](https://github.com/UOR-Foundation/uor-r4/issues/820) and
   [Geometric Intelligence Programme](geometric_intelligence_programme.md)
@@ -382,3 +382,23 @@ generation, correctness, reasoning, performance, integer/multiply-free
 serving, an E8 identity theorem, a Riemann-hypothesis result, novelty,
 patentability, product chat, formal closure, or release readiness. Those claims
 remain separately gated in the native programme order.
+
+## Executed outcome — 2026-08-28
+
+#986 stopped at its frozen pre-sealed feasibility boundary. The pinned
+3,000-document raw corpus reproduced its declared content identity, but no
+source-free corpus-scale codec or exact induction/calibration/sealed pair
+commitment existed from which to freeze the required 16 plus 32 matched pairs.
+Separately, the exact SpiralCore operator/table reproduced at control scope,
+while the only six-prime chart still declared cross-chart transport
+`NOT_ESTABLISHED` and supplied no complete lexical-route `O(x)` binding or
+compiler/query frame identity.
+
+The prerequisite certificate is
+`blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`.
+Placement, link construction, diffusion, Gate 0, calibration, sealed labels,
+selection, payload replay, and #953 generation were `NOT_RUN`. The binding
+terminal is `UNAVAILABLE_FRAME_OR_POPULATION`. This closes the frozen plan;
+any repair requires a newly frozen population/frame successor rather than a
+retry or second representation in #986. See the
+[#986 evidence record](corpus_signed_transport_attention_986.md).

--- a/docs/corpus_signed_transport_attention_986.md
+++ b/docs/corpus_signed_transport_attention_986.md
@@ -1,0 +1,202 @@
+# CorpusSignedTransportV1 pre-geometry feasibility record — issue #986
+
+## Status and decision
+
+- **Issue:** [#986](https://github.com/UOR-Foundation/uor-r4/issues/986)
+- **Audited live main:**
+  `5de08b7e21cdd100a89782f480dc129cef3cd04d`
+- **Date:** 2026-08-28
+- **Terminal bounded result:** `UNAVAILABLE_FRAME_OR_POPULATION`
+- **Prerequisite-certificate identity:**
+  `blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`
+
+The pinned raw text corpus reproduced its declared content identity and its
+document partition could be counted without labels. The required #986
+population nevertheless was not available: no source-free corpus artifact,
+corpus-scale canonical codec, three-way document/CID split, or ordered
+16-calibration-pair plus 32-test-pair commitment exists in the repository.
+This is an availability failure, not a claim that the corpus contains too few
+eligible pairs.
+
+The independent exact-operator audit reached the same terminal. The current
+SpiralCore implementation reproduces its finite Cl(0,6) control, but its
+`SixPrimeOperatorChart` covers only the canonical first-six-prime chart,
+declares cross-chart transport `NOT_ESTABLISHED`, and exposes no complete
+lexical-route-to-operator binding `O(x)` or compiler/query frame identity. No
+hash, modulo, CID spelling, prime rollover, or target-tuned substitute was
+introduced.
+
+The predeclared terminal precedence therefore stopped the experiment before
+placement, link construction, diffusion, Gate 0, calibration, sealed labels,
+selection, payload inversion, replay, or #953 generation.
+
+## Frozen authority and observed identities
+
+| Object | Identity or status |
+|---|---|
+| Live #986 issue body at the audit boundary | `blake3:36fdeea36a182adf9c7743e21b920408f97f4082d73f077623d11816c5b88de8` |
+| Frozen #986 plan at audited main | `blake3:37cdef5f24a621f5c2e842a5c2698c089aa7923f8535772318bd74fcf08a63f3` |
+| Live `AGENTS.md` at audited main | `blake3:5bc10b61b9e5034c9938e78d7209c2662f13f5fb209fb66203622d4f07bc5efb` |
+| Raw corpus manifest bytes | `blake3:bb5f446ce92df60f7824ed5a1f04ede385386e7a47b9c198ae83a5d0f907bab3` |
+| Declared and reproduced raw corpus bytes | `blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf` |
+| Existing D3 document partition rule | `blake3:1756e46f6131979959ce8b02f42c73a6c30609bfa23f1f0ccdd82e9e05a0fa8b` |
+| #986 canonical codec/vocabulary | `UNAVAILABLE_NOT_COMPILED` |
+| #986 induction/calibration/sealed split commitment | `UNAVAILABLE_NOT_EMITTED` |
+| Ordered 16-pair calibration commitment | `UNAVAILABLE_NOT_EMITTED` |
+| Ordered 32-pair sealed-test commitment | `UNAVAILABLE_NOT_EMITTED` |
+| Placement identity | `NOT_EMITTED_PREREQUISITE_FAILURE` |
+| `HarmonicLinkState7` identity | `NOT_EMITTED_PREREQUISITE_FAILURE` |
+| SpiralCore exact operator | `blake3:a0ea3a10dd10c5f4856b0d881d33d94c3293bad0e68bd07a47918e2bb82c819b` |
+| Cl(0,6) finite composition table | `blake3:f2986c8e68dcb30a9cb511a42547179a87b66ef212a87b728765d03e70e640b0` |
+| Complete lexical `O(x)` map | `UNAVAILABLE_NOT_ESTABLISHED` |
+| Compiler/query frame identity | `UNAVAILABLE_NOT_ESTABLISHED` |
+| Full mechanism/work policy identity | `NOT_EMITTED_PREREQUISITE_FAILURE` |
+| Immutable pre-geometry checkpoint | `NOT_EMITTED_PREREQUISITE_FAILURE` |
+| Prerequisite certificate | `blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337` |
+
+The first three identities bind the exact pre-run authority bytes. The corpus
+manifest identity is the BLAKE3 of the manifest file itself; the separate
+corpus identity is the BLAKE3 of `articles.jsonl` and matches the manifest's
+declared value. `UNAVAILABLE` and `NOT_EMITTED` are deliberate statuses, not
+placeholder hashes.
+
+## Population-first feasibility result
+
+The checked corpus manifest declares 3,000 Simple English Wikipedia documents
+and 12,038,579 UTF-8 text bytes. The read-only raw corpus contained 3,000 JSONL
+rows, 3,000 unique article IDs, and 12,539,119 total file bytes. Rehashing those
+bytes reproduced the declared corpus identity exactly. Applying the existing
+D3 article-ID rule yielded:
+
+| Census | Count |
+|---|---:|
+| Source documents | 3,000 |
+| Existing D3 construction documents | 2,404 |
+| Existing D3 held-out documents | 596 |
+| Frozen #986 induction documents | `UNAVAILABLE` |
+| Frozen #986 calibration pairs / decisions | `0 frozen / 0 frozen` of required `16 / 32` |
+| Frozen #986 sealed-test pairs / decisions | `0 frozen / 0 frozen` of required `32 / 64` |
+
+The zeroes mean no #986 pair artifact was frozen; they do **not** mean an
+eligibility scan found zero pairs. Such a scan was not authorized without the
+missing canonical population builder.
+
+The current `CanonicalLexicalCodec` is a bounded conversation codec: at most
+64 KiB of source, 512 lexical units, and 256 vocabulary entries. The current
+schema-2 child is also a tiny canary rather than a corpus-stream builder. The
+repository has no domain-separated induction/calibration/sealed document
+commitment, decision/pair CID builder, sealed expected-route join, or canonical
+vertex-disjoint sampler for #986. The existing teacher-forced observation
+bundle was excluded because it is not the required source-free population.
+The #953, #970, and #983 fixtures were also excluded exactly as required.
+
+Consequently, full-history, trailing-four, ordered-route, operative-key,
+document/CID, and prohibited-fixture anti-recall comparisons are
+`NOT_RUN_NO_FROZEN_POPULATION`, not PASS. No expected-route label was opened.
+
+## Exact operator/frame feasibility result
+
+The offline prerequisite certificate re-executed the exact SpiralCore v63
+operator and finite composition-table validations. The exact substrate
+reproduced:
+
+| Operator measure | Result |
+|---|---:|
+| Canonical carrier primes | `5, 7, 11, 13, 17, 19` |
+| Bivector slots | 15 |
+| Finite group states | 64 |
+| Composition entries | 4,096 |
+| Associativity checks | 262,144 |
+| Two-sided inverses | 64 |
+| Cross-chart transport | `NOT_ESTABLISHED` |
+| Operator semantic status | `OPTIONAL_CONTROL_PENDING` |
+| Verified lexical routes with bound `O(x)` | 0 |
+| Complete same-frame lexical operator mapping | no |
+| Compiler/query frame identity | no |
+
+This validates the finite algebra only at its existing control scope. The
+repository does not choose left versus right action for a lexical route,
+resolve the directed `B_ij` versus `B_ji=-B_ij` orientation, select a generator
+versus finite-group-state convention, define chart rollover, bind rank-8
+semantic-placement axes to the octonion basis, or publish a route-map
+manifest. Even a population using no more than six routes would therefore lack
+the required `O(x)` contract; a seventh route is additionally outside the only
+implemented chart.
+
+## Execution boundary
+
+| Stage or result | Status |
+|---|---|
+| Raw corpus bytes and D3 document census | `RUN_READ_ONLY_FEASIBILITY` |
+| Canonical #986 population and pair freeze | `UNAVAILABLE` |
+| Exact SpiralCore control/table reproduction | `RUN_OFFLINE_PREREQUISITE` |
+| Complete lexical operator/frame binding | `UNAVAILABLE` |
+| Placement and rank-8 factorization | `NOT_RUN_PREREQUISITE_FAILURE` |
+| `HarmonicLinkState7` construction | `NOT_RUN_PREREQUISITE_FAILURE` |
+| Six-step candidate-rooted diffusion | `NOT_RUN_PREREQUISITE_FAILURE` |
+| Label-free Gate 0 | `NOT_RUN_PREREQUISITE_FAILURE` |
+| Calibration label join and two margins | `NOT_RUN` |
+| Sealed 64-decision label join | `NOT_RUN` |
+| Full arm, table comparator, and all controls | `NOT_RUN` |
+| Coverage, accuracy, pair success, and paired tests | `NOT_RUN` |
+| Coherent relabeling equivariance | `NOT_RUN_NO_MECHANISM_ARTIFACT` |
+| Two multithreaded mechanism rebuilds / incremental-full replay | `NOT_RUN_NO_POPULATION` |
+| Candidate payload inversion / replay | `NOT_RUN` |
+| #953 decoded generation | `NOT_RUN` |
+
+Because neither a calibration nor sealed-test join loaded, there are no full,
+table, control, coverage, accuracy, pair-success, or p-value results to report.
+No abstention was relabeled as a selection.
+
+## Integrity and verification
+
+The certificate surface is compiler/certifier-side only and is excluded from
+WASM. It accepts only label-free readiness facts, revalidates the existing
+exact operator/table, records zero verified lexical bindings, emits canonical
+JSON, and returns the pre-sealed terminal before exposing any later-stage API.
+Its focused tests include a synthetic population-ready structural control so a
+valid finite table cannot be mistaken for a lexical route map, the observed
+missing-population case, and byte-identical report/CID replay.
+
+| Check | Status |
+|---|---|
+| Raw manifest/corpus content reproduction | `PASS_READ_ONLY_FEASIBILITY` |
+| 3,000 unique IDs and D3 2,404/596 document census | `PASS_READ_ONLY_FEASIBILITY` |
+| Exact operator/composition validation | `PASS_CONTROL_SCOPE` |
+| Canonical prerequisite JSON/CID replay | `PASS` |
+| Certificate source closure | `PASS_ZERO_FORBIDDEN_INPUTS` |
+| Focused graph-certify tests | `PASS` — 3/3 |
+| Focused graph-certify all-target check | `PASS` |
+| Targeted Clippy, formatting, diff whitespace, claim wording | `PASS` |
+| Dependency-inclusive graph-certify Clippy | `NOT_CLEAN_PRE_EXISTING_UNRELATED_WARNINGS` |
+| #953 implementation/test/fixture/data quarantine | `PASS` |
+| WASM target | `NOT_APPLICABLE_NON_WASM_CERTIFIER_ONLY` |
+| Workspace/BDD/teacher/corpus-scale/κ/audit/fuzz/product/release suites | `DORMANT_SCOPE_NOT_RUN` |
+
+The certificate consumes no source-model weights, provider text, teacher
+output, expected route, actual future route, validation label, or #953 input.
+The raw corpus was read only to verify the already-declared corpus identity and
+document split counts. No placement or score diagnostic was inspected.
+
+The dependency-inclusive Clippy attempt reached pre-existing warnings in
+unchanged `uor-r4-graph-runtime/src/vp_tree.rs` and
+`uor-r4-model-source/src/geometric_decoder.rs`. The strict target-only
+`--no-deps` check for the changed certifier surface passed; no unrelated code
+was changed to make #986 green.
+
+## Claim boundary and successor category
+
+This result does not reject corpus-induced semantic value, harmonic link-state
+diffusion, signed zero-sum contrast, Cl(0,6), SpiralCore, H4, paired H4, fixed
+zeta coordinates, prime/semiprime routing, or the broader geometric programme.
+It establishes no semantic placement, attention, coherent generation,
+correctness, reasoning, performance, multiply-free serving, novelty,
+patentability, formal closure, or release readiness.
+
+#986 is complete at its frozen pre-sealed terminal. #953 remains open,
+unassigned, untouched, and ineligible. No successor was created inside #986.
+Any next local qualification must be a freshly frozen population/frame
+successor that first supplies both (1) a source-free corpus-scale canonical
+codec and exact three-way pair commitment and (2) a complete same-frame
+lexical-route-to-SpiralCore operator mapping. It may not re-freeze or continue
+`CorpusSignedTransportV1` under #986.

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -42,8 +42,10 @@ three-family, six-decision population. Its usable construction classes were
 pure but reached 0/6 held-out decisions; the sealed strict ceiling was also
 0/6. It stopped `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before a deployed
 selector or payload inversion and is now closed bounded negative evidence.
-#986 owns the fresh corpus-induced semantic-placement and signed-transport
-qualification and blocks untouched #953; #953 continues to block #973 and
+#986 then closed `UNAVAILABLE_FRAME_OR_POPULATION` before placement because its
+exact population/codec commitment and complete lexical SpiralCore frame were
+unavailable. Gate 0, labels, selection, and #953 were `NOT_RUN`. Untouched #953
+remains parked pending a freshly frozen population/frame successor and blocks #973 and
 #954; and #973 continues to block #954.
 
 A negative result remains evidence about its declared mechanism and
@@ -55,12 +57,10 @@ attention, inference, correctness, reasoning, or product readiness.
 
 The stages are ordered because each later claim depends on the earlier one:
 
-In this policy, the **accepted local semantic selector lineage** means either
-`CorpusSignedTransportV1` after #986 reaches its full positive terminal, or the
-separate table-value selector after #986 takes the table branch and that
-successor independently qualifies. #983 and #986 remain in evidence
-provenance; neither a failed experiment nor a conditional issue number is
-automatically a serving consumer.
+In this policy, the **accepted local semantic selector lineage** now means a
+freshly frozen successor that independently qualifies its complete local
+causal contract. #983 and #986 remain in evidence provenance; neither a failed
+experiment nor a conditional issue number is automatically a serving consumer.
 
 1. **Local route-attention mechanism (#969)** — natural schema-2 adjacency,
    causal ordered R4/S3 path state, retained prefix memory, and deterministic
@@ -623,6 +623,18 @@ re-freeze, retry, second representation, or #953 generation runs in #986. Any
 repair requires a freshly frozen successor. The complete contract is the
 [#986 plan](corpus_induced_signed_transport_attention_plan_986.md).
 
+**Observed #986 result, 2026-08-28.** The pinned raw corpus reproduced its
+content identity and 3,000-document census, but no source-free corpus-scale
+codec or exact induction/calibration/sealed pair commitment was available. The
+exact 64-state SpiralCore operator/table reproduced at control scope, while
+chart transport remained `NOT_ESTABLISHED` and no complete lexical `O(x)` or
+compiler/query frame identity existed. The prerequisite certificate
+`blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`
+therefore records `UNAVAILABLE_FRAME_OR_POPULATION` before placement. Gate 0,
+calibration, sealed labels, full/table/control arms, coverage, paired tests,
+payload replay, and #953 were `NOT_RUN`. See the
+[#986 evidence record](corpus_signed_transport_attention_986.md).
+
 ### I1/#953 bounded decoded generation contract
 
 #953 owns the preserved production vertical slice, not a qualification matrix.
@@ -667,8 +679,8 @@ nondeterminism, a short cycle, or exceeding the eight-unit state bound. The
 historical direct-repair rule produced the observed record below. It is now
 superseded for forward sequencing: another representation judged on the known
 #953 population would risk post-hoc fixture tuning. #983 supplied the completed
-independent negative; #986 now owns the fresh-population qualification and #953
-remains untouched.
+independent negative; #986 then supplied a completed unavailable population/
+frame result and #953 remains untouched.
 
 The implemented repair has one frozen admission policy. I1/last-one, I2/last-two,
 ordered-sentence, and divisor rows form the primary tier. With non-empty primary
@@ -689,9 +701,9 @@ The frozen terminals are:
   must be repaired before #953 can close.
 
 Invalid or unavailable work leaves #953 open. It is currently unassigned and
-blocked by #986. A later positive result qualifies only the full #986 mechanism
-or separately qualified table-value successor, plus #953's decoded grammar/
-sentence loop. Paragraph,
+parked pending a freshly frozen population/frame successor. A later positive
+result qualifies only that independently accepted selector plus #953's decoded
+grammar/sentence loop. Paragraph,
 conversation, and global influence remain inert until #973; correctness,
 reasoning, product chat, optimization, formal closure, and release remain
 downstream.
@@ -772,8 +784,8 @@ under #986; #973 and downstream #954 remain blocked.
 
 ### A1Q-H/#973 exact-spin global operator prototype
 
-#973 owns paragraph, conversation, and bounded-global influence after #986
-qualifies an accepted local selector path and #953 qualifies the decoded loop.
+#973 owns paragraph, conversation, and bounded-global influence after a fresh
+successor qualifies an accepted local selector path and #953 qualifies the decoded loop.
 Operator influence consumes #953-admitted support;
 it does not participate in admission. The existing adjacent-spin retrieval rows
 remain fallback/diagnostic data, not operator coefficients; any neighbor
@@ -1125,9 +1137,10 @@ Use these outcomes literally:
   attention, correctness, or reasoning claims.
 - `REVISE_I1_GENERATOR_IN_PLACE` — a valid #953 smoke localizes a generator
   defect. This remains #953's historical terminal, but its former immediate
-  in-place-repair action is superseded by completed-negative #983 and open #986
-  because the known population is no longer independent. Keep #953 open,
-  unassigned, blocked, and untouched.
+  in-place-repair action is superseded by completed-negative #983 and closed-
+  unavailable #986 because the known population is no longer independent. Keep
+  #953 open, unassigned, parked, and untouched pending a freshly frozen
+  successor.
 
 Never convert a missing fixture, empty denominator, skipped test, or unrelated
 green suite into `PASS`. Every report preserves artifact kappas, partition CIDs,

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -133,12 +133,13 @@ three-family, six-decision construction/validation population. Its pure
 construction classes transferred structurally on 0/6 decisions and the sealed
 strict ceiling was 0/6, so it stopped
 `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before a deployed selector or payload
-inversion. #983 is closed bounded negative evidence. #986 now owns exactly one
-fresh `CorpusSignedTransportV1` contract: construction-only corpus induction
-must first produce held-out semantic placement/value; only then may signed
-zero-sum Cl(0,6)/SpiralCore transport be credited if it causally beats a
-matched table-native value comparator and required controls. #986 blocks
-parked, unassigned, untouched #953; #953 continues to block #973 and #954; and
+inversion. #983 is closed bounded negative evidence. #986 then executed its one
+frozen `CorpusSignedTransportV1` feasibility contract and stopped
+`UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but its exact
+codec/pair commitment and a complete same-frame lexical SpiralCore frame were
+unavailable. Placement, Gate 0, labels, table/geometric arms, and #953 were
+`NOT_RUN`. Parked, unassigned, untouched #953 now awaits a freshly frozen
+population/frame successor; #953 continues to block #973 and #954; and
 #973 continues to block #954. Calling the later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
@@ -666,9 +667,9 @@ Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
 #972; #969 positive bounded mechanism result
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #983 then independently tested
 construction-transferred candidate-conditioned local attention and stopped at
-0/6 transfer before selection and closed. #986 is the fresh open semantic-
-placement and signed-transport qualifier. Parked, unassigned #953 remains
-untouched and blocked by #986; #953 and #973 retain
+0/6 transfer before selection and closed. #986 then closed at its pre-sealed
+population/frame unavailable terminal. Parked, unassigned #953 remains
+untouched pending a newly frozen successor; #953 and #973 retain
 their downstream blocker edges**.
 
 The frozen A1.0 probe stopped before scorer implementation with
@@ -840,7 +841,7 @@ see the [#969 record](local_geometric_attention_969.md).
 ### GI-2 A1Q-L2 / #983 — construction-transferred candidate-conditioned local attention
 
 #983 is a closed negative-evidence child of #820 after closed #967/#970/#969
-and before open #986 and parked #953; #969 and #970 are its direct evidence-bearing
+and before closed #986 and parked #953; #969 and #970 are its direct evidence-bearing
 predecessors. It does not
 consume the #953 or #970 populations. Its independently frozen natural
 population contains exactly three candidate-pair families—`is/are`, `has/have`,
@@ -911,9 +912,9 @@ and decoded generation were `NOT_RUN`. See the
 
 ### GI-2 A1Q-L3 / #986 — corpus-induced harmonic signed local transport
 
-#986 is the only open local qualification. It is blocked by completed-negative
-#983 and blocks parked #953. It does not reinterpret #983 or reuse the #953,
-#970, or #983 populations.
+#986 is a closed pre-sealed feasibility result after completed-negative #983
+and before parked #953. It did not reinterpret #983 or reuse the #953, #970,
+or #983 populations.
 
 `CorpusSignedTransportV1` separates semantic value from exact transport. A
 source-free observation corpus induces a deterministic directed causal
@@ -1014,6 +1015,20 @@ and must later reproduce the same decisions. The complete mechanism,
 thresholds, controls, related work, and nonclaims are frozen in the
 [#986 plan](corpus_induced_signed_transport_attention_plan_986.md).
 
+**Observed #986 result, 2026-08-28.** The raw corpus bytes and 3,000-document
+D3 census reproduced, but the repository had no source-free corpus-scale codec
+or exact induction/calibration/sealed pair commitment. The finite 64-state
+SpiralCore control/table also reproduced, while chart transport remained
+`NOT_ESTABLISHED` and no complete lexical `O(x)` or compiler/query frame
+identity existed. The prerequisite certificate
+`blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`
+therefore records `UNAVAILABLE_FRAME_OR_POPULATION`. Placement, link-state,
+diffusion, Gate 0, calibration, sealed labels, all full/table/control arms,
+payload replay, and #953 were `NOT_RUN`. The
+[#986 evidence record](corpus_signed_transport_attention_986.md) is the
+binding claim boundary. Any next local qualifier must be a freshly frozen
+population/frame successor; #986 does not retry.
+
 ### GI-3 / #953 — bounded source-free geometric generation loop
 
 #969 qualified only an identity-derived local causal path selector. It did not
@@ -1058,14 +1073,15 @@ fixture tuning.
 
 The frozen positive terminal is
 `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`; direct repair
-is `REVISE_I1_GENERATOR_IN_PLACE`. #953 remains open, unassigned, and blocked by
-#986. Paragraph, conversation, and global selection remain inert until #973.
+is `REVISE_I1_GENERATOR_IN_PLACE`. #953 remains open, unassigned, parked, and
+ineligible pending a newly frozen population/frame successor. Paragraph,
+conversation, and global selection remain inert until #973.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
 identity-scoped hive-memory lifecycle remain #962 scope.
 
-A future positive at this stage could establish only that the accepted local
-semantic selector—the full-positive #986 mechanism or its separately qualified
-table-value successor—drives one #953-qualified decoded grammar/sentence loop.
+A future positive at this stage could establish only that an independently
+qualified local semantic selector drives one #953-qualified decoded grammar/
+sentence loop.
 #969, #983, and #986 remain evidence provenance as applicable. The result could
 not establish factual correctness, broad coherence, knowledge, reasoning,
 higher-scope attention, performance advantage, chat quality, formal closure,
@@ -1119,12 +1135,11 @@ while the same-artifact placement-permuted and order-shuffled controls selected
 2/2 and 1/2. Full-history absence was not operative-representation anti-recall
 because decisive retained suffixes exactly recalled construction subhistories.
 Generator execution and replay were `NOT_RUN`. This chronology remains
-append-only evidence. The fixture, overlay, generator, and records are untouched
-under #986. Only a full positive protected #986 terminal, or a separately
-qualified table-value successor created by #986's table branch, may be applied
-unchanged in a later #953 session after a new label-free preflight; #973 remains
-blocked. The phrase **accepted local semantic selector** below means exactly one
-of those two outcomes. #983 and #986 remain evidence provenance; neither a
+append-only evidence. The fixture, overlay, generator, and records remained
+untouched through #986. Only a freshly frozen successor that independently
+qualifies its complete mechanism may be applied unchanged in a later #953
+session after a new label-free preflight; #973 remains blocked. #983 and #986
+remain evidence provenance; neither a
 failed experiment nor a conditional issue number is automatically a serving
 consumer.
 
@@ -1197,8 +1212,9 @@ That first attempt failed before decoded generation or replay, and exact
 shorter-suffix recall showed that full-history disjointness was not
 operative-representation anti-recall. The result does not authorize broad
 corpus expansion, a metric sweep, higher-scope induction, or another discovery
-representation inside #953. #986 owns the intervening independent local
-qualification; its bounded CID-disjoint corpus is not this later scale ladder.
+representation inside #953. Closed #986 owns the intervening unavailable
+population/frame evidence; any replacement is a fresh qualifier, not this
+later scale ladder.
 
 Freeze the document/conversation/task partitions before compiling rows or
 operator statistics. Construction data may supply causal
@@ -1343,9 +1359,9 @@ hours remains a hard kill ceiling, never an estimate.
   #969 establishes only its identity-derived local path mechanism as
   load-bearing. #983 tested one construction-transferred local geometric
   mechanism on six held-out choices and stopped at 0/6 transfer before a
-  deployed selector. #986 now tests corpus-induced semantic placement/value
-  plus bounded harmonic link state before signed exact transport and reports a
-  table-native comparator. #953 has
+  deployed selector. #986 then stopped before placement because its exact
+  population/codec commitment and lexical SpiralCore frame were unavailable;
+  no table-native or geometric arm ran. #953 has
   implemented decoded-loop plumbing but has not qualified a natural grammar
   loop. Only an accepted local semantic selector and an accepted #953 result can expose #973,
   and only #973 may qualify

--- a/docs/local_geometric_generation_953.md
+++ b/docs/local_geometric_generation_953.md
@@ -697,3 +697,17 @@ and untouched behind #986. Only a full-positive #986
 created by #986's table branch, may enter this decoded loop after a fresh
 label-free preflight. The known #953 population remains quarantined; this
 handoff authorizes no new representation, generation run, or replay inside it.
+
+## Post-#986 blocker state (2026-08-28)
+
+The prior handoff above records the live state when #986 opened. #986 has since
+closed at `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus reproduced, but its
+exact codec/pair commitment and complete same-frame lexical SpiralCore operator
+map were unavailable. Placement, Gate 0, labels, selection, payload replay,
+and this #953 loop were `NOT_RUN`.
+
+#953 therefore remains open, unassigned, parked, and untouched. Closure of the
+historical native blocker does not authorize execution. Only a freshly frozen
+population/frame successor that independently qualifies an accepted local
+semantic selector may enter #953 in a later session after a new label-free
+preflight. No successor was created as part of #986.

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -154,20 +154,20 @@ one another.
   corpus or load source tensors.
 - **Corpus-induced semantic placement** — a versioned compiler-side coordinate
   overlay learned only from past construction observations while preserving
-  immutable lexical-route, prime, CID, and payload identities. #986 freezes one
-  deterministic causal co-occurrence/PPMI rank-8 placement and tests held-out
-  document/CID transfer before any attention claim. A hash, prime index,
+  immutable lexical-route, prime, CID, and payload identities. #986 proposed one
+  deterministic causal co-occurrence/PPMI rank-8 placement but stopped before
+  construction because its population/frame prerequisites were unavailable. A hash, prime index,
   hexadecimal spelling, exact route key, or historical `%500` hive cell is an
   address, not semantic placement.
-- **HarmonicLinkState7** — #986's static per-route link-state record: the route
+- **HarmonicLinkState7** — #986's unconstructed static per-route link-state proposal: the route
   itself plus at most six construction-derived positive PPMI peers, with exact
   operator/phase identities and null slots. Six fixed half-restart Jacobi steps
   produce a candidate-rooted screened-harmonic reachability field used by the
-  transport arm. Seven is a bounded
+  transport arm. #986 emitted no such rows. Seven is a bounded
   center-plus-six stencil, not an OSPF implementation and not seven Euclidean
-  nearest neighbors. The record is semantic substrate, not attention; #986
-  compares it with link-disabled and distance-only controls.
-- **Signed transport attention candidate** — #986's proposed local readout.
+  nearest neighbors. The record is semantic substrate, not attention; #986's
+  frozen contract would have compared it with link-disabled and distance-only controls.
+- **Signed transport attention candidate** — #986's proposed but unexecuted local readout.
   Exact ordered Cl(0,6)/SpiralCore state transports a bounded causal history;
   each already-admitted candidate receives one transported value per retained
   history slot. Its radial/angular alignments are centered across those slots
@@ -215,8 +215,9 @@ one another.
 - **Geometric-intelligence sequence** — lexical ingestion, canonical
   serialization, and address membership are prerequisite plumbing. Delivery
   then proceeds in this order: one qualified local causal-path mechanism
-  (#969); one completed-negative construction-transfer probe (#983); one fresh
-  corpus-induced semantic-placement and signed-transport qualifier (#986); one
+  (#969); one completed-negative construction-transfer probe (#983); one
+  completed-unavailable corpus/frame qualifier (#986); one freshly frozen
+  population/frame successor (not yet authored); one
   bounded decoded generation loop with repaired admission (#953);
   paragraph, conversation, and global exact-spin operator qualification through
   that loop plus controlled higher-scope/corpus-scale induction and final


### PR DESCRIPTION
## Outcome

Executes the frozen pre-sealed feasibility boundary for #986 and records the
single terminal:

`UNAVAILABLE_FRAME_OR_POPULATION`

The pinned 3,000-document raw corpus reproduces its declared bytes and D3
document census, but no source-free corpus-scale canonical codec or exact
induction/calibration/sealed pair commitment exists. Independently, the exact
64-state SpiralCore operator/table reproduces at control scope while chart
transport remains `NOT_ESTABLISHED` and no complete lexical-route `O(x)` or
compiler/query frame identity exists.

The offline certificate is
`blake3:3fff541e4ac37193babaacd25227019fb401950ccdd936ab38ac46c6c2916337`.

## Scope

- Adds one non-WASM graph-certify prerequisite certificate and focused test.
- Records corpus/source identities and 3,000 / 2,404 / 596 document counts.
- Records unavailable codec/split/pair and lexical operator/frame identities
  without inventing substitutes.
- Updates current programme, roadmap, research, evaluation, lifecycle,
  glossary, and append-only evidence mirrors.
- Leaves #953 implementation, tests, fixtures, data, generation, and replay
  untouched.

Placement, link construction, diffusion, Gate 0, calibration, sealed labels,
full/table/control selection, payload replay, and #953 are `NOT_RUN`.

## Focused verification

- `cargo test -p uor-r4-graph-certify --test corpus_signed_transport_attention_986 --offline -- --nocapture` — 3/3
- `cargo check -p uor-r4-graph-certify --all-targets --offline`
- strict target-only Clippy with `--no-deps -D warnings`
- `cargo fmt --check`
- claim-wording gate
- staged diff whitespace and #953 quarantine checks

Dependency-inclusive Clippy reaches pre-existing warnings in unchanged
graph-runtime/model-source files; no unrelated code was changed. Workspace,
BDD, teacher, corpus-scale, kappa, audit, fuzz, product, performance, formal,
and release suites remain deliberately dormant for this pre-sealed terminal.

Closes #986
