### PR TITLE
Establish source-free lexical table baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,35 @@ compiler/query frame identity. #986 therefore closed
 selection, or #953. #953 remains parked, unassigned, and untouched; it is not
 eligible merely because its completed native blocker is now closed. Do not add
 a second representation under #983/#986, reuse their populations, or resume
-#953. A new local attempt first requires a freshly frozen population/frame
-successor issue. The completed evidence chain is #983 → #986; downstream
-#953 → #973 → #954 → #955 → #962–#965 remains parked. The complete #986 result
-and nonclaim boundary is
+#953. The pre-reset handoff called for a fresh population/frame successor; the
+capability-first section below supersedes that forward action with B0/#989. The
+completed evidence chain remains #983 → #986; downstream #953 → #973 → #954 →
+#955 → #962–#965 remains parked. The complete #986 result and nonclaim boundary
+is
 [`docs/corpus_signed_transport_attention_986.md`](docs/corpus_signed_transport_attention_986.md).
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
+
+## Capability-first baseline — #989 established
+
+Effective 2026-08-28, #989 established the deterministic source-free
+table-native lexical baseline at
+`ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`. Across 446,342 held-out known-target
+positions, the table scored 99,362 (22.261404%) versus 24,163 (5.413561%) for
+unigram, an uplift of +16.847843 percentage points. The 35,655,288-byte
+artifact is frozen at
+`blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`;
+two complete executions produced identical report bytes and artifacts.
+
+This is a statistical lexical baseline with bounded exact decoding, not
+semantics, attention, geometry, correctness, reasoning, chat, performance, or
+release evidence. Freeze the table artifact and permit exactly one later #953
+geometric intervention under the same corpus, support, decode, and work
+budget. #973 remains blocked behind #953. New H4, SpiralCore, harmonic,
+algebraic, placement, transport, higher-scope, and scale work remains dormant
+outside that one intervention. See the
+[#989 evidence record](docs/source_free_table_baseline_989.md).
 
 ## What this repo is
 
@@ -279,16 +300,16 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   #986 then stopped `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus
   reproduced, but the exact population/codec commitment and a complete
   same-frame lexical SpiralCore operator map were unavailable. Placement,
-  Gate 0, labels, selection, and #953 were `NOT_RUN`. #953 stays parked,
-  unassigned, and untouched pending a newly frozen population/frame successor;
-  #973 and #954 remain blocked.
+  Gate 0, labels, selection, and #953 were `NOT_RUN`. #953 is now on hold behind
+  B0/#989; #973 and #954 remain blocked.
   #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
-- Sequence strictly: lexical/address plumbing → bounded corpus semantic-
-  placement transfer → candidate-relative signed transport qualification →
-  source-free grammatical inference/generation → higher-scope attention →
-  correctness/abstention → reasoning → optimization/purity/release.
+- Sequence strictly from the current reset: working source-free table baseline
+  (#989, established) → exactly one matched geometric intervention in #953 →
+  higher-scope attention (#973) → correctness/abstention → reasoning →
+  optimization/purity/release. The older placement/transport
+  sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic
   distance. The pinned lexical codec is provenance-bound but opens no weights.
 - Preserve the project shorthand `E8 = H4 x H4`. Its concrete implementation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,18 @@ Do not create a new test framework for routine confidence.
 
 The experiment must be able to change the next programme decision:
 
-- **Follow the GI sequence.** GI-1 makes lexical/address state reversible;
+- **Preserve the established B0 reference.** #989 reached
+  `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`: 99,362/446,342 (22.261404%)
+  held-out table top-1 versus 24,163/446,342 (5.413561%) unigram, a
+  +16.847843-point uplift, with bounded exact decoding and byte-identical full
+  replay. This is statistical lexical prediction, not semantics, attention,
+  geometry, correctness, reasoning, chat, or release evidence. Exactly one
+  later #953 intervention may use the frozen corpus, support, decode, table
+  artifact, and work budget; #973 remains blocked. Do not start another H4,
+  SpiralCore, harmonic, algebraic, placement, transport, higher-scope, or scale
+  probe. See the [#989 record](docs/source_free_table_baseline_989.md).
+- **Preserve the GI evidence lineage.** GI-1 makes lexical/address state
+  reversible;
   #952 found the reusable ordered-state defect; A1R/#967 repaired the fold but
   terminated `RETAIN_STATE_ONLY` after its scalar readout tied distinct
   candidate-relative states on 6/6 queries; A1P/#970's target-free paired-H4
@@ -125,14 +136,17 @@ The experiment must be able to change the next programme decision:
   `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus reproduced, but the exact
   corpus-scale codec/pair commitment and complete same-frame lexical
   Cl(0,6)/SpiralCore operator map were unavailable. Gate 0, labels, selection,
-  and #953 were `NOT_RUN`. #953 remains parked, unassigned, and untouched until
-  a freshly frozen population/frame successor independently qualifies. A1Q-H/
-  #973 and GI-4/#954 remain blocked, with GI-5/#955 downstream.
-- **Exercise the real route path.** Geometry must run before token choice and
-  emit its admitted support and energy trace. Add a global-context coverage
-  witness when the active issue, beginning with #973, activates higher scopes.
-- **Use the smallest falsifier.** Start with a bounded source-free route
-  fixture, hierarchy intervention, or held-out continuation before adding data.
+  and #953 were `NOT_RUN`. That pre-reset handoff left #953 parked pending a
+  fresh successor; the established B0/#989 result above supersedes that action.
+  A1Q-H/#973 and GI-4/#954 remain blocked, with GI-5/#955 downstream.
+- **Exercise the real route path only when reactivated.** When a later #953
+  issue activates the one matched intervention, geometry must
+  run before token choice and emit its admitted support and energy trace. Add a
+  global-context coverage witness only when #973 is eligible and active.
+- **Use the smallest falsifier.** #989 began with its bounded natural lexical
+  fixture before the declared real corpus run. The one permitted #953
+  intervention must begin with its own bounded matched falsifier before any
+  broader data or mechanism work.
 - **Parallelize deterministic corpus work.** Partition by content identity,
   use all available local workers with canonical ordered reductions, and
   compare independent multithreaded rebuilds. Do not launch a long experiment

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ local hardware. The project is testing whether language context, inference,
 and reasoning can emerge from routes through a canonical geometric memory. The
 target serving engine uses no Ollama, hosted model, or source-model weights.
 
+> **Current capability-first result (2026-08-28):** #989 established the
+> deterministic source-free lexical table baseline. On 446,342 held-out known
+> targets it scored 22.261404% top-1 versus 5.413561% for unigram, a
+> +16.847843-point uplift. Two complete 3,000-document executions produced
+> identical reports and artifacts. The fixed prompt `The United States`
+> decoded 16 units as
+> `. It is the most important thing to do so.\n 1985 – The first people` and
+> stopped at the cap without a period-1/2 cycle. This is a statistical lexical
+> baseline, not semantics, attention, geometry, correctness, reasoning, chat,
+> or release evidence. Its artifact is now the fixed non-geometric reference
+> for exactly one later #953 intervention under matched corpus, support, decode,
+> and work; #973 remains blocked. See the
+> [#989 evidence record](docs/source_free_table_baseline_989.md).
+
 > **Honest status:** the geometric storage/identity foundation, one bounded
 > causal R4/S3 path selector, and reusable provider-free decode/render/append
 > plumbing exist. The first #953 smoke was an exact lexical relabel of #969, so
@@ -32,9 +46,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `UNAVAILABLE_FRAME_OR_POPULATION`: the pinned raw corpus reproduced, but its
 > exact #986 codec/pair commitment and a complete same-frame lexical SpiralCore
 > operator map were unavailable. Placement, diffusion, Gate 0, calibration,
-> sealed labels, selection, and #953 were `NOT_RUN`. #953 remains parked,
-> unassigned, and untouched pending a newly frozen population/frame successor;
-> #973 and #954 remain blocked.
+> sealed labels, selection, and #953 were `NOT_RUN`. The later established #989
+> result now permits one matched #953 intervention; #973 and #954 remain
+> blocked.
 > Higher-scope attention, correct answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
@@ -67,6 +81,24 @@ To run the one fixed canonical-ingestion witness:
 ```bash
 cargo run --bin r4 -- lexical-ingestion-witness
 ```
+
+To compile and evaluate the established #989 source-free lexical table path:
+
+```bash
+cargo run --bin r4 -- source-free-table \
+  --corpus /path/to/articles.jsonl \
+  --prompt "The United States" \
+  --continuation-cap 16 \
+  --artifact-out /path/to/source-free-table.bin \
+  --json
+```
+
+The corpus directory must also contain its pinned `manifest.json`. The command
+uses only the D3 construction partition for its vocabulary and integer
+unigram/bigram/trigram counts, evaluates held-out next-unit prediction, writes
+the deterministic packed artifact, and emits the exact decoded continuation.
+It is a statistical lexical baseline command, not an attention, semantic,
+correctness, chat, or release surface.
 
 To reproduce the bounded A1R associative ordered-summary decision:
 
@@ -266,12 +298,16 @@ the current product path and are not prerequisites for trying the dashboard.
 The programme is deliberately sequential so that infrastructure and testing do
 not become substitutes for working intelligence:
 
-1. **Make language reversible in geometry** — lexical codec, canonical route
-   hierarchy, serialization, and reconstruction.
-2. **Qualify semantic placement and local attention** — corpus-induced value
-   must transfer, then signed candidate-relative exact transport must causally
-   improve selection beyond matched controls and a table-native comparator.
-3. **Generate coherent text** — source-free grammar and next-route decoding.
+1. **Retain the established source-free table baseline (#989)** — 22.261404%
+   held-out top-1 versus 5.413561% unigram on 446,342 known targets, exact
+   bounded decoding, and byte-identical replay. Preserve its artifact and claim
+   boundary as a statistical lexical reference.
+2. **Compare one geometric intervention (#953)** — keep #989's corpus, support,
+   decode, and work fixed while exactly one geometric term competes against the
+   frozen table reference.
+3. **Qualify higher-scope attention (#973)** — only through an accepted #953
+   path; historical placement and transport probes remain evidence, not Now
+   work.
 4. **Establish correctness** — relevance, contradiction handling, and honest
    abstention.
 5. **Establish reasoning** — bounded multi-step route composition.
@@ -283,10 +319,10 @@ sequence so each new mechanism can become visible before the final engine is
 complete.
 
 The active dependency chain is tracked in
-[#820](https://github.com/UOR-Foundation/uor-r4/issues/820). #986 is closed at
-its pre-sealed unavailable terminal. There is no eligible local implementation
-stage until a fresh population/frame successor is frozen. #953 remains parked;
-#973 and #954 remain blocked downstream of #953, and #954 also depends on #973.
+[#820](https://github.com/UOR-Foundation/uor-r4/issues/820). #989 established
+the frozen table reference; exactly one matched #953 intervention is the only
+permitted local successor. #973 and #954 remain blocked downstream of #953,
+and #954 also depends on #973.
 
 ## Find your way around
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,8 +36,9 @@ closed as negative evidence. A1Q-L3/#986 then stopped
 corpus-scale codec/three-way pair commitment or complete same-frame lexical
 SpiralCore operator map was available. Placement, diffusion, Gate 0, labels,
 selection, and #953 were `NOT_RUN`. #986 is closed; parked, unassigned,
-untouched #953 remains ineligible pending a freshly frozen population/frame
-successor and continues to block #973 and #954._
+untouched #953 is now limited to one matched intervention against the
+established B0/#989 table baseline and continues to block #973 and #954. #989
+closed its frozen decision at `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -76,7 +77,8 @@ successor and continues to block #973 and #954._
 > exact population and lexical SpiralCore frame were unavailable. It stopped
 > before placement or labels; no table or geometric arm transferred. A new
 > local attempt must freeze a population/frame successor rather than retry
-> #986. Once #953 is accepted and every required #973 scope
+> #986. That pre-reset handoff is retained as history; B0/#989 now supersedes
+> it. Once #953 is accepted and every required #973 scope
 > qualifies, a separately frozen higher-scope/corpus-scale offline induction
 > ladder may compile causal prefix-to-observed-next-route examples, multiscale
 > route summaries, versioned placement overlays that preserve immutable
@@ -107,10 +109,21 @@ successor and continues to block #973 and #954._
 
 Native GitHub relationships are the source of truth:
 
-The current priority view is **Now:** freeze no implementation until a fresh
-population/frame successor is authored; **Parked:** #953 → #973 → #954;
-**Later:** #955 → #962 → #963 → #964 → #965. The completed #986 feasibility
-boundary is recorded in the
+The current priority view is **Established baseline:** #989 at
+`ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`; **Next permitted:** exactly one #953
+geometric intervention against that frozen reference; **Blocked:** #973 → #954;
+**Later:** #955 → #962 → #963 → #964 → #965.
+
+This capability-first reset supersedes the old forward action implied by the
+numbered evidence ladder below without rewriting that history. #989 scored
+99,362/446,342 (22.261404%) held-out top-1 versus 24,163/446,342 (5.413561%)
+for unigram, an uplift of +16.847843 percentage points, with byte-identical
+double execution. Freeze its non-geometric table engine, corpus, support,
+decode, and work budget. Do not start another attention, H4, SpiralCore,
+harmonic, algebraic, placement, transport, higher-scope, or scale probe outside
+the one matched #953 intervention. See the
+[#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
+feasibility boundary remains in the
 [#986 evidence](docs/corpus_signed_transport_attention_986.md).
 
 1. **GI-0 — retain #958 foundation:** keep the schema-2 manifest, bounded route
@@ -310,10 +323,9 @@ boundary is recorded in the
    frozen construction-induced placement overlay reproduced its exact classes,
    but real placement chose `run/runs` (0/2 intended) while the cyclic
    placement-permuted control chose `runs/run` (2/2); generation therefore
-   remained `NOT_RUN`. #953 is now a parked, unassigned, untouched integration
-   regression. Only a newly frozen successor that independently qualifies a
-   local semantic selector may be applied there in a later session, unchanged
-   and behind a new label-free preflight. Harmonic
+   remained `NOT_RUN`. #953 is a preserved integration regression. Established
+   B0/#989 now permits exactly one later intervention against its frozen table
+   reference under matched corpus, support, decode, and work. Harmonic
    influence remains dormant in #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
 9. **GI-2 A1Q-H / #973 — higher-scope attention:** after the accepted local
@@ -373,11 +385,10 @@ plumbing and tiered admission remain preserved, but its known placement
 population is quarantined after 0/2 real versus 2/2 placement-permuted and
 decoded generation/replay `NOT_RUN`. #983 is closed bounded negative evidence
 after its independent Gate 0 transferred on 0/6 decisions. #986 is also closed
-at its pre-sealed population/frame unavailable terminal. No local
-implementation issue is eligible until a fresh successor is frozen. The live
-sequence is closed #967/#970/#969/#983/#986 → parked #953 → blocked #973 →
-blocked #954 → #955 → #962–#965. #953 continues to block #973 and #954; #973
-continues to block #954.
+at its pre-sealed population/frame unavailable terminal. #989 has now
+established the frozen table reference. The live sequence is established #989
+→ exactly one matched #953 intervention → blocked #973 → blocked #954 → #955 →
+#962–#965. #953 continues to block #973 and #954; #973 continues to block #954.
 Legacy tracker #949 is closed as
 superseded; #958 is retained directly under programme root #820 as GI-0
 foundation.
@@ -386,12 +397,19 @@ The old S5–S7 and F0 issues are closed not planned/not triggered. R4G1/TLA,
 XOR/popcount, W(3,3), proof, conformance, and release work remains preserved as
 historical evidence and comparators.
 
-## Now
+## Established baseline and only permitted successor
 
-- [ ] **Fresh population/frame successor — not yet authored.** Before any local
-  semantic selector can run, a new issue must freeze a source-free corpus-scale
-  codec plus exact three-way pair commitment and a complete same-frame lexical
-  SpiralCore operator map. Do not resume #986 or #953 to invent either contract.
+- [x] **#989 B0 source-free table-native lexical baseline — established.** The
+  3,000-document D3 run produced 116,061 lexical routes and a 35,655,288-byte
+  artifact at
+  `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`.
+  Table top-1 was 22.261404% versus 5.413561% unigram, the fixed prompt emitted
+  16 valid UTF-8 units without a period-1/2 cycle, and full replay was byte
+  identical. This establishes statistical lexical prediction and decoding
+  only.
+- [ ] **#953 — exactly one matched geometric intervention.** Hold #989's
+  corpus, support, decode, table artifact, and work fixed. No broader geometry
+  or attention programme is eligible; #973 remains blocked.
 
 ## Completed negative
 
@@ -411,11 +429,9 @@ historical evidence and comparators.
 ## Parked
 
 - [ ] **#953 bounded source-free geometric generation loop** — preserved at
-  historical terminal `REVISE_I1_GENERATOR_IN_PLACE`, open and unassigned. Its
-  fixture, placement overlay, decoded loop, and records remain untouched while
-  no accepted semantic selector exists. Only a newly frozen successor that
-  independently qualifies a local semantic selector may later authorize a
-  separate #953 session beginning with a new label-free preflight. #953
+  historical terminal `REVISE_I1_GENERATOR_IN_PLACE`, open and unassigned.
+  Established B0/#989 authorizes exactly one intervention against its frozen
+  table reference under matched corpus, support, decode, and work. #953
   continues to block #973 and #954.
 
 ## Landed

--- a/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
+++ b/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
@@ -830,6 +830,28 @@ fn segment_paragraph(bytes: &[u8]) -> Result<(Vec<RawSegment>, Vec<u8>), Canonic
     Ok((segments, bytes[boundary_start..].to_vec()))
 }
 
+/// Split UTF-8 text with the canonical lexical-run rule while making every
+/// returned piece independently decodable.
+///
+/// Each non-whitespace run owns the whitespace immediately before it. A
+/// trailing whitespace-only suffix is its own final piece. Concatenating the
+/// returned pieces therefore reproduces `bytes` exactly. This is the small,
+/// geometry-free segmentation surface used by the source-free table baseline;
+/// it deliberately reuses the codec's established Unicode boundary rule.
+pub fn canonical_lexical_piece_bytes(bytes: &[u8]) -> Result<Vec<Vec<u8>>, CanonicalLexicalError> {
+    let (segments, trailing) = segment_paragraph(bytes)?;
+    let mut pieces = Vec::with_capacity(segments.len() + usize::from(!trailing.is_empty()));
+    for segment in segments {
+        let mut piece = segment.leading;
+        piece.extend_from_slice(&segment.surface);
+        pieces.push(piece);
+    }
+    if !trailing.is_empty() {
+        pieces.push(trailing);
+    }
+    Ok(pieces)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 struct ContentBlob {
     cid: String,

--- a/crates/uor-r4-core/src/lib.rs
+++ b/crates/uor-r4-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod prime_route_attention;
 pub mod prime_route_geometric_attention;
 pub mod recursive_geometric_attention;
 pub mod semantic;
+pub mod source_free_table;
 pub mod spiralcore_operator;
 pub mod transformerless;
 pub mod zeta_projection;

--- a/crates/uor-r4-core/src/source_free_table.rs
+++ b/crates/uor-r4-core/src/source_free_table.rs
@@ -1,0 +1,903 @@
+//! Source-free lexical transition baseline (issue #989).
+//!
+//! This module is intentionally geometry-free. It compiles raw UTF-8
+//! construction documents into a reversible lexical-piece codec plus integer
+//! unigram, bigram, and trigram count tables. Held-out documents are never
+//! consulted during fitting. Runtime selection is the fixed precedence
+//! trigram -> bigram -> unigram with highest-count/lowest-token tie breaking.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::canonical_lexical_ingestion::{canonical_lexical_piece_bytes, CanonicalLexicalError};
+
+const ARTIFACT_MAGIC: [u8; 8] = *b"SFTBL001";
+const ARTIFACT_VERSION: u32 = 1;
+const HEADER_LEN: usize = 40;
+const BYTE_TOKEN_BASE: u32 = 2;
+const LEXICAL_TOKEN_BASE: u32 = BYTE_TOKEN_BASE + 256;
+pub const BOS_TOKEN: u32 = 0;
+pub const EOS_TOKEN: u32 = 1;
+pub const MAX_CONTINUATION_UNITS: usize = 64;
+
+type Distribution = BTreeMap<u32, u64>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceFreeTableError {
+    Invalid(String),
+    Lexical(String),
+    ArithmeticOverflow,
+}
+
+impl std::fmt::Display for SourceFreeTableError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(reason) => formatter.write_str(reason),
+            Self::Lexical(reason) => write!(formatter, "lexical input: {reason}"),
+            Self::ArithmeticOverflow => {
+                formatter.write_str("source-free table arithmetic overflow")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SourceFreeTableError {}
+
+impl From<CanonicalLexicalError> for SourceFreeTableError {
+    fn from(error: CanonicalLexicalError) -> Self {
+        Self::Lexical(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDocument {
+    pub id: String,
+    pub text: Vec<u8>,
+}
+
+impl SourceDocument {
+    pub fn new(id: impl Into<String>, text: impl Into<Vec<u8>>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+        }
+    }
+
+    pub fn text_cid(&self) -> [u8; 32] {
+        *blake3::hash(&self.text).as_bytes()
+    }
+}
+
+/// The repository's canonical D3 document partition.
+pub fn d3_is_held_out(document_id: &str) -> bool {
+    blake3::hash(document_id.as_bytes()).as_bytes()[0].is_multiple_of(5)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackoffOrder {
+    Unigram,
+    Bigram,
+    Trigram,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TablePrediction {
+    pub token: u32,
+    pub count: u64,
+    pub order: BackoffOrder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HeldOutEvaluation {
+    pub documents: u64,
+    /// Every scored stream target, including held-out byte-fallback targets.
+    pub positions: u64,
+    /// Targets represented by a construction-fitted lexical payload. Accuracy,
+    /// changed-choice, and order counters below use only this denominator.
+    pub known_target_positions: u64,
+    pub table_correct: u64,
+    pub unigram_correct: u64,
+    pub changed_choices: u64,
+    pub changed_choice_correct: u64,
+    pub trigram_choices: u64,
+    pub bigram_choices: u64,
+    pub unigram_choices: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContinuationStop {
+    EndOfDocument,
+    PeriodOneCycle,
+    PeriodTwoCycle,
+    Bound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Continuation {
+    pub tokens: Vec<u32>,
+    pub decoded: Vec<u8>,
+    pub stop: ContinuationStop,
+}
+
+/// Deterministic construction-only lexical count model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceFreeTable {
+    /// Lexical payloads in ascending byte order. Token id is
+    /// `LEXICAL_TOKEN_BASE + index`.
+    lexical_pieces: Vec<Vec<u8>>,
+    piece_tokens: BTreeMap<Vec<u8>, u32>,
+    unigram: Distribution,
+    bigram: BTreeMap<u32, Distribution>,
+    trigram: BTreeMap<(u32, u32), Distribution>,
+    construction_document_ids: BTreeSet<String>,
+    construction_text_cids: BTreeSet<[u8; 32]>,
+}
+
+impl SourceFreeTable {
+    /// Fit the codec and every count table from D3 construction documents.
+    /// A held-out id is rejected rather than silently admitted.
+    pub fn compile(construction: &[SourceDocument]) -> Result<Self, SourceFreeTableError> {
+        if construction.is_empty() {
+            return Err(SourceFreeTableError::Invalid(
+                "construction document set is empty".to_owned(),
+            ));
+        }
+
+        let mut construction_document_ids = BTreeSet::new();
+        let mut construction_text_cids = BTreeSet::new();
+        let mut lexical_piece_set = BTreeSet::new();
+        for document in construction {
+            validate_document_id(&document.id)?;
+            if d3_is_held_out(&document.id) {
+                return Err(SourceFreeTableError::Invalid(format!(
+                    "D3 held-out document {} cannot enter construction",
+                    document.id
+                )));
+            }
+            if !construction_document_ids.insert(document.id.clone()) {
+                return Err(SourceFreeTableError::Invalid(format!(
+                    "duplicate construction document id {}",
+                    document.id
+                )));
+            }
+            construction_text_cids.insert(document.text_cid());
+            lexical_piece_set.extend(canonical_lexical_piece_bytes(&document.text)?);
+        }
+        if lexical_piece_set.is_empty() {
+            return Err(SourceFreeTableError::Invalid(
+                "construction corpus has no lexical pieces".to_owned(),
+            ));
+        }
+
+        let lexical_pieces = lexical_piece_set.into_iter().collect::<Vec<_>>();
+        let piece_tokens = build_piece_tokens(&lexical_pieces)?;
+        let mut table = Self {
+            lexical_pieces,
+            piece_tokens,
+            unigram: BTreeMap::new(),
+            bigram: BTreeMap::new(),
+            trigram: BTreeMap::new(),
+            construction_document_ids,
+            construction_text_cids,
+        };
+
+        for document in construction {
+            let mut stream = Vec::new();
+            stream.push(BOS_TOKEN);
+            stream.extend(table.encode_text(&document.text)?);
+            stream.push(EOS_TOKEN);
+            for target_index in 1..stream.len() {
+                let target = stream[target_index];
+                add_count(&mut table.unigram, target)?;
+                add_count(
+                    table.bigram.entry(stream[target_index - 1]).or_default(),
+                    target,
+                )?;
+                if target_index >= 2 {
+                    add_count(
+                        table
+                            .trigram
+                            .entry((stream[target_index - 2], stream[target_index - 1]))
+                            .or_default(),
+                        target,
+                    )?;
+                }
+            }
+        }
+        table.validate()?;
+        Ok(table)
+    }
+
+    pub fn construction_document_count(&self) -> usize {
+        self.construction_document_ids.len()
+    }
+
+    pub fn lexical_piece_count(&self) -> usize {
+        self.lexical_pieces.len()
+    }
+
+    pub fn artifact_cid(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.to_bytes()).to_hex())
+    }
+
+    /// Encode with construction-fitted lexical pieces and a total raw-byte
+    /// fallback. The fallback makes every valid UTF-8 held-out payload exactly
+    /// representable without admitting held-out vocabulary into fitting.
+    pub fn encode_text(&self, bytes: &[u8]) -> Result<Vec<u32>, SourceFreeTableError> {
+        let pieces = canonical_lexical_piece_bytes(bytes)?;
+        let mut tokens = Vec::new();
+        for piece in pieces {
+            if let Some(&token) = self.piece_tokens.get(&piece) {
+                tokens.push(token);
+            } else {
+                tokens.extend(piece.into_iter().map(byte_token));
+            }
+        }
+        Ok(tokens)
+    }
+
+    /// Exact inverse of [`Self::encode_text`] for every valid token id.
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<Vec<u8>, SourceFreeTableError> {
+        let mut bytes = Vec::new();
+        for &token in tokens {
+            match token {
+                BOS_TOKEN | EOS_TOKEN => {}
+                BYTE_TOKEN_BASE..=257 => bytes.push((token - BYTE_TOKEN_BASE) as u8),
+                _ => {
+                    let index = token
+                        .checked_sub(LEXICAL_TOKEN_BASE)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .ok_or_else(|| invalid_token(token))?;
+                    let piece = self
+                        .lexical_pieces
+                        .get(index)
+                        .ok_or_else(|| invalid_token(token))?;
+                    bytes.extend_from_slice(piece);
+                }
+            }
+        }
+        Ok(bytes)
+    }
+
+    /// Integer-only trigram -> bigram -> unigram selection. Distributions are
+    /// B-trees, so retaining the first maximum implements the canonical
+    /// lowest-token tie break.
+    pub fn predict(&self, context: &[u32]) -> TablePrediction {
+        if context.len() >= 2 {
+            let key = (context[context.len() - 2], context[context.len() - 1]);
+            if let Some(distribution) = self.trigram.get(&key) {
+                let (token, count) = distribution_winner(distribution);
+                return TablePrediction {
+                    token,
+                    count,
+                    order: BackoffOrder::Trigram,
+                };
+            }
+        }
+        if let Some(&last) = context.last() {
+            if let Some(distribution) = self.bigram.get(&last) {
+                let (token, count) = distribution_winner(distribution);
+                return TablePrediction {
+                    token,
+                    count,
+                    order: BackoffOrder::Bigram,
+                };
+            }
+        }
+        let (token, count) = distribution_winner(&self.unigram);
+        TablePrediction {
+            token,
+            count,
+            order: BackoffOrder::Unigram,
+        }
+    }
+
+    pub fn unigram_prediction(&self) -> TablePrediction {
+        let (token, count) = distribution_winner(&self.unigram);
+        TablePrediction {
+            token,
+            count,
+            order: BackoffOrder::Unigram,
+        }
+    }
+
+    /// Score pristine D3 held-out documents. Evaluation fails closed on
+    /// document-id overlap, exact text-CID overlap, duplicates, or a document
+    /// whose D3 partition is construction.
+    pub fn evaluate_held_out(
+        &self,
+        held_out: &[SourceDocument],
+    ) -> Result<HeldOutEvaluation, SourceFreeTableError> {
+        if held_out.is_empty() {
+            return Err(SourceFreeTableError::Invalid(
+                "held-out document set is empty".to_owned(),
+            ));
+        }
+        let mut seen_ids = BTreeSet::new();
+        let unigram = self.unigram_prediction();
+        let mut evaluation = HeldOutEvaluation::default();
+        for document in held_out {
+            validate_document_id(&document.id)?;
+            if !d3_is_held_out(&document.id) {
+                return Err(SourceFreeTableError::Invalid(format!(
+                    "D3 construction document {} cannot enter held-out evaluation",
+                    document.id
+                )));
+            }
+            let text_cid = document.text_cid();
+            if self.construction_document_ids.contains(&document.id) {
+                return Err(SourceFreeTableError::Invalid(format!(
+                    "held-out document id {} overlaps construction",
+                    document.id
+                )));
+            }
+            if self.construction_text_cids.contains(&text_cid) {
+                return Err(SourceFreeTableError::Invalid(format!(
+                    "held-out document {} has construction text CID",
+                    document.id
+                )));
+            }
+            if !seen_ids.insert(document.id.clone()) {
+                return Err(SourceFreeTableError::Invalid(
+                    "held-out documents contain a duplicate id".to_owned(),
+                ));
+            }
+
+            let mut stream = Vec::new();
+            stream.push(BOS_TOKEN);
+            stream.extend(self.encode_text(&document.text)?);
+            stream.push(EOS_TOKEN);
+            evaluation.documents = checked_increment(evaluation.documents)?;
+            for target_index in 1..stream.len() {
+                let target = stream[target_index];
+                evaluation.positions = checked_increment(evaluation.positions)?;
+                if !self.is_fitted_lexical_token(target) {
+                    continue;
+                }
+                evaluation.known_target_positions =
+                    checked_increment(evaluation.known_target_positions)?;
+                let prediction = self.predict(&stream[..target_index]);
+                match prediction.order {
+                    BackoffOrder::Trigram => {
+                        evaluation.trigram_choices = checked_increment(evaluation.trigram_choices)?
+                    }
+                    BackoffOrder::Bigram => {
+                        evaluation.bigram_choices = checked_increment(evaluation.bigram_choices)?
+                    }
+                    BackoffOrder::Unigram => {
+                        evaluation.unigram_choices = checked_increment(evaluation.unigram_choices)?
+                    }
+                }
+                if prediction.token == target {
+                    evaluation.table_correct = checked_increment(evaluation.table_correct)?;
+                }
+                if unigram.token == target {
+                    evaluation.unigram_correct = checked_increment(evaluation.unigram_correct)?;
+                }
+                if prediction.token != unigram.token {
+                    evaluation.changed_choices = checked_increment(evaluation.changed_choices)?;
+                    if prediction.token == target {
+                        evaluation.changed_choice_correct =
+                            checked_increment(evaluation.changed_choice_correct)?;
+                    }
+                }
+            }
+        }
+        Ok(evaluation)
+    }
+
+    /// Canonical, human-readable evidence bytes for the smallest vertical
+    /// slice. The zero counters are claim-bearing: this path has no API by
+    /// which a teacher, provider, source weights, or geometry can be read.
+    pub fn canonical_transcript_bytes(
+        &self,
+        evaluation: &HeldOutEvaluation,
+        seed: &[u8],
+        continuation: &Continuation,
+    ) -> Vec<u8> {
+        format!(
+            "source_free_table_schema=1\nartifact_cid={}\nconstruction_documents={}\nlexical_pieces={}\nheld_out_documents={}\npositions={}\nknown_target_positions={}\ntable_correct={}\nunigram_correct={}\nchanged_choices={}\nchanged_choice_correct={}\ntrigram_choices={}\nbigram_choices={}\nunigram_choices={}\nteacher_calls=0\nprovider_calls=0\nsource_weight_reads=0\ngeometry_calls=0\nseed_hex={}\ncontinuation_tokens={}\ncontinuation_hex={}\ncontinuation_stop={}\n",
+            self.artifact_cid(),
+            self.construction_document_count(),
+            self.lexical_piece_count(),
+            evaluation.documents,
+            evaluation.positions,
+            evaluation.known_target_positions,
+            evaluation.table_correct,
+            evaluation.unigram_correct,
+            evaluation.changed_choices,
+            evaluation.changed_choice_correct,
+            evaluation.trigram_choices,
+            evaluation.bigram_choices,
+            evaluation.unigram_choices,
+            hex::encode(seed),
+            continuation.tokens.len(),
+            hex::encode(&continuation.decoded),
+            continuation_stop_name(continuation.stop),
+        )
+        .into_bytes()
+    }
+
+    /// Deterministically continue a prompt for at most `max_units`. EOS and
+    /// period-one/two cycles stop before their sentinel token is appended.
+    pub fn continue_text(
+        &self,
+        seed: &[u8],
+        max_units: usize,
+    ) -> Result<Continuation, SourceFreeTableError> {
+        if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
+            return Err(SourceFreeTableError::Invalid(format!(
+                "continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
+            )));
+        }
+        let mut context = Vec::new();
+        context.push(BOS_TOKEN);
+        context.extend(self.encode_text(seed)?);
+        let mut generated = Vec::new();
+        let mut stop = ContinuationStop::Bound;
+        while generated.len() < max_units {
+            let token = self.predict(&context).token;
+            if token == EOS_TOKEN {
+                stop = ContinuationStop::EndOfDocument;
+                break;
+            }
+            if generated.last() == Some(&token) {
+                stop = ContinuationStop::PeriodOneCycle;
+                break;
+            }
+            if generated.len() >= 3
+                && generated[generated.len() - 2] == token
+                && generated[generated.len() - 3] == generated[generated.len() - 1]
+            {
+                stop = ContinuationStop::PeriodTwoCycle;
+                break;
+            }
+            generated.push(token);
+            context.push(token);
+        }
+        let decoded = self.decode_tokens(&generated)?;
+        Ok(Continuation {
+            tokens: generated,
+            decoded,
+            stop,
+        })
+    }
+
+    /// Canonical packed bytes. Maps and sets serialize in their B-tree order.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&ARTIFACT_MAGIC);
+        push_u32(&mut bytes, ARTIFACT_VERSION);
+        push_u32(&mut bytes, usize_u32(self.lexical_pieces.len()));
+        push_u32(&mut bytes, usize_u32(self.construction_document_ids.len()));
+        push_u32(&mut bytes, usize_u32(self.construction_text_cids.len()));
+        push_u32(&mut bytes, usize_u32(self.unigram.len()));
+        push_u32(&mut bytes, usize_u32(self.bigram.len()));
+        push_u32(&mut bytes, usize_u32(self.trigram.len()));
+        push_u32(&mut bytes, 0);
+        debug_assert_eq!(bytes.len(), HEADER_LEN);
+
+        for piece in &self.lexical_pieces {
+            push_len_bytes(&mut bytes, piece);
+        }
+        for id in &self.construction_document_ids {
+            push_len_bytes(&mut bytes, id.as_bytes());
+        }
+        for cid in &self.construction_text_cids {
+            bytes.extend_from_slice(cid);
+        }
+        push_distribution(&mut bytes, &self.unigram);
+        for (&key, distribution) in &self.bigram {
+            push_u32(&mut bytes, key);
+            push_u32(&mut bytes, usize_u32(distribution.len()));
+            push_distribution(&mut bytes, distribution);
+        }
+        for (&(key0, key1), distribution) in &self.trigram {
+            push_u32(&mut bytes, key0);
+            push_u32(&mut bytes, key1);
+            push_u32(&mut bytes, usize_u32(distribution.len()));
+            push_distribution(&mut bytes, distribution);
+        }
+        bytes
+    }
+
+    /// Validate and reload canonical packed bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SourceFreeTableError> {
+        if bytes.len() < HEADER_LEN || bytes[..8] != ARTIFACT_MAGIC {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table magic/header is invalid".to_owned(),
+            ));
+        }
+        let mut cursor = Cursor::new(bytes);
+        cursor.take(8)?;
+        if cursor.u32()? != ARTIFACT_VERSION {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table version is unsupported".to_owned(),
+            ));
+        }
+        let piece_count = cursor.count("lexical piece")?;
+        let document_id_count = cursor.count("construction document id")?;
+        let text_cid_count = cursor.count("construction text CID")?;
+        let unigram_count = cursor.count("unigram entry")?;
+        let bigram_count = cursor.count("bigram row")?;
+        let trigram_count = cursor.count("trigram row")?;
+        if cursor.u32()? != 0 {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table reserved field is nonzero".to_owned(),
+            ));
+        }
+
+        let mut lexical_pieces = Vec::with_capacity(piece_count);
+        for _ in 0..piece_count {
+            lexical_pieces.push(cursor.length_prefixed("lexical piece")?.to_vec());
+        }
+        ensure_strictly_sorted_nonempty(&lexical_pieces, "lexical pieces")?;
+        let piece_tokens = build_piece_tokens(&lexical_pieces)?;
+
+        let mut construction_document_ids = BTreeSet::new();
+        let mut previous_id: Option<String> = None;
+        for _ in 0..document_id_count {
+            let raw = cursor.length_prefixed("construction document id")?;
+            let id = std::str::from_utf8(raw)
+                .map_err(|_| {
+                    SourceFreeTableError::Invalid(
+                        "construction document id is not UTF-8".to_owned(),
+                    )
+                })?
+                .to_owned();
+            validate_document_id(&id)?;
+            if previous_id.as_ref().is_some_and(|previous| previous >= &id) {
+                return Err(SourceFreeTableError::Invalid(
+                    "construction document ids are not strictly sorted".to_owned(),
+                ));
+            }
+            previous_id = Some(id.clone());
+            construction_document_ids.insert(id);
+        }
+
+        let mut construction_text_cids = BTreeSet::new();
+        let mut previous_cid = None;
+        for _ in 0..text_cid_count {
+            let cid: [u8; 32] = cursor
+                .take(32)?
+                .try_into()
+                .map_err(|_| SourceFreeTableError::ArithmeticOverflow)?;
+            if previous_cid.is_some_and(|previous| previous >= cid) {
+                return Err(SourceFreeTableError::Invalid(
+                    "construction text CIDs are not strictly sorted".to_owned(),
+                ));
+            }
+            previous_cid = Some(cid);
+            construction_text_cids.insert(cid);
+        }
+
+        let unigram = cursor.distribution(unigram_count, lexical_pieces.len())?;
+        let mut bigram = BTreeMap::new();
+        let mut previous_bigram = None;
+        for _ in 0..bigram_count {
+            let key = cursor.u32()?;
+            if previous_bigram.is_some_and(|previous| previous >= key) {
+                return Err(SourceFreeTableError::Invalid(
+                    "bigram rows are not strictly sorted".to_owned(),
+                ));
+            }
+            validate_token(key, lexical_pieces.len())?;
+            previous_bigram = Some(key);
+            let entries = cursor.count("bigram entry")?;
+            if entries == 0 {
+                return Err(SourceFreeTableError::Invalid(
+                    "bigram row is empty".to_owned(),
+                ));
+            }
+            bigram.insert(key, cursor.distribution(entries, lexical_pieces.len())?);
+        }
+        let mut trigram = BTreeMap::new();
+        let mut previous_trigram = None;
+        for _ in 0..trigram_count {
+            let key = (cursor.u32()?, cursor.u32()?);
+            if previous_trigram.is_some_and(|previous| previous >= key) {
+                return Err(SourceFreeTableError::Invalid(
+                    "trigram rows are not strictly sorted".to_owned(),
+                ));
+            }
+            validate_token(key.0, lexical_pieces.len())?;
+            validate_token(key.1, lexical_pieces.len())?;
+            previous_trigram = Some(key);
+            let entries = cursor.count("trigram entry")?;
+            if entries == 0 {
+                return Err(SourceFreeTableError::Invalid(
+                    "trigram row is empty".to_owned(),
+                ));
+            }
+            trigram.insert(key, cursor.distribution(entries, lexical_pieces.len())?);
+        }
+        if !cursor.is_finished() {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table has trailing bytes".to_owned(),
+            ));
+        }
+
+        let table = Self {
+            lexical_pieces,
+            piece_tokens,
+            unigram,
+            bigram,
+            trigram,
+            construction_document_ids,
+            construction_text_cids,
+        };
+        table.validate()?;
+        if table.to_bytes() != bytes {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table is not canonical".to_owned(),
+            ));
+        }
+        Ok(table)
+    }
+
+    fn validate(&self) -> Result<(), SourceFreeTableError> {
+        if self.lexical_pieces.is_empty()
+            || self.unigram.is_empty()
+            || self.construction_document_ids.is_empty()
+            || self.construction_text_cids.is_empty()
+        {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free table has an empty required section".to_owned(),
+            ));
+        }
+        ensure_strictly_sorted_nonempty(&self.lexical_pieces, "lexical pieces")?;
+        if build_piece_tokens(&self.lexical_pieces)? != self.piece_tokens {
+            return Err(SourceFreeTableError::Invalid(
+                "lexical piece index does not reproduce".to_owned(),
+            ));
+        }
+        validate_distribution(&self.unigram, self.lexical_pieces.len())?;
+        for (&key, distribution) in &self.bigram {
+            validate_token(key, self.lexical_pieces.len())?;
+            validate_distribution(distribution, self.lexical_pieces.len())?;
+        }
+        for (&(key0, key1), distribution) in &self.trigram {
+            validate_token(key0, self.lexical_pieces.len())?;
+            validate_token(key1, self.lexical_pieces.len())?;
+            validate_distribution(distribution, self.lexical_pieces.len())?;
+        }
+        Ok(())
+    }
+
+    fn is_fitted_lexical_token(&self, token: u32) -> bool {
+        token.checked_sub(LEXICAL_TOKEN_BASE).is_some_and(|offset| {
+            usize::try_from(offset)
+                .ok()
+                .is_some_and(|index| index < self.lexical_pieces.len())
+        })
+    }
+}
+
+fn continuation_stop_name(stop: ContinuationStop) -> &'static str {
+    match stop {
+        ContinuationStop::EndOfDocument => "end_of_document",
+        ContinuationStop::PeriodOneCycle => "period_one_cycle",
+        ContinuationStop::PeriodTwoCycle => "period_two_cycle",
+        ContinuationStop::Bound => "bound",
+    }
+}
+
+fn validate_document_id(id: &str) -> Result<(), SourceFreeTableError> {
+    if id.is_empty() || id.len() > u32::MAX as usize {
+        return Err(SourceFreeTableError::Invalid(
+            "document id is empty or too long".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn build_piece_tokens(
+    lexical_pieces: &[Vec<u8>],
+) -> Result<BTreeMap<Vec<u8>, u32>, SourceFreeTableError> {
+    lexical_pieces
+        .iter()
+        .enumerate()
+        .map(|(index, piece)| {
+            let offset =
+                u32::try_from(index).map_err(|_| SourceFreeTableError::ArithmeticOverflow)?;
+            let token = LEXICAL_TOKEN_BASE
+                .checked_add(offset)
+                .ok_or(SourceFreeTableError::ArithmeticOverflow)?;
+            Ok((piece.clone(), token))
+        })
+        .collect()
+}
+
+fn byte_token(byte: u8) -> u32 {
+    BYTE_TOKEN_BASE + u32::from(byte)
+}
+
+fn invalid_token(token: u32) -> SourceFreeTableError {
+    SourceFreeTableError::Invalid(format!("unknown source-free token id {token}"))
+}
+
+fn validate_token(token: u32, piece_count: usize) -> Result<(), SourceFreeTableError> {
+    if token <= 257 {
+        return Ok(());
+    }
+    let index = token
+        .checked_sub(LEXICAL_TOKEN_BASE)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| invalid_token(token))?;
+    if index >= piece_count {
+        return Err(invalid_token(token));
+    }
+    Ok(())
+}
+
+fn add_count(distribution: &mut Distribution, token: u32) -> Result<(), SourceFreeTableError> {
+    let count = distribution.entry(token).or_insert(0);
+    *count = count
+        .checked_add(1)
+        .ok_or(SourceFreeTableError::ArithmeticOverflow)?;
+    Ok(())
+}
+
+fn checked_increment(value: u64) -> Result<u64, SourceFreeTableError> {
+    value
+        .checked_add(1)
+        .ok_or(SourceFreeTableError::ArithmeticOverflow)
+}
+
+fn distribution_winner(distribution: &Distribution) -> (u32, u64) {
+    let mut winner = (0, 0);
+    for (&token, &count) in distribution {
+        if count > winner.1 {
+            winner = (token, count);
+        }
+    }
+    winner
+}
+
+fn validate_distribution(
+    distribution: &Distribution,
+    piece_count: usize,
+) -> Result<(), SourceFreeTableError> {
+    if distribution.is_empty() {
+        return Err(SourceFreeTableError::Invalid(
+            "source-free distribution is empty".to_owned(),
+        ));
+    }
+    for (&token, &count) in distribution {
+        validate_token(token, piece_count)?;
+        if count == 0 {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free distribution contains a zero count".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_strictly_sorted_nonempty(
+    values: &[Vec<u8>],
+    label: &str,
+) -> Result<(), SourceFreeTableError> {
+    if values.is_empty()
+        || values.iter().any(Vec::is_empty)
+        || values.windows(2).any(|pair| pair[0] >= pair[1])
+    {
+        return Err(SourceFreeTableError::Invalid(format!(
+            "{label} are empty, duplicated, or not strictly sorted"
+        )));
+    }
+    Ok(())
+}
+
+fn usize_u32(value: usize) -> u32 {
+    u32::try_from(value).expect("validated source-free table length exceeds u32")
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_len_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
+    push_u32(output, usize_u32(bytes.len()));
+    output.extend_from_slice(bytes);
+}
+
+fn push_distribution(output: &mut Vec<u8>, distribution: &Distribution) {
+    for (&token, &count) in distribution {
+        push_u32(output, token);
+        push_u64(output, count);
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], SourceFreeTableError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(SourceFreeTableError::ArithmeticOverflow)?;
+        let value = self.bytes.get(self.offset..end).ok_or_else(|| {
+            SourceFreeTableError::Invalid("source-free table is truncated".to_owned())
+        })?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u32(&mut self) -> Result<u32, SourceFreeTableError> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?
+                .try_into()
+                .map_err(|_| SourceFreeTableError::ArithmeticOverflow)?,
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, SourceFreeTableError> {
+        Ok(u64::from_le_bytes(
+            self.take(8)?
+                .try_into()
+                .map_err(|_| SourceFreeTableError::ArithmeticOverflow)?,
+        ))
+    }
+
+    fn count(&mut self, label: &str) -> Result<usize, SourceFreeTableError> {
+        let count =
+            usize::try_from(self.u32()?).map_err(|_| SourceFreeTableError::ArithmeticOverflow)?;
+        if count > self.bytes.len().saturating_sub(self.offset) {
+            return Err(SourceFreeTableError::Invalid(format!(
+                "{label} count exceeds remaining artifact bytes"
+            )));
+        }
+        Ok(count)
+    }
+
+    fn length_prefixed(&mut self, label: &str) -> Result<&'a [u8], SourceFreeTableError> {
+        let length =
+            usize::try_from(self.u32()?).map_err(|_| SourceFreeTableError::ArithmeticOverflow)?;
+        if length == 0 {
+            return Err(SourceFreeTableError::Invalid(format!("{label} is empty")));
+        }
+        self.take(length)
+    }
+
+    fn distribution(
+        &mut self,
+        entries: usize,
+        piece_count: usize,
+    ) -> Result<Distribution, SourceFreeTableError> {
+        if entries == 0 {
+            return Err(SourceFreeTableError::Invalid(
+                "source-free distribution is empty".to_owned(),
+            ));
+        }
+        let mut distribution = BTreeMap::new();
+        let mut previous = None;
+        for _ in 0..entries {
+            let token = self.u32()?;
+            let count = self.u64()?;
+            validate_token(token, piece_count)?;
+            if count == 0 || previous.is_some_and(|prior| prior >= token) {
+                return Err(SourceFreeTableError::Invalid(
+                    "distribution entries are zero or not strictly sorted".to_owned(),
+                ));
+            }
+            previous = Some(token);
+            distribution.insert(token, count);
+        }
+        Ok(distribution)
+    }
+
+    fn is_finished(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+}

--- a/crates/uor-r4-core/tests/source_free_table_baseline_989.rs
+++ b/crates/uor-r4-core/tests/source_free_table_baseline_989.rs
@@ -1,0 +1,143 @@
+//! Natural, source-free lexical table vertical slice for issue #989.
+//!
+//! Excerpts are from the pinned Simple English Wikipedia D3 corpus
+//! (CC-BY-SA-4.0; Wikimedia contributors) and retain their corpus article ids.
+
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, BackoffOrder, ContinuationStop, SourceDocument, SourceFreeTable,
+};
+
+fn construction_documents() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new("14", b"She was born in Ottawa, Canada.".to_vec()),
+        SourceDocument::new("657", b"He was born in Bombay, India.".to_vec()),
+        SourceDocument::new(
+            "4579",
+            b"Alexander Graham Bell was born in Edinburgh, Scotland.".to_vec(),
+        ),
+        SourceDocument::new("5121", b"He was born in Shrewsbury, Shropshire.".to_vec()),
+    ]
+}
+
+fn held_out_documents() -> Vec<SourceDocument> {
+    vec![SourceDocument::new(
+        "13",
+        "Alan Mathison Turing OBE FRS (London, 23 June 1912 – Wilmslow, Cheshire, 7 June 1954) was an English mathematician and computer scientist. He was born in Maida Vale, London."
+            .as_bytes()
+            .to_vec(),
+    )]
+}
+
+fn has_period_one_or_two_cycle(tokens: &[u32]) -> bool {
+    tokens.windows(2).any(|window| window[0] == window[1])
+        || tokens
+            .windows(4)
+            .any(|window| window[0] == window[2] && window[1] == window[3])
+}
+
+#[test]
+fn natural_held_out_choice_beats_unigram_and_decodes_continuation() {
+    let construction = construction_documents();
+    let held_out = held_out_documents();
+    assert!(construction
+        .iter()
+        .all(|document| !d3_is_held_out(&document.id)));
+    assert!(held_out.iter().all(|document| d3_is_held_out(&document.id)));
+
+    let table = SourceFreeTable::compile(&construction).expect("construction-only table compiles");
+    let held_tokens = table
+        .encode_text(&held_out[0].text)
+        .expect("held-out text encodes with byte fallback");
+    assert_eq!(
+        table.decode_tokens(&held_tokens).unwrap(),
+        held_out[0].text,
+        "held-out payload must invert without fitting its vocabulary"
+    );
+
+    let evaluation = table
+        .evaluate_held_out(&held_out)
+        .expect("D3 held-out evaluation is disjoint");
+    assert!(evaluation.changed_choices > 0);
+    assert!(evaluation.changed_choice_correct > 0);
+    assert!(evaluation.known_target_positions > 0);
+    assert!(
+        evaluation.table_correct > evaluation.unigram_correct,
+        "context table must improve the natural held-out fixture: {evaluation:?}"
+    );
+
+    let seed = table.encode_text(b"He was born").unwrap();
+    let prediction = table.predict(&seed);
+    assert_eq!(prediction.order, BackoffOrder::Trigram);
+    assert_eq!(table.decode_tokens(&[prediction.token]).unwrap(), b" in");
+
+    let continuation = table.continue_text(b"He was born", 8).unwrap();
+    assert!(continuation.tokens.len() >= 4, "{continuation:?}");
+    assert!(!has_period_one_or_two_cycle(&continuation.tokens));
+    assert_ne!(continuation.stop, ContinuationStop::PeriodOneCycle);
+    assert_ne!(continuation.stop, ContinuationStop::PeriodTwoCycle);
+    assert!(
+        continuation.decoded.starts_with(b" in Bombay, India"),
+        "decoded continuation was {:?}",
+        String::from_utf8_lossy(&continuation.decoded)
+    );
+
+    let transcript = table.canonical_transcript_bytes(&evaluation, b"He was born", &continuation);
+    assert_eq!(
+        transcript,
+        table.canonical_transcript_bytes(&evaluation, b"He was born", &continuation)
+    );
+    let transcript_text = std::str::from_utf8(&transcript).unwrap();
+    println!("{transcript_text}");
+    for zero_counter in [
+        "teacher_calls=0",
+        "provider_calls=0",
+        "source_weight_reads=0",
+        "geometry_calls=0",
+    ] {
+        assert!(transcript_text.contains(zero_counter), "{transcript_text}");
+    }
+}
+
+#[test]
+fn artifact_reloads_byte_identically_and_preserves_predictions() {
+    let table = SourceFreeTable::compile(&construction_documents()).unwrap();
+    let bytes = table.to_bytes();
+    let reloaded = SourceFreeTable::from_bytes(&bytes).expect("canonical artifact reloads");
+    assert_eq!(reloaded.to_bytes(), bytes);
+    assert_eq!(reloaded.artifact_cid(), table.artifact_cid());
+
+    let context = table.encode_text(b"He was born").unwrap();
+    assert_eq!(reloaded.predict(&context), table.predict(&context));
+    assert_eq!(
+        reloaded.continue_text(b"He was born", 8).unwrap(),
+        table.continue_text(b"He was born", 8).unwrap()
+    );
+
+    let held_out = held_out_documents();
+    let evaluation = table.evaluate_held_out(&held_out).unwrap();
+    let continuation = table.continue_text(b"He was born", 8).unwrap();
+    assert_eq!(
+        reloaded.canonical_transcript_bytes(&evaluation, b"He was born", &continuation,),
+        table.canonical_transcript_bytes(&evaluation, b"He was born", &continuation)
+    );
+}
+
+#[test]
+fn held_out_overlap_is_rejected_before_scoring() {
+    let table = SourceFreeTable::compile(&construction_documents()).unwrap();
+    let held_out_id = held_out_documents()[0].id.clone();
+    let construction_text = construction_documents()[0].text.clone();
+    let overlap = SourceDocument::new(held_out_id, construction_text);
+    let error = table.evaluate_held_out(&[overlap]).unwrap_err();
+    assert!(error.to_string().contains("construction text CID"));
+
+    let repeated_text = b"This held-out text is repeated.".to_vec();
+    let repeated_held_out = [
+        SourceDocument::new("12", repeated_text.clone()),
+        SourceDocument::new("13", repeated_text),
+    ];
+    let evaluation = table
+        .evaluate_held_out(&repeated_held_out)
+        .expect("same-partition text repetition is allowed");
+    assert_eq!(evaluation.documents, 2);
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -5,6 +5,18 @@
 > lifecycle. Architecture and sequencing authority lives in the
 > [Geometric Intelligence Programme](geometric_intelligence_programme.md).
 
+> **Current capability-first result (2026-08-28):** #989 established the
+> deterministic source-free lexical table baseline at
+> `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`. It scored 22.261404% held-out
+> top-1 versus 5.413561% unigram over 446,342 known targets, decoded a bounded
+> 16-unit valid UTF-8 continuation, and replayed byte identically. Its
+> 35,655,288-byte artifact is frozen at
+> `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`.
+> This is a statistical lexical baseline, not semantics, attention, geometry,
+> correctness, reasoning, chat, or release evidence. Exactly one later #953
+> intervention may compare against it under matched conditions; #973 remains
+> blocked. See the [#989 record](source_free_table_baseline_989.md).
+
 **Current truth:** #958 retained canonical prime-route/spin manifests,
 bounded indexes, controls, and deterministic worker evidence as a
 storage/recall foundation. It did not establish full geometric attention,
@@ -45,8 +57,8 @@ pure, but structural coverage and the sealed strict ceiling were both 0/6. It
 closed `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before selection. #986 then
 closed `UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but its
 exact codec/pair commitment and complete same-frame lexical SpiralCore frame
-were unavailable. Placement, Gate 0, labels, and #953 were `NOT_RUN`; #953 is
-parked, unassigned, and untouched pending a freshly frozen successor.
+were unavailable. Placement, Gate 0, labels, and #953 were `NOT_RUN`; the later
+established B0/#989 result now limits #953 to one matched intervention.
 Corpus-scale and higher-scope induction remain blocked in #973; #954 remains
 blocked downstream. #962 separately owns durable
 multi-turn CLI/HTTP chat, persisted conversation state, session/identity
@@ -69,8 +81,8 @@ canonical text/corpus
     -> qualified local causal R4/S3 path mechanism (#969)
     -> failed construction-return transfer (#983, bounded negative)
     -> unavailable corpus/frame feasibility boundary (#986, completed)
-    -> freshly frozen population/frame successor (not yet authored)
-    -> bounded decoded loop + tiered admission + preserved failed preflights (#953)
+    -> source-free table-native lexical baseline (#989, established)
+    -> exactly one matched geometric intervention using the frozen table reference (#953)
     -> higher-scope attention and corpus-scale induction (#973)
     -> correctness + typed abstention (#954)
     -> bounded reasoning (#955)
@@ -104,8 +116,9 @@ ordered n-lets, exact `phi` radial transport, and typed
 inputs. #970 and #969 are closed at their bounded claim scopes; neither result
 establishes semantics. #983's later construction-return representation also
 failed to transfer. #986 then stopped before geometry at its unavailable
-population/frame boundary. No active qualification now authorizes #953, which
-remains the preserved integration regression.
+population/frame boundary. The later established B0/#989 table reference now
+authorizes exactly one matched #953 intervention; #953 otherwise remains the
+preserved integration regression.
 See the
 [#952 A1.0 record](recursive_geometric_attention_a1_952.md).
 
@@ -1396,13 +1409,13 @@ Passing `--cover` reuses the measured cover. It may be omitted to re-induce
 the default cover deterministically during scoring. For experiments, `cover`
 also accepts `--depths`, `--k0`, `--regions-budget`, and `--memory-budget`.
 
-**Current production boundary pending an accepted local semantic selector →
-#953 → #973 → #954 → #955 before #962.** #986 closed before producing such a
-selector; a freshly frozen population/frame successor must qualify one
-independently. #970, #969, #983, and #986 are closed at their bounded claim
-scopes. #953
-owns the preserved bounded source-free library/CLI inference and generation
-engine but remains untouched and blocked; #973 and #954 remain blocked.
+**Current production boundary pending one matched #953 intervention against
+established #989 → #973 → #954 → #955 before #962.** #989 has qualified its
+source-free statistical lexical table baseline only. #970, #969, #983, and
+#986 remain closed at their bounded claim scopes. #953 owns the preserved
+bounded source-free library/CLI inference and generation engine; exactly one
+intervention against the frozen #989 reference is permitted. #973 and #954
+remain blocked.
 #962 owns integration into durable multi-turn CLI/HTTP chat, persisted
 conversation state, session/identity isolation, and
 identity-scoped hive memory. Until that product stage, the public `ask`, `chat`,

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,23 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
+> **Established capability-first result, 2026-08-28 (#989).** #989 reached
+> `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`. Its deterministic construction-only
+> table scored 99,362/446,342 (22.261404%) held-out top-1 versus
+> 24,163/446,342 (5.413561%) for unigram, an uplift of +16.847843 percentage
+> points. The 35,655,288-byte artifact at
+> `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`
+> and the full report replayed byte identically across two complete executions.
+> The fixed prompt emitted 16 valid UTF-8 units without a period-1/2 cycle.
+> This establishes a statistical lexical prediction and exact-decoding
+> baseline, not semantics, coherent generation, attention, geometry,
+> correctness, reasoning, chat, performance, or release readiness. Freeze it as
+> the non-geometric reference for exactly one matched #953 intervention; #973
+> remains blocked. See the
+> [#989 evidence record](source_free_table_baseline_989.md). This notice
+> supersedes forward-looking actions in the dated ledger below without
+> rewriting their measurements or terminals.
+
 > **Forward sequencing** now lives in the
 > [Geometric Intelligence Programme](geometric_intelligence_programme.md).
 > The geometric causal decoder roadmap and S0–S7 completion plan are retained
@@ -46,9 +63,9 @@ assumptions, or objectives rather than measured results.
 > #986 then closed `UNAVAILABLE_FRAME_OR_POPULATION`: its raw corpus
 > reproduced, but the exact corpus-scale codec/pair commitment and complete
 > same-frame lexical SpiralCore frame were unavailable. Placement, Gate 0,
-> labels, all arms, and #953 were `NOT_RUN`. Parked, unassigned, untouched #953
-> now awaits a freshly frozen population/frame successor; #953 continues to
-> block #973 and #954; and #973 continues to block #954.
+> labels, all arms, and #953 were `NOT_RUN`. The later established B0/#989
+> result now permits one matched #953 intervention; #953 continues to block
+> #973 and #954, and #973 continues to block #954.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1160,10 +1177,10 @@ and the sealed strict ceiling were both 0/6. It stopped
 `UNAVAILABLE_ZERO_CONSTRUCTION_TRANSFER` before deployed selection, payload
 inversion, or #953 generation and is now closed bounded negative evidence.
 #986 also closed at `UNAVAILABLE_FRAME_OR_POPULATION` before placement, labels,
-or selection. Parked, unassigned, untouched #953 awaits a freshly frozen
-population/frame successor; #953 continues to block #973/#954, and #973
-continues to block #954. Any eventual accepted local semantic selector must be
-independently qualified by that successor. #955 invokes that accepted selector/
+or selection. Established B0/#989 now permits exactly one matched #953
+intervention; #953 continues to block #973/#954, and #973 continues to block
+#954. That intervention must use the frozen #989 table reference under its
+matched contract. #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains
 measured cost; #964 binds evidence provenance #970 → #969 → #983 → #986 plus

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -2,8 +2,9 @@
 
 - **Status:** Normative experiment policy; mechanisms remain dormant unless a
   named product decision activates the smallest relevant probe.
-- **Applies to:** geometric recall, geometric attention, inference,
-  correctness, bounded reasoning, and provider-free serving.
+- **Applies to:** source-free lexical prediction, geometric recall, geometric
+  attention, inference, correctness, bounded reasoning, and provider-free
+  serving.
 - **Architecture:** [ADR-0004](adr/0004-geometric-intelligence-route-hierarchy.md)
 - **Vocabulary:** [Formal Vocabulary](formal_vocabulary.md) and the
   [Glossary](transformerless/GLOSSARY.md)
@@ -15,6 +16,24 @@ accumulate indiscriminate gates, run every available test because it exists, or
 make an hours-long run the price of learning whether a mechanism is reachable.
 Experimental evaluations are dormant by default. Activate only the smallest
 probe whose possible outcomes cause different next actions.
+
+### Established product decision — B0/#989
+
+#989 returned `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`. The deterministic
+construction-trained table scored 99,362/446,342 (22.261404%) held-out top-1
+versus 24,163/446,342 (5.413561%) for unigram, a +16.847843 percentage-point
+uplift. Trigram, bigram, and unigram selection counts were 319,336, 108,738,
+and 18,268 respectively. The fixed prompt emitted 16 valid UTF-8 units, stopped
+at the cap, and did not enter a period-1/2 cycle. Two complete executions
+emitted identical reports and artifacts. The binding record is
+[#989](source_free_table_baseline_989.md).
+
+This is an established statistical lexical prediction and bounded-decoding
+baseline, not semantics, attention, geometry, correctness, reasoning, chat,
+performance, or release evidence. Its exact artifact, corpus, support, decode,
+and work are frozen as the non-geometric reference for one later #953
+intervention. All unrelated geometric, attention, teacher, broad-QA, and
+release probes remain dormant; #973 remains blocked behind #953.
 
 Lexical ingestion, canonical serialization, registered-address membership,
 and rebuild witnesses are prerequisite plumbing, not inference. The delivery
@@ -44,9 +63,9 @@ pure but reached 0/6 held-out decisions; the sealed strict ceiling was also
 selector or payload inversion and is now closed bounded negative evidence.
 #986 then closed `UNAVAILABLE_FRAME_OR_POPULATION` before placement because its
 exact population/codec commitment and complete lexical SpiralCore frame were
-unavailable. Gate 0, labels, selection, and #953 were `NOT_RUN`. Untouched #953
-remains parked pending a freshly frozen population/frame successor and blocks #973 and
-#954; and #973 continues to block #954.
+unavailable. Gate 0, labels, selection, and #953 were `NOT_RUN`. The later
+established B0/#989 result now exposes one matched #953 intervention; #953
+continues to block #973 and #954, and #973 continues to block #954.
 
 A negative result remains evidence about its declared mechanism and
 distribution. It does not erase a separately established storage, identity,
@@ -55,12 +74,20 @@ attention, inference, correctness, reasoning, or product readiness.
 
 ## 1. Evidence ladder and delivery order
 
-The stages are ordered because each later claim depends on the earlier one:
+The current ladder starts with the established B0/#989 reference. The older
+mechanism stages below remain as historical provenance and future
+dependencies; they are not a competing queue.
 
-In this policy, the **accepted local semantic selector lineage** now means a
-freshly frozen successor that independently qualifies its complete local
-causal contract. #983 and #986 remain in evidence provenance; neither a failed
+In this policy, the **accepted local semantic selector lineage** can resume only
+through the one permitted #953 intervention matched to the established #989
+reference. #983 and #986 remain in evidence provenance; neither a failed
 experiment nor a conditional issue number is automatically a serving consumer.
+
+0. **Source-free table baseline (B0/#989; established)** — construction-only
+   integer lexical counts drove 22.261404% held-out top-1 versus 5.413561%
+   unigram, exact decode, a bounded 16-unit continuation, and byte-identical
+   replay. Geometry was absent. The artifact is now the fixed reference for one
+   matched #953 intervention; all other later stages remain dormant or blocked.
 
 1. **Local route-attention mechanism (#969)** — natural schema-2 adjacency,
    causal ordered R4/S3 path state, retained prefix memory, and deterministic
@@ -700,9 +727,9 @@ The frozen terminals are:
 - `REVISE_I1_GENERATOR_IN_PLACE` — a valid run localizes a generator seam that
   must be repaired before #953 can close.
 
-Invalid or unavailable work leaves #953 open. It is currently unassigned and
-parked pending a freshly frozen population/frame successor. A later positive
-result qualifies only that independently accepted selector plus #953's decoded
+Invalid or unavailable work leaves #953 open. Established B0/#989 now permits
+one #953 intervention against its fixed table reference. A later positive #953
+result qualifies only that matched intervention plus #953's decoded
 grammar/sentence loop. Paragraph,
 conversation, and global influence remain inert until #973; correctness,
 reasoning, product chat, optimization, formal closure, and release remain
@@ -784,8 +811,8 @@ under #986; #973 and downstream #954 remain blocked.
 
 ### A1Q-H/#973 exact-spin global operator prototype
 
-#973 owns paragraph, conversation, and bounded-global influence after a fresh
-successor qualifies an accepted local selector path and #953 qualifies the decoded loop.
+#973 owns paragraph, conversation, and bounded-global influence only after the
+one #989-matched #953 intervention qualifies the decoded loop.
 Operator influence consumes #953-admitted support;
 it does not participate in admission. The existing adjacent-spin retrieval rows
 remain fallback/diagnostic data, not operator coefficients; any neighbor
@@ -1138,9 +1165,9 @@ Use these outcomes literally:
 - `REVISE_I1_GENERATOR_IN_PLACE` — a valid #953 smoke localizes a generator
   defect. This remains #953's historical terminal, but its former immediate
   in-place-repair action is superseded by completed-negative #983 and closed-
-  unavailable #986 because the known population is no longer independent. Keep
-  #953 open, unassigned, parked, and untouched pending a freshly frozen
-  successor.
+  unavailable #986 because the known population is no longer independent. The
+  established B0/#989 result supersedes their former fresh-successor handoff:
+  permit exactly one #953 intervention against the fixed table reference.
 
 Never convert a missing fixture, empty denominator, skipped test, or unrelated
 green suite into `PASS`. Every report preserves artifact kappas, partition CIDs,

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -40,18 +40,36 @@ the ordered route through those locations carries causal context; local
 spin/torsion changes move the state; and a bounded least-cost lookup chooses the
 next route. The route must remain reconstructable and causally falsifiable.
 
-The programme is sequenced by capability: lexically reversible geometry first;
-one identity-derived local route-attention mechanism (#969); one independently
-construction-transferred, candidate-conditioned negative (#983); one fresh
-corpus-induced semantic-placement and signed-transport qualification (#986);
-one bounded decoded loop with repaired admission (#953); paragraph,
-conversation, and global qualification through that loop (#973); then measured
-correctness and only then multi-step reasoning. Semantic placement, table value,
-exact transport, attention, generation, correctness, and reasoning are separate
-claims.
+The completed evidence lineage before the current reset is: lexically
+reversible geometry (#961); one identity-derived local route-attention
+mechanism (#969); one independently construction-transferred,
+candidate-conditioned negative (#983); and one unavailable corpus/frame
+feasibility boundary (#986). Those results remain provenance, not an active
+queue. Semantic placement, table value, exact transport, attention, generation,
+correctness, and reasoning remain separate claims.
 
 Optimization, broad QA, formalization, and release certification follow a
 working decision-bearing product slice. They do not replace it.
+
+## Current capability-first delivery decision — #989
+
+#989 reached `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`. On 446,342 held-out
+known-target positions, its deterministic construction-trained integer table
+scored 99,362 (22.261404%) versus 24,163 (5.413561%) for unigram, an uplift of
++16.847843 percentage points. Its 35,655,288-byte artifact is
+`blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`.
+Two complete executions produced identical report bytes and packed artifacts.
+The fixed prompt emitted 16 valid UTF-8 units and stopped at the cap without a
+period-1/2 cycle. See the
+[#989 record](source_free_table_baseline_989.md).
+
+This establishes a statistical lexical baseline with bounded exact decoding,
+not semantics, attention, geometry, correctness, reasoning, chat, performance,
+or release readiness. Freeze the table engine as the non-geometric reference
+for exactly one #953 geometric intervention under the same corpus, support,
+decode, and work budget. #973 remains blocked behind #953. No new H4,
+SpiralCore, harmonic, algebraic, placement, transport, higher-scope, or scale
+qualifier is eligible outside that one comparison.
 
 ## Current truth and post-A1Q-L2 decision
 
@@ -138,9 +156,8 @@ frozen `CorpusSignedTransportV1` feasibility contract and stopped
 `UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but its exact
 codec/pair commitment and a complete same-frame lexical SpiralCore frame were
 unavailable. Placement, Gate 0, labels, table/geometric arms, and #953 were
-`NOT_RUN`. Parked, unassigned, untouched #953 now awaits a freshly frozen
-population/frame successor; #953 continues to block #973 and #954; and
-#973 continues to block #954. Calling the later
+`NOT_RUN`. The later B0/#989 result now limits #953 to one matched intervention;
+#953 continues to block #973 and #954, and #973 continues to block #954. Calling the later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive
@@ -633,6 +650,21 @@ grammar from load-bearing geometry.
 
 ## Programme sequence
 
+### B0 / #989 — source-free table-native lexical baseline
+
+Status: **established at `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`**.
+
+The deterministic construction-only lexical count tables scored 22.261404%
+held-out top-1 against 5.413561% unigram over 446,342 known targets, inverted
+selected payloads exactly, emitted a bounded 16-unit continuation, and replayed
+byte identically. Geometry was absent from B0. Preserve the table engine
+unchanged as the reference for exactly one later #953 geometric intervention
+under matched corpus, support, decode, and work.
+
+The GI sections below preserve the completed evidence lineage and downstream
+dependency structure. They remain dormant, limited to the one #953 comparison,
+or blocked.
+
 ### GI-0 — retained foundation
 
 Status: **established within #958's declared source-free scope**.
@@ -668,9 +700,9 @@ Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`; #983 then independently tested
 construction-transferred candidate-conditioned local attention and stopped at
 0/6 transfer before selection and closed. #986 then closed at its pre-sealed
-population/frame unavailable terminal. Parked, unassigned #953 remains
-untouched pending a newly frozen successor; #953 and #973 retain
-their downstream blocker edges**.
+population/frame unavailable terminal. Established B0/#989 now exposes exactly
+one matched #953 intervention; #953 and #973 retain their downstream blocker
+edges**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -1066,15 +1098,14 @@ cycle, and no provider, source weight, target row, future event, or exact
 full-history continuation. Support drift, unequal work, inert path influence,
 decode failure, nondeterminism, a short cycle, or an eight-unit bound violation
 stopped the historical smoke. The earlier direct-revision instruction produced
-the preserved #953 evidence below. It is now superseded for forward sequencing
-by #983's completed negative and #986's fresh-population qualification because
-another representation judged on the known #953 population would risk post-hoc
-fixture tuning.
+the preserved #953 evidence below. #983's completed negative and #986's
+unavailable boundary first superseded that instruction; B0/#989 now supersedes
+their former fresh-population handoff for forward sequencing.
 
 The frozen positive terminal is
 `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`; direct repair
-is `REVISE_I1_GENERATOR_IN_PLACE`. #953 remains open, unassigned, parked, and
-ineligible pending a newly frozen population/frame successor. Paragraph,
+is `REVISE_I1_GENERATOR_IN_PLACE`. Established B0/#989 now permits exactly one
+matched #953 intervention against its fixed table reference. Paragraph,
 conversation, and global selection remain inert until #973.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
 identity-scoped hive-memory lifecycle remain #962 scope.
@@ -1136,10 +1167,10 @@ while the same-artifact placement-permuted and order-shuffled controls selected
 because decisive retained suffixes exactly recalled construction subhistories.
 Generator execution and replay were `NOT_RUN`. This chronology remains
 append-only evidence. The fixture, overlay, generator, and records remained
-untouched through #986. Only a freshly frozen successor that independently
-qualifies its complete mechanism may be applied unchanged in a later #953
-session after a new label-free preflight; #973 remains blocked. #983 and #986
-remain evidence provenance; neither a
+untouched through #986. The established #989 result now exposes one later #953
+intervention, with the table reference and matched
+corpus, support, decode, and work held fixed; #973 remains blocked. #983 and
+#986 remain evidence provenance; neither a
 failed experiment nor a conditional issue number is automatically a serving
 consumer.
 

--- a/docs/source_free_table_baseline_989.md
+++ b/docs/source_free_table_baseline_989.md
@@ -1,0 +1,117 @@
+# #989 source-free table-native lexical baseline
+
+- **Date:** 2026-08-28
+- **Issue:** #989
+- **Status:** established empirical lexical baseline
+- **Terminal:** `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`
+- **Claim scope:** construction-trained statistical lexical prediction and
+  bounded exact decoding only
+
+## Decision
+
+The frozen B0 decision is positive. A deterministic source-free integer table
+engine compiled from the construction partition, predicted held-out known
+lexical targets at 22.261404% top-1 versus 5.413561% for the construction-only
+unigram baseline, decoded a 16-unit continuation, and reproduced byte for byte
+in two complete executions. The uplift is +16.847843 percentage points, above
+the predeclared +5-point floor.
+
+This establishes the table engine as the frozen non-geometric lexical reference
+for exactly one later #953 geometric intervention under the same corpus,
+support, decode, and work budget. It does not establish semantics, attention,
+geometry, correctness, reasoning, chat, product readiness, performance
+superiority, formal closure, or release readiness.
+
+## Frozen input and artifact identities
+
+| Item | Identity or value |
+| --- | --- |
+| Corpus CID | `blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf` |
+| Manifest CID | `blake3:bb5f446ce92df60f7824ed5a1f04ede385386e7a47b9c198ae83a5d0f907bab3` |
+| Unique documents | 3,000 |
+| D3 construction documents | 2,404 |
+| D3 held-out documents | 596 |
+| Lexical routes | 116,061 |
+| Packed table artifact bytes | 35,655,288 |
+| Packed table artifact CID | `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297` |
+| Report payload CID | `blake3:6427efadc889f795d80bceeb508ac5f88f6d4934ac1cb4904706f1a92acf5fc3` |
+| Artifact SHA-256 | `129d7061c652cc57616863f7a3a456cd00f1ec841780b672964438fa82767d7d` |
+
+The corpus contained 3,000 unique document IDs. The D3 partition produced
+2,404 construction documents and 596 held-out documents. Held-out documents
+did not alter the lexical vocabulary, transition counts, candidates, or
+selection.
+
+## Held-out result
+
+| Metric | Result |
+| --- | ---: |
+| Encoded held-out positions | 617,710 |
+| Known-target positions | 446,342 |
+| Table top-1 correct | 99,362 / 446,342 = 22.261404% |
+| Unigram top-1 correct | 24,163 / 446,342 = 5.413561% |
+| Absolute uplift | +16.847843 percentage points |
+| Trigram selections | 319,336 |
+| Bigram selections | 108,738 |
+| Unigram selections | 18,268 |
+
+The trigram, bigram, and unigram selection counts sum exactly to the 446,342
+known-target positions. This is a statistical lexical result. It is not a
+semantic score and does not turn context-table usage into attention.
+
+## Bounded decoded continuation
+
+The fixed prompt was `The United States` with a continuation cap of 16 lexical
+units. The engine emitted all 16 units and stopped at the cap:
+
+```text
+. It is the most important thing to do so.
+ 1985 – The first people
+```
+
+The continuation contains a newline between `so.` and ` 1985`. The decoded
+bytes were valid UTF-8 and contained no period-1 or period-2 cycle.
+Readable text is evidence that the full corpus-to-table-to-payload path is
+working; it is not evidence of factual correctness, coherence beyond this
+bounded sample, semantics, or reasoning.
+
+## Deterministic replay
+
+Two complete corpus-to-report executions emitted identical report bytes. Their
+packed artifacts were identical under byte comparison and shared the artifact
+CID and SHA-256 above. The report payload CID was also identical. This closes
+the external replay requirement for the frozen B0 run.
+
+## Cheap natural fixture
+
+The focused test completed 3/3 checks. Its held-out transcript recorded 2/10
+correct table choices versus 0/10 for unigram and decoded:
+
+```text
+ in Bombay, India.
+```
+
+That fixture shows a construction-transferred lexical context effect and exact
+decoding at small scale. It does not establish semantic understanding.
+
+## Activated checks
+
+- Focused `source_free_table_baseline_989` test: 3/3.
+- Focused compile for `uor-r4-core` and the `r4` CLI: clean.
+- Formatting for the named touched Rust paths: clean.
+- Frozen real-corpus command: completed twice with identical reports and
+  artifacts.
+
+No broader verification was activated. Workspace tests, BDD, teacher paths,
+graph and Gate C work, kappa reproduction, audit, fuzz, WASM, conformance,
+formal verification, performance qualification, product chat, and release
+checks are `NOT_RUN`, not PASS.
+
+## Forward boundary
+
+The table artifact and its corpus/support/decode/work contract are now frozen.
+The only permitted next local comparison is exactly one #953 geometric
+intervention against this unchanged reference. H4, SpiralCore, harmonic,
+algebraic, placement, transport, higher-scope, and scale expansions remain
+dormant unless that one issue explicitly activates the needed mechanism. #973
+remains blocked behind #953.

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -177,6 +177,17 @@ one another.
   full arm causally beats matched placement/link/distance/transport/order/state
   controls and
   the table-native value comparator.
+- **Source-free table-native lexical baseline (B0/#989)** — the established
+  deterministic non-geometric engine compiled only from construction-corpus
+  lexical observations, using integer context/count tables to predict held-out
+  next units, invert the selected payload exactly, and produce a bounded
+  continuation. #989 measured 22.261404% held-out top-1 versus 5.413561%
+  unigram on 446,342 known targets and reproduced its complete report and
+  artifact byte identically. It loads no teacher, provider, source weights, H4,
+  SpiralCore, harmonic, placement, transport, or attention mechanism. This is
+  a statistical lexical baseline, not semantics, attention, geometry,
+  correctness, reasoning, chat, or release evidence. Its frozen artifact is
+  the fixed comparator for one later matched #953 geometric intervention.
 - **Table-native semantic-value comparator** — a non-geometric candidate-value
   engine compiled from the same source-free construction observations and
   evaluated with the same natural candidates, information, and work as the
@@ -213,17 +224,15 @@ one another.
   state, and eventually decode bytes. Reachable attention is one input to
   inference; it is not coherent generation by itself.
 - **Geometric-intelligence sequence** — lexical ingestion, canonical
-  serialization, and address membership are prerequisite plumbing. Delivery
-  then proceeds in this order: one qualified local causal-path mechanism
-  (#969); one completed-negative construction-transfer probe (#983); one
-  completed-unavailable corpus/frame qualifier (#986); one freshly frozen
-  population/frame successor (not yet authored); one
-  bounded decoded generation loop with repaired admission (#953);
-  paragraph, conversation, and global exact-spin operator qualification through
-  that loop plus controlled higher-scope/corpus-scale induction and final
-  requalification (#973);
+  serialization, and address membership are prerequisite plumbing. The current
+  delivery order is the established source-free table-native lexical baseline
+  (B0/#989), then exactly one #953 geometric intervention under the same
+  corpus, support, decode, and work budget; paragraph, conversation, and
+  global exact-spin operator qualification through that loop plus controlled
+  higher-scope/corpus-scale induction and final requalification (#973);
   correctness with abstention (#954); then bounded hypothetical-branch reasoning
-  (#955).
+  (#955). #969, #983, and #986 remain evidence provenance rather than a
+  parallel implementation queue.
   Evidence may not skip a stage or count prerequisite plumbing as inference.
 - **Correctness** — agreement with an independent task oracle, executable
   constraint, cited source, or other predeclared ground truth, reported with

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -7,6 +9,9 @@ use std::time::Duration;
 use uor_r4_api::{BundleCapability, UorMatmulProvenance};
 use uor_r4_core::local_geometric_generation::{
     LocalGenerationControl, LocalGenerationStopReason, LocalGeometricGenerator,
+};
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, ContinuationStop, SourceDocument, SourceFreeTable,
 };
 use uor_r4_core::transformerless::hf_bpe::{resolve_source_tokenizer, TokenizerAdapterKey};
 use uor_r4_graph_cli as transformerless_command;
@@ -26,7 +31,7 @@ use uor_r4_wasm_router::tless_uor;
     name = "r4",
     version,
     about,
-    long_about = "Inspect the current geometric router or launch its local research dashboard.\n\nThe demo remains route-only. `bounded-geometric-generate` exercises the accepted #969 local selector through the bounded #953 decoded loop; it does not establish correctness, reasoning, higher-scope attention, product chat, or release readiness. Preserved compiler and certification commands remain available through `r4 research-tools`."
+    long_about = "Build the current source-free lexical table baseline or inspect the preserved geometric router.\n\n`source-free-table` is the active capability-first path: it learns construction-only integer lexical transition tables, measures held-out next-route choices, and emits bounded decoded text. It is a statistical lexical baseline, not semantics, attention, correctness, reasoning, product chat, or release readiness. Preserved compiler and certification commands remain available through `r4 research-tools`."
 )]
 struct Cli {
     /// Increase log verbosity (-v info, -vv debug, -vvv trace).
@@ -102,6 +107,8 @@ enum Command {
     Route(RouteArgs),
     /// Run the bounded #953 provider-free decoded geometric generation witness.
     BoundedGeometricGenerate(BoundedGeometricGenerateArgs),
+    /// Build and measure the #989 source-free lexical table baseline.
+    SourceFreeTable(SourceFreeTableArgs),
     /// Run the fixed S0 lexical/route-state round-trip witness without loading a model.
     LexicalIngestionWitness,
     /// Run the frozen A1.0 ordered-state/value-reachability gate without a scorer.
@@ -274,6 +281,29 @@ struct BoundedGeometricGenerateArgs {
     control: BoundedGeometricControl,
 
     /// Emit the generator's deterministic canonical JSON report.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args, Debug)]
+struct SourceFreeTableArgs {
+    /// Pinned JSONL corpus: one object per line with `id` and UTF-8 `text`.
+    #[arg(long, value_name = "ARTICLES_JSONL")]
+    corpus: PathBuf,
+
+    /// Exact prompt bytes to continue through the fitted lexical tables.
+    #[arg(long, value_name = "PROMPT")]
+    prompt: String,
+
+    /// Hard maximum number of emitted continuation lexical units.
+    #[arg(long, value_name = "UNITS")]
+    continuation_cap: usize,
+
+    /// Optional destination for the deterministic packed table artifact.
+    #[arg(long, value_name = "FILE")]
+    artifact_out: Option<PathBuf>,
+
+    /// Emit the deterministic measurement report as JSON.
     #[arg(long)]
     json: bool,
 }
@@ -1334,6 +1364,330 @@ fn bounded_geometric_generate(args: &BoundedGeometricGenerateArgs) -> Result<(),
     Ok(())
 }
 
+const SOURCE_FREE_TABLE_REPORT_SCHEMA: &str = "uor-r4-source-free-table-report/1";
+const SOURCE_FREE_TABLE_POSITIVE: &str = "NUMERIC_BASELINE_GATE_MET_PENDING_REPLAY_BINDING";
+const SOURCE_FREE_TABLE_NEGATIVE: &str = "REPAIR_LEXICAL_REPRESENTATION_OR_COUNT_OBJECTIVE";
+
+#[derive(Debug, Deserialize)]
+struct SourceFreeCorpusArticle {
+    id: String,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceFreeCorpusManifest {
+    article_count: usize,
+    corpus_cid: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeClosureCounters {
+    teacher_calls: u64,
+    provider_calls: u64,
+    source_weight_reads: u64,
+    geometry_operations: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeCriteria {
+    pinned_three_thousand_documents: bool,
+    at_least_one_hundred_thousand_known_targets: bool,
+    nonzero_context_coverage: bool,
+    at_least_five_percentage_point_uplift: bool,
+    continuation_at_least_four_units: bool,
+    continuation_has_no_period_one_or_two_cycle: bool,
+    continuation_is_utf8: bool,
+    external_byte_identical_replay_required: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeContinuationReport {
+    prompt: String,
+    continuation_cap: usize,
+    emitted_units: usize,
+    decoded_text: String,
+    stop: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeTableReport {
+    schema: &'static str,
+    decision: &'static str,
+    capability: &'static str,
+    nonclaims: &'static str,
+    corpus_cid: String,
+    manifest_cid: String,
+    document_count: usize,
+    construction_documents: usize,
+    held_out_documents: usize,
+    unique_document_ids: usize,
+    lexical_routes: usize,
+    artifact_bytes: usize,
+    artifact_cid: String,
+    held_out_encoded_positions: u64,
+    held_out_known_target_positions: u64,
+    table_correct: u64,
+    unigram_correct: u64,
+    table_top1_percent: String,
+    unigram_top1_percent: String,
+    uplift_percentage_points: String,
+    trigram_choices: u64,
+    bigram_choices: u64,
+    unigram_choices: u64,
+    changed_choices: u64,
+    changed_choice_correct: u64,
+    continuation: SourceFreeContinuationReport,
+    source_closure: SourceFreeClosureCounters,
+    criteria: SourceFreeCriteria,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeTableEnvelope {
+    report_payload_cid: String,
+    report: SourceFreeTableReport,
+}
+
+fn source_free_table(args: &SourceFreeTableArgs) -> Result<(), RunError> {
+    let corpus_bytes = std::fs::read(&args.corpus).map_err(|error| {
+        RunError::Command(format!(
+            "read source-free corpus {}: {error}",
+            args.corpus.display()
+        ))
+    })?;
+    let corpus_cid = format!("blake3:{}", blake3::hash(&corpus_bytes).to_hex());
+    let manifest_path = args
+        .corpus
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("manifest.json");
+    let manifest_bytes = std::fs::read(&manifest_path).map_err(|error| {
+        RunError::Command(format!(
+            "read source-free corpus manifest {}: {error}",
+            manifest_path.display()
+        ))
+    })?;
+    let manifest: SourceFreeCorpusManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|error| {
+            RunError::Command(format!(
+                "parse source-free corpus manifest {}: {error}",
+                manifest_path.display()
+            ))
+        })?;
+    if manifest.corpus_cid != corpus_cid {
+        return Err(RunError::Command(format!(
+            "corpus CID mismatch: manifest {} != actual {corpus_cid}",
+            manifest.corpus_cid
+        )));
+    }
+
+    let mut documents = Vec::new();
+    let mut unique_ids = BTreeSet::new();
+    let jsonl_line_count = corpus_bytes.split(|byte| *byte == b'\n').count();
+    for (line_index, line) in corpus_bytes.split(|byte| *byte == b'\n').enumerate() {
+        if line.is_empty() && line_index + 1 == jsonl_line_count {
+            continue;
+        }
+        if line.is_empty() {
+            return Err(RunError::Command(format!(
+                "empty JSONL row at line {}",
+                line_index + 1
+            )));
+        }
+        let article: SourceFreeCorpusArticle = serde_json::from_slice(line).map_err(|error| {
+            RunError::Command(format!(
+                "parse source-free corpus line {}: {error}",
+                line_index + 1
+            ))
+        })?;
+        if !unique_ids.insert(article.id.clone()) {
+            return Err(RunError::Command(format!(
+                "duplicate source-free corpus article id {}",
+                article.id
+            )));
+        }
+        documents.push(SourceDocument::new(article.id, article.text.into_bytes()));
+    }
+    if documents.len() != manifest.article_count {
+        return Err(RunError::Command(format!(
+            "manifest article_count {} != parsed document count {}",
+            manifest.article_count,
+            documents.len()
+        )));
+    }
+    documents.sort_by(|left, right| left.id.cmp(&right.id));
+    let (held_out, construction): (Vec<_>, Vec<_>) = documents
+        .into_iter()
+        .partition(|document| d3_is_held_out(&document.id));
+
+    let table = SourceFreeTable::compile(&construction)
+        .map_err(|error| RunError::Command(format!("compile source-free table: {error}")))?;
+    let evaluation = table
+        .evaluate_held_out(&held_out)
+        .map_err(|error| RunError::Command(format!("evaluate source-free table: {error}")))?;
+    let continuation = table
+        .continue_text(args.prompt.as_bytes(), args.continuation_cap)
+        .map_err(|error| RunError::Command(format!("continue source-free table: {error}")))?;
+    let continuation_utf8 = String::from_utf8(continuation.decoded.clone()).map_err(|error| {
+        RunError::Command(format!("source-free continuation is not UTF-8: {error}"))
+    })?;
+    let artifact_bytes = table.to_bytes();
+    let artifact_cid = format!("blake3:{}", blake3::hash(&artifact_bytes).to_hex());
+    if let Some(path) = &args.artifact_out {
+        std::fs::write(path, &artifact_bytes).map_err(|error| {
+            RunError::Command(format!(
+                "write source-free table artifact {}: {error}",
+                path.display()
+            ))
+        })?;
+    }
+
+    let no_short_cycle = !matches!(
+        continuation.stop,
+        ContinuationStop::PeriodOneCycle | ContinuationStop::PeriodTwoCycle
+    );
+    let context_choices = evaluation
+        .trigram_choices
+        .checked_add(evaluation.bigram_choices)
+        .ok_or_else(|| RunError::Command("context choice count overflow".to_owned()))?;
+    let five_point_uplift = u128::from(evaluation.table_correct) * 20
+        >= u128::from(evaluation.unigram_correct) * 20
+            + u128::from(evaluation.known_target_positions);
+    let criteria = SourceFreeCriteria {
+        pinned_three_thousand_documents: manifest.article_count == 3_000
+            && construction.len() + held_out.len() == 3_000,
+        at_least_one_hundred_thousand_known_targets: evaluation.known_target_positions >= 100_000,
+        nonzero_context_coverage: context_choices > 0,
+        at_least_five_percentage_point_uplift: five_point_uplift,
+        continuation_at_least_four_units: continuation.tokens.len() >= 4,
+        continuation_has_no_period_one_or_two_cycle: no_short_cycle,
+        continuation_is_utf8: true,
+        external_byte_identical_replay_required: true,
+    };
+    let numeric_gate_met = criteria.pinned_three_thousand_documents
+        && criteria.at_least_one_hundred_thousand_known_targets
+        && criteria.nonzero_context_coverage
+        && criteria.at_least_five_percentage_point_uplift
+        && criteria.continuation_at_least_four_units
+        && criteria.continuation_has_no_period_one_or_two_cycle;
+    let report = SourceFreeTableReport {
+        schema: SOURCE_FREE_TABLE_REPORT_SCHEMA,
+        decision: if numeric_gate_met {
+            SOURCE_FREE_TABLE_POSITIVE
+        } else {
+            SOURCE_FREE_TABLE_NEGATIVE
+        },
+        capability: "construction-trained source-free lexical table prediction and bounded decoding",
+        nonclaims: "does not establish semantics, attention, geometry, correctness, reasoning, chat quality, multiplication-free serving, performance superiority, or release readiness",
+        corpus_cid,
+        manifest_cid: format!("blake3:{}", blake3::hash(&manifest_bytes).to_hex()),
+        document_count: construction.len() + held_out.len(),
+        construction_documents: construction.len(),
+        held_out_documents: held_out.len(),
+        unique_document_ids: unique_ids.len(),
+        lexical_routes: table.lexical_piece_count(),
+        artifact_bytes: artifact_bytes.len(),
+        artifact_cid,
+        held_out_encoded_positions: evaluation.positions,
+        held_out_known_target_positions: evaluation.known_target_positions,
+        table_correct: evaluation.table_correct,
+        unigram_correct: evaluation.unigram_correct,
+        table_top1_percent: fixed_percent(
+            evaluation.table_correct,
+            evaluation.known_target_positions,
+        ),
+        unigram_top1_percent: fixed_percent(
+            evaluation.unigram_correct,
+            evaluation.known_target_positions,
+        ),
+        uplift_percentage_points: fixed_percentage_point_difference(
+            evaluation.table_correct,
+            evaluation.unigram_correct,
+            evaluation.known_target_positions,
+        ),
+        trigram_choices: evaluation.trigram_choices,
+        bigram_choices: evaluation.bigram_choices,
+        unigram_choices: evaluation.unigram_choices,
+        changed_choices: evaluation.changed_choices,
+        changed_choice_correct: evaluation.changed_choice_correct,
+        continuation: SourceFreeContinuationReport {
+            prompt: args.prompt.clone(),
+            continuation_cap: args.continuation_cap,
+            emitted_units: continuation.tokens.len(),
+            decoded_text: continuation_utf8,
+            stop: source_free_continuation_stop(continuation.stop),
+        },
+        source_closure: SourceFreeClosureCounters {
+            teacher_calls: 0,
+            provider_calls: 0,
+            source_weight_reads: 0,
+            geometry_operations: 0,
+        },
+        criteria,
+    };
+    let report_payload = serde_json::to_vec(&report)
+        .map_err(|error| RunError::Command(format!("serialize source-free report: {error}")))?;
+    let envelope = SourceFreeTableEnvelope {
+        report_payload_cid: format!("blake3:{}", blake3::hash(&report_payload).to_hex()),
+        report,
+    };
+
+    if args.json {
+        let mut bytes = serde_json::to_vec_pretty(&envelope).map_err(|error| {
+            RunError::Command(format!("serialize source-free report envelope: {error}"))
+        })?;
+        bytes.push(b'\n');
+        io::stdout().lock().write_all(&bytes)?;
+    } else {
+        println!("source-free lexical table baseline");
+        println!("  decision: {}", envelope.report.decision);
+        println!(
+            "  held-out top-1: {}% table vs {}% unigram ({} pp)",
+            envelope.report.table_top1_percent,
+            envelope.report.unigram_top1_percent,
+            envelope.report.uplift_percentage_points
+        );
+        println!(
+            "  continuation: {}",
+            envelope.report.continuation.decoded_text
+        );
+        println!("  artifact: {}", envelope.report.artifact_cid);
+        println!("  report: {}", envelope.report_payload_cid);
+    }
+    Ok(())
+}
+
+fn fixed_percent(numerator: u64, denominator: u64) -> String {
+    if denominator == 0 {
+        return "0.000000".to_owned();
+    }
+    let scaled = u128::from(numerator) * 100_000_000 / u128::from(denominator);
+    format!("{}.{:06}", scaled / 1_000_000, scaled % 1_000_000)
+}
+
+fn fixed_percentage_point_difference(table: u64, unigram: u64, denominator: u64) -> String {
+    if denominator == 0 {
+        return "0.000000".to_owned();
+    }
+    let difference = i128::from(table) - i128::from(unigram);
+    let scaled = difference * 100_000_000 / i128::from(denominator);
+    let sign = if scaled < 0 { "-" } else { "" };
+    let magnitude = scaled.unsigned_abs();
+    format!(
+        "{sign}{}.{:06}",
+        magnitude / 1_000_000,
+        magnitude % 1_000_000
+    )
+}
+
+fn source_free_continuation_stop(stop: ContinuationStop) -> &'static str {
+    match stop {
+        ContinuationStop::EndOfDocument => "end_of_document",
+        ContinuationStop::PeriodOneCycle => "period_one_cycle",
+        ContinuationStop::PeriodTwoCycle => "period_two_cycle",
+        ContinuationStop::Bound => "continuation_cap",
+    }
+}
+
 fn local_generation_stop_label(reason: LocalGenerationStopReason) -> String {
     match reason {
         LocalGenerationStopReason::Abstained { tie } => format!("abstained(tie={tie})"),
@@ -1346,10 +1700,11 @@ fn local_generation_stop_label(reason: LocalGenerationStopReason) -> String {
 }
 
 fn print_research_tools() {
-    println!("Active route-native mechanism command:");
-    println!("  bounded-geometric-generate");
+    println!("Active capability-first command:");
+    println!("  source-free-table");
     println!();
-    println!("Preserved research commands (not required for the geometric demo):");
+    println!("Preserved research commands (not required for the table baseline):");
+    println!("  bounded-geometric-generate");
     println!("  ask, chat, client, audit");
     println!("  compile, download, import, install-release, package-release-bundle");
     println!("  transformerless, graph, graph-compile, graph-observe");
@@ -1391,6 +1746,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         }
         Some(Command::Route(args)) => route_demo(args),
         Some(Command::BoundedGeometricGenerate(args)) => bounded_geometric_generate(args),
+        Some(Command::SourceFreeTable(args)) => source_free_table(args),
         Some(Command::LexicalIngestionWitness) => {
             let witness = uor_r4_core::canonical_lexical_ingestion::run_authorized_probe()
                 .map_err(|error| RunError::Command(error.to_string()))?;
@@ -2999,6 +3355,7 @@ mod tests {
             "demo",
             "route",
             "serve",
+            "source-free-table",
             "bounded-geometric-generate",
             "lexical-ingestion-witness",
             "research-tools",
@@ -3047,6 +3404,35 @@ mod tests {
         assert_eq!(args.prompt, "active  agile athletes run");
         assert_eq!(args.continuation_cap, 2);
         assert_eq!(args.control, BoundedGeometricControl::StateDisabled);
+        assert!(args.json);
+    }
+
+    #[test]
+    fn parses_source_free_table_command_without_rewriting_prompt_bytes() {
+        let cli = Cli::try_parse_from([
+            "r4",
+            "source-free-table",
+            "--corpus",
+            "/tmp/articles.jsonl",
+            "--prompt",
+            "The  United States",
+            "--continuation-cap",
+            "16",
+            "--artifact-out",
+            "/tmp/source-free-table.bin",
+            "--json",
+        ])
+        .unwrap();
+        let Some(Command::SourceFreeTable(args)) = cli.command else {
+            panic!("expected source-free-table")
+        };
+        assert_eq!(args.corpus, PathBuf::from("/tmp/articles.jsonl"));
+        assert_eq!(args.prompt, "The  United States");
+        assert_eq!(args.continuation_cap, 16);
+        assert_eq!(
+            args.artifact_out,
+            Some(PathBuf::from("/tmp/source-free-table.bin"))
+        );
         assert!(args.json);
     }
 


### PR DESCRIPTION
Closes #989

## Outcome

Ships the first working source-free corpus-to-decoded-text baseline: deterministic construction-only lexical unigram/bigram/trigram tables, D3 held-out evaluation, exact payload inversion, bounded continuation, canonical artifact bytes, and a visible source-free-table CLI.

The pinned 3,000-document run scored 99,362/446,342 known held-out targets (22.261404%) versus 24,163/446,342 (5.413561%) for unigram, a +16.847843 percentage-point uplift. The fixed prompt emitted 16 valid UTF-8 units without a period-1/2 cycle. Two complete runs produced byte-identical reports and 35,655,288-byte artifacts.

Terminal: ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE.

## Activated evidence

- focused source_free_table_baseline_989 test: 3/3
- focused compile of uor-r4-core and the r4 CLI: clean
- named Rust formatting: clean
- real 3,000-document command twice: identical report and artifact bytes

All broad/workspace/BDD/teacher/graph/Gate C/kappa/audit/fuzz/WASM/conformance/formal/performance/product-chat/release checks remain NOT_RUN.

## Claim boundary

This establishes only a construction-trained statistical lexical table baseline with held-out next-route evidence and bounded exact decoding. It does not establish semantics, attention, geometry, correctness, reasoning, chat quality, performance superiority, multiplication-free serving, or release readiness.