### PR TITLE
#973 Gate 0: make prior-sentence R4 state load-bearing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,16 +48,26 @@ zero candidate-support/declared-work-ledger mismatches and byte-identical
 replay. The external replay adjudication promoted each report's pending verdict
 to `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`. This does not
 rehabilitate the failed #983/#986 representations or establish semantics,
-attention, correctness, reasoning, chat, or release readiness. #973 is now the
-next eligible issue; #954 remains blocked behind it. Do not add a second #953
-intervention or reuse the #983/#986 populations. The complete #986 result and
-nonclaim boundary is
+attention, correctness, reasoning, chat, or release readiness. #973 Gate 0 then
+retained `PriorSentenceCountRadiusR4V1` at
+`RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`. On two
+synthetic D3-partitioned histories with identical local #953 evidence, its
+prefix-before-final-period coordinate made exact earlier-candidate state
+causally load-bearing: real decoded ` tea.` / ` coffee.` (2/2), scope-disabled
+decoded ` coffee.` / ` coffee.` (1/2), and candidate-permuted decoded
+` coffee.` / ` tea.` (0/2), with zero support/work mismatches and exact replay.
+This establishes only one bounded lexical copy-attention mechanism, not
+semantic or general paragraph/conversation/global attention. #973 remains
+active; #954 remains blocked behind it. Do not add a second #953 intervention
+or reuse the #983/#986 populations. The complete #973 Gate 0 record is
+[`docs/prior_sentence_count_radius_attention_973.md`](docs/prior_sentence_count_radius_attention_973.md).
+The complete #986 result and nonclaim boundary is
 [`docs/corpus_signed_transport_attention_986.md`](docs/corpus_signed_transport_attention_986.md).
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
 
-## Capability-first baseline and geometric increment — #989/#953 established
+## Capability-first baseline and geometric increment — #989/#953 established; #973 Gate 0 retained
 
 Effective 2026-08-28, #989 established the deterministic source-free
 table-native lexical baseline at
@@ -85,11 +95,14 @@ This establishes a bounded source-free geometric increment over a statistical
 lexical baseline. It does not establish semantics, broad attention, general
 coherence, correctness, reasoning, chat, performance, or release readiness.
 The #989 table remains the frozen non-geometric reference; no second #953
-formula, axis, prompt, or corpus run is permitted. #973 is next. New H4,
+formula, axis, prompt, or corpus run is permitted. #973 Gate 0 has retained one
+exact-candidate prior-prefix copy mechanism; the independently frozen
+non-copy paragraph/conversation/global qualifications remain active. New H4,
 SpiralCore, harmonic, algebraic, placement, transport, scale, and later-stage
 work remains dormant unless its issue is exposed. See the
 [#989 evidence record](docs/source_free_table_baseline_989.md) and
-[#953 evidence record](docs/source_free_table_geometric_intervention_953.md).
+[#953 evidence record](docs/source_free_table_geometric_intervention_953.md),
+then the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
 
 ## What this repo is
 
@@ -320,13 +333,16 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   same-frame lexical SpiralCore operator map were unavailable. Placement,
   Gate 0, labels, selection, and the historical #953 path were `NOT_RUN`. The
   later B0/#989 reset and separate matched #953 table-tie intervention have
-  since passed. #973 is now next; #954 remains blocked behind it.
+  since passed. #973 Gate 0 has now retained one bounded exact-candidate
+  prior-prefix copy-attention mechanism; required higher-scope qualifications
+  remain active and #954 remains blocked behind #973.
   #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
 - Sequence strictly from the current reset: working source-free table baseline
   (#989, established) → one matched geometric intervention (#953, accepted) →
-  higher-scope attention (#973, next) → correctness/abstention → reasoning →
+  higher-scope attention (#973, Gate 0 retained; non-copy paragraph,
+  conversation, and bounded-global qualification active) → correctness/abstention → reasoning →
   optimization/purity/release. The older placement/transport
   sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic
@@ -345,8 +361,9 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   decoded-loop plumbing and tiered admission, but its unchanged full-path
   choice did not establish natural grammar. The separate B0 table-tie
   intervention now establishes only its bounded geometric accuracy increment
-  and decoded comparison. That accepted result exposes #973; only #973 may
-  qualify paragraph, conversation, or global state.
+  and decoded comparison. #973 Gate 0 adds one exact-candidate prior-prefix
+  copy mechanism; only the remaining #973 subprobes may qualify non-copy
+  paragraph, conversation, or global state.
 - Keep **candidate admission** separate from **harmonic influence**. In #953,
   `PrimaryThenAdjacentSpinFallbackV1` uses I1/I2/ordered-sentence plus divisor
   as the primary admission tier. Adjacent-spin rows are always consulted and
@@ -382,8 +399,9 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   representation, a wider split, or broader scope under the same contract.
 - Teacher output may label or compare only after a source-free report freezes.
   It is never substituted for the product response.
-- Once #973 activates higher scopes, every hierarchy selection emits a
-  global-context coverage witness. Exact recall, grammatical generation,
+- #973 Gate 0 selections emit their exact prefix-coverage and matched-work
+  witnesses; later hierarchy selections must emit their corresponding scope
+  coverage witness. Exact recall, grammatical generation,
   correctness, and reasoning remain separate gates.
 - Start with the smallest product artifact that can falsify the stage. A
   negative stops or redesigns it; it does not authorize a larger harness.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ local hardware. The project is testing whether language context, inference,
 and reasoning can emerge from routes through a canonical geometric memory. The
 target serving engine uses no Ollama, hosted model, or source-model weights.
 
+> **Current bounded attention result (2026-08-28):** #973 Gate 0 retained
+> `PriorSentenceCountRadiusR4V1` at
+> `RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`.
+> Across two synthetic D3-partitioned histories with the same final
+> ` asked` / ` for` frame, exact `{ coffee, tea }` tie, local #953 coordinates,
+> support, and declared work, the real arm decoded ` tea.` / ` coffee.` (2/2),
+> scope-disabled decoded ` coffee.` / ` coffee.` (1/2), and
+> candidate-permuted decoded ` coffee.` / ` tea.` (0/2). Support/work
+> mismatches and source-closure counters were zero; operator, target-free
+> census, and decoded-smoke identities replayed exactly. This establishes one
+> bounded exact-candidate prior-prefix lexical copy-attention mechanism, not
+> semantic transfer or general paragraph/conversation/global attention. #973
+> remains open and #954 remains blocked. See the
+> [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
+
 > **Current capability-first result (2026-08-28):** #953's frozen
 > `MultiscaleCountRadiusR4V1` comparison is positive. Against #989's unchanged
 > 99,362/446,342 (22.261404%) table reference, the construction-only R4 tie
@@ -51,9 +66,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > operator map were unavailable. Placement, diffusion, Gate 0, calibration,
 > sealed labels, selection, and #953 were `NOT_RUN`. The later #989 table reset
 > supplied a working reference, and the one matched #953 R4 tie intervention
-> has now passed its held-out and decoded-output contract. #973 is the next
-> intelligence stage; #954 remains blocked behind it.
-> Higher-scope attention, correct answers, and reasoning do not exist yet. The
+> has now passed its held-out and decoded-output contract. #973 Gate 0 has also
+> retained one exact-candidate prior-prefix copy-attention mechanism; independent
+> non-copy paragraph, conversation, and bounded-global qualification remain.
+> #954 remains blocked behind #973. General higher-scope attention, correct
+> answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
 
@@ -249,10 +266,12 @@ classes then transferred to 0/6 held-out decisions. #986's later local
 qualification stopped before geometry because neither its exact corpus/codec
 population nor a complete lexical Cl(0,6)/SpiralCore frame was available.
 #953's historical H4/placement fixtures remain untouched. The later B0 reset
-accepted a separate fixed-point R4 table-tie intervention and closes #953 at
-its positive terminal; #973 is next and #954 remains blocked behind it.
+accepted a separate fixed-point R4 table-tie intervention and closed #953 at
+its positive terminal. #973 Gate 0 has since retained one bounded prior-prefix
+copy mechanism; required higher scopes remain active and #954 remains blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
+See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
 See the [#986 evidence record](docs/corpus_signed_transport_attention_986.md)
 for the exact feasibility boundary and deliberately unrun stages.
 Stored H4/Hopf/zeta/icosian and related route fields remain
@@ -336,9 +355,10 @@ not become substitutes for working intelligence:
    top-1, +4,242 correct choices over the unchanged table, a distinct bounded
    continuation, matched support and declared-work ledger, and byte-identical
    replay.
-3. **Qualify higher-scope attention (#973)** — this is now the next
-   decision-bearing intelligence stage; historical placement and transport
-   probes remain evidence, not current work.
+3. **Continue higher-scope attention (#973)** — retain the positive Gate 0
+   exact-candidate prior-prefix mechanism, then run independently frozen
+   non-copy paragraph, conversation, and bounded-global qualifications.
+   Historical placement and transport probes remain evidence, not current work.
 4. **Establish correctness** — relevance, contradiction handling, and honest
    abstention.
 5. **Establish reasoning** — bounded multi-step route composition.
@@ -351,9 +371,10 @@ complete.
 
 The active dependency chain is tracked in
 [#820](https://github.com/UOR-Foundation/uor-r4/issues/820). #989 established
-the frozen table reference and #953 established one matched R4 tie
-intervention over it. After protected #953 closure, #973 is the next eligible
-stage; #954 remains blocked behind #973.
+the frozen table reference, #953 established one matched R4 tie intervention
+over it, and #973 Gate 0 retained one bounded prior-prefix copy mechanism.
+Required #973 higher-scope work remains active; #954 remains blocked behind
+#973.
 
 ## Find your way around
 

--- a/crates/uor-r4-core/src/higher_scope_geometric_attention.rs
+++ b/crates/uor-r4-core/src/higher_scope_geometric_attention.rs
@@ -1,0 +1,1044 @@
+//! Bounded higher-scope geometric attention for issue #973.
+//!
+//! `PriorSentenceCountRadiusR4V1` leaves the source-free table and the #953
+//! count-radius overlay byte-for-byte unchanged. It can only rank the maximum-
+//! count tie already admitted by #953. The fourth R4 coordinate is replaced by
+//! exact candidate occupancy in the prefix before the final fitted period.
+//! This is deliberately an exact lexical attention/copy mechanism, not a
+//! semantic-similarity or general paragraph-attention claim.
+
+use crate::source_free_table::{
+    BackoffOrder, Continuation, ContinuationStop, MatchedGeometricPrediction,
+    MultiscaleCountRadiusCandidate, MultiscaleCountRadiusCoordinates, MultiscaleCountRadiusR4V1,
+    MultiscaleCountRadiusWork, SourceFreeTable, SourceFreeTableError, BOS_TOKEN, EOS_TOKEN,
+    MAX_CONTINUATION_UNITS,
+};
+
+const OPERATOR_MAGIC: [u8; 8] = *b"SFTHSA01";
+const OPERATOR_VERSION: u32 = 1;
+const OPERATOR_HEADER_LEN: usize = 144;
+const Q32_SCALE: u128 = 1_u128 << 32;
+const TRIGRAM_DEPTH_Q32: u64 = 3_u64 << 30;
+const BIGRAM_DEPTH_Q32: u64 = 2_u64 << 30;
+
+pub const MAX_PRIOR_PREFIX_UNITS: usize = 64;
+pub const MAX_PRIOR_TIED_CANDIDATES: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HigherScopeGeometricAttentionError {
+    Invalid(String),
+    SourceFree(String),
+    ArithmeticOverflow,
+}
+
+impl std::fmt::Display for HigherScopeGeometricAttentionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(reason) => formatter.write_str(reason),
+            Self::SourceFree(reason) => write!(formatter, "source-free table: {reason}"),
+            Self::ArithmeticOverflow => {
+                formatter.write_str("higher-scope attention arithmetic overflow")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HigherScopeGeometricAttentionError {}
+
+impl From<SourceFreeTableError> for HigherScopeGeometricAttentionError {
+    fn from(error: SourceFreeTableError) -> Self {
+        Self::SourceFree(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum PriorSentenceCountRadiusArm {
+    Real,
+    ScopeDisabled,
+    CandidatePermuted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum PriorSentenceCountRadiusAbstention {
+    LocalGeometryIneligible,
+    MissingSentenceBoundary,
+    NoPriorCandidateOccurrence,
+    RadiusTie,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct PriorSentenceCountRadiusCandidateEvidence {
+    pub token: u32,
+    pub count: u64,
+    pub local_coordinates: MultiscaleCountRadiusCoordinates,
+    pub local_radius: u128,
+    pub prior_count: u32,
+    pub real_prior_q32: u64,
+    pub real_radius: u128,
+    pub disabled_prior_q32: u64,
+    pub disabled_radius: u128,
+    pub permuted_prior_count: u32,
+    pub permuted_prior_q32: u64,
+    pub permuted_radius: u128,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct PriorSentenceCountRadiusWork {
+    pub local: MultiscaleCountRadiusWork,
+    pub prior_prefix_units_scanned: u64,
+    pub candidate_membership_checks: u64,
+    pub normalization_table_reads: u64,
+    pub square_table_reads: u64,
+    pub coordinate_replacements: u64,
+    pub radius_comparisons: u64,
+    pub final_choice_operations: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct PriorSentenceCountRadiusDecision {
+    pub arm: PriorSentenceCountRadiusArm,
+    pub token: u32,
+    pub unique_radius_winner: Option<u32>,
+    pub support_tokens: Vec<u32>,
+    pub work: PriorSentenceCountRadiusWork,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MatchedPriorSentenceCountRadiusPrediction {
+    pub local: MatchedGeometricPrediction,
+    pub sentence_boundary_token: u32,
+    pub sentence_boundary_index: Option<usize>,
+    pub prior_prefix_units: usize,
+    pub prior_candidate_occurrences: u32,
+    pub candidate_evidence: Vec<PriorSentenceCountRadiusCandidateEvidence>,
+    pub real: PriorSentenceCountRadiusDecision,
+    pub scope_disabled: PriorSentenceCountRadiusDecision,
+    pub candidate_permuted: PriorSentenceCountRadiusDecision,
+    pub operator_abstention: Option<PriorSentenceCountRadiusAbstention>,
+    pub support_matched: bool,
+    pub work_matched: bool,
+    pub teacher_calls: u64,
+    pub provider_calls: u64,
+    pub source_weight_reads: u64,
+    pub future_unit_reads: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MatchedPriorSentenceCountRadiusContinuation {
+    pub first_decision: MatchedPriorSentenceCountRadiusPrediction,
+    pub real: Continuation,
+    pub scope_disabled: Continuation,
+    pub candidate_permuted: Continuation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NormalizationCell {
+    count: u32,
+    q32: u64,
+    square: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizationRow {
+    total: u32,
+    cells: Vec<NormalizationCell>,
+}
+
+/// Canonical, construction-bound lookup artifact for the frozen Gate 0
+/// higher-scope operator. Multiplication, division, and fixed-point squaring
+/// happen only in [`Self::compile`]; prediction reads the stored cells.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PriorSentenceCountRadiusR4V1 {
+    table_artifact_hash: [u8; 32],
+    base_overlay_artifact_hash: [u8; 32],
+    sentence_boundary_token: u32,
+    max_prior_prefix_units: u32,
+    max_tied_candidates: u32,
+    trigram_depth_square: u128,
+    bigram_depth_square: u128,
+    normalization_rows: Vec<NormalizationRow>,
+}
+
+impl PriorSentenceCountRadiusR4V1 {
+    pub fn compile(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+    ) -> Result<Self, HigherScopeGeometricAttentionError> {
+        if base_overlay.table_artifact_cid() != table.artifact_cid() {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "#953 overlay table binding mismatches".to_owned(),
+            ));
+        }
+        let boundary = table.encode_text(b".")?;
+        if boundary.len() != 1
+            || table.decode_tokens(&boundary)? != b"."
+            || !table.is_fitted_lexical_token(boundary[0])
+        {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "the fitted period sentence-boundary token is unavailable".to_owned(),
+            ));
+        }
+        let mut normalization_rows = Vec::with_capacity(MAX_PRIOR_PREFIX_UNITS);
+        for total in 1..=u32::try_from(MAX_PRIOR_PREFIX_UNITS)
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+        {
+            let mut cells = Vec::with_capacity(
+                usize::try_from(total)
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+                    .checked_add(1)
+                    .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?,
+            );
+            for count in 0..=total {
+                let numerator = u128::from(count)
+                    .checked_mul(Q32_SCALE)
+                    .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+                let q32 = u64::try_from(numerator / u128::from(total))
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+                let square = u128::from(q32)
+                    .checked_mul(u128::from(q32))
+                    .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+                cells.push(NormalizationCell { count, q32, square });
+            }
+            normalization_rows.push(NormalizationRow { total, cells });
+        }
+        Ok(Self {
+            table_artifact_hash: cid_digest(&table.artifact_cid())?,
+            base_overlay_artifact_hash: cid_digest(&base_overlay.artifact_cid())?,
+            sentence_boundary_token: boundary[0],
+            max_prior_prefix_units: u32::try_from(MAX_PRIOR_PREFIX_UNITS)
+                .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?,
+            max_tied_candidates: u32::try_from(MAX_PRIOR_TIED_CANDIDATES)
+                .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?,
+            trigram_depth_square: compile_square(TRIGRAM_DEPTH_Q32)?,
+            bigram_depth_square: compile_square(BIGRAM_DEPTH_Q32)?,
+            normalization_rows,
+        })
+    }
+
+    pub fn table_artifact_cid(&self) -> String {
+        format!("blake3:{}", hex::encode(self.table_artifact_hash))
+    }
+
+    pub fn base_overlay_artifact_cid(&self) -> String {
+        format!("blake3:{}", hex::encode(self.base_overlay_artifact_hash))
+    }
+
+    pub fn artifact_cid(&self) -> String {
+        format!("blake3:{}", blake3::hash(&self.to_bytes()).to_hex())
+    }
+
+    pub fn sentence_boundary_token(&self) -> u32 {
+        self.sentence_boundary_token
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&OPERATOR_MAGIC);
+        push_u32(&mut bytes, OPERATOR_VERSION);
+        bytes.extend_from_slice(&self.table_artifact_hash);
+        bytes.extend_from_slice(&self.base_overlay_artifact_hash);
+        push_u32(&mut bytes, self.sentence_boundary_token);
+        push_u32(&mut bytes, self.max_prior_prefix_units);
+        push_u32(&mut bytes, self.max_tied_candidates);
+        push_u32(&mut bytes, usize_u32(self.normalization_rows.len()));
+        push_u64(&mut bytes, TRIGRAM_DEPTH_Q32);
+        push_u128(&mut bytes, self.trigram_depth_square);
+        push_u64(&mut bytes, BIGRAM_DEPTH_Q32);
+        push_u128(&mut bytes, self.bigram_depth_square);
+        push_u32(&mut bytes, 0);
+        debug_assert_eq!(bytes.len(), OPERATOR_HEADER_LEN);
+        for row in &self.normalization_rows {
+            push_u32(&mut bytes, row.total);
+            push_u32(&mut bytes, usize_u32(row.cells.len()));
+            for cell in &row.cells {
+                push_u32(&mut bytes, cell.count);
+                push_u64(&mut bytes, cell.q32);
+                push_u128(&mut bytes, cell.square);
+            }
+        }
+        bytes
+    }
+
+    pub fn from_bytes(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        bytes: &[u8],
+    ) -> Result<Self, HigherScopeGeometricAttentionError> {
+        if bytes.len() < OPERATOR_HEADER_LEN || bytes[..8] != OPERATOR_MAGIC {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator magic/header is invalid".to_owned(),
+            ));
+        }
+        let mut cursor = Cursor::new(bytes);
+        cursor.take(8)?;
+        if cursor.u32()? != OPERATOR_VERSION {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator version is unsupported".to_owned(),
+            ));
+        }
+        let table_artifact_hash = cursor.array_32()?;
+        let base_overlay_artifact_hash = cursor.array_32()?;
+        let sentence_boundary_token = cursor.u32()?;
+        let max_prior_prefix_units = cursor.u32()?;
+        let max_tied_candidates = cursor.u32()?;
+        let row_count = cursor.count("normalization row", MAX_PRIOR_PREFIX_UNITS)?;
+        let trigram_depth_q32 = cursor.u64()?;
+        let trigram_depth_square = cursor.u128()?;
+        let bigram_depth_q32 = cursor.u64()?;
+        let bigram_depth_square = cursor.u128()?;
+        if cursor.u32()? != 0 {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator reserved field is nonzero".to_owned(),
+            ));
+        }
+        if trigram_depth_q32 != TRIGRAM_DEPTH_Q32 || bigram_depth_q32 != BIGRAM_DEPTH_Q32 {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator depth coordinates drifted".to_owned(),
+            ));
+        }
+        let mut normalization_rows = Vec::with_capacity(row_count);
+        for expected_total in 1..=row_count {
+            let total = cursor.u32()?;
+            if usize::try_from(total).ok() != Some(expected_total) {
+                return Err(HigherScopeGeometricAttentionError::Invalid(
+                    "normalization totals are not canonical".to_owned(),
+                ));
+            }
+            let maximum_cells = expected_total
+                .checked_add(1)
+                .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+            let cell_count = cursor.count("normalization cell", maximum_cells)?;
+            if cell_count != maximum_cells {
+                return Err(HigherScopeGeometricAttentionError::Invalid(
+                    "normalization row is incomplete".to_owned(),
+                ));
+            }
+            let mut cells = Vec::with_capacity(cell_count);
+            for expected_count in 0..cell_count {
+                let count = cursor.u32()?;
+                if usize::try_from(count).ok() != Some(expected_count) {
+                    return Err(HigherScopeGeometricAttentionError::Invalid(
+                        "normalization counts are not canonical".to_owned(),
+                    ));
+                }
+                cells.push(NormalizationCell {
+                    count,
+                    q32: cursor.u64()?,
+                    square: cursor.u128()?,
+                });
+            }
+            normalization_rows.push(NormalizationRow { total, cells });
+        }
+        if !cursor.is_finished() {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator has trailing bytes".to_owned(),
+            ));
+        }
+        let operator = Self {
+            table_artifact_hash,
+            base_overlay_artifact_hash,
+            sentence_boundary_token,
+            max_prior_prefix_units,
+            max_tied_candidates,
+            trigram_depth_square,
+            bigram_depth_square,
+            normalization_rows,
+        };
+        let expected = Self::compile(table, base_overlay)?;
+        if operator != expected || operator.to_bytes() != bytes {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator is non-canonical or does not reproduce".to_owned(),
+            ));
+        }
+        Ok(operator)
+    }
+
+    pub fn predict_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        context: &[u32],
+    ) -> Result<MatchedPriorSentenceCountRadiusPrediction, HigherScopeGeometricAttentionError> {
+        self.ensure_bound(table, base_overlay)?;
+        let local = table.predict_multiscale_count_radius(context, base_overlay)?;
+        if local.baseline_support_tokens != local.geometric_support_tokens {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "#953 support differs across matched arms".to_owned(),
+            ));
+        }
+        if local.baseline_work != local.geometric_work {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "#953 declared work differs across matched arms".to_owned(),
+            ));
+        }
+        if local.max_count_tie_tokens.len() > MAX_PRIOR_TIED_CANDIDATES {
+            return Err(HigherScopeGeometricAttentionError::Invalid(format!(
+                "max-count tie exceeds the {}-candidate operator bound",
+                MAX_PRIOR_TIED_CANDIDATES
+            )));
+        }
+        let boundary_index = context
+            .iter()
+            .rposition(|token| *token == self.sentence_boundary_token);
+        let prefix_start = usize::from(context.first() == Some(&BOS_TOKEN));
+        let prior_prefix = match boundary_index {
+            Some(index) if index >= prefix_start => &context[prefix_start..index],
+            _ => &[],
+        };
+        if prior_prefix.len() > MAX_PRIOR_PREFIX_UNITS {
+            return Err(HigherScopeGeometricAttentionError::Invalid(format!(
+                "prior prefix exceeds the {}-unit operator bound",
+                MAX_PRIOR_PREFIX_UNITS
+            )));
+        }
+        if !local.geometry_reachable || local.max_count_tie_tokens.len() < 2 {
+            return Ok(abstaining_prediction(
+                local,
+                self.sentence_boundary_token,
+                boundary_index,
+                0,
+                0,
+                zero_higher_scope_work(),
+                PriorSentenceCountRadiusAbstention::LocalGeometryIneligible,
+            ));
+        }
+        if local.tie_evidence.len() != local.max_count_tie_tokens.len()
+            || local
+                .tie_evidence
+                .iter()
+                .map(|candidate| candidate.token)
+                .ne(local.max_count_tie_tokens.iter().copied())
+        {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "#953 tie evidence does not match canonical max-count support".to_owned(),
+            ));
+        }
+        let mut prior_counts = vec![0_u32; local.max_count_tie_tokens.len()];
+        let mut membership_checks = 0_u64;
+        for &observed in prior_prefix {
+            for (index, &candidate) in local.max_count_tie_tokens.iter().enumerate() {
+                membership_checks = checked_increment(membership_checks)?;
+                if observed == candidate {
+                    prior_counts[index] = prior_counts[index]
+                        .checked_add(1)
+                        .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+                }
+            }
+        }
+        let prior_total = prior_counts.iter().try_fold(0_u32, |total, count| {
+            total
+                .checked_add(*count)
+                .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)
+        })?;
+        if usize::try_from(prior_total)
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+            > prior_prefix.len()
+        {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "candidate occupancy exceeds the prior prefix".to_owned(),
+            ));
+        }
+
+        let work = PriorSentenceCountRadiusWork {
+            local: local.geometric_work,
+            prior_prefix_units_scanned: u64::try_from(prior_prefix.len())
+                .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?,
+            candidate_membership_checks: membership_checks,
+            normalization_table_reads: if prior_total == 0 {
+                0
+            } else {
+                u64::try_from(local.max_count_tie_tokens.len())
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+            },
+            square_table_reads: if prior_total == 0 {
+                0
+            } else {
+                u64::try_from(local.max_count_tie_tokens.len())
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+            },
+            coordinate_replacements: if prior_total == 0 {
+                0
+            } else {
+                u64::try_from(local.max_count_tie_tokens.len())
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+            },
+            radius_comparisons: if prior_total == 0 {
+                0
+            } else {
+                u64::try_from(local.max_count_tie_tokens.len())
+                    .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?
+            },
+            final_choice_operations: 1,
+        };
+
+        if boundary_index.is_none() {
+            return Ok(abstaining_prediction(
+                local,
+                self.sentence_boundary_token,
+                None,
+                prior_prefix.len(),
+                prior_total,
+                work,
+                PriorSentenceCountRadiusAbstention::MissingSentenceBoundary,
+            ));
+        }
+        if prior_total == 0 {
+            return Ok(abstaining_prediction(
+                local,
+                self.sentence_boundary_token,
+                boundary_index,
+                prior_prefix.len(),
+                prior_total,
+                work,
+                PriorSentenceCountRadiusAbstention::NoPriorCandidateOccurrence,
+            ));
+        }
+
+        let real_scores = self.score_arm(
+            &local.tie_evidence,
+            &prior_counts,
+            prior_total,
+            local.order,
+            PriorSentenceCountRadiusArm::Real,
+        )?;
+        let disabled_scores = self.score_arm(
+            &local.tie_evidence,
+            &prior_counts,
+            prior_total,
+            local.order,
+            PriorSentenceCountRadiusArm::ScopeDisabled,
+        )?;
+        let permuted_scores = self.score_arm(
+            &local.tie_evidence,
+            &prior_counts,
+            prior_total,
+            local.order,
+            PriorSentenceCountRadiusArm::CandidatePermuted,
+        )?;
+        let real_winner = unique_radius_winner(&real_scores);
+        let disabled_winner = unique_radius_winner(&disabled_scores);
+        let permuted_winner = unique_radius_winner(&permuted_scores);
+        let fallback = local.geometric_token;
+
+        let mut candidate_evidence = Vec::with_capacity(local.tie_evidence.len());
+        for index in 0..local.tie_evidence.len() {
+            let local_candidate = &local.tie_evidence[index];
+            let real = &real_scores[index];
+            let disabled = &disabled_scores[index];
+            let permuted = &permuted_scores[index];
+            if local_candidate.token != real.token
+                || real.token != disabled.token
+                || disabled.token != permuted.token
+            {
+                return Err(HigherScopeGeometricAttentionError::Invalid(
+                    "matched arm candidate order drifted".to_owned(),
+                ));
+            }
+            candidate_evidence.push(PriorSentenceCountRadiusCandidateEvidence {
+                token: local_candidate.token,
+                count: local_candidate.count,
+                local_coordinates: local_candidate.coordinates,
+                local_radius: local_candidate.radius,
+                prior_count: prior_counts[index],
+                real_prior_q32: real.prior_q32,
+                real_radius: real.radius,
+                disabled_prior_q32: disabled.prior_q32,
+                disabled_radius: disabled.radius,
+                permuted_prior_count: permuted.prior_count,
+                permuted_prior_q32: permuted.prior_q32,
+                permuted_radius: permuted.radius,
+            });
+        }
+
+        let support = local.max_count_tie_tokens.clone();
+        let real = decision(
+            PriorSentenceCountRadiusArm::Real,
+            real_winner.unwrap_or(fallback),
+            real_winner,
+            support.clone(),
+            work,
+        );
+        let scope_disabled = decision(
+            PriorSentenceCountRadiusArm::ScopeDisabled,
+            fallback,
+            disabled_winner,
+            support.clone(),
+            work,
+        );
+        let candidate_permuted = decision(
+            PriorSentenceCountRadiusArm::CandidatePermuted,
+            permuted_winner.unwrap_or(fallback),
+            permuted_winner,
+            support.clone(),
+            work,
+        );
+        let support_matched = real.support_tokens == scope_disabled.support_tokens
+            && real.support_tokens == candidate_permuted.support_tokens;
+        let work_matched = real.work == scope_disabled.work
+            && real.work == candidate_permuted.work
+            && local.baseline_work == local.geometric_work;
+
+        Ok(MatchedPriorSentenceCountRadiusPrediction {
+            local,
+            sentence_boundary_token: self.sentence_boundary_token,
+            sentence_boundary_index: boundary_index,
+            prior_prefix_units: prior_prefix.len(),
+            prior_candidate_occurrences: prior_total,
+            candidate_evidence,
+            real,
+            scope_disabled,
+            candidate_permuted,
+            operator_abstention: real_winner
+                .is_none()
+                .then_some(PriorSentenceCountRadiusAbstention::RadiusTie),
+            support_matched,
+            work_matched,
+            teacher_calls: 0,
+            provider_calls: 0,
+            source_weight_reads: 0,
+            future_unit_reads: 0,
+        })
+    }
+
+    pub fn continue_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        seed: &[u8],
+        max_units: usize,
+    ) -> Result<MatchedPriorSentenceCountRadiusContinuation, HigherScopeGeometricAttentionError>
+    {
+        if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
+            return Err(HigherScopeGeometricAttentionError::Invalid(format!(
+                "continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
+            )));
+        }
+        let mut initial_context = vec![BOS_TOKEN];
+        initial_context.extend(table.encode_text(seed)?);
+        let first_decision = self.predict_matched(table, base_overlay, &initial_context)?;
+        let mut real = ContinuationState::new(initial_context.clone());
+        let mut disabled = ContinuationState::new(initial_context.clone());
+        let mut permuted = ContinuationState::new(initial_context);
+        real.accept(first_decision.real.token);
+        disabled.accept(first_decision.scope_disabled.token);
+        permuted.accept(first_decision.candidate_permuted.token);
+
+        while real.can_step(max_units)
+            || disabled.can_step(max_units)
+            || permuted.can_step(max_units)
+        {
+            if real.can_step(max_units) {
+                let prediction =
+                    table.predict_multiscale_count_radius(&real.context, base_overlay)?;
+                real.accept(prediction.geometric_token);
+            }
+            if disabled.can_step(max_units) {
+                let prediction =
+                    table.predict_multiscale_count_radius(&disabled.context, base_overlay)?;
+                disabled.accept(prediction.geometric_token);
+            }
+            if permuted.can_step(max_units) {
+                let prediction =
+                    table.predict_multiscale_count_radius(&permuted.context, base_overlay)?;
+                permuted.accept(prediction.geometric_token);
+            }
+        }
+
+        Ok(MatchedPriorSentenceCountRadiusContinuation {
+            first_decision,
+            real: real.finish(table)?,
+            scope_disabled: disabled.finish(table)?,
+            candidate_permuted: permuted.finish(table)?,
+        })
+    }
+
+    fn ensure_bound(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+    ) -> Result<(), HigherScopeGeometricAttentionError> {
+        if self.table_artifact_hash != cid_digest(&table.artifact_cid())?
+            || self.base_overlay_artifact_hash != cid_digest(&base_overlay.artifact_cid())?
+            || base_overlay.table_artifact_cid() != table.artifact_cid()
+        {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator artifact binding mismatches".to_owned(),
+            ));
+        }
+        let boundary = table.encode_text(b".")?;
+        if boundary.as_slice() != [self.sentence_boundary_token]
+            || !table.is_fitted_lexical_token(self.sentence_boundary_token)
+        {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator sentence-boundary binding mismatches".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn score_arm(
+        &self,
+        local_candidates: &[MultiscaleCountRadiusCandidate],
+        prior_counts: &[u32],
+        prior_total: u32,
+        order: BackoffOrder,
+        arm: PriorSentenceCountRadiusArm,
+    ) -> Result<Vec<ScoredCandidate>, HigherScopeGeometricAttentionError> {
+        let mut scored = Vec::with_capacity(local_candidates.len());
+        for (index, candidate) in local_candidates.iter().enumerate() {
+            let source_index = match arm {
+                PriorSentenceCountRadiusArm::Real | PriorSentenceCountRadiusArm::ScopeDisabled => {
+                    index
+                }
+                PriorSentenceCountRadiusArm::CandidatePermuted => {
+                    let next = index
+                        .checked_add(1)
+                        .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+                    if next == prior_counts.len() {
+                        0
+                    } else {
+                        next
+                    }
+                }
+            };
+            let prior_count = prior_counts[source_index];
+            let cell = if prior_total == 0 {
+                NormalizationCell {
+                    count: 0,
+                    q32: 0,
+                    square: 0,
+                }
+            } else {
+                self.normalization_cell(prior_count, prior_total)?
+            };
+            let depth_square = match (order, candidate.coordinates.depth_q32) {
+                (BackoffOrder::Trigram, TRIGRAM_DEPTH_Q32) => self.trigram_depth_square,
+                (BackoffOrder::Bigram, BIGRAM_DEPTH_Q32) => self.bigram_depth_square,
+                _ => {
+                    return Err(HigherScopeGeometricAttentionError::Invalid(
+                        "#953 candidate depth coordinate is not typed".to_owned(),
+                    ))
+                }
+            };
+            let base_radius = candidate.radius.checked_sub(depth_square).ok_or_else(|| {
+                HigherScopeGeometricAttentionError::Invalid(
+                    "#953 radius is smaller than its depth contribution".to_owned(),
+                )
+            })?;
+            let (prior_q32, contribution) = match arm {
+                PriorSentenceCountRadiusArm::ScopeDisabled => (0, 0),
+                PriorSentenceCountRadiusArm::Real
+                | PriorSentenceCountRadiusArm::CandidatePermuted => (cell.q32, cell.square),
+            };
+            let radius = base_radius
+                .checked_add(contribution)
+                .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+            scored.push(ScoredCandidate {
+                token: candidate.token,
+                prior_count,
+                prior_q32,
+                radius,
+            });
+        }
+        Ok(scored)
+    }
+
+    fn normalization_cell(
+        &self,
+        count: u32,
+        total: u32,
+    ) -> Result<NormalizationCell, HigherScopeGeometricAttentionError> {
+        if total == 0 || count > total || total > self.max_prior_prefix_units {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "prior-prefix normalization coordinates are out of bounds".to_owned(),
+            ));
+        }
+        let row_index = usize::try_from(total - 1)
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+        let cell_index = usize::try_from(count)
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+        let row = self.normalization_rows.get(row_index).ok_or_else(|| {
+            HigherScopeGeometricAttentionError::Invalid(
+                "prior-prefix normalization row is absent".to_owned(),
+            )
+        })?;
+        let cell = row.cells.get(cell_index).copied().ok_or_else(|| {
+            HigherScopeGeometricAttentionError::Invalid(
+                "prior-prefix normalization cell is absent".to_owned(),
+            )
+        })?;
+        if row.total != total || cell.count != count {
+            return Err(HigherScopeGeometricAttentionError::Invalid(
+                "prior-prefix normalization lookup identity drifted".to_owned(),
+            ));
+        }
+        Ok(cell)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScoredCandidate {
+    token: u32,
+    prior_count: u32,
+    prior_q32: u64,
+    radius: u128,
+}
+
+fn unique_radius_winner(candidates: &[ScoredCandidate]) -> Option<u32> {
+    let mut winner = None;
+    let mut maximum = 0_u128;
+    let mut tied = false;
+    for candidate in candidates {
+        if winner.is_none() || candidate.radius > maximum {
+            winner = Some(candidate.token);
+            maximum = candidate.radius;
+            tied = false;
+        } else if candidate.radius == maximum {
+            tied = true;
+        }
+    }
+    if tied {
+        None
+    } else {
+        winner
+    }
+}
+
+fn decision(
+    arm: PriorSentenceCountRadiusArm,
+    token: u32,
+    unique_radius_winner: Option<u32>,
+    support_tokens: Vec<u32>,
+    work: PriorSentenceCountRadiusWork,
+) -> PriorSentenceCountRadiusDecision {
+    PriorSentenceCountRadiusDecision {
+        arm,
+        token,
+        unique_radius_winner,
+        support_tokens,
+        work,
+    }
+}
+
+fn zero_higher_scope_work() -> PriorSentenceCountRadiusWork {
+    PriorSentenceCountRadiusWork {
+        local: MultiscaleCountRadiusWork::default(),
+        prior_prefix_units_scanned: 0,
+        candidate_membership_checks: 0,
+        normalization_table_reads: 0,
+        square_table_reads: 0,
+        coordinate_replacements: 0,
+        radius_comparisons: 0,
+        final_choice_operations: 1,
+    }
+}
+
+fn abstaining_prediction(
+    local: MatchedGeometricPrediction,
+    sentence_boundary_token: u32,
+    sentence_boundary_index: Option<usize>,
+    prior_prefix_units: usize,
+    prior_candidate_occurrences: u32,
+    mut work: PriorSentenceCountRadiusWork,
+    reason: PriorSentenceCountRadiusAbstention,
+) -> MatchedPriorSentenceCountRadiusPrediction {
+    work.local = local.geometric_work;
+    let support = local.max_count_tie_tokens.clone();
+    let fallback = local.geometric_token;
+    MatchedPriorSentenceCountRadiusPrediction {
+        local,
+        sentence_boundary_token,
+        sentence_boundary_index,
+        prior_prefix_units,
+        prior_candidate_occurrences,
+        candidate_evidence: Vec::new(),
+        real: decision(
+            PriorSentenceCountRadiusArm::Real,
+            fallback,
+            None,
+            support.clone(),
+            work,
+        ),
+        scope_disabled: decision(
+            PriorSentenceCountRadiusArm::ScopeDisabled,
+            fallback,
+            None,
+            support.clone(),
+            work,
+        ),
+        candidate_permuted: decision(
+            PriorSentenceCountRadiusArm::CandidatePermuted,
+            fallback,
+            None,
+            support,
+            work,
+        ),
+        operator_abstention: Some(reason),
+        support_matched: true,
+        work_matched: true,
+        teacher_calls: 0,
+        provider_calls: 0,
+        source_weight_reads: 0,
+        future_unit_reads: 0,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ContinuationState {
+    context: Vec<u32>,
+    generated: Vec<u32>,
+    stop: ContinuationStop,
+}
+
+impl ContinuationState {
+    fn new(context: Vec<u32>) -> Self {
+        Self {
+            context,
+            generated: Vec::new(),
+            stop: ContinuationStop::Bound,
+        }
+    }
+
+    fn can_step(&self, max_units: usize) -> bool {
+        self.stop == ContinuationStop::Bound && self.generated.len() < max_units
+    }
+
+    fn accept(&mut self, token: u32) {
+        if token == EOS_TOKEN {
+            self.stop = ContinuationStop::EndOfDocument;
+            return;
+        }
+        if self.generated.last() == Some(&token) {
+            self.stop = ContinuationStop::PeriodOneCycle;
+            return;
+        }
+        if self.generated.len() >= 3
+            && self.generated[self.generated.len() - 2] == token
+            && self.generated[self.generated.len() - 3] == self.generated[self.generated.len() - 1]
+        {
+            self.stop = ContinuationStop::PeriodTwoCycle;
+            return;
+        }
+        self.generated.push(token);
+        self.context.push(token);
+    }
+
+    fn finish(
+        self,
+        table: &SourceFreeTable,
+    ) -> Result<Continuation, HigherScopeGeometricAttentionError> {
+        Ok(Continuation {
+            decoded: table.decode_tokens(&self.generated)?,
+            tokens: self.generated,
+            stop: self.stop,
+        })
+    }
+}
+
+fn compile_square(value: u64) -> Result<u128, HigherScopeGeometricAttentionError> {
+    u128::from(value)
+        .checked_mul(u128::from(value))
+        .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)
+}
+
+fn checked_increment(value: u64) -> Result<u64, HigherScopeGeometricAttentionError> {
+    value
+        .checked_add(1)
+        .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)
+}
+
+fn cid_digest(cid: &str) -> Result<[u8; 32], HigherScopeGeometricAttentionError> {
+    let hex_digest = cid.strip_prefix("blake3:").ok_or_else(|| {
+        HigherScopeGeometricAttentionError::Invalid("artifact CID is not BLAKE3".to_owned())
+    })?;
+    let bytes = hex::decode(hex_digest).map_err(|_| {
+        HigherScopeGeometricAttentionError::Invalid("artifact CID hex is invalid".to_owned())
+    })?;
+    bytes.try_into().map_err(|_| {
+        HigherScopeGeometricAttentionError::Invalid("artifact CID length is invalid".to_owned())
+    })
+}
+
+fn usize_u32(value: usize) -> u32 {
+    u32::try_from(value).expect("validated higher-scope artifact length exceeds u32")
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u128(bytes: &mut Vec<u8>, value: u128) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], HigherScopeGeometricAttentionError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+        let value = self.bytes.get(self.offset..end).ok_or_else(|| {
+            HigherScopeGeometricAttentionError::Invalid(
+                "higher-scope operator is truncated".to_owned(),
+            )
+        })?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u32(&mut self) -> Result<u32, HigherScopeGeometricAttentionError> {
+        Ok(u32::from_le_bytes(self.take(4)?.try_into().map_err(
+            |_| HigherScopeGeometricAttentionError::ArithmeticOverflow,
+        )?))
+    }
+
+    fn u64(&mut self) -> Result<u64, HigherScopeGeometricAttentionError> {
+        Ok(u64::from_le_bytes(self.take(8)?.try_into().map_err(
+            |_| HigherScopeGeometricAttentionError::ArithmeticOverflow,
+        )?))
+    }
+
+    fn u128(&mut self) -> Result<u128, HigherScopeGeometricAttentionError> {
+        Ok(u128::from_le_bytes(self.take(16)?.try_into().map_err(
+            |_| HigherScopeGeometricAttentionError::ArithmeticOverflow,
+        )?))
+    }
+
+    fn array_32(&mut self) -> Result<[u8; 32], HigherScopeGeometricAttentionError> {
+        self.take(32)?
+            .try_into()
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)
+    }
+
+    fn count(
+        &mut self,
+        label: &str,
+        maximum: usize,
+    ) -> Result<usize, HigherScopeGeometricAttentionError> {
+        let count = usize::try_from(self.u32()?)
+            .map_err(|_| HigherScopeGeometricAttentionError::ArithmeticOverflow)?;
+        if count > maximum {
+            return Err(HigherScopeGeometricAttentionError::Invalid(format!(
+                "{label} count exceeds its bound"
+            )));
+        }
+        Ok(count)
+    }
+
+    fn is_finished(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+}

--- a/crates/uor-r4-core/src/lib.rs
+++ b/crates/uor-r4-core/src/lib.rs
@@ -10,6 +10,7 @@ use std::f64::consts::PI;
 pub mod canonical_lexical_ingestion;
 pub mod cayley_dickson;
 pub mod construction_causal_return_attention;
+pub mod higher_scope_geometric_attention;
 pub mod local_geometric_generation;
 pub mod prime_route_attention;
 pub mod prime_route_geometric_attention;

--- a/crates/uor-r4-core/src/source_free_table.rs
+++ b/crates/uor-r4-core/src/source_free_table.rs
@@ -1193,7 +1193,7 @@ impl SourceFreeTable {
         Ok(())
     }
 
-    fn is_fitted_lexical_token(&self, token: u32) -> bool {
+    pub(crate) fn is_fitted_lexical_token(&self, token: u32) -> bool {
         token.checked_sub(LEXICAL_TOKEN_BASE).is_some_and(|offset| {
             usize::try_from(offset)
                 .ok()

--- a/crates/uor-r4-core/tests/prior_sentence_count_radius_attention_973.rs
+++ b/crates/uor-r4-core/tests/prior_sentence_count_radius_attention_973.rs
@@ -1,0 +1,505 @@
+//! Frozen Gate 0 probe for #973 `PriorSentenceCountRadiusR4V1`.
+//!
+//! The English text is synthetic. D3 hashes enforce construction/held-out
+//! partition separation for this bounded causal probe; they do not make the
+//! fixture corpus-derived or establish natural-distribution transfer.
+
+use serde::Serialize;
+use uor_r4_core::higher_scope_geometric_attention::{
+    MatchedPriorSentenceCountRadiusContinuation, MatchedPriorSentenceCountRadiusPrediction,
+    PriorSentenceCountRadiusAbstention, PriorSentenceCountRadiusR4V1,
+};
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, BackoffOrder, ContinuationStop, MultiscaleCountRadiusR4V1, SourceDocument,
+    SourceFreeTable, BOS_TOKEN,
+};
+
+const TEA_PROMPT: &[u8] = b"Mara chose tea before lunch. When the server arrived, Mara asked for";
+const COFFEE_PROMPT: &[u8] =
+    b"Mara chose coffee before lunch. When the server arrived, Mara asked for";
+
+fn construction_documents() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new(
+            "14",
+            b"Nora chose tea before breakfast. Later Nora asked for tea.".to_vec(),
+        ),
+        SourceDocument::new(
+            "657",
+            b"Owen chose coffee before breakfast. Later Owen asked for coffee.".to_vec(),
+        ),
+    ]
+}
+
+fn context(table: &SourceFreeTable, prompt: &[u8]) -> Vec<u32> {
+    let mut context = vec![BOS_TOKEN];
+    context.extend(table.encode_text(prompt).unwrap());
+    context
+}
+
+fn decoded(table: &SourceFreeTable, token: u32) -> Vec<u8> {
+    table.decode_tokens(&[token]).unwrap()
+}
+
+fn decoded_tokens(table: &SourceFreeTable, tokens: &[u32]) -> Vec<Vec<u8>> {
+    tokens.iter().map(|token| decoded(table, *token)).collect()
+}
+
+#[derive(Serialize)]
+struct LabelBlindCensus<'a> {
+    schema: u32,
+    domain: &'static str,
+    table_cid: String,
+    base_overlay_cid: String,
+    operator_cid: String,
+    cases: Vec<LabelBlindCase<'a>>,
+    teacher_calls: u64,
+    provider_calls: u64,
+    source_weight_reads: u64,
+    future_unit_reads: u64,
+}
+
+#[derive(Serialize)]
+struct LabelBlindCase<'a> {
+    partition_id: &'static str,
+    prompt_cid: String,
+    prediction: &'a MatchedPriorSentenceCountRadiusPrediction,
+}
+
+#[derive(Serialize)]
+struct DecodedSmoke<'a> {
+    schema: u32,
+    domain: &'static str,
+    operator_cid: String,
+    cases: Vec<DecodedCase<'a>>,
+    real_correct: u32,
+    disabled_correct: u32,
+    permuted_correct: u32,
+    support_mismatches: u32,
+    work_mismatches: u32,
+    terminal: &'static str,
+}
+
+#[derive(Serialize)]
+struct DecodedCase<'a> {
+    partition_id: &'static str,
+    target_hex: String,
+    continuation: &'a MatchedPriorSentenceCountRadiusContinuation,
+}
+
+#[test]
+fn label_blind_gate0_then_decoded_controls_make_prior_scope_load_bearing() {
+    let construction = construction_documents();
+    assert!(construction
+        .iter()
+        .all(|document| !d3_is_held_out(&document.id)));
+    assert!(d3_is_held_out("12"));
+    assert!(d3_is_held_out("13"));
+
+    let prompt_documents = [
+        SourceDocument::new("12", TEA_PROMPT.to_vec()),
+        SourceDocument::new("13", COFFEE_PROMPT.to_vec()),
+    ];
+    for prompt in &prompt_documents {
+        assert!(construction
+            .iter()
+            .all(|document| document.id != prompt.id && document.text_cid() != prompt.text_cid()));
+    }
+
+    let table = SourceFreeTable::compile(&construction).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::compile(&table).unwrap();
+    let operator = PriorSentenceCountRadiusR4V1::compile(&table, &base_overlay).unwrap();
+    let operator_bytes = operator.to_bytes();
+    let operator_cid = operator.artifact_cid();
+    let reloaded =
+        PriorSentenceCountRadiusR4V1::from_bytes(&table, &base_overlay, &operator_bytes).unwrap();
+    assert_eq!(reloaded.to_bytes(), operator_bytes);
+    assert_eq!(reloaded.artifact_cid(), operator_cid);
+    assert_eq!(reloaded.table_artifact_cid(), table.artifact_cid());
+    assert_eq!(
+        reloaded.base_overlay_artifact_cid(),
+        base_overlay.artifact_cid()
+    );
+
+    // Gate 0 sees prompts only. No continuation target is constructed above
+    // this point.
+    let tea_context = context(&table, TEA_PROMPT);
+    let coffee_context = context(&table, COFFEE_PROMPT);
+    assert_eq!(
+        &tea_context[tea_context.len() - 2..],
+        &coffee_context[coffee_context.len() - 2..]
+    );
+    assert_eq!(
+        decoded_tokens(&table, &tea_context[tea_context.len() - 2..]),
+        vec![b" asked".to_vec(), b" for".to_vec()]
+    );
+
+    let tea = reloaded
+        .predict_matched(&table, &base_overlay, &tea_context)
+        .unwrap();
+    let coffee = reloaded
+        .predict_matched(&table, &base_overlay, &coffee_context)
+        .unwrap();
+    for prediction in [&tea, &coffee] {
+        assert_eq!(prediction.local.order, BackoffOrder::Trigram);
+        assert_eq!(prediction.local.max_count, 1);
+        assert!(prediction.local.geometry_reachable);
+        assert_eq!(
+            decoded_tokens(&table, &prediction.local.baseline_support_tokens),
+            vec![b" coffee".to_vec(), b" tea".to_vec()]
+        );
+        assert_eq!(
+            prediction.local.baseline_support_tokens,
+            prediction.local.geometric_support_tokens
+        );
+        assert_eq!(
+            prediction.local.max_count_tie_tokens,
+            prediction.local.baseline_support_tokens
+        );
+        assert_eq!(
+            prediction.local.baseline_work,
+            prediction.local.geometric_work
+        );
+        assert_eq!(decoded(&table, prediction.local.baseline_token), b" coffee");
+        assert_eq!(
+            decoded(&table, prediction.local.geometric_token),
+            b" coffee"
+        );
+        assert_eq!(prediction.prior_prefix_units, 13);
+        assert_eq!(prediction.prior_candidate_occurrences, 1);
+        assert_eq!(prediction.real.work.candidate_membership_checks, 26);
+        assert!(prediction.sentence_boundary_index.is_some());
+        assert!(prediction.support_matched);
+        assert!(prediction.work_matched);
+        assert_eq!(prediction.operator_abstention, None);
+        assert_eq!(prediction.teacher_calls, 0);
+        assert_eq!(prediction.provider_calls, 0);
+        assert_eq!(prediction.source_weight_reads, 0);
+        assert_eq!(prediction.future_unit_reads, 0);
+        assert_eq!(prediction.candidate_evidence.len(), 2);
+        for candidate in &prediction.candidate_evidence {
+            assert_eq!(candidate.count, 1);
+            assert_eq!(candidate.local_coordinates.trigram_q32, 1_u64 << 31);
+            assert_eq!(candidate.local_coordinates.bigram_q32, 1_u64 << 31);
+            assert_eq!(candidate.local_coordinates.unigram_q32, 330_382_099);
+            assert_eq!(candidate.local_coordinates.depth_q32, 3_u64 << 30);
+            assert_eq!(candidate.local_radius, 19_708_817_909_656_044_393);
+            assert_eq!(candidate.disabled_prior_q32, 0);
+            assert_eq!(candidate.disabled_radius, 9_332_524_368_194_421_609);
+        }
+    }
+
+    assert_eq!(decoded(&table, tea.real.token), b" tea");
+    assert_eq!(decoded(&table, coffee.real.token), b" coffee");
+    assert_eq!(decoded(&table, tea.scope_disabled.token), b" coffee");
+    assert_eq!(decoded(&table, coffee.scope_disabled.token), b" coffee");
+    assert_eq!(decoded(&table, tea.candidate_permuted.token), b" coffee");
+    assert_eq!(decoded(&table, coffee.candidate_permuted.token), b" tea");
+    assert_ne!(tea.real.token, coffee.real.token);
+    assert_eq!(tea.scope_disabled.token, coffee.scope_disabled.token);
+
+    for prediction in [&tea, &coffee] {
+        let present = prediction
+            .candidate_evidence
+            .iter()
+            .find(|candidate| candidate.prior_count == 1)
+            .unwrap();
+        let absent = prediction
+            .candidate_evidence
+            .iter()
+            .find(|candidate| candidate.prior_count == 0)
+            .unwrap();
+        assert_eq!(present.real_prior_q32, 1_u64 << 32);
+        assert_eq!(present.real_radius, 27_779_268_441_903_973_225);
+        assert_eq!(absent.real_prior_q32, 0);
+        assert_eq!(absent.real_radius, 9_332_524_368_194_421_609);
+    }
+
+    // Candidate-relative transformed classes are frozen before labels. The
+    // same class may not demand incompatible actions.
+    let tea_class = tea
+        .candidate_evidence
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.token,
+                candidate.prior_count,
+                candidate.real_radius,
+            )
+        })
+        .collect::<Vec<_>>();
+    let coffee_class = coffee
+        .candidate_evidence
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.token,
+                candidate.prior_count,
+                candidate.real_radius,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_ne!(tea_class, coffee_class);
+    let mut class_actions = std::collections::BTreeMap::new();
+    assert_eq!(class_actions.insert(tea_class, tea.real.token), None);
+    assert_eq!(class_actions.insert(coffee_class, coffee.real.token), None);
+
+    let label_blind_census = LabelBlindCensus {
+        schema: 1,
+        domain: "uor-r4.prior-sentence-count-radius-gate0-census/1",
+        table_cid: table.artifact_cid(),
+        base_overlay_cid: base_overlay.artifact_cid(),
+        operator_cid: operator_cid.clone(),
+        cases: vec![
+            LabelBlindCase {
+                partition_id: "12",
+                prompt_cid: format!("blake3:{}", blake3::hash(TEA_PROMPT).to_hex()),
+                prediction: &tea,
+            },
+            LabelBlindCase {
+                partition_id: "13",
+                prompt_cid: format!("blake3:{}", blake3::hash(COFFEE_PROMPT).to_hex()),
+                prediction: &coffee,
+            },
+        ],
+        teacher_calls: 0,
+        provider_calls: 0,
+        source_weight_reads: 0,
+        future_unit_reads: 0,
+    };
+    let frozen_census_bytes = serde_json::to_vec(&label_blind_census).unwrap();
+    let frozen_census_cid = format!("blake3:{}", blake3::hash(&frozen_census_bytes).to_hex());
+    assert_eq!(
+        serde_json::to_vec(&label_blind_census).unwrap(),
+        frozen_census_bytes
+    );
+
+    // The sealed continuations are attached only after the target-free census
+    // and bound operator bytes have been frozen.
+    let sealed = [
+        ("12", TEA_PROMPT, b" tea.".as_slice()),
+        ("13", COFFEE_PROMPT, b" coffee.".as_slice()),
+    ];
+    let tea_continuation = reloaded
+        .continue_matched(&table, &base_overlay, sealed[0].1, 3)
+        .unwrap();
+    let coffee_continuation = reloaded
+        .continue_matched(&table, &base_overlay, sealed[1].1, 3)
+        .unwrap();
+    let continuations = [&tea_continuation, &coffee_continuation];
+    let mut real_correct = 0_u32;
+    let mut disabled_correct = 0_u32;
+    let mut permuted_correct = 0_u32;
+    for (index, continuation) in continuations.iter().enumerate() {
+        let target = sealed[index].2;
+        real_correct += u32::from(continuation.real.decoded == target);
+        disabled_correct += u32::from(continuation.scope_disabled.decoded == target);
+        permuted_correct += u32::from(continuation.candidate_permuted.decoded == target);
+        assert_eq!(continuation.real.stop, ContinuationStop::EndOfDocument);
+        assert_eq!(
+            continuation.scope_disabled.stop,
+            ContinuationStop::EndOfDocument
+        );
+        assert_eq!(
+            continuation.candidate_permuted.stop,
+            ContinuationStop::EndOfDocument
+        );
+        assert_eq!(continuation.real.tokens.len(), 2);
+        assert_eq!(continuation.scope_disabled.tokens.len(), 2);
+        assert_eq!(continuation.candidate_permuted.tokens.len(), 2);
+        assert!(continuation.first_decision.support_matched);
+        assert!(continuation.first_decision.work_matched);
+    }
+    assert_eq!(tea_continuation.real.decoded, b" tea.");
+    assert_eq!(coffee_continuation.real.decoded, b" coffee.");
+    assert_eq!(tea_continuation.scope_disabled.decoded, b" coffee.");
+    assert_eq!(coffee_continuation.scope_disabled.decoded, b" coffee.");
+    assert_eq!(tea_continuation.candidate_permuted.decoded, b" coffee.");
+    assert_eq!(coffee_continuation.candidate_permuted.decoded, b" tea.");
+    assert_eq!(real_correct, 2);
+    assert_eq!(disabled_correct, 1);
+    assert_eq!(permuted_correct, 0);
+
+    let decoded_smoke = DecodedSmoke {
+        schema: 1,
+        domain: "uor-r4.prior-sentence-count-radius-decoded-smoke/1",
+        operator_cid: operator_cid.clone(),
+        cases: vec![
+            DecodedCase {
+                partition_id: sealed[0].0,
+                target_hex: hex::encode(sealed[0].2),
+                continuation: &tea_continuation,
+            },
+            DecodedCase {
+                partition_id: sealed[1].0,
+                target_hex: hex::encode(sealed[1].2),
+                continuation: &coffee_continuation,
+            },
+        ],
+        real_correct,
+        disabled_correct,
+        permuted_correct,
+        support_mismatches: 0,
+        work_mismatches: 0,
+        terminal: "RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION",
+    };
+    let smoke_bytes = serde_json::to_vec(&decoded_smoke).unwrap();
+    let smoke_cid = format!("blake3:{}", blake3::hash(&smoke_bytes).to_hex());
+
+    let tea_replay = reloaded
+        .continue_matched(&table, &base_overlay, sealed[0].1, 3)
+        .unwrap();
+    let coffee_replay = reloaded
+        .continue_matched(&table, &base_overlay, sealed[1].1, 3)
+        .unwrap();
+    assert_eq!(tea_replay, tea_continuation);
+    assert_eq!(coffee_replay, coffee_continuation);
+    let replay_smoke = DecodedSmoke {
+        schema: 1,
+        domain: "uor-r4.prior-sentence-count-radius-decoded-smoke/1",
+        operator_cid: operator_cid.clone(),
+        cases: vec![
+            DecodedCase {
+                partition_id: sealed[0].0,
+                target_hex: hex::encode(sealed[0].2),
+                continuation: &tea_replay,
+            },
+            DecodedCase {
+                partition_id: sealed[1].0,
+                target_hex: hex::encode(sealed[1].2),
+                continuation: &coffee_replay,
+            },
+        ],
+        real_correct,
+        disabled_correct,
+        permuted_correct,
+        support_mismatches: 0,
+        work_mismatches: 0,
+        terminal: "RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION",
+    };
+    assert_eq!(serde_json::to_vec(&replay_smoke).unwrap(), smoke_bytes);
+    assert_eq!(reloaded.to_bytes(), operator_bytes);
+
+    println!(
+        "table_cid={}\nbase_overlay_cid={}\noperator_bytes={}\noperator_cid={operator_cid}\nlabel_blind_census_cid={frozen_census_cid}\ndecoded_smoke_cid={smoke_cid}\nreal=2/2\nscope_disabled=1/2\ncandidate_permuted=0/2\nsupport_mismatches=0\nwork_mismatches=0\nterminal=RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION",
+        table.artifact_cid(),
+        base_overlay.artifact_cid(),
+        operator_bytes.len(),
+    );
+}
+
+#[test]
+fn operator_rejects_binding_drift_tamper_and_excess_scope() {
+    let table = SourceFreeTable::compile(&construction_documents()).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::compile(&table).unwrap();
+    let operator = PriorSentenceCountRadiusR4V1::compile(&table, &base_overlay).unwrap();
+    let bytes = operator.to_bytes();
+
+    let other_table = SourceFreeTable::compile(&[
+        SourceDocument::new("14", b"A separate alpha construction.".to_vec()),
+        SourceDocument::new("657", b"A separate beta construction.".to_vec()),
+    ])
+    .unwrap();
+    let other_overlay = MultiscaleCountRadiusR4V1::compile(&other_table).unwrap();
+    assert!(
+        PriorSentenceCountRadiusR4V1::from_bytes(&other_table, &other_overlay, &bytes).is_err()
+    );
+    assert!(PriorSentenceCountRadiusR4V1::from_bytes(&table, &other_overlay, &bytes).is_err());
+
+    let mut tampered = bytes;
+    let final_index = tampered.len() - 1;
+    tampered[final_index] ^= 1;
+    assert!(PriorSentenceCountRadiusR4V1::from_bytes(&table, &base_overlay, &tampered).is_err());
+
+    let mut excessive = b" tea".repeat(65);
+    excessive.extend_from_slice(b". When the server arrived, Mara asked for");
+    let excessive_context = context(&table, &excessive);
+    let error = operator
+        .predict_matched(&table, &base_overlay, &excessive_context)
+        .unwrap_err();
+    assert!(error.to_string().contains("64-unit operator bound"));
+
+    let mut excessive_ineligible = b" tea".repeat(65);
+    excessive_ineligible.extend_from_slice(b". Later Nora asked");
+    let excessive_ineligible_context = context(&table, &excessive_ineligible);
+    let error = operator
+        .predict_matched(&table, &base_overlay, &excessive_ineligible_context)
+        .unwrap_err();
+    assert!(error.to_string().contains("64-unit operator bound"));
+
+    let missing_boundary = context(&table, b"Mara asked for");
+    let missing = operator
+        .predict_matched(&table, &base_overlay, &missing_boundary)
+        .unwrap();
+    assert_eq!(
+        missing.operator_abstention,
+        Some(PriorSentenceCountRadiusAbstention::MissingSentenceBoundary)
+    );
+    assert_eq!(missing.real.token, missing.local.geometric_token);
+    assert_eq!(missing.real.unique_radius_winner, None);
+
+    let zero_signal = context(
+        &table,
+        b"Mara chose cocoa before lunch. When the server arrived, Mara asked for",
+    );
+    let zero = operator
+        .predict_matched(&table, &base_overlay, &zero_signal)
+        .unwrap();
+    assert_eq!(
+        zero.operator_abstention,
+        Some(PriorSentenceCountRadiusAbstention::NoPriorCandidateOccurrence)
+    );
+    assert_eq!(zero.real.token, zero.local.geometric_token);
+    assert_eq!(zero.real.unique_radius_winner, None);
+    assert!(zero.work_matched);
+}
+
+#[test]
+fn decision_support_is_exactly_the_max_count_tie_not_the_full_row() {
+    let wide_construction = vec![
+        SourceDocument::new(
+            "14",
+            b"Nora asked for tea. Later Nora asked for tea.".to_vec(),
+        ),
+        SourceDocument::new(
+            "657",
+            b"Owen asked for coffee. Later Owen asked for coffee.".to_vec(),
+        ),
+        SourceDocument::new("4579", b"Iris asked for cocoa.".to_vec()),
+    ];
+    assert!(wide_construction
+        .iter()
+        .all(|document| !d3_is_held_out(&document.id)));
+    let wide_table = SourceFreeTable::compile(&wide_construction).unwrap();
+    let wide_overlay = MultiscaleCountRadiusR4V1::compile(&wide_table).unwrap();
+    let wide_operator = PriorSentenceCountRadiusR4V1::compile(&wide_table, &wide_overlay).unwrap();
+    let wide_context = context(
+        &wide_table,
+        b"Mara chose tea before lunch. When the server arrived, Mara asked for",
+    );
+    let prediction = wide_operator
+        .predict_matched(&wide_table, &wide_overlay, &wide_context)
+        .unwrap();
+
+    assert_eq!(
+        decoded_tokens(&wide_table, &prediction.local.baseline_support_tokens),
+        vec![b" cocoa".to_vec(), b" coffee".to_vec(), b" tea".to_vec()]
+    );
+    assert_eq!(
+        decoded_tokens(&wide_table, &prediction.local.max_count_tie_tokens),
+        vec![b" coffee".to_vec(), b" tea".to_vec()]
+    );
+    assert_eq!(
+        prediction.real.support_tokens,
+        prediction.local.max_count_tie_tokens
+    );
+    assert_eq!(
+        prediction.scope_disabled.support_tokens,
+        prediction.local.max_count_tie_tokens
+    );
+    assert_eq!(
+        prediction.candidate_permuted.support_tokens,
+        prediction.local.max_count_tie_tokens
+    );
+    assert!(prediction.support_matched);
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,24 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
+> **Retained #973 Gate 0 mechanism, 2026-08-28.**
+> `PriorSentenceCountRadiusR4V1` reached
+> `RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`.
+> On two synthetic D3-partitioned histories with an identical final
+> ` asked` / ` for` frame, exact `{ coffee, tea }` max-count tie, #953 local
+> coordinates, support, and declared work, the prefix-before-final-period R4
+> coordinate made exact earlier-candidate state causally load-bearing. Real
+> decoded ` tea.` / ` coffee.` (2/2), scope-disabled decoded
+> ` coffee.` / ` coffee.` (1/2), and candidate-permuted decoded
+> ` coffee.` / ` tea.` (0/2). Support/work mismatches and teacher, provider,
+> source-weight, and future-unit reads were zero; artifact and report identities
+> replayed exactly. This establishes one bounded lexical copy-attention
+> mechanism, not semantic placement, natural-distribution transfer, general
+> paragraph/conversation/global attention, correctness, reasoning, coherence,
+> chat, performance, formal closure, or release readiness. #973 remains open;
+> #954 remains blocked. See the
+> [#973 Gate 0 record](prior_sentence_count_radius_attention_973.md).
+
 > **Accepted geometric increment, 2026-08-28 (#953).** The one frozen
 > `MultiscaleCountRadiusR4V1` comparison reached
 > `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`. Over the
@@ -29,8 +47,8 @@ assumptions, or objectives rather than measured results.
 > reports' pending verdict to the frozen positive terminal. This establishes
 > causal incremental value for this exact R4 evidence-radius tie intervention,
 > not semantic geometry, attention, correctness, reasoning, broad coherence, chat, performance, or
-> release readiness. #973 is the next intelligence stage after protected #953
-> closure. See the
+> release readiness. It is the accepted local input to the now-active #973
+> higher-scope stage. See the
 > [#953 table-tie evidence record](source_free_table_geometric_intervention_953.md).
 
 > **Established capability-first result, 2026-08-28 (#989).** #989 reached
@@ -83,8 +101,10 @@ assumptions, or objectives rather than measured results.
 > reproduced, but the exact corpus-scale codec/pair commitment and complete
 > same-frame lexical SpiralCore frame were unavailable. Placement, Gate 0,
 > labels, all arms, and #953 were `NOT_RUN`. The later B0/#989 reset and
-> accepted R4 table-tie result supersede that forward action: #953 may close at
-> its positive terminal, #973 is next, and #954 remains blocked behind #973.
+> accepted R4 table-tie result supersede that forward action: #953 closed at
+> its positive terminal; #973 Gate 0 has since retained one exact-candidate
+> prior-prefix copy mechanism, and required higher scopes remain active. #954
+> remains blocked behind #973.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1204,9 +1224,11 @@ or selection. Established B0/#989 then supplied the frozen reference for the
 one accepted #953 `MultiscaleCountRadiusR4V1` intervention: 103,604 versus
 99,362 held-out correct choices, a distinct bounded continuation, zero
 candidate-support/declared-work-ledger mismatches, and byte-identical replay.
-External replay adjudication promoted the reports' pending verdict, so #953 may
-close at `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`; #973 is next
-and continues to block #954. #955 invokes that accepted selector/
+External replay adjudication promoted the reports' pending verdict and #953
+closed at `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`.
+#973 Gate 0 has since retained one bounded exact-candidate prior-prefix copy
+mechanism; required higher scopes remain active and continue to block #954.
+#955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains
 measured cost; #964 binds evidence provenance #970 → #969 → #983 → #986 plus

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -81,7 +81,8 @@ This establishes a bounded source-free geometric increment over a statistical
 lexical baseline. It does not establish semantics, broad attention, general
 coherence, correctness, reasoning, chat, performance, or release readiness.
 No second #953 formula, axis, prompt, corpus run, or representation is
-permitted. #973 is next; #954 remains blocked behind it. No new H4,
+permitted. #973 Gate 0 has retained one bounded prior-prefix copy mechanism;
+required higher scopes remain active and #954 remains blocked. No new H4,
 SpiralCore, harmonic, algebraic, placement, transport, or scale qualifier is
 eligible outside its exposed issue.
 
@@ -171,8 +172,9 @@ frozen `CorpusSignedTransportV1` feasibility contract and stopped
 codec/pair commitment and a complete same-frame lexical SpiralCore frame were
 unavailable. Placement, Gate 0, labels, table/geometric arms, and #953 were
 `NOT_RUN`. The later B0/#989 reset limited #953 to one separate matched
-table-tie intervention. That intervention has now passed; #973 is next and
-continues to block #954. Calling the later
+table-tie intervention. That intervention passed, and #973 has since retained
+one bounded prior-prefix copy mechanism at Gate 0; required higher scopes
+remain active and continue to block #954. Calling a later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive
@@ -686,7 +688,8 @@ points, +4,242 correct), held candidate support and its declared-work ledger
 equal at all teacher-forced positions and through the first decoded divergence,
 kept every structural source-closure counter at zero, emitted a distinct
 bounded valid UTF-8 continuation, and replayed table, overlay, and report bytes
-identically. This is the only accepted claim. #973 is next.
+identically. This is the only accepted #953 claim. #973 Gate 0 has since
+retained the separate bounded prior-prefix mechanism recorded below.
 
 The GI sections below preserve the completed evidence lineage and downstream
 dependency structure. They remain dormant or blocked except for the exposed
@@ -728,8 +731,9 @@ Status: **#952 A1.0 terminal negative; #967 A1R `RETAIN_STATE_ONLY`; #970 A1P
 construction-transferred candidate-conditioned local attention and stopped at
 0/6 transfer before selection and closed. #986 then closed at its pre-sealed
 population/frame unavailable terminal. B0/#989 then supplied the frozen
-reference for the accepted matched #953 intervention. #973 is now next and
-continues to block #954**.
+reference for the accepted matched #953 intervention. #973 Gate 0 has since
+retained one bounded exact-candidate prior-prefix copy mechanism; required
+higher scopes remain active and continue to block #954**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -1214,20 +1218,38 @@ record is [here](source_free_table_geometric_intervention_953.md).
 
 This result does not rehabilitate the historical #953 selector, #983, or #986,
 and does not establish semantics, broad attention, general coherence,
-correctness, reasoning, or release readiness. #973 is now next. Neither a
+correctness, reasoning, or release readiness. It is the accepted local input
+to #973. Neither a
 failed experiment nor a conditional issue number is automatically a serving
 consumer.
 
 ### GI-2 A1Q-H / #973 — paragraph, conversation, and global attention
 
-With #953 accepted at its bounded source-free geometric terminal, test
+With #953 accepted at its bounded source-free geometric terminal, #973 tests
 paragraph, conversation, and bounded global state through the real decoded
-autoregressive loop. Before #973,
-those scopes may remain serialized and incrementally updated but cannot
-influence selection. #973 blocks #954.
+autoregressive loop. #973 blocks #954.
 
-Global qualification begins with one exact-spin global operator prototype, not
-a larger channel census. Freeze a construction-independent global snapshot with
+The first frozen Gate 0 built `PriorSentenceCountRadiusR4V1` over a separate
+two-document synthetic table and #953-formula overlay. Two target-free prompts
+had the same final ` asked` / ` for` frame, exact `{ coffee, tea }` tie,
+identical local coordinates, support, and declared work. The real
+prefix-before-final-period coordinate decoded ` tea.` / ` coffee.` (2/2);
+scope-disabled decoded ` coffee.` / ` coffee.` (1/2); candidate-permuted
+decoded ` coffee.` / ` tea.` (0/2). Support/work mismatches and structural
+source/future reads were zero, and the operator/census/smoke identities replayed
+exactly. The terminal is
+`RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`; see the
+[#973 Gate 0 record](prior_sentence_count_radius_attention_973.md).
+
+This retains one bounded exact-candidate prior-prefix lexical copy-attention
+mechanism. It does not establish semantic or anti-recall transfer, general
+paragraph/conversation/global attention, coherence, correctness, or reasoning.
+The next #973 decision is an independently frozen paragraph-scope contrast
+that cannot be solved by exact recurrence of the admitted candidate, followed
+by conversation scope only if that mechanism remains load-bearing.
+
+A later bounded-global qualification may use one exact-spin global operator
+prototype, not a larger channel census. Freeze a construction-independent global snapshot with
 enough ordered state to produce a witnessed non-identity transition, at least
 two immutable references in one exact spin class, and one different
 `shared_class_kappa` intentionally occupying the same current `SpinSector`.

--- a/docs/prior_sentence_count_radius_attention_973.md
+++ b/docs/prior_sentence_count_radius_attention_973.md
@@ -1,0 +1,185 @@
+# #973 Gate 0 prior-prefix geometric-attention record
+
+- **Date:** 2026-08-28
+- **Issue:** #973
+- **Contract:** frozen on the live issue before implementation or query outcome
+- **Mechanism:** `PriorSentenceCountRadiusR4V1`
+- **Outcome:** positive on the exact two-history Gate 0 contract
+- **Terminal:**
+  `RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`
+- **Issue state after this result:** #973 remains open; #954 remains blocked
+
+## Question and accepted input
+
+The empirical question was whether one candidate-relative R4 operator could
+make state before the active sentence causally load-bearing through decoded
+output while the local #953 evidence stayed exactly matched.
+
+The operator consumes only the maximum-count tie already admitted by the
+unchanged #953 `MultiscaleCountRadiusR4V1` API. It does not alter the source-free
+table, lexical ids, active backoff row, candidate support, maximum count,
+decoder, or later #953 continuation policy. The production #989/#953 artifacts
+remain unchanged; this Gate 0 record uses a separate tiny synthetic fixture.
+
+## Frozen synthetic contrast
+
+Construction used D3-construction partition ids `14` and `657`:
+
+```text
+Nora chose tea before breakfast. Later Nora asked for tea.
+Owen chose coffee before breakfast. Later Owen asked for coffee.
+```
+
+The target-free census then used D3-held-out partition ids `12` and `13`:
+
+```text
+Mara chose tea before lunch. When the server arrived, Mara asked for
+Mara chose coffee before lunch. When the server arrived, Mara asked for
+```
+
+Only after the target-free operator bytes and census were frozen did the probe
+attach the sealed continuations ` tea.` and ` coffee.`.
+
+The prose is synthetic. The D3 hashes enforce partition separation for this
+probe, but do not supply corpus provenance, natural-distribution evidence, or
+semantic transfer.
+
+## Frozen operator
+
+For each candidate `c` in the #953 maximum-count tie, the operator uses
+
+```text
+x_H(c) = [q_3(c), q_2(c), q_1(c), q_P(c)]
+q_P(c) = floor(n_P(c) * 2^32 / T_P)
+R_H(c) = sum_i x_H(c)^2
+```
+
+The first three coordinates are copied from the bound #953 evidence. `n_P(c)`
+is the exact count of candidate token `c` in the prefix before the last fitted
+period token, excluding BOS, the period, and the active suffix. `T_P` is the
+sum across the admitted candidates. A missing boundary, zero `T_P`, or a tied
+maximum abstains to the exact #953 choice. More than 64 encoded prefix units or
+more than eight tied candidates fails closed.
+
+The artifact compiles every bounded `(n_P,T_P)` fixed-point value and square,
+plus the trigram/bigram depth squares. Query selection therefore uses exact
+token comparisons, integer counts/add/subtract/compare, and table reads; it
+does not calculate a fixed-point division or square. The artifact binds both
+the source-free table CID and the #953 overlay CID and rejects binding drift,
+noncanonical bytes, trailing bytes, tamper, and scope overflow.
+
+Three arms share the same active row, prefix scan, candidate comparisons,
+normalization reads, square reads, radius comparisons, support, and declared
+work:
+
+- **real:** use the candidate-relative prefix coordinate;
+- **scope-disabled:** perform the census but mask that coordinate and return
+  the #953 choice; and
+- **candidate-permuted:** cyclically reassign the same candidate-relative
+  contributions in canonical tied-token order.
+
+## Label-blind Gate 0 result
+
+Both prompts ended in the exact active frame ` asked` / ` for`. The active
+trigram support was exactly ` coffee` and ` tea`, each at count one. Both
+candidates had identical #953 coordinates
+
+```text
+(2^31, 2^31, 330382099, 3 * 2^30)
+```
+
+and identical #953 radius `19708817909656044393`. Both #953 arms therefore
+selected the canonical fallback ` coffee` with identical local work.
+
+Each prompt had 13 encoded prefix units and the matched census performed 26
+candidate-membership checks. The one earlier exact candidate occurrence gave
+the present candidate `q_P = 2^32` and radius `27779268441903973225`; the absent
+candidate had `q_P = 0` and radius `9332524368194421609`. The transformed
+candidate-relative state classes were distinct, each had one unique winner,
+and no retained class required incompatible selections.
+
+| Target-free prompt state | Real | Scope disabled | Candidate permuted |
+| --- | --- | --- | --- |
+| earlier `tea` | ` tea` | ` coffee` | ` coffee` |
+| earlier `coffee` | ` coffee` | ` coffee` | ` tea` |
+
+Support mismatches and declared-work mismatches were both zero. Structural
+teacher, provider, source-weight, and future-unit read counters were all zero.
+
+## Decoded causal consequence
+
+After the label-blind census was frozen, the same bound operator ran exactly
+two histories by three arms. The first selected unit came from #973; subsequent
+units returned to unchanged #953 selection. A three-attempt bound allowed the
+two visible units to append and then observe EOS.
+
+| Arm | Earlier `tea` | Earlier `coffee` | Exact sealed continuations |
+| --- | --- | --- | ---: |
+| Real | ` tea.` | ` coffee.` | 2/2 |
+| Scope disabled | ` coffee.` | ` coffee.` | 1/2 |
+| Candidate permuted | ` coffee.` | ` tea.` | 0/2 |
+
+All six continuations emitted two lexical units, observed EOS, and avoided a
+period-one or period-two cycle. The focal `tea` candidate and decoded output
+changed only when the real higher-scope coordinate was active. This is the
+load-bearing causal result; a changed trace alone would not have qualified.
+
+Support/work equality is claimed at the shared first decision only. Once arms
+choose different first units, their later contexts differ and no cross-arm
+support/work equality is inferred.
+
+## Canonical artifacts and replay
+
+| Item | Result |
+| --- | --- |
+| Tiny synthetic source-free table CID | `blake3:60a9d2cc2f6da53f1a2f47d64531f41b03c4654d347ca9640820256ae962146e` |
+| Tiny #953 overlay CID | `blake3:d513a15e4d7f3438d728ca438f1031e935f144f7b13875c2ec147accd5e4ba58` |
+| #973 operator bytes | 60,688 |
+| #973 operator CID | `blake3:556e0ea2e08958ca0671b531bdc1a743e32a4a362767dac778210c6b2da9a38b` |
+| Target-free census CID | `blake3:c70d4f333ded6b247bb97ddccb3b5895078cb293eff9567cc53428db5a1b568d` |
+| Decoded-smoke CID | `blake3:804d52e9beffd240046d98783cc7f1c506a2b27d70aecab8b33898e806f7ce4f` |
+
+The operator recompiled and reloaded byte identically. Both matched
+continuations and the complete decoded-smoke report replayed byte identically.
+The CIDs above identify deterministic in-memory probe artifacts reconstructed
+by the focused test; no generated binary fixture is checked into the repository.
+
+## Decision and claim boundary
+
+The frozen positive terminal is
+`RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`.
+
+This establishes one bounded exact-candidate prior-prefix geometric
+attention/copy mechanism whose state changes an already-admitted candidate and
+the decoded output under matched controls. It is the first #973 mechanism, not
+pre-attention scaffolding.
+
+It does not establish semantic placement, paraphrastic or anti-recall transfer,
+general sentence/paragraph/conversation/global attention, broad coherence,
+correctness, reasoning, performance, allocation-free serving, chat readiness,
+formal closure, or release readiness. Exact earlier-candidate recurrence is the
+operative signal, so calling this semantic attention would be false.
+
+#973 remains open. The next decision-bearing #973 action is one independently
+frozen paragraph-scope contrast that cannot be solved by exact recurrence of
+the admitted candidate, followed by conversation and bounded-global scope only
+if each preceding mechanism remains load-bearing. Corpus scale remains dormant.
+#954 stays blocked until #973 reaches its full native terminal.
+
+## Activated checks
+
+- focused #973 Gate 0, binding/tamper/abstention, and exact-support tests: 3/3 PASS;
+- touched `uor-r4-core` compilation: PASS;
+- touched core lint after suppressing only pre-existing origin-main lint
+  families: PASS;
+- operator/census/decoded-smoke exact replay: PASS; and
+- touched Rust formatting and diff whitespace: PASS.
+
+Unmodified strict core/dependency clippy was exercised but is `UNAVAILABLE` as
+a change-specific verdict because current `origin/main` already violates the
+new toolchain's warnings in untouched graph-runtime, model-source,
+prime-route, recursive-attention, and SpiralCore code. Workspace-wide tests,
+wasm, BDD, teacher/model paths, no-std ladders, Gate C, kappa reproduction,
+audit, fuzz, conformance, corpus-scale, product, performance, formal, and
+release qualification are `NOT_RUN` unless a later activated check is
+explicitly recorded here.


### PR DESCRIPTION
## What changed

- adds the construction-bound `PriorSentenceCountRadiusR4V1` operator over #953's existing maximum-count tie;
- makes exact candidate occupancy before the final fitted period the fourth R4 coordinate, with all fixed-point values and squares compiled into a canonical bound artifact;
- runs real, scope-disabled, and deterministic candidate-permuted controls over identical support and declared work;
- adds explicit abstention, fail-closed bounds, binding/tamper rejection, and a bounded continuation that returns to unchanged #953 selection after the first decision; and
- records and reconciles the frozen #973 Gate 0 result.

## Frozen result

Two synthetic D3-partitioned prompts had the same final ` asked` / ` for` frame, exact `{ coffee, tea }` max-count tie, identical #953 local coordinates, support, and declared work.

| Arm | Earlier `tea` | Earlier `coffee` | Exact targets |
| --- | --- | --- | ---: |
| real | ` tea.` | ` coffee.` | 2/2 |
| scope-disabled | ` coffee.` | ` coffee.` | 1/2 |
| candidate-permuted | ` coffee.` | ` tea.` | 0/2 |

Support/work mismatches and teacher/provider/source-weight/future-unit reads were zero. Operator, target-free census, and decoded-smoke identities replayed exactly. Terminal:

`RETAIN_GATE0_PRIOR_SENTENCE_ATTENTION_CONTINUE_PARAGRAPH_CONVERSATION`

This establishes one bounded exact-candidate prior-prefix lexical copy-attention mechanism through decoded output. It does not establish semantic transfer, natural-distribution generalization, general paragraph/conversation/global attention, coherence, correctness, reasoning, chat, performance, formal closure, or release readiness. #973 remains open and #954 remains blocked.

## Activated checks

- `cargo test -p uor-r4-core --offline --test prior_sentence_count_radius_attention_973 -- --nocapture` — 3/3 PASS
- `cargo check -p uor-r4-core --offline` — PASS
- targeted changed-core clippy after suppressing only pre-existing origin-main lint families — PASS
- `cargo fmt --all -- --check` — PASS
- `python3 scripts/check_claim_wording.py` — PASS
- `git diff --check` — PASS

Unmodified strict core/dependency clippy was exercised but current `origin/main` already triggers the pinned toolchain's warnings in untouched files, so it supplies no change-specific verdict. Broad QA and corpus-scale work remain `NOT_RUN`; PR/merge checks are the repository's documented transport acknowledgements.

References #973
