### PR TITLE
feat(core): record bounded-global exact-spin relation gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,19 @@ decoded-smoke identities are respectively
 `blake3:343c961b06605f6ae9bb6160ac34a98224991715b706156349a8fd544b6dbb35`,
 `blake3:649d733a194469aa648101a873d9e2ee323266b18872ced412d1da2cc6a56635`,
 and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
-#973 remains active for one independently frozen bounded-global contrast, then
-corpus induction; #954 remains blocked.
+The independently frozen bounded-global exact-spin contrast then stopped
+target-free at
+`RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
+Its detached carriers retained four references, three classes, one same-address
+reuse, distinct epochs/roots, one common lower artifact, and equal support/work,
+but `Pavel`/`helix` share one H4 root and `prism` is identity, so both swapped
+orders finish at the identical complete `-1`/fiber/torsion state. Real roles
+were `helix/helix`; permuted roles were `prism/prism`. Target loads were zero
+and decoded execution is `NOT_RUN`. Operator and census identities are
+`blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
+and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
+#973 remains active for a newly frozen noncommuting relation/population repair;
+corpus induction is not authorized, and #954 remains blocked.
 Do not add a second #953 intervention or reuse the #983/#986 populations. The
 complete #973 Gate 0 record is
 [`docs/prior_sentence_count_radius_attention_973.md`](docs/prior_sentence_count_radius_attention_973.md).
@@ -100,13 +111,15 @@ The complete paragraph record is
 [`docs/paragraph_entity_spin_path_attention_973.md`](docs/paragraph_entity_spin_path_attention_973.md).
 The complete conversation record is
 [`docs/conversation_entity_spin_path_attention_973.md`](docs/conversation_entity_spin_path_attention_973.md).
+The complete bounded-global target-free negative record is
+[`docs/bounded_global_exact_spin_attention_973.md`](docs/bounded_global_exact_spin_attention_973.md).
 The complete #986 result and nonclaim boundary is
 [`docs/corpus_signed_transport_attention_986.md`](docs/corpus_signed_transport_attention_986.md).
 Terminology lives in
 `docs/transformerless/GLOSSARY.md`. Keep this file current when conventions
 change.
 
-## Capability-first baseline and geometric increment — #989/#953 established; #973 Gate 0, paragraph, and conversation retained
+## Capability-first baseline and geometric increment — #989/#953 established; #973 local/paragraph/conversation retained, first global relation negative
 
 Effective 2026-08-28, #989 established the deterministic source-free
 table-native lexical baseline at
@@ -142,8 +155,9 @@ Its independently frozen conversation slice then retained one construction-
 bound exact-descriptor cross-turn entity-role stored-spin path selector while
 all lower scopes and global state stayed fixed. These are not semantic,
 paraphrastic, natural-distribution, or general higher-scope evidence. One
-independently frozen bounded-global contrast is now next; corpus work remains
-subsequent. New H4, SpiralCore, harmonic, algebraic,
+independently frozen bounded-global exact-spin contrast then failed target-free
+because its swapped states commute. A new noncommuting relation/population
+repair is next; corpus work remains unauthorized. New H4, SpiralCore, harmonic, algebraic,
 placement, transport, scale, and later-stage work remains dormant unless its
 issue is exposed. See the
 [#989 evidence record](docs/source_free_table_baseline_989.md) and
@@ -151,7 +165,8 @@ issue is exposed. See the
 then the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md)
 and [#973 paragraph record](docs/paragraph_entity_spin_path_attention_973.md),
 then the
-[#973 conversation record](docs/conversation_entity_spin_path_attention_973.md).
+[#973 conversation record](docs/conversation_entity_spin_path_attention_973.md)
+and [#973 bounded-global negative record](docs/bounded_global_exact_spin_attention_973.md).
 
 ## What this repo is
 
@@ -386,7 +401,8 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   prior-prefix copy-attention mechanism, the frozen paragraph slice retained
   one exact-descriptor/entity-binding stored-phase path selector, and the
   frozen conversation slice retained one exact-descriptor cross-turn entity-
-  role stored-spin path selector. Bounded-global and corpus qualifications
+  role stored-spin path selector. The first bounded-global relation failed
+  target-free; a fresh relation/population repair and later corpus qualification
   remain active in that order, and #954 remains blocked behind #973.
   #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
@@ -394,7 +410,8 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
 - Sequence strictly from the current reset: working source-free table baseline
   (#989, established) → one matched geometric intervention (#953, accepted) →
   higher-scope attention (#973, Gate 0 plus bounded paragraph and conversation
-  slices retained; bounded-global then corpus qualification active) →
+  slices retained; first bounded-global relation negative, fresh repair then
+  corpus qualification active) →
   correctness/abstention → reasoning → optimization/purity/release. The older placement/transport
   sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic
@@ -418,14 +435,14 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   descriptor/entity-binding stored-phase path selector, and its conversation
   slice adds only one construction-bound exact-descriptor cross-turn entity-
   role stored-spin path selector. They do not qualify a general entity,
-  paragraph, or conversation model. Only the remaining #973 subprobes may
-  qualify bounded-global state.
+  paragraph, or conversation model. The first global exact-spin relation failed
+  target-free; only a newly frozen #973 repair may qualify bounded-global state.
 - Keep **candidate admission** separate from **harmonic influence**. In #953,
   `PrimaryThenAdjacentSpinFallbackV1` uses I1/I2/ordered-sentence plus divisor
   as the primary admission tier. Adjacent-spin rows are always consulted and
   report physical presence truthfully, but admit candidates only when that tier
   is empty. Do not delete or disguise a physical adjacent-spin hit.
-  #973 may later apply one global-epoch/operator-bound result to every immutable
+  A newly frozen #973 repair may apply one global-epoch/operator-bound result to every immutable
   reference in the same exact signed-S3/Hopf/fiber/torsion class. Similar but
   non-identical states require a separately frozen finite relative-angular
   kernel built independently over exact classes. The existing adjacent-spin
@@ -459,7 +476,9 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   witnesses. The retained paragraph selector emits its exact two-fact binding,
   stored-phase path, and matched-work witnesses. The retained conversation
   selector emits its cross-turn binding, lower/global-scope isolation, stored-
-  spin path, and matched-work witnesses; later hierarchy selections must emit
+  spin path, and matched-work witnesses. The first global relation emitted its
+  detached-carrier/exact-class census and commuting-fold negative; later
+  hierarchy selections must emit
   their corresponding scope coverage witness. Exact recall,
   grammatical generation,
   correctness, and reasoning remain separate gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,11 +98,13 @@ The experiment must be able to change the next programme decision:
   held-out table top-1 versus 24,163/446,342 (5.413561%) unigram, a
   +16.847843-point uplift, with bounded exact decoding and byte-identical full
   replay. This is statistical lexical prediction, not semantics, attention,
-  geometry, correctness, reasoning, chat, or release evidence. Exactly one
-  later #953 intervention may use the frozen corpus, support, decode, table
-  artifact, and work budget; #973 remains blocked. Do not start another H4,
-  SpiralCore, harmonic, algebraic, placement, transport, higher-scope, or scale
-  probe. See the [#989 record](docs/source_free_table_baseline_989.md).
+  geometry, correctness, reasoning, chat, or release evidence. The one
+  permitted #953 intervention has since been accepted over this unchanged
+  reference. #973 retained bounded prior-prefix, paragraph, and conversation
+  mechanisms, then rejected its first bounded-global exact-spin relation at a
+  target-free commuting-fold gate. Do not start corpus/scale work until a
+  newly frozen noncommuting #973 repair qualifies. See the
+  [#989 record](docs/source_free_table_baseline_989.md).
 - **Preserve the GI evidence lineage.** GI-1 makes lexical/address state
   reversible;
   #952 found the reusable ordered-state defect; A1R/#967 repaired the fold but
@@ -137,16 +139,23 @@ The experiment must be able to change the next programme decision:
   corpus-scale codec/pair commitment and complete same-frame lexical
   Cl(0,6)/SpiralCore operator map were unavailable. Gate 0, labels, selection,
   and #953 were `NOT_RUN`. That pre-reset handoff left #953 parked pending a
-  fresh successor; the established B0/#989 result above supersedes that action.
-  A1Q-H/#973 and GI-4/#954 remain blocked, with GI-5/#955 downstream.
-- **Exercise the real route path only when reactivated.** When a later #953
-  issue activates the one matched intervention, geometry must
-  run before token choice and emit its admitted support and energy trace. Add a
-  global-context coverage witness only when #973 is eligible and active.
+  fresh successor; B0/#989 and the later accepted matched #953 intervention
+  supersede that action. A1Q-H/#973 is active: Gate 0, paragraph, and
+  conversation are retained, while its first bounded-global relation is
+  target-free negative at
+  `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
+  #973 now owns one newly frozen noncommuting relation/population repair; GI-4/
+  #954 remains blocked, with GI-5/#955 downstream.
+- **Exercise the accepted route path.** #953 geometry runs before token choice
+  and emits admitted support and its fixed-point radius trace. A #973 global
+  repair must additionally emit detached lower/snapshot bindings, exact class
+  reuse, complete fold steps, and the target-free incompatibility gate before
+  any decoded target join.
 - **Use the smallest falsifier.** #989 began with its bounded natural lexical
-  fixture before the declared real corpus run. The one permitted #953
-  intervention must begin with its own bounded matched falsifier before any
-  broader data or mechanism work.
+  fixture before the declared real corpus run. #973's first global relation
+  correctly stopped on its two-case target-free commuting-fold falsifier. Its
+  repair must prove a distinct noncommuting exact relation before any broader
+  data, decoded target, neighbor operator, or corpus mechanism is activated.
 - **Parallelize deterministic corpus work.** Partition by content identity,
   use all available local workers with canonical ordered reductions, and
   compare independent multithreaded rebuilds. Do not launch a long experiment

--- a/README.md
+++ b/README.md
@@ -14,7 +14,25 @@ local hardware. The project is testing whether language context, inference,
 and reasoning can emerge from routes through a canonical geometric memory. The
 target serving engine uses no Ollama, hosted model, or source-model weights.
 
-> **Current bounded attention result (2026-08-28):** #973 retains three narrow
+> **Current bounded-global result (2026-08-28):** #973's independently frozen
+> exact-spin contrast stopped at the target-free relation gate with
+> `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
+> Both same-multiset snapshot carriers had distinct canonical epochs/roots,
+> four references, three exact classes, and one byte-identical same-address
+> class-result reuse, while sharing one byte-identical lower artifact and equal
+> admitted support/work. But `Pavel` and `helix` map to the same H4 root and
+> `prism` maps to identity, so both frozen orders produce the same complete
+> `-1` fold, fiber, torsion, real `helix` role, and permuted `prism` role. The
+> frozen incompatible-winner premise was false. Target loads were zero and the
+> decoded smoke is `NOT_RUN`. Operator and target-free census identities are
+> `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
+> and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
+> This rejects one frozen global relation, not geometry generally. #973 remains
+> open for a newly frozen noncommuting relation/population repair before corpus
+> induction; #954 remains blocked. See the
+> [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
+
+> **Current retained bounded attention result (2026-08-28):** #973 retains three narrow
 > mechanisms: Gate 0's exact-candidate prior-prefix copy mechanism, one
 > construction-bound exact-descriptor paragraph path selector, and now
 > `ConversationEntitySpinPathR4V1` at
@@ -37,8 +55,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `blake3:343c961b06605f6ae9bb6160ac34a98224991715b706156349a8fd544b6dbb35`,
 > `blake3:649d733a194469aa648101a873d9e2ee323266b18872ced412d1da2cc6a56635`,
 > and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
-> #973 stays open for one independently frozen bounded-global contrast, then
-> corpus induction; #954 remains blocked. See the
+> The subsequent independently frozen bounded-global contrast failed its
+> target-free relation gate. #973 stays open for a fresh bounded-global repair
+> before corpus induction; #954 remains blocked. See the
 > [conversation record](docs/conversation_entity_spin_path_attention_973.md).
 
 > **Current capability-first result (2026-08-28):** #953's frozen
@@ -83,8 +102,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > frozen paragraph slice retained one construction-bound exact-descriptor/
 > entity-binding stored-phase path selector, and its frozen conversation slice
 > retained one construction-bound exact-descriptor cross-turn entity-role path
-> selector, each with the narrow boundary above. Independent bounded-global,
-> then corpus qualification, remain.
+> selector, each with the narrow boundary above. The first independent bounded-
+> global exact-spin relation failed target-free because its swapped states
+> commute; a fresh relation/population repair, then corpus qualification,
+> remain.
 > #954 remains blocked behind #973. General higher-scope attention, correct
 > answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
@@ -286,13 +307,15 @@ accepted a separate fixed-point R4 table-tie intervention and closed #953 at
 its positive terminal. #973 Gate 0 has since retained one bounded prior-prefix
 copy mechanism. Its frozen paragraph and conversation slices retained one
 exact-descriptor/entity-binding path selector apiece at their respective
-scopes; bounded-global and corpus qualification remain active and #954 remains
-blocked.
+   scopes; the first bounded-global exact-spin relation failed target-free, so
+   a newly frozen noncommuting relation/population repair and corpus
+   qualification remain active while #954 stays blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
 See the [#973 paragraph record](docs/paragraph_entity_spin_path_attention_973.md).
 See the [#973 conversation record](docs/conversation_entity_spin_path_attention_973.md).
+See the [#973 bounded-global negative record](docs/bounded_global_exact_spin_attention_973.md).
 See the [#986 evidence record](docs/corpus_signed_transport_attention_986.md)
 for the exact feasibility boundary and deliberately unrun stages.
 Stored H4/Hopf/zeta/icosian and related route fields remain
@@ -376,11 +399,13 @@ not become substitutes for working intelligence:
    top-1, +4,242 correct choices over the unchanged table, a distinct bounded
    continuation, matched support and declared-work ledger, and byte-identical
    replay.
-3. **Continue higher-scope attention (#973)** — retain the positive Gate 0
+3. **Repair higher-scope attention (#973)** — retain the positive Gate 0
    exact-candidate prior-prefix mechanism and the bounded construction-bound
-   paragraph and conversation selectors. Run one independently frozen bounded-
-   global contrast next, followed only then by corpus induction. Historical
-   placement and transport probes remain evidence, not current work.
+   paragraph and conversation selectors. Preserve the first bounded-global
+   exact-spin contrast as a target-free negative: its frozen swapped states
+   commute. Freeze a noncommuting relation/population repair next; only a
+   positive bounded-global requalification may authorize corpus induction.
+   Historical placement and transport probes remain evidence, not current work.
 4. **Establish correctness** — relevance, contradiction handling, and honest
    abstention.
 5. **Establish reasoning** — bounded multi-step route composition.
@@ -396,8 +421,9 @@ The active dependency chain is tracked in
 the frozen table reference, #953 established one matched R4 tie intervention
 over it, and #973 retained one bounded prior-prefix copy mechanism plus bounded
 exact-descriptor/entity-binding path selectors at paragraph and conversation
-scope. Bounded-global and corpus work remain active; #954 remains blocked
-behind #973.
+scope. The first bounded-global relation is closed-negative within the still-open
+#973 track; its fresh repair and later corpus work remain active. #954 remains
+blocked behind #973.
 
 ## Find your way around
 

--- a/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
+++ b/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
@@ -1,0 +1,2027 @@
+//! Frozen bounded-global exact stored-spin contrast for issue #973.
+//!
+//! This operator owns no candidate admission. It ranks only the exact
+//! maximum-count tie exposed by the bound #953 overlay. An independently
+//! supplied immutable global snapshot is folded in stored-S3/H4, fiber, and
+//! torsion state; one query-specific result is evaluated per exact snapshot
+//! class and reused across repeated immutable references.
+
+use serde::Serialize;
+
+use crate::canonical_lexical_ingestion::{
+    canonical_global_epoch, shared_class_kappa, validate_h4_binary_icosahedral_closure,
+    AttentionHierarchyView, AttentionOrderedFoldLevel, CanonicalLexicalCodec,
+    CanonicalLexicalError, CanonicalRouteArtifact, ConversationInput, GlobalExactSpinSnapshotEntry,
+    GlobalExactSpinSnapshotView, H4BinaryIcosahedralClosure, H4RootCoordinate, OpaqueH4TableIndex,
+    OrderedH4FoldState, ParagraphInput, SpinTorsionStateTrace, TurnInput,
+};
+use crate::prime_route_attention::GeometricAddress;
+use crate::prime_route_geometric_attention::H4S3AngularShell;
+use crate::source_free_table::{
+    d3_is_held_out, BackoffOrder, Continuation, ContinuationStop, MatchedGeometricPrediction,
+    MultiscaleCountRadiusR4V1, MultiscaleCountRadiusWork, SourceDocument, SourceFreeTable,
+    SourceFreeTableError, BOS_TOKEN, EOS_TOKEN, MAX_CONTINUATION_UNITS,
+};
+
+const OPERATOR_MAGIC: [u8; 8] = *b"BGESP001";
+const OPERATOR_SCHEMA: u32 = 1;
+const OPERATOR_DOMAIN: &str = "uor-r4.bounded-global-exact-spin-left-fold/1";
+const SPIN_MAP_DOMAIN: &str = "uor-r4.canonical-s3-spin-to-h4/1";
+const SPIN_MAP_RULE_IDENTITY: &str = "exact-s3-q30-components-divisible-by-2^29; arithmetic-right-shift-29-to-scaled-zphi-rational-coefficients; phi-coefficients-zero; unique-coordinate-membership-in-canonical-120-root-h4-table; reject-nonmultiple-nonmember-and-alias; no-prime-hash-candidate-or-nearest-root-placement";
+const GRAMMAR_IDENTITY_BYTES: &[u8] = b"uor-r4 bounded global exact spin grammar/1\nconstruction=<ENTITY> bound the <ANCHOR> class.\\n\\nThe bounded global code is <CANDIDATE>.\nactive-query=The bounded global code is\nprototype-bindings=bronze->helix,teal->prism\nevaluation-snapshots=Pavel,Pavel,helix,prism|Pavel,Pavel,prism,helix\nevaluation-snapshots-are-not-fitting-inputs=true";
+const ROUTING_POLICY_IDENTITY: &str = "uor-r4 bounded global exact spin routing policy/1\nmap=exact-stored-s3-to-canonical-h4-membership; q30-to-h4-shift=29; phi-coefficients=0\nfold=left-to-right exact H4 product with wrapped Q29 fiber/torsion addition\nphase-law=canonical interval [-1686629713,1686629713) with modulus 3373259426\nclass-result=C^-1*G with the same wrapped phase law\ncache-key=global-root,global-epoch,operator,map,chart,root-and-product-inverse-table,exact-class\ncost=lexicographic(h4-s3-angular-shell,fiber-circular-abs-q29,torsion-circular-abs-q29)\nselection=unique-minimum-or-abstain\ncontrols=real,identity-disabled,class-operator-permuted\nidentity-disabled=compute-all-then-return-bound-953-fallback\nclass-operator-permuted=swap-two-prototype-class-results\nscore-firewall=no-token-id,payload,address,prime,digest,ordinal,spin-sector,adjacent-row-or-target-numeric-input";
+const CONSTRUCTION_IDENTITY_SCOPE: &str = "issue-973/bounded-global-exact-spin-construction-v1";
+const HELD_OUT_IDENTITY_SCOPE: &str = "issue-973/bounded-global-exact-spin-heldout-v1";
+const ACTIVE_TURN_ID: &str = "active-turn-0001";
+const ACTIVE_QUERY_BYTES: &[u8] = b"The bounded global code is";
+const CONSTRUCTION_GLOBAL_UNIT: &[u8] = b"global";
+const FROZEN_CONSTRUCTION: [(&str, &[u8]); 2] = [
+    (
+        "51",
+        b"Lena bound the helix class.\n\nThe bounded global code is bronze.",
+    ),
+    (
+        "52",
+        b"Pavel bound the prism class.\n\nThe bounded global code is teal.",
+    ),
+];
+const LEFT_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"helix", b"prism"];
+const RIGHT_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"prism", b"helix"];
+const PROTOTYPE_BINDINGS: [(&[u8], &[u8]); 2] = [(b"bronze", b"helix"), (b"teal", b"prism")];
+const PHASE_HALF_Q29: i64 = 1_686_629_713;
+const PHASE_MODULUS_Q29: i64 = 3_373_259_426;
+const Q29_H4_SCALE_SHIFT: u32 = 29;
+const Q29_H4_SCALE_MASK: i32 = (1_i32 << Q29_H4_SCALE_SHIFT) - 1;
+const TORSION_BINS: i64 = 8;
+
+pub const BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES: usize = 2;
+pub const BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES: usize = 4;
+pub const BOUNDED_GLOBAL_EXACT_SPIN_CLASSES: usize = 3;
+pub const BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS: u64 = 1;
+pub const MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES: usize = 1024 * 1024;
+pub const MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES: usize = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundedGlobalExactSpinError {
+    Invalid(String),
+    SourceFree(String),
+    CanonicalLexical(String),
+    Serialization(String),
+    ArithmeticOverflow,
+}
+
+impl std::fmt::Display for BoundedGlobalExactSpinError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(reason) => formatter.write_str(reason),
+            Self::SourceFree(reason) => write!(formatter, "source-free table: {reason}"),
+            Self::CanonicalLexical(reason) => write!(formatter, "canonical lexical: {reason}"),
+            Self::Serialization(reason) => write!(formatter, "serialization: {reason}"),
+            Self::ArithmeticOverflow => {
+                formatter.write_str("bounded-global exact-spin arithmetic overflow")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BoundedGlobalExactSpinError {}
+
+impl From<SourceFreeTableError> for BoundedGlobalExactSpinError {
+    fn from(error: SourceFreeTableError) -> Self {
+        Self::SourceFree(error.to_string())
+    }
+}
+
+impl From<CanonicalLexicalError> for BoundedGlobalExactSpinError {
+    fn from(error: CanonicalLexicalError) -> Self {
+        Self::CanonicalLexical(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundedGlobalExactSpinArm {
+    Real,
+    IdentityDisabled,
+    ClassOperatorPermuted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundedGlobalExactSpinAbstention {
+    CostTie,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct BoundedGlobalExactSpinCost {
+    pub angular_shell: H4S3AngularShell,
+    pub fiber_distance_q29: u64,
+    pub torsion_distance_q29: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinStateTrace {
+    pub h4_coordinate: H4RootCoordinate,
+    pub fiber_q29: i64,
+    pub torsion_q29: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalSpinSectorTrace {
+    pub hopf_octant: u8,
+    pub torsion_bin: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinPrototypeTrace {
+    pub candidate_token: u32,
+    pub candidate_hex: String,
+    pub anchor_hex: String,
+    pub anchor_lexical_unit_id: u32,
+    pub anchor_address_kappa: String,
+    pub anchor_payload_cid: String,
+    pub anchor_spin: SpinTorsionStateTrace,
+    pub anchor_class_kappa: String,
+    pub anchor_state: BoundedGlobalExactSpinStateTrace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinSnapshotEntryTrace {
+    pub ordinal: u16,
+    pub entry_kappa: String,
+    pub lexical_unit_id: u32,
+    pub address_index: u16,
+    pub address_kappa: String,
+    pub payload_cid: String,
+    pub payload_hex: String,
+    pub spin: SpinTorsionStateTrace,
+    pub shared_class_kappa: String,
+    pub mapped_state: BoundedGlobalExactSpinStateTrace,
+    pub diagnostic_sector: BoundedGlobalSpinSectorTrace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinFoldStepTrace {
+    pub ordinal: u16,
+    pub entry_kappa: String,
+    pub before: BoundedGlobalExactSpinStateTrace,
+    pub entry: BoundedGlobalExactSpinStateTrace,
+    pub after: BoundedGlobalExactSpinStateTrace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinClassEvaluationTrace {
+    pub shared_class_kappa: String,
+    pub reference_entry_kappas: Vec<String>,
+    pub reference_count: u64,
+    pub evaluation_count: u64,
+    pub reuse_count: u64,
+    pub class_state: BoundedGlobalExactSpinStateTrace,
+    pub relative_result: BoundedGlobalExactSpinStateTrace,
+    pub cost: BoundedGlobalExactSpinCost,
+    pub result_cid: String,
+    pub cold_result_cid: String,
+    pub cold_recomputation_equal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinCandidateEvidence {
+    pub token: u32,
+    pub count: u64,
+    pub candidate_hex: String,
+    pub prototype_anchor_hex: String,
+    pub prototype_class_kappa: String,
+    pub base_coordinates: crate::source_free_table::MultiscaleCountRadiusCoordinates,
+    pub base_radius: u128,
+    pub real_class_result_cid: String,
+    pub real_relative_state: BoundedGlobalExactSpinStateTrace,
+    pub real_measured_cost: BoundedGlobalExactSpinCost,
+    pub real_ranking_cost: Option<BoundedGlobalExactSpinCost>,
+    pub identity_disabled_measured_cost: BoundedGlobalExactSpinCost,
+    pub identity_disabled_ranking_cost: Option<BoundedGlobalExactSpinCost>,
+    pub permuted_class_result_cid: String,
+    pub permuted_relative_state: BoundedGlobalExactSpinStateTrace,
+    pub permuted_measured_cost: BoundedGlobalExactSpinCost,
+    pub permuted_ranking_cost: Option<BoundedGlobalExactSpinCost>,
+    pub candidate_state_kappa: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinWork {
+    pub local: MultiscaleCountRadiusWork,
+    pub snapshot_entry_reads: u64,
+    pub exact_class_comparisons: u64,
+    pub unique_class_evaluations: u64,
+    pub class_reuse_hits: u64,
+    pub class_result_applications: u64,
+    pub h4_product_table_reads: u64,
+    pub h4_inverse_table_reads: u64,
+    pub phase_additions: u64,
+    pub phase_distance_reads: u64,
+    pub angular_shell_reads: u64,
+    pub candidate_class_lookups: u64,
+    pub cost_comparisons: u64,
+    pub final_choice_operations: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub struct BoundedGlobalExactSpinForbiddenReads {
+    pub target_reads: u64,
+    pub future_unit_reads: u64,
+    pub teacher_calls: u64,
+    pub provider_calls: u64,
+    pub corpus_reads: u64,
+    pub partition_id_reads: u64,
+    pub full_history_key_reads: u64,
+    pub candidate_identity_score_reads: u64,
+    pub payload_score_reads: u64,
+    pub address_score_reads: u64,
+    pub prime_score_reads: u64,
+    pub digest_score_reads: u64,
+    pub class_kappa_score_reads: u64,
+    pub ordinal_score_reads: u64,
+    pub spin_sector_score_reads: u64,
+    pub adjacent_row_score_reads: u64,
+    pub construction_identity_score_reads: u64,
+    pub prompt_identity_score_reads: u64,
+    pub table_identity_score_reads: u64,
+    pub base_evidence_score_reads: u64,
+    pub lower_state_score_reads: u64,
+    pub declared_work_score_reads: u64,
+    pub global_summary_score_reads: u64,
+    pub hierarchy_h4_score_reads: u64,
+}
+
+impl BoundedGlobalExactSpinForbiddenReads {
+    pub fn total(self) -> u64 {
+        self.target_reads
+            + self.future_unit_reads
+            + self.teacher_calls
+            + self.provider_calls
+            + self.corpus_reads
+            + self.partition_id_reads
+            + self.full_history_key_reads
+            + self.candidate_identity_score_reads
+            + self.payload_score_reads
+            + self.address_score_reads
+            + self.prime_score_reads
+            + self.digest_score_reads
+            + self.class_kappa_score_reads
+            + self.ordinal_score_reads
+            + self.spin_sector_score_reads
+            + self.adjacent_row_score_reads
+            + self.construction_identity_score_reads
+            + self.prompt_identity_score_reads
+            + self.table_identity_score_reads
+            + self.base_evidence_score_reads
+            + self.lower_state_score_reads
+            + self.declared_work_score_reads
+            + self.global_summary_score_reads
+            + self.hierarchy_h4_score_reads
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinDecision {
+    pub arm: BoundedGlobalExactSpinArm,
+    pub token: u32,
+    pub unique_minimum: Option<u32>,
+    pub minimum_cost: Option<BoundedGlobalExactSpinCost>,
+    pub support_tokens: Vec<u32>,
+    pub work: BoundedGlobalExactSpinWork,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedBoundedGlobalExactSpinPrediction {
+    pub local: MatchedGeometricPrediction,
+    pub base_lower_artifact_manifest_kappa: String,
+    pub source_snapshot_artifact_manifest_kappa: String,
+    pub global_epoch: String,
+    pub global_snapshot_kappa: String,
+    pub global_root_kappa: String,
+    pub operator_cid: String,
+    pub spin_map_kappa: String,
+    pub chart_profile_kappa: String,
+    pub h4_root_table_kappa: String,
+    pub h4_multiplication_table_kappa: String,
+    pub snapshot_entries: Vec<BoundedGlobalExactSpinSnapshotEntryTrace>,
+    pub fold_steps: Vec<BoundedGlobalExactSpinFoldStepTrace>,
+    pub global_result: BoundedGlobalExactSpinStateTrace,
+    pub class_evaluations: Vec<BoundedGlobalExactSpinClassEvaluationTrace>,
+    pub candidate_evidence: Vec<BoundedGlobalExactSpinCandidateEvidence>,
+    pub real: BoundedGlobalExactSpinDecision,
+    pub identity_disabled: BoundedGlobalExactSpinDecision,
+    pub class_operator_permuted: BoundedGlobalExactSpinDecision,
+    pub support_reversed_real_token: u32,
+    pub support_reversal_invariant: bool,
+    pub coherent_relabel_equivariant: bool,
+    pub support_matched: bool,
+    pub work_matched: bool,
+    pub operator_abstention: Option<BoundedGlobalExactSpinAbstention>,
+    pub forbidden_reads: BoundedGlobalExactSpinForbiddenReads,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedBoundedGlobalExactSpinContinuation {
+    pub first_decision: MatchedBoundedGlobalExactSpinPrediction,
+    pub real: Continuation,
+    pub identity_disabled: Continuation,
+    pub class_operator_permuted: Continuation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinHierarchyLevelAudit {
+    pub level: String,
+    pub left_identity_kappa: String,
+    pub right_identity_kappa: String,
+    pub identity_equal: bool,
+    pub left_state: OrderedH4FoldState,
+    pub right_state: OrderedH4FoldState,
+    pub ordered_state_equal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalExactSpinHierarchyAudit {
+    pub levels: Vec<BoundedGlobalExactSpinHierarchyLevelAudit>,
+    pub lower_through_conversation_identity_equal: bool,
+    pub lower_through_conversation_ordered_state_equal: bool,
+    pub global_identity_distinct: bool,
+    pub global_ordered_state_distinct: bool,
+    pub left_global_snapshot_kappa: String,
+    pub right_global_snapshot_kappa: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExactSpinState {
+    h4: OrderedH4FoldState,
+    fiber_q29: i64,
+    torsion_q29: i64,
+}
+
+impl ExactSpinState {
+    fn identity(table: &H4BinaryIcosahedralClosure) -> Result<Self, BoundedGlobalExactSpinError> {
+        Ok(Self {
+            h4: OrderedH4FoldState::identity(table)?,
+            fiber_q29: 0,
+            torsion_q29: 0,
+        })
+    }
+
+    fn compose(
+        self,
+        right: Self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        Ok(Self {
+            h4: self.h4.compose(right.h4, table)?,
+            fiber_q29: wrap_phase_q29(
+                self.fiber_q29
+                    .checked_add(right.fiber_q29)
+                    .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            ),
+            torsion_q29: wrap_phase_q29(
+                self.torsion_q29
+                    .checked_add(right.torsion_q29)
+                    .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            ),
+        })
+    }
+
+    fn inverse(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        Ok(Self {
+            h4: self.h4.inverse(table)?,
+            fiber_q29: wrap_phase_q29(
+                self.fiber_q29
+                    .checked_neg()
+                    .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            ),
+            torsion_q29: wrap_phase_q29(
+                self.torsion_q29
+                    .checked_neg()
+                    .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            ),
+        })
+    }
+
+    fn trace(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<BoundedGlobalExactSpinStateTrace, BoundedGlobalExactSpinError> {
+        Ok(BoundedGlobalExactSpinStateTrace {
+            h4_coordinate: self.h4.root_coordinate(table)?,
+            fiber_q29: self.fiber_q29,
+            torsion_q29: self.torsion_q29,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CandidatePrototype {
+    candidate_token: u32,
+    candidate_bytes: Vec<u8>,
+    anchor_bytes: Vec<u8>,
+    anchor_lexical_unit_id: u32,
+    anchor_address: GeometricAddress,
+    anchor_address_kappa: String,
+    anchor_payload_cid: String,
+    anchor_class_kappa: String,
+    anchor_state: ExactSpinState,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoundedGlobalExactSpinR4V1 {
+    table_artifact_cid: String,
+    base_overlay_artifact_cid: String,
+    construction_ids: Vec<String>,
+    construction_text_cids: Vec<[u8; 32]>,
+    codec: CanonicalLexicalCodec,
+    construction_artifact: CanonicalRouteArtifact,
+    h4_table: H4BinaryIcosahedralClosure,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    spin_map_kappa: String,
+    chart_profile_kappa: String,
+    prototypes: Vec<CandidatePrototype>,
+}
+
+#[derive(Debug, Clone)]
+struct ArmEvaluation {
+    entries: Vec<BoundedGlobalExactSpinSnapshotEntryTrace>,
+    fold_steps: Vec<BoundedGlobalExactSpinFoldStepTrace>,
+    global_result: ExactSpinState,
+    classes: Vec<BoundedGlobalExactSpinClassEvaluationTrace>,
+    candidate_rows: Vec<ArmCandidateRow>,
+    decision: BoundedGlobalExactSpinDecision,
+}
+
+#[derive(Debug, Clone)]
+struct ArmCandidateRow {
+    token: u32,
+    class_result_cid: String,
+    relative_state: BoundedGlobalExactSpinStateTrace,
+    measured_cost: BoundedGlobalExactSpinCost,
+    ranking_cost: Option<BoundedGlobalExactSpinCost>,
+}
+
+impl BoundedGlobalExactSpinR4V1 {
+    pub fn compile(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        if base_overlay.table_artifact_cid() != table.artifact_cid() {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "#953 overlay table binding mismatches".to_owned(),
+            ));
+        }
+        if construction.len() != FROZEN_CONSTRUCTION.len()
+            || construction
+                .iter()
+                .any(|document| d3_is_held_out(&document.id))
+            || !table.is_bound_to_construction_documents(construction)
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "operator is not bound to the exact D3 construction set".to_owned(),
+            ));
+        }
+        let mut sorted = construction.to_vec();
+        sorted.sort_by(|left, right| left.id.cmp(&right.id));
+        for (document, (expected_id, expected_text)) in sorted.iter().zip(FROZEN_CONSTRUCTION) {
+            if document.id != expected_id || document.text.as_slice() != expected_text {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "construction differs from the frozen bounded-global documents".to_owned(),
+                ));
+            }
+        }
+        if SourceFreeTable::compile(&sorted)?.artifact_cid() != table.artifact_cid() {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "source-free table does not reproduce from frozen construction".to_owned(),
+            ));
+        }
+
+        let geometry_input = construction_geometry_input(&sorted)?;
+        let codec = CanonicalLexicalCodec::compile(&geometry_input)?;
+        let construction_artifact = CanonicalRouteArtifact::ingest(&codec, &geometry_input)?;
+        let chart_profile_kappa = construction_artifact
+            .attention_consumer_trace()?
+            .chart_profile_kappa;
+        let h4_table = validate_h4_binary_icosahedral_closure()?;
+        let grammar_kappa = blake3_label(GRAMMAR_IDENTITY_BYTES);
+        let routing_policy_kappa = blake3_label(ROUTING_POLICY_IDENTITY.as_bytes());
+        let spin_map_kappa = spin_map_kappa(&h4_table)?;
+
+        let mut prototypes = Vec::with_capacity(PROTOTYPE_BINDINGS.len());
+        for (candidate, anchor) in PROTOTYPE_BINDINGS {
+            let mut candidate_bytes = Vec::with_capacity(candidate.len() + 1);
+            candidate_bytes.push(b' ');
+            candidate_bytes.extend_from_slice(candidate);
+            let candidate_tokens = table.encode_text(&candidate_bytes)?;
+            if candidate_tokens.len() != 1
+                || !table.is_fitted_lexical_token(candidate_tokens[0])
+                || table.decode_tokens(&candidate_tokens)? != candidate_bytes
+            {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "prototype candidate is not one exact fitted lexical unit".to_owned(),
+                ));
+            }
+            let encoded_anchor = codec.encode(0, 0, anchor)?;
+            if encoded_anchor.units.len() != 1 || !encoded_anchor.trailing_bytes.is_empty() {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "prototype anchor is not one exact canonical lexical unit".to_owned(),
+                ));
+            }
+            let unit_id = encoded_anchor.units[0].unit_id;
+            let address = construction_artifact
+                .lexical_route_address(unit_id)?
+                .ok_or_else(|| {
+                    BoundedGlobalExactSpinError::Invalid(
+                        "prototype anchor has no registered address".to_owned(),
+                    )
+                })?;
+            let value = construction_artifact
+                .lexical_route_value_for_address(&address)?
+                .ok_or_else(|| {
+                    BoundedGlobalExactSpinError::Invalid(
+                        "prototype anchor address has no payload inversion".to_owned(),
+                    )
+                })?;
+            if value.payload_bytes != anchor {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "prototype anchor payload inversion mismatches".to_owned(),
+                ));
+            }
+            let state = exact_state_from_address(&address, &h4_table)?;
+            prototypes.push(CandidatePrototype {
+                candidate_token: candidate_tokens[0],
+                candidate_bytes,
+                anchor_bytes: anchor.to_vec(),
+                anchor_lexical_unit_id: unit_id,
+                anchor_address_kappa: address.canonical_kappa().map_err(|error| {
+                    BoundedGlobalExactSpinError::Invalid(format!(
+                        "prototype anchor address kappa failed: {error}"
+                    ))
+                })?,
+                anchor_payload_cid: address.payload_cid.clone(),
+                anchor_class_kappa: shared_class_kappa(address.spin)?,
+                anchor_address: address,
+                anchor_state: state,
+            });
+        }
+        prototypes.sort_by_key(|prototype| prototype.candidate_token);
+        if prototypes.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES
+            || prototypes.windows(2).any(|pair| {
+                pair[0].candidate_token >= pair[1].candidate_token
+                    || pair[0].anchor_class_kappa == pair[1].anchor_class_kappa
+            })
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "prototype tokens or exact anchor classes alias".to_owned(),
+            ));
+        }
+
+        let operator = Self {
+            table_artifact_cid: table.artifact_cid(),
+            base_overlay_artifact_cid: base_overlay.artifact_cid(),
+            construction_ids: sorted.iter().map(|document| document.id.clone()).collect(),
+            construction_text_cids: sorted.iter().map(SourceDocument::text_cid).collect(),
+            codec,
+            construction_artifact,
+            h4_table,
+            grammar_kappa,
+            routing_policy_kappa,
+            spin_map_kappa,
+            chart_profile_kappa,
+            prototypes,
+        };
+        operator.validate_binding(table, base_overlay)?;
+        if operator.to_bytes()?.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        Ok(operator)
+    }
+
+    pub fn from_bytes(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+        bytes: &[u8],
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        if bytes.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        if bytes.len() < OPERATOR_MAGIC.len() || bytes[..OPERATOR_MAGIC.len()] != OPERATOR_MAGIC {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator magic is invalid".to_owned(),
+            ));
+        }
+        let expected = Self::compile(table, base_overlay, construction)?;
+        if expected.to_bytes()? != bytes {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator is noncanonical or binding-drifted".to_owned(),
+            ));
+        }
+        Ok(expected)
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, BoundedGlobalExactSpinError> {
+        let wire = OperatorWire {
+            schema: OPERATOR_SCHEMA,
+            domain: OPERATOR_DOMAIN,
+            table_artifact_cid: self.table_artifact_cid.clone(),
+            base_overlay_artifact_cid: self.base_overlay_artifact_cid.clone(),
+            construction_ids: self.construction_ids.clone(),
+            construction_text_cids: self
+                .construction_text_cids
+                .iter()
+                .map(hex::encode)
+                .collect(),
+            codec_kappa: self.construction_artifact.codec_kappa().to_owned(),
+            vocabulary_kappa: self.construction_artifact.vocabulary_kappa().to_owned(),
+            route_manifest_kappa: self.construction_artifact.manifest_kappa().to_owned(),
+            h4_root_table_kappa: self.h4_table.h4_root_table_kappa.clone(),
+            h4_multiplication_table_kappa: self.h4_table.multiplication_table_kappa.clone(),
+            grammar_kappa: self.grammar_kappa.clone(),
+            routing_policy_kappa: self.routing_policy_kappa.clone(),
+            spin_map_kappa: self.spin_map_kappa.clone(),
+            chart_profile_kappa: self.chart_profile_kappa.clone(),
+            construction_identity_scope: CONSTRUCTION_IDENTITY_SCOPE,
+            held_out_identity_scope: HELD_OUT_IDENTITY_SCOPE,
+            active_turn_id: ACTIVE_TURN_ID,
+            active_query_hex: hex::encode(ACTIVE_QUERY_BYTES),
+            construction_global_unit_hex: hex::encode(CONSTRUCTION_GLOBAL_UNIT),
+            left_snapshot_hex: LEFT_SNAPSHOT.map(hex::encode),
+            right_snapshot_hex: RIGHT_SNAPSHOT.map(hex::encode),
+            candidates: BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES,
+            snapshot_entries: BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES,
+            snapshot_classes: BOUNDED_GLOBAL_EXACT_SPIN_CLASSES,
+            reuse_hits: BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS,
+            max_query_bytes: MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES,
+            max_operator_bytes: MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES,
+            prototypes: self.prototype_traces()?,
+        };
+        let payload = serde_json::to_vec(&wire)
+            .map_err(|error| BoundedGlobalExactSpinError::Serialization(error.to_string()))?;
+        let mut bytes = Vec::with_capacity(OPERATOR_MAGIC.len() + payload.len());
+        bytes.extend_from_slice(&OPERATOR_MAGIC);
+        bytes.extend_from_slice(&payload);
+        if bytes.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    pub fn artifact_cid(&self) -> Result<String, BoundedGlobalExactSpinError> {
+        Ok(blake3_label(&self.to_bytes()?))
+    }
+
+    pub fn table_artifact_cid(&self) -> &str {
+        &self.table_artifact_cid
+    }
+
+    pub fn base_overlay_artifact_cid(&self) -> &str {
+        &self.base_overlay_artifact_cid
+    }
+
+    pub fn codec_kappa(&self) -> &str {
+        self.construction_artifact.codec_kappa()
+    }
+
+    pub fn vocabulary_kappa(&self) -> &str {
+        self.construction_artifact.vocabulary_kappa()
+    }
+
+    pub fn route_manifest_kappa(&self) -> &str {
+        self.construction_artifact.manifest_kappa()
+    }
+
+    pub fn spin_map_kappa(&self) -> &str {
+        &self.spin_map_kappa
+    }
+
+    pub fn chart_profile_kappa(&self) -> &str {
+        &self.chart_profile_kappa
+    }
+
+    pub fn grammar_kappa(&self) -> &str {
+        &self.grammar_kappa
+    }
+
+    pub fn routing_policy_kappa(&self) -> &str {
+        &self.routing_policy_kappa
+    }
+
+    pub fn h4_root_table_kappa(&self) -> &str {
+        &self.h4_table.h4_root_table_kappa
+    }
+
+    pub fn h4_multiplication_table_kappa(&self) -> &str {
+        &self.h4_table.multiplication_table_kappa
+    }
+
+    pub fn prototype_traces(
+        &self,
+    ) -> Result<Vec<BoundedGlobalExactSpinPrototypeTrace>, BoundedGlobalExactSpinError> {
+        self.prototypes
+            .iter()
+            .map(|prototype| {
+                Ok(BoundedGlobalExactSpinPrototypeTrace {
+                    candidate_token: prototype.candidate_token,
+                    candidate_hex: hex::encode(&prototype.candidate_bytes),
+                    anchor_hex: hex::encode(&prototype.anchor_bytes),
+                    anchor_lexical_unit_id: prototype.anchor_lexical_unit_id,
+                    anchor_address_kappa: prototype.anchor_address_kappa.clone(),
+                    anchor_payload_cid: prototype.anchor_payload_cid.clone(),
+                    anchor_spin: spin_trace(prototype.anchor_address.spin),
+                    anchor_class_kappa: prototype.anchor_class_kappa.clone(),
+                    anchor_state: prototype.anchor_state.trace(&self.h4_table)?,
+                })
+            })
+            .collect()
+    }
+
+    pub fn build_query_artifact(
+        &self,
+        active_query: &[u8],
+    ) -> Result<CanonicalRouteArtifact, BoundedGlobalExactSpinError> {
+        validate_active_query(active_query)?;
+        let input = observed_base_input(active_query)?;
+        Ok(CanonicalRouteArtifact::ingest(&self.codec, &input)?)
+    }
+
+    pub fn build_snapshot_artifact(
+        &self,
+        active_query: &[u8],
+        global_snapshot_units: &[Vec<u8>],
+    ) -> Result<CanonicalRouteArtifact, BoundedGlobalExactSpinError> {
+        validate_active_query(active_query)?;
+        validate_snapshot_units(global_snapshot_units)?;
+        let input = observed_global_input(active_query, global_snapshot_units)?;
+        Ok(CanonicalRouteArtifact::ingest(&self.codec, &input)?)
+    }
+
+    pub fn predict_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        base_artifact: &CanonicalRouteArtifact,
+        snapshot_artifact: &CanonicalRouteArtifact,
+        active_query: &[u8],
+    ) -> Result<MatchedBoundedGlobalExactSpinPrediction, BoundedGlobalExactSpinError> {
+        self.validate_binding(table, base_overlay)?;
+        validate_active_query(active_query)?;
+        let base_input = base_artifact.reconstruct_input()?;
+        if base_input != observed_base_input(active_query)?
+            || base_artifact.codec_kappa() != self.codec.codec_kappa()
+            || base_artifact.vocabulary_kappa() != self.codec.vocabulary_kappa()
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "base query artifact is not the exact frozen lower input".to_owned(),
+            ));
+        }
+        let snapshot_input = snapshot_artifact.reconstruct_input()?;
+        if snapshot_input
+            != observed_global_input(active_query, &snapshot_input.global_snapshot_units)?
+            || snapshot_artifact.codec_kappa() != self.codec.codec_kappa()
+            || snapshot_artifact.vocabulary_kappa() != self.codec.vocabulary_kappa()
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "snapshot artifact is not an exact frozen global input".to_owned(),
+            ));
+        }
+        validate_snapshot_units(&snapshot_input.global_snapshot_units)?;
+        let view = snapshot_artifact.global_exact_spin_snapshot_view()?;
+        if view.global_epoch != snapshot_input.global_epoch
+            || view.snapshot_kappa != snapshot_input.global_epoch
+            || view.entries.len() != BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "global exact-spin view mismatches the frozen snapshot".to_owned(),
+            ));
+        }
+
+        for prototype in &self.prototypes {
+            if contains_bytes(active_query, &prototype.candidate_bytes)
+                || view
+                    .entries
+                    .iter()
+                    .any(|entry| entry.payload_bytes == prototype.candidate_bytes[1..])
+            {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "observed prompt or global snapshot contains an admitted candidate".to_owned(),
+                ));
+            }
+        }
+
+        let mut context = vec![BOS_TOKEN];
+        context.extend(table.encode_text(active_query)?);
+        let local = table.predict_multiscale_count_radius(&context, base_overlay)?;
+        let prototype_tokens = self
+            .prototypes
+            .iter()
+            .map(|prototype| prototype.candidate_token)
+            .collect::<Vec<_>>();
+        if local.order != BackoffOrder::Trigram
+            || local.max_count != 1
+            || local.max_count_tie_tokens != prototype_tokens
+            || local.baseline_support_tokens != local.geometric_support_tokens
+            || local.baseline_work != local.geometric_work
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "#953 admission is not the frozen exact count-one tie".to_owned(),
+            ));
+        }
+
+        let real = self.evaluate_arm(&view, &local, BoundedGlobalExactSpinArm::Real, false)?;
+        let disabled = self.evaluate_arm(
+            &view,
+            &local,
+            BoundedGlobalExactSpinArm::IdentityDisabled,
+            false,
+        )?;
+        let permuted = self.evaluate_arm(
+            &view,
+            &local,
+            BoundedGlobalExactSpinArm::ClassOperatorPermuted,
+            false,
+        )?;
+        let reversed = self.evaluate_arm(&view, &local, BoundedGlobalExactSpinArm::Real, true)?;
+
+        if real.entries != disabled.entries
+            || real.entries != permuted.entries
+            || real.fold_steps != disabled.fold_steps
+            || real.fold_steps != permuted.fold_steps
+            || real.classes != disabled.classes
+            || real.classes != permuted.classes
+            || real.decision.work != disabled.decision.work
+            || real.decision.work != permuted.decision.work
+            || real.decision.support_tokens != disabled.decision.support_tokens
+            || real.decision.support_tokens != permuted.decision.support_tokens
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "matched global arms differ in inputs, class results, support, or work".to_owned(),
+            ));
+        }
+
+        let mut candidate_evidence = Vec::with_capacity(self.prototypes.len());
+        for (index, prototype) in self.prototypes.iter().enumerate() {
+            let base = local.tie_evidence.get(index).ok_or_else(|| {
+                BoundedGlobalExactSpinError::Invalid(
+                    "#953 tie evidence omitted a prototype candidate".to_owned(),
+                )
+            })?;
+            if base.token != prototype.candidate_token
+                || real.candidate_rows[index].token != prototype.candidate_token
+                || disabled.candidate_rows[index].token != prototype.candidate_token
+                || permuted.candidate_rows[index].token != prototype.candidate_token
+            {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "candidate evidence order differs from bound prototype order".to_owned(),
+                ));
+            }
+            let real_row = &real.candidate_rows[index];
+            let disabled_row = &disabled.candidate_rows[index];
+            let permuted_row = &permuted.candidate_rows[index];
+            candidate_evidence.push(BoundedGlobalExactSpinCandidateEvidence {
+                token: prototype.candidate_token,
+                count: base.count,
+                candidate_hex: hex::encode(&prototype.candidate_bytes),
+                prototype_anchor_hex: hex::encode(&prototype.anchor_bytes),
+                prototype_class_kappa: prototype.anchor_class_kappa.clone(),
+                base_coordinates: base.coordinates,
+                base_radius: base.radius,
+                real_class_result_cid: real_row.class_result_cid.clone(),
+                real_relative_state: real_row.relative_state,
+                real_measured_cost: real_row.measured_cost,
+                real_ranking_cost: real_row.ranking_cost,
+                identity_disabled_measured_cost: disabled_row.measured_cost,
+                identity_disabled_ranking_cost: disabled_row.ranking_cost,
+                permuted_class_result_cid: permuted_row.class_result_cid.clone(),
+                permuted_relative_state: permuted_row.relative_state,
+                permuted_measured_cost: permuted_row.measured_cost,
+                permuted_ranking_cost: permuted_row.ranking_cost,
+                candidate_state_kappa: candidate_state_kappa(
+                    real.global_result,
+                    prototype.anchor_state,
+                    real_row.measured_cost,
+                    &self.h4_table,
+                )?,
+            });
+        }
+
+        let support_reversal_invariant = reversed.decision.token == real.decision.token;
+        let coherent_relabel_equivariant = coherent_relabel_equivariant(
+            &real.candidate_rows,
+            real.decision.token,
+            &prototype_tokens,
+        )?;
+        let work_matched = real.decision.work == disabled.decision.work
+            && real.decision.work == permuted.decision.work;
+        let support_matched = real.decision.support_tokens == disabled.decision.support_tokens
+            && real.decision.support_tokens == permuted.decision.support_tokens;
+        let operator_abstention = real
+            .decision
+            .unique_minimum
+            .is_none()
+            .then_some(BoundedGlobalExactSpinAbstention::CostTie);
+
+        Ok(MatchedBoundedGlobalExactSpinPrediction {
+            local,
+            base_lower_artifact_manifest_kappa: base_artifact.manifest_kappa().to_owned(),
+            source_snapshot_artifact_manifest_kappa: view.source_artifact_manifest_kappa,
+            global_epoch: view.global_epoch,
+            global_snapshot_kappa: view.snapshot_kappa,
+            global_root_kappa: view.global_root_kappa,
+            operator_cid: self.artifact_cid()?,
+            spin_map_kappa: self.spin_map_kappa.clone(),
+            chart_profile_kappa: self.chart_profile_kappa.clone(),
+            h4_root_table_kappa: self.h4_table.h4_root_table_kappa.clone(),
+            h4_multiplication_table_kappa: self.h4_table.multiplication_table_kappa.clone(),
+            snapshot_entries: real.entries,
+            fold_steps: real.fold_steps,
+            global_result: real.global_result.trace(&self.h4_table)?,
+            class_evaluations: real.classes,
+            candidate_evidence,
+            real: real.decision,
+            identity_disabled: disabled.decision,
+            class_operator_permuted: permuted.decision,
+            support_reversed_real_token: reversed.decision.token,
+            support_reversal_invariant,
+            coherent_relabel_equivariant,
+            support_matched,
+            work_matched,
+            operator_abstention,
+            forbidden_reads: BoundedGlobalExactSpinForbiddenReads::default(),
+        })
+    }
+
+    pub fn continue_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        base_artifact: &CanonicalRouteArtifact,
+        snapshot_artifact: &CanonicalRouteArtifact,
+        active_query: &[u8],
+        max_units: usize,
+    ) -> Result<MatchedBoundedGlobalExactSpinContinuation, BoundedGlobalExactSpinError> {
+        if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
+            return Err(BoundedGlobalExactSpinError::Invalid(format!(
+                "continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
+            )));
+        }
+        let first_decision = self.predict_matched(
+            table,
+            base_overlay,
+            base_artifact,
+            snapshot_artifact,
+            active_query,
+        )?;
+        if first_decision.operator_abstention.is_some()
+            || !first_decision.support_matched
+            || !first_decision.work_matched
+            || !first_decision.support_reversal_invariant
+            || !first_decision.coherent_relabel_equivariant
+            || first_decision.real.unique_minimum.is_none()
+            || first_decision
+                .class_operator_permuted
+                .unique_minimum
+                .is_none()
+            || first_decision.identity_disabled.unique_minimum.is_some()
+            || first_decision.forbidden_reads.total() != 0
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global hard gate stopped before decoding".to_owned(),
+            ));
+        }
+        let mut initial_context = vec![BOS_TOKEN];
+        initial_context.extend(table.encode_text(active_query)?);
+        let mut real = ContinuationState::new(initial_context.clone());
+        let mut disabled = ContinuationState::new(initial_context.clone());
+        let mut permuted = ContinuationState::new(initial_context);
+        real.accept(first_decision.real.token);
+        disabled.accept(first_decision.identity_disabled.token);
+        permuted.accept(first_decision.class_operator_permuted.token);
+        while real.can_step(max_units)
+            || disabled.can_step(max_units)
+            || permuted.can_step(max_units)
+        {
+            if real.can_step(max_units) {
+                real.accept(
+                    table
+                        .predict_multiscale_count_radius(&real.context, base_overlay)?
+                        .geometric_token,
+                );
+            }
+            if disabled.can_step(max_units) {
+                disabled.accept(
+                    table
+                        .predict_multiscale_count_radius(&disabled.context, base_overlay)?
+                        .geometric_token,
+                );
+            }
+            if permuted.can_step(max_units) {
+                permuted.accept(
+                    table
+                        .predict_multiscale_count_radius(&permuted.context, base_overlay)?
+                        .geometric_token,
+                );
+            }
+        }
+        Ok(MatchedBoundedGlobalExactSpinContinuation {
+            first_decision,
+            real: real.finish(table)?,
+            identity_disabled: disabled.finish(table)?,
+            class_operator_permuted: permuted.finish(table)?,
+        })
+    }
+
+    pub fn audit_hierarchy_pair(
+        &self,
+        left: &CanonicalRouteArtifact,
+        right: &CanonicalRouteArtifact,
+    ) -> Result<BoundedGlobalExactSpinHierarchyAudit, BoundedGlobalExactSpinError> {
+        let left_view = left.attention_hierarchy_view();
+        let right_view = right.attention_hierarchy_view();
+        let left_ordered = left.attention_consumer_trace_with_ordered_h4(&self.h4_table)?;
+        let right_ordered = right.attention_consumer_trace_with_ordered_h4(&self.h4_table)?;
+        if left_ordered.ordered_levels.len() != 7 || right_ordered.ordered_levels.len() != 7 {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "hierarchy audit did not expose seven ordered levels".to_owned(),
+            ));
+        }
+        let left_ids = hierarchy_identities(&left_view);
+        let right_ids = hierarchy_identities(&right_view);
+        let mut levels = Vec::with_capacity(7);
+        for index in 0..7 {
+            let left_level = &left_ordered.ordered_levels[index];
+            let right_level = &right_ordered.ordered_levels[index];
+            if left_level.level != HIERARCHY_LEVELS[index]
+                || right_level.level != HIERARCHY_LEVELS[index]
+            {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "hierarchy level order differs from the fixed consumer order".to_owned(),
+                ));
+            }
+            levels.push(hierarchy_level_audit(
+                HIERARCHY_LEVELS[index],
+                left_ids[index],
+                right_ids[index],
+                left_level,
+                right_level,
+            ));
+        }
+        Ok(BoundedGlobalExactSpinHierarchyAudit {
+            lower_through_conversation_identity_equal: levels[..6]
+                .iter()
+                .all(|level| level.identity_equal),
+            lower_through_conversation_ordered_state_equal: levels[..6]
+                .iter()
+                .all(|level| level.ordered_state_equal),
+            global_identity_distinct: !levels[6].identity_equal,
+            global_ordered_state_distinct: !levels[6].ordered_state_equal,
+            left_global_snapshot_kappa: left.global_exact_spin_snapshot_view()?.snapshot_kappa,
+            right_global_snapshot_kappa: right.global_exact_spin_snapshot_view()?.snapshot_kappa,
+            levels,
+        })
+    }
+
+    fn validate_binding(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+    ) -> Result<(), BoundedGlobalExactSpinError> {
+        if self.table_artifact_cid != table.artifact_cid()
+            || self.base_overlay_artifact_cid != base_overlay.artifact_cid()
+            || base_overlay.table_artifact_cid() != table.artifact_cid()
+            || self.codec.codec_kappa() != self.construction_artifact.codec_kappa()
+            || self.codec.vocabulary_kappa() != self.construction_artifact.vocabulary_kappa()
+            || self.h4_table.reproduce_multiplication_table_kappa()?
+                != self.h4_table.multiplication_table_kappa
+            || spin_map_kappa(&self.h4_table)? != self.spin_map_kappa
+            || blake3_label(GRAMMAR_IDENTITY_BYTES) != self.grammar_kappa
+            || blake3_label(ROUTING_POLICY_IDENTITY.as_bytes()) != self.routing_policy_kappa
+            || self
+                .construction_artifact
+                .attention_consumer_trace()?
+                .chart_profile_kappa
+                != self.chart_profile_kappa
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global operator binding does not reproduce".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn evaluate_arm(
+        &self,
+        view: &GlobalExactSpinSnapshotView,
+        local: &MatchedGeometricPrediction,
+        arm: BoundedGlobalExactSpinArm,
+        reverse_support_iteration: bool,
+    ) -> Result<ArmEvaluation, BoundedGlobalExactSpinError> {
+        let mut work = WorkCounter::new(local.geometric_work);
+        let mut entries = Vec::with_capacity(view.entries.len());
+        let mut states = Vec::with_capacity(view.entries.len());
+        for entry in &view.entries {
+            work.snapshot_entry_reads += 1;
+            let state = exact_state_from_entry(entry, &self.h4_table)?;
+            states.push(state);
+            entries.push(BoundedGlobalExactSpinSnapshotEntryTrace {
+                ordinal: entry.ordinal,
+                entry_kappa: entry.entry_kappa.clone(),
+                lexical_unit_id: entry.lexical_unit_id,
+                address_index: entry.address_index,
+                address_kappa: entry.address_kappa.clone(),
+                payload_cid: entry.payload_cid.clone(),
+                payload_hex: hex::encode(&entry.payload_bytes),
+                spin: entry.spin,
+                shared_class_kappa: entry.shared_class_kappa.clone(),
+                mapped_state: state.trace(&self.h4_table)?,
+                diagnostic_sector: diagnostic_sector(entry.spin),
+            });
+        }
+
+        let mut fold = ExactSpinState::identity(&self.h4_table)?;
+        let mut fold_steps = Vec::with_capacity(states.len());
+        for (entry, state) in view.entries.iter().zip(states.iter().copied()) {
+            let before = fold;
+            fold = fold.compose(state, &self.h4_table)?;
+            work.h4_product_table_reads += 1;
+            work.phase_additions += 2;
+            fold_steps.push(BoundedGlobalExactSpinFoldStepTrace {
+                ordinal: entry.ordinal,
+                entry_kappa: entry.entry_kappa.clone(),
+                before: before.trace(&self.h4_table)?,
+                entry: state.trace(&self.h4_table)?,
+                after: fold.trace(&self.h4_table)?,
+            });
+        }
+        if fold == ExactSpinState::identity(&self.h4_table)? {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "global stored-spin fold is identity".to_owned(),
+            ));
+        }
+
+        let mut unique = Vec::<ClassAccumulator>::new();
+        for ((entry, trace), state) in view
+            .entries
+            .iter()
+            .zip(entries.iter())
+            .zip(states.iter().copied())
+        {
+            let mut found = None;
+            for (index, class) in unique.iter().enumerate() {
+                work.exact_class_comparisons += 1;
+                if class.class_kappa == entry.shared_class_kappa {
+                    found = Some(index);
+                    break;
+                }
+            }
+            if let Some(index) = found {
+                let class = &mut unique[index];
+                if class.state != state
+                    || class.address_kappa != trace.address_kappa
+                    || class.payload_cid != trace.payload_cid
+                {
+                    return Err(BoundedGlobalExactSpinError::Invalid(
+                        "one exact class aliases different state/address/payload".to_owned(),
+                    ));
+                }
+                class.reference_entry_kappas.push(entry.entry_kappa.clone());
+                work.class_reuse_hits += 1;
+            } else {
+                unique.push(ClassAccumulator {
+                    class_kappa: entry.shared_class_kappa.clone(),
+                    address_kappa: trace.address_kappa.clone(),
+                    payload_cid: trace.payload_cid.clone(),
+                    state,
+                    reference_entry_kappas: vec![entry.entry_kappa.clone()],
+                });
+            }
+        }
+        if unique.len() != BOUNDED_GLOBAL_EXACT_SPIN_CLASSES
+            || work.class_reuse_hits != BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "snapshot exact-class population differs from the frozen census".to_owned(),
+            ));
+        }
+
+        let operator_cid = self.artifact_cid()?;
+        let result_binding = ClassResultBinding {
+            global_root_kappa: &view.global_root_kappa,
+            global_epoch: &view.global_epoch,
+            operator_cid: &operator_cid,
+            spin_map_kappa: &self.spin_map_kappa,
+            chart_profile_kappa: &self.chart_profile_kappa,
+            table: &self.h4_table,
+        };
+        let mut class_results = Vec::<ClassResult>::with_capacity(unique.len());
+        let mut class_traces = Vec::with_capacity(unique.len());
+        for class in unique {
+            let relative = class
+                .state
+                .inverse(&self.h4_table)?
+                .compose(fold, &self.h4_table)?;
+            work.h4_inverse_table_reads += 1;
+            work.h4_product_table_reads += 1;
+            work.phase_additions += 2;
+            let cost = exact_cost(relative, &self.h4_table)?;
+            work.angular_shell_reads += 1;
+            work.phase_distance_reads += 2;
+            work.unique_class_evaluations += 1;
+            work.class_result_applications += u64::try_from(class.reference_entry_kappas.len())
+                .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+            let cold = class
+                .state
+                .inverse(&self.h4_table)?
+                .compose(fold, &self.h4_table)?;
+            let cold_cost = exact_cost(cold, &self.h4_table)?;
+            work.h4_inverse_table_reads += 1;
+            work.h4_product_table_reads += 1;
+            work.phase_additions += 2;
+            work.angular_shell_reads += 1;
+            work.phase_distance_reads += 2;
+            let result_bytes =
+                class_result_bytes(&result_binding, &class.class_kappa, relative, cost)?;
+            let cold_result_bytes =
+                class_result_bytes(&result_binding, &class.class_kappa, cold, cold_cost)?;
+            let result_cid = blake3_label(&result_bytes);
+            let cold_result_cid = blake3_label(&cold_result_bytes);
+            let trace = BoundedGlobalExactSpinClassEvaluationTrace {
+                shared_class_kappa: class.class_kappa.clone(),
+                reference_count: u64::try_from(class.reference_entry_kappas.len())
+                    .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+                evaluation_count: 1,
+                reuse_count: u64::try_from(class.reference_entry_kappas.len().saturating_sub(1))
+                    .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+                reference_entry_kappas: class.reference_entry_kappas,
+                class_state: class.state.trace(&self.h4_table)?,
+                relative_result: relative.trace(&self.h4_table)?,
+                cost,
+                result_cid: result_cid.clone(),
+                cold_result_cid: cold_result_cid.clone(),
+                cold_recomputation_equal: result_bytes == cold_result_bytes,
+            };
+            class_results.push(ClassResult {
+                class_kappa: class.class_kappa,
+                relative,
+                cost,
+                result_cid,
+            });
+            class_traces.push(trace);
+        }
+
+        let mut candidate_rows = Vec::with_capacity(self.prototypes.len());
+        for (index, prototype) in self.prototypes.iter().enumerate() {
+            work.candidate_class_lookups += 1;
+            let source_index = match arm {
+                BoundedGlobalExactSpinArm::ClassOperatorPermuted => {
+                    (index + 1) % self.prototypes.len()
+                }
+                BoundedGlobalExactSpinArm::Real | BoundedGlobalExactSpinArm::IdentityDisabled => {
+                    index
+                }
+            };
+            let source_class = &self.prototypes[source_index].anchor_class_kappa;
+            let result = class_results
+                .iter()
+                .find(|result| result.class_kappa == *source_class)
+                .ok_or_else(|| {
+                    BoundedGlobalExactSpinError::Invalid(
+                        "snapshot omitted one admitted prototype exact class".to_owned(),
+                    )
+                })?;
+            candidate_rows.push(ArmCandidateRow {
+                token: prototype.candidate_token,
+                class_result_cid: result.result_cid.clone(),
+                relative_state: result.relative.trace(&self.h4_table)?,
+                measured_cost: result.cost,
+                ranking_cost: (arm != BoundedGlobalExactSpinArm::IdentityDisabled)
+                    .then_some(result.cost),
+            });
+        }
+        if reverse_support_iteration {
+            candidate_rows.reverse();
+        }
+        let support_tokens = self
+            .prototypes
+            .iter()
+            .map(|prototype| prototype.candidate_token)
+            .collect::<Vec<_>>();
+        let selection = select_candidate_rows(&candidate_rows)?;
+        work.cost_comparisons = work
+            .cost_comparisons
+            .checked_add(selection.comparisons)
+            .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+        work.final_choice_operations = work
+            .final_choice_operations
+            .checked_add(1)
+            .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+        let decision = decision_from_selection(
+            arm,
+            local.geometric_token,
+            selection,
+            support_tokens,
+            work.finish(),
+        );
+        Ok(ArmEvaluation {
+            entries,
+            fold_steps,
+            global_result: fold,
+            classes: class_traces,
+            candidate_rows,
+            decision,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClassAccumulator {
+    class_kappa: String,
+    address_kappa: String,
+    payload_cid: String,
+    state: ExactSpinState,
+    reference_entry_kappas: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ClassResult {
+    class_kappa: String,
+    relative: ExactSpinState,
+    cost: BoundedGlobalExactSpinCost,
+    result_cid: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WorkCounter {
+    local: MultiscaleCountRadiusWork,
+    snapshot_entry_reads: u64,
+    exact_class_comparisons: u64,
+    unique_class_evaluations: u64,
+    class_reuse_hits: u64,
+    class_result_applications: u64,
+    h4_product_table_reads: u64,
+    h4_inverse_table_reads: u64,
+    phase_additions: u64,
+    phase_distance_reads: u64,
+    angular_shell_reads: u64,
+    candidate_class_lookups: u64,
+    cost_comparisons: u64,
+    final_choice_operations: u64,
+}
+
+impl WorkCounter {
+    const fn new(local: MultiscaleCountRadiusWork) -> Self {
+        Self {
+            local,
+            snapshot_entry_reads: 0,
+            exact_class_comparisons: 0,
+            unique_class_evaluations: 0,
+            class_reuse_hits: 0,
+            class_result_applications: 0,
+            h4_product_table_reads: 0,
+            h4_inverse_table_reads: 0,
+            phase_additions: 0,
+            phase_distance_reads: 0,
+            angular_shell_reads: 0,
+            candidate_class_lookups: 0,
+            cost_comparisons: 0,
+            final_choice_operations: 0,
+        }
+    }
+
+    const fn finish(self) -> BoundedGlobalExactSpinWork {
+        BoundedGlobalExactSpinWork {
+            local: self.local,
+            snapshot_entry_reads: self.snapshot_entry_reads,
+            exact_class_comparisons: self.exact_class_comparisons,
+            unique_class_evaluations: self.unique_class_evaluations,
+            class_reuse_hits: self.class_reuse_hits,
+            class_result_applications: self.class_result_applications,
+            h4_product_table_reads: self.h4_product_table_reads,
+            h4_inverse_table_reads: self.h4_inverse_table_reads,
+            phase_additions: self.phase_additions,
+            phase_distance_reads: self.phase_distance_reads,
+            angular_shell_reads: self.angular_shell_reads,
+            candidate_class_lookups: self.candidate_class_lookups,
+            cost_comparisons: self.cost_comparisons,
+            final_choice_operations: self.final_choice_operations,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct OperatorWire {
+    schema: u32,
+    domain: &'static str,
+    table_artifact_cid: String,
+    base_overlay_artifact_cid: String,
+    construction_ids: Vec<String>,
+    construction_text_cids: Vec<String>,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    route_manifest_kappa: String,
+    h4_root_table_kappa: String,
+    h4_multiplication_table_kappa: String,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    spin_map_kappa: String,
+    chart_profile_kappa: String,
+    construction_identity_scope: &'static str,
+    held_out_identity_scope: &'static str,
+    active_turn_id: &'static str,
+    active_query_hex: String,
+    construction_global_unit_hex: String,
+    left_snapshot_hex: [String; 4],
+    right_snapshot_hex: [String; 4],
+    candidates: usize,
+    snapshot_entries: usize,
+    snapshot_classes: usize,
+    reuse_hits: u64,
+    max_query_bytes: usize,
+    max_operator_bytes: usize,
+    prototypes: Vec<BoundedGlobalExactSpinPrototypeTrace>,
+}
+
+#[derive(Serialize)]
+struct SpinMapWire {
+    schema: u32,
+    domain: &'static str,
+    exact_mapping_rule: &'static str,
+    h4_root_table_kappa: String,
+    rows: Vec<SpinMapRow>,
+}
+
+#[derive(Serialize)]
+struct SpinMapRow {
+    s3_q30: [i32; 4],
+    h4_coordinate: H4RootCoordinate,
+}
+
+#[derive(Serialize)]
+struct ClassResultCidWire<'a> {
+    schema: u32,
+    domain: &'static str,
+    global_root_kappa: &'a str,
+    global_epoch: &'a str,
+    operator_cid: &'a str,
+    spin_map_kappa: &'a str,
+    chart_profile_kappa: &'a str,
+    h4_root_table_kappa: &'a str,
+    h4_multiplication_table_kappa: &'a str,
+    shared_class_kappa: &'a str,
+    relative_result: BoundedGlobalExactSpinStateTrace,
+    cost: BoundedGlobalExactSpinCost,
+}
+
+#[derive(Serialize)]
+struct CandidateStateKappaWire {
+    schema: u32,
+    domain: &'static str,
+    global: BoundedGlobalExactSpinStateTrace,
+    prototype: BoundedGlobalExactSpinStateTrace,
+    cost: BoundedGlobalExactSpinCost,
+}
+
+fn construction_geometry_input(
+    construction: &[SourceDocument],
+) -> Result<ConversationInput, BoundedGlobalExactSpinError> {
+    let mut turns = Vec::with_capacity(construction.len());
+    for document in construction {
+        let (binding, active) = split_once_exact(&document.text, b"\n\n").ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "construction document lacks the frozen paragraph boundary".to_owned(),
+            )
+        })?;
+        turns.push(TurnInput {
+            turn_id: format!("construction-turn-{}", document.id),
+            paragraphs: vec![
+                ParagraphInput {
+                    sentences: vec![binding.to_vec()],
+                },
+                ParagraphInput {
+                    sentences: vec![active.to_vec()],
+                },
+            ],
+        });
+    }
+    let global_snapshot_units = vec![CONSTRUCTION_GLOBAL_UNIT.to_vec()];
+    Ok(ConversationInput {
+        identity_scope: CONSTRUCTION_IDENTITY_SCOPE.to_owned(),
+        global_epoch: canonical_global_epoch(&global_snapshot_units)?,
+        global_snapshot_units,
+        turns,
+    })
+}
+
+fn observed_global_input(
+    active_query: &[u8],
+    global_snapshot_units: &[Vec<u8>],
+) -> Result<ConversationInput, BoundedGlobalExactSpinError> {
+    validate_active_query(active_query)?;
+    validate_snapshot_units(global_snapshot_units)?;
+    Ok(ConversationInput {
+        identity_scope: HELD_OUT_IDENTITY_SCOPE.to_owned(),
+        global_epoch: canonical_global_epoch(global_snapshot_units)?,
+        global_snapshot_units: global_snapshot_units.to_vec(),
+        turns: vec![TurnInput {
+            turn_id: ACTIVE_TURN_ID.to_owned(),
+            paragraphs: vec![ParagraphInput {
+                sentences: vec![active_query.to_vec()],
+            }],
+        }],
+    })
+}
+
+fn observed_base_input(
+    active_query: &[u8],
+) -> Result<ConversationInput, BoundedGlobalExactSpinError> {
+    validate_active_query(active_query)?;
+    let global_snapshot_units = vec![CONSTRUCTION_GLOBAL_UNIT.to_vec()];
+    Ok(ConversationInput {
+        identity_scope: HELD_OUT_IDENTITY_SCOPE.to_owned(),
+        global_epoch: canonical_global_epoch(&global_snapshot_units)?,
+        global_snapshot_units,
+        turns: vec![TurnInput {
+            turn_id: ACTIVE_TURN_ID.to_owned(),
+            paragraphs: vec![ParagraphInput {
+                sentences: vec![active_query.to_vec()],
+            }],
+        }],
+    })
+}
+
+fn validate_active_query(active_query: &[u8]) -> Result<(), BoundedGlobalExactSpinError> {
+    if active_query != ACTIVE_QUERY_BYTES
+        || active_query.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES
+    {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "active query differs from the frozen bounded-global prompt".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_snapshot_units(units: &[Vec<u8>]) -> Result<(), BoundedGlobalExactSpinError> {
+    let left = LEFT_SNAPSHOT.map(<[u8]>::to_vec).to_vec();
+    let right = RIGHT_SNAPSHOT.map(<[u8]>::to_vec).to_vec();
+    if units != left && units != right {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "global snapshot differs from both frozen order controls".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn exact_state_from_address(
+    address: &GeometricAddress,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
+    Ok(ExactSpinState {
+        h4: exact_s3_spin_to_h4(address.spin.s3.raw(), table)?,
+        fiber_q29: i64::from(address.spin.fiber.raw()),
+        torsion_q29: i64::from(address.spin.torsion.raw()),
+    })
+}
+
+fn exact_state_from_entry(
+    entry: &GlobalExactSpinSnapshotEntry,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
+    Ok(ExactSpinState {
+        h4: exact_s3_spin_to_h4(entry.spin.s3_q30, table)?,
+        fiber_q29: i64::from(entry.spin.fiber_q29),
+        torsion_q29: i64::from(entry.spin.torsion_q29),
+    })
+}
+
+fn exact_s3_spin_to_h4(
+    raw: [i32; 4],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<OrderedH4FoldState, BoundedGlobalExactSpinError> {
+    let mut coordinate = [[0_i64; 2]; 4];
+    for (target, value) in coordinate.iter_mut().zip(raw) {
+        if value & Q29_H4_SCALE_MASK != 0 {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "stored S3 spin is not an exact scaled H4 coordinate".to_owned(),
+            ));
+        }
+        target[0] = i64::from(value >> Q29_H4_SCALE_SHIFT);
+    }
+    let expected = H4RootCoordinate {
+        scaled_zphi_quaternion: coordinate,
+    };
+    let mut matched = None;
+    let mut matches = 0usize;
+    for offset in 0..table.root_count {
+        let offset =
+            u16::try_from(offset).map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+        let index = OpaqueH4TableIndex::from_table_offset(offset, table).ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "stored-spin H4 map addressed outside the exact table".to_owned(),
+            )
+        })?;
+        let state = OrderedH4FoldState::from_table_index(index, table)?;
+        if state.root_coordinate(table)? == expected {
+            matches += 1;
+            matched = Some(state);
+        }
+    }
+    if matches != 1 {
+        return Err(BoundedGlobalExactSpinError::Invalid(format!(
+            "stored S3 spin has {matches} exact H4 coordinate matches"
+        )));
+    }
+    matched.ok_or_else(|| {
+        BoundedGlobalExactSpinError::Invalid("stored S3 spin has no exact H4 match".to_owned())
+    })
+}
+
+fn spin_map_kappa(
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<String, BoundedGlobalExactSpinError> {
+    let half = 1_i32 << 29;
+    let one = 1_i32 << 30;
+    let raw_rows = [
+        [one, 0, 0, 0],
+        [0, one, 0, 0],
+        [half, half, half, half],
+        [half, -half, half, -half],
+    ];
+    let rows = raw_rows
+        .into_iter()
+        .map(|raw| {
+            let state = exact_s3_spin_to_h4(raw, table)?;
+            Ok(SpinMapRow {
+                s3_q30: raw,
+                h4_coordinate: state.root_coordinate(table)?,
+            })
+        })
+        .collect::<Result<Vec<_>, BoundedGlobalExactSpinError>>()?;
+    let bytes = serde_json::to_vec(&SpinMapWire {
+        schema: 1,
+        domain: SPIN_MAP_DOMAIN,
+        exact_mapping_rule: SPIN_MAP_RULE_IDENTITY,
+        h4_root_table_kappa: table.h4_root_table_kappa.clone(),
+        rows,
+    })
+    .map_err(|error| BoundedGlobalExactSpinError::Serialization(error.to_string()))?;
+    Ok(blake3_label(&bytes))
+}
+
+fn exact_cost(
+    relative: ExactSpinState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<BoundedGlobalExactSpinCost, BoundedGlobalExactSpinError> {
+    let real = relative.root_real(table)?;
+    let angular_shell = match real {
+        [2, 0] => H4S3AngularShell::Coincident,
+        [0, 1] => H4S3AngularShell::Degrees36,
+        [1, 0] => H4S3AngularShell::Degrees60,
+        [-1, 1] => H4S3AngularShell::Degrees72,
+        [0, 0] => H4S3AngularShell::Orthogonal,
+        [1, -1] => H4S3AngularShell::Degrees108,
+        [-1, 0] => H4S3AngularShell::Degrees120,
+        [0, -1] => H4S3AngularShell::Degrees144,
+        [-2, 0] => H4S3AngularShell::Antipodal,
+        other => {
+            return Err(BoundedGlobalExactSpinError::Invalid(format!(
+                "relative H4 state has noncanonical signed real coordinate {other:?}"
+            )))
+        }
+    };
+    Ok(BoundedGlobalExactSpinCost {
+        angular_shell,
+        fiber_distance_q29: relative.fiber_q29.unsigned_abs(),
+        torsion_distance_q29: relative.torsion_q29.unsigned_abs(),
+    })
+}
+
+impl ExactSpinState {
+    fn root_real(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<[i64; 2], BoundedGlobalExactSpinError> {
+        Ok(self.h4.root_coordinate(table)?.scaled_zphi_quaternion[0])
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SelectionOutcome {
+    unique_minimum: Option<u32>,
+    minimum_cost: Option<BoundedGlobalExactSpinCost>,
+    comparisons: u64,
+}
+
+fn select_candidate_rows(
+    rows: &[ArmCandidateRow],
+) -> Result<SelectionOutcome, BoundedGlobalExactSpinError> {
+    if rows.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "bounded-global candidate row count differs from the frozen support".to_owned(),
+        ));
+    }
+    let mut minimum: Option<(u32, BoundedGlobalExactSpinCost)> = None;
+    let mut tied = false;
+    let mut comparisons = 0_u64;
+    for row in rows {
+        comparisons = comparisons
+            .checked_add(1)
+            .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+        let cost = row.measured_cost;
+        match minimum {
+            None => {
+                minimum = Some((row.token, cost));
+                tied = false;
+            }
+            Some((_, current)) if cost < current => {
+                minimum = Some((row.token, cost));
+                tied = false;
+            }
+            Some((_, current)) if cost == current => tied = true,
+            Some(_) => {}
+        }
+    }
+    Ok(SelectionOutcome {
+        unique_minimum: (!tied).then_some(minimum.map(|value| value.0)).flatten(),
+        minimum_cost: (!tied).then_some(minimum.map(|value| value.1)).flatten(),
+        comparisons,
+    })
+}
+
+fn decision_from_selection(
+    arm: BoundedGlobalExactSpinArm,
+    fallback: u32,
+    selection: SelectionOutcome,
+    support_tokens: Vec<u32>,
+    work: BoundedGlobalExactSpinWork,
+) -> BoundedGlobalExactSpinDecision {
+    if arm == BoundedGlobalExactSpinArm::IdentityDisabled {
+        return BoundedGlobalExactSpinDecision {
+            arm,
+            token: fallback,
+            unique_minimum: None,
+            minimum_cost: None,
+            support_tokens,
+            work,
+        };
+    }
+    BoundedGlobalExactSpinDecision {
+        arm,
+        token: selection.unique_minimum.unwrap_or(fallback),
+        unique_minimum: selection.unique_minimum,
+        minimum_cost: selection.minimum_cost,
+        support_tokens,
+        work,
+    }
+}
+
+fn coherent_relabel_equivariant(
+    rows: &[ArmCandidateRow],
+    original_winner: u32,
+    tokens: &[u32],
+) -> Result<bool, BoundedGlobalExactSpinError> {
+    if rows.len() != 2 || tokens.len() != 2 {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "coherent relabel requires exactly two candidates".to_owned(),
+        ));
+    }
+    let swapped_winner = if original_winner == tokens[0] {
+        tokens[1]
+    } else if original_winner == tokens[1] {
+        tokens[0]
+    } else {
+        return Ok(false);
+    };
+    let relabeled = [
+        ArmCandidateRow {
+            token: tokens[1],
+            ..rows[0].clone()
+        },
+        ArmCandidateRow {
+            token: tokens[0],
+            ..rows[1].clone()
+        },
+    ];
+    let selection = select_candidate_rows(&relabeled)?;
+    let relabeled_decision = decision_from_selection(
+        BoundedGlobalExactSpinArm::Real,
+        tokens[1],
+        selection,
+        tokens.to_vec(),
+        BoundedGlobalExactSpinWork {
+            local: MultiscaleCountRadiusWork::default(),
+            snapshot_entry_reads: 0,
+            exact_class_comparisons: 0,
+            unique_class_evaluations: 0,
+            class_reuse_hits: 0,
+            class_result_applications: 0,
+            h4_product_table_reads: 0,
+            h4_inverse_table_reads: 0,
+            phase_additions: 0,
+            phase_distance_reads: 0,
+            angular_shell_reads: 0,
+            candidate_class_lookups: 0,
+            cost_comparisons: 2,
+            final_choice_operations: 1,
+        },
+    );
+    Ok(relabeled_decision.token == swapped_winner)
+}
+
+struct ClassResultBinding<'a> {
+    global_root_kappa: &'a str,
+    global_epoch: &'a str,
+    operator_cid: &'a str,
+    spin_map_kappa: &'a str,
+    chart_profile_kappa: &'a str,
+    table: &'a H4BinaryIcosahedralClosure,
+}
+
+fn class_result_bytes(
+    binding: &ClassResultBinding<'_>,
+    class_kappa: &str,
+    relative: ExactSpinState,
+    cost: BoundedGlobalExactSpinCost,
+) -> Result<Vec<u8>, BoundedGlobalExactSpinError> {
+    serde_json::to_vec(&ClassResultCidWire {
+        schema: 1,
+        domain: "uor-r4.bounded-global-exact-spin-class-result/1",
+        global_root_kappa: binding.global_root_kappa,
+        global_epoch: binding.global_epoch,
+        operator_cid: binding.operator_cid,
+        spin_map_kappa: binding.spin_map_kappa,
+        chart_profile_kappa: binding.chart_profile_kappa,
+        h4_root_table_kappa: &binding.table.h4_root_table_kappa,
+        h4_multiplication_table_kappa: &binding.table.multiplication_table_kappa,
+        shared_class_kappa: class_kappa,
+        relative_result: relative.trace(binding.table)?,
+        cost,
+    })
+    .map_err(|error| BoundedGlobalExactSpinError::Serialization(error.to_string()))
+}
+
+fn candidate_state_kappa(
+    global: ExactSpinState,
+    prototype: ExactSpinState,
+    cost: BoundedGlobalExactSpinCost,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<String, BoundedGlobalExactSpinError> {
+    let bytes = serde_json::to_vec(&CandidateStateKappaWire {
+        schema: 1,
+        domain: "uor-r4.bounded-global-candidate-state-class/1",
+        global: global.trace(table)?,
+        prototype: prototype.trace(table)?,
+        cost,
+    })
+    .map_err(|error| BoundedGlobalExactSpinError::Serialization(error.to_string()))?;
+    Ok(blake3_label(&bytes))
+}
+
+fn diagnostic_sector(spin: SpinTorsionStateTrace) -> BoundedGlobalSpinSectorTrace {
+    let hopf = spin.hopf_q30;
+    let hopf_octant =
+        u8::from(hopf[0] >= 0) | (u8::from(hopf[1] >= 0) << 1) | (u8::from(hopf[2] >= 0) << 2);
+    let shifted = i64::from(spin.torsion_q29) + PHASE_HALF_Q29;
+    let bin = (shifted * TORSION_BINS) / PHASE_MODULUS_Q29;
+    BoundedGlobalSpinSectorTrace {
+        hopf_octant,
+        torsion_bin: bin.clamp(0, TORSION_BINS - 1) as u8,
+    }
+}
+
+fn spin_trace(spin: crate::prime_route_attention::SpinTorsionState) -> SpinTorsionStateTrace {
+    SpinTorsionStateTrace {
+        s3_q30: spin.s3.raw(),
+        hopf_q30: spin.hopf.raw(),
+        fiber_q29: spin.fiber.raw(),
+        torsion_q29: spin.torsion.raw(),
+    }
+}
+
+fn wrap_phase_q29(mut value: i64) -> i64 {
+    while value >= PHASE_HALF_Q29 {
+        value -= PHASE_MODULUS_Q29;
+    }
+    while value < -PHASE_HALF_Q29 {
+        value += PHASE_MODULUS_Q29;
+    }
+    value
+}
+
+const HIERARCHY_LEVELS: [&str; 7] = [
+    "current",
+    "previous",
+    "last-two",
+    "sentence",
+    "paragraph",
+    "conversation",
+    "global",
+];
+
+fn hierarchy_identities(view: &AttentionHierarchyView) -> [&str; 7] {
+    [
+        view.current.as_str(),
+        view.previous.as_str(),
+        view.last_two.as_str(),
+        view.sentence.as_str(),
+        view.paragraph.as_str(),
+        view.conversation.as_str(),
+        view.global.as_str(),
+    ]
+}
+
+fn hierarchy_level_audit(
+    level: &str,
+    left_identity: &str,
+    right_identity: &str,
+    left: &AttentionOrderedFoldLevel,
+    right: &AttentionOrderedFoldLevel,
+) -> BoundedGlobalExactSpinHierarchyLevelAudit {
+    BoundedGlobalExactSpinHierarchyLevelAudit {
+        level: level.to_owned(),
+        left_identity_kappa: left_identity.to_owned(),
+        right_identity_kappa: right_identity.to_owned(),
+        identity_equal: left_identity == right_identity,
+        left_state: left.state,
+        right_state: right.state,
+        ordered_state_equal: left.state == right.state
+            && left.observed_routes == right.observed_routes
+            && left.root_coordinate == right.root_coordinate,
+    }
+}
+
+fn split_once_exact<'a>(bytes: &'a [u8], needle: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    let index = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)?;
+    let right = index.checked_add(needle.len())?;
+    Some((&bytes[..index], &bytes[right..]))
+}
+
+fn contains_bytes(bytes: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && bytes.windows(needle.len()).any(|window| window == needle)
+}
+
+fn blake3_label(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+#[derive(Debug, Clone)]
+struct ContinuationState {
+    context: Vec<u32>,
+    generated: Vec<u32>,
+    stop: ContinuationStop,
+}
+
+impl ContinuationState {
+    fn new(context: Vec<u32>) -> Self {
+        Self {
+            context,
+            generated: Vec::new(),
+            stop: ContinuationStop::Bound,
+        }
+    }
+
+    fn can_step(&self, max_units: usize) -> bool {
+        self.stop == ContinuationStop::Bound && self.generated.len() < max_units
+    }
+
+    fn accept(&mut self, token: u32) {
+        if token == EOS_TOKEN {
+            self.stop = ContinuationStop::EndOfDocument;
+            return;
+        }
+        if self.generated.last() == Some(&token) {
+            self.stop = ContinuationStop::PeriodOneCycle;
+            return;
+        }
+        if self.generated.len() >= 3
+            && self.generated[self.generated.len() - 2] == token
+            && self.generated[self.generated.len() - 3] == self.generated[self.generated.len() - 1]
+        {
+            self.stop = ContinuationStop::PeriodTwoCycle;
+            return;
+        }
+        self.generated.push(token);
+        self.context.push(token);
+    }
+
+    fn finish(self, table: &SourceFreeTable) -> Result<Continuation, BoundedGlobalExactSpinError> {
+        Ok(Continuation {
+            decoded: table.decode_tokens(&self.generated)?,
+            tokens: self.generated,
+            stop: self.stop,
+        })
+    }
+}

--- a/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
+++ b/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
@@ -1539,6 +1539,55 @@ pub struct AttentionHierarchyView {
     pub global: String,
 }
 
+pub const GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_SCHEMA: u32 = 1;
+pub const GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_DOMAIN: &str = "uor-r4.global-exact-spin-snapshot-view/1";
+
+/// Read-only exact spin/torsion fields for one canonical lexical address.
+///
+/// This trace mirrors the complete [`SpinTorsionState`] without adding a new
+/// field to the canonical artifact or changing its serialized identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SpinTorsionStateTrace {
+    pub s3_q30: [i32; 4],
+    pub hopf_q30: [i32; 3],
+    pub fiber_q29: i32,
+    pub torsion_q29: i32,
+}
+
+/// One immutable ordered reference in the bounded-global snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GlobalExactSpinSnapshotEntry {
+    pub ordinal: u16,
+    pub entry_kappa: String,
+    pub lexical_unit_id: u32,
+    pub address_index: u16,
+    pub address_kappa: String,
+    pub payload_cid: String,
+    pub payload_bytes: Vec<u8>,
+    pub spin: SpinTorsionStateTrace,
+    pub shared_class_kappa: String,
+}
+
+/// Validated read-only view of the immutable bounded-global snapshot.
+///
+/// The view exposes exact reference, address, payload, and spin identities for
+/// operator compilation. It is derived from a transitively validated artifact
+/// and is deliberately absent from [`CanonicalRouteArtifact`]'s wire body, so
+/// requesting it cannot alter canonical artifact bytes or its manifest kappa.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GlobalExactSpinSnapshotView {
+    pub schema: u32,
+    pub domain: String,
+    pub source_artifact_manifest_kappa: String,
+    pub identity_scope: String,
+    pub global_epoch: String,
+    pub snapshot_kappa: String,
+    pub snapshot_summary_kappa: String,
+    pub global_root_kappa: String,
+    pub global_exact_chain_kappa: String,
+    pub entries: Vec<GlobalExactSpinSnapshotEntry>,
+}
+
 pub const ATTENTION_CONSUMER_TRACE_SCHEMA: u32 = 1;
 pub const ATTENTION_CONSUMER_TRACE_DOMAIN: &str = "uor-r4.canonical-attention-consumer-trace/1";
 
@@ -2778,7 +2827,7 @@ fn icosian_coordinate_kappa(
     canonical_kappa(&canonical_json(&seed)?)
 }
 
-fn shared_class_kappa(spin: SpinTorsionState) -> Result<String, CanonicalLexicalError> {
+pub(crate) fn shared_class_kappa(spin: SpinTorsionState) -> Result<String, CanonicalLexicalError> {
     canonical_kappa(&canonical_json(&SpinClassKeyWire {
         schema: 1,
         domain: "uor-r4.exact-spin-torsion-class/1",
@@ -4539,6 +4588,92 @@ impl CanonicalRouteArtifact {
         };
         validate_input_shape(&input)?;
         Ok(input)
+    }
+
+    /// Resolve the bounded-global snapshot to its exact stored lexical
+    /// addresses, payloads, and full spin/torsion class identities.
+    ///
+    /// This is a derived consumer view only. The canonical artifact is fully
+    /// validated first, and neither its body nor its manifest identity is
+    /// mutated or reserialized.
+    pub fn global_exact_spin_snapshot_view(
+        &self,
+    ) -> Result<GlobalExactSpinSnapshotView, CanonicalLexicalError> {
+        self.validate_transitive()?;
+        let global_root = self
+            .node(&self.body.hierarchy_roots.global)
+            .ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "bounded-global exact-spin view cannot resolve the global root".to_owned(),
+                )
+            })?;
+        if global_root.body.scope != "global"
+            || global_root.body.ordered_child_kind != "global-snapshot"
+            || global_root.body.ordered_child_kappa != self.body.global_snapshot.snapshot_kappa
+        {
+            return Err(CanonicalLexicalError::Invalid(
+                "bounded-global exact-spin view resolved an invalid global root".to_owned(),
+            ));
+        }
+
+        let mut entries = Vec::with_capacity(self.body.global_snapshot.ordered_units.len());
+        for binding in &self.body.global_snapshot.ordered_units {
+            let address = self
+                .lexical_route_address_unvalidated(binding.lexical_unit_id)?
+                .ok_or_else(|| {
+                    CanonicalLexicalError::Invalid(
+                        "bounded-global exact-spin entry has no registered address".to_owned(),
+                    )
+                })?;
+            let vocabulary_index = usize::try_from(binding.lexical_unit_id)
+                .map_err(|_| CanonicalLexicalError::ArithmeticOverflow)?;
+            let vocabulary = self.body.vocabulary.get(vocabulary_index).ok_or_else(|| {
+                CanonicalLexicalError::Invalid(
+                    "bounded-global exact-spin entry has no vocabulary binding".to_owned(),
+                )
+            })?;
+            let payload_bytes =
+                decode_hex(&vocabulary.surface_hex, "bounded-global exact-spin payload")?;
+            if vocabulary.unit_id != binding.lexical_unit_id
+                || vocabulary.payload_cid != address.payload_cid
+                || usize::from(binding.address_index) != vocabulary_index
+                || binding.address_kappa != address.canonical_kappa()?
+            {
+                return Err(CanonicalLexicalError::Invalid(
+                    "bounded-global exact-spin entry does not match its canonical registry"
+                        .to_owned(),
+                ));
+            }
+            entries.push(GlobalExactSpinSnapshotEntry {
+                ordinal: binding.ordinal,
+                entry_kappa: binding.entry_kappa.clone(),
+                lexical_unit_id: binding.lexical_unit_id,
+                address_index: binding.address_index,
+                address_kappa: binding.address_kappa.clone(),
+                payload_cid: vocabulary.payload_cid.clone(),
+                payload_bytes,
+                spin: SpinTorsionStateTrace {
+                    s3_q30: address.spin.s3.raw(),
+                    hopf_q30: address.spin.hopf.raw(),
+                    fiber_q29: address.spin.fiber.raw(),
+                    torsion_q29: address.spin.torsion.raw(),
+                },
+                shared_class_kappa: shared_class_kappa(address.spin)?,
+            });
+        }
+
+        Ok(GlobalExactSpinSnapshotView {
+            schema: GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_SCHEMA,
+            domain: GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_DOMAIN.to_owned(),
+            source_artifact_manifest_kappa: self.manifest_kappa.clone(),
+            identity_scope: self.body.provenance.identity_scope.clone(),
+            global_epoch: self.body.provenance.global_epoch.clone(),
+            snapshot_kappa: self.body.global_snapshot.snapshot_kappa.clone(),
+            snapshot_summary_kappa: self.body.global_snapshot.summary_kappa.clone(),
+            global_root_kappa: global_root.node_kappa.clone(),
+            global_exact_chain_kappa: global_root.body.exact_chain_kappa.clone(),
+            entries,
+        })
     }
 
     pub fn attention_hierarchy_view(&self) -> AttentionHierarchyView {
@@ -6652,4 +6787,53 @@ pub fn run_authorized_probe() -> Result<ProbeWitness, CanonicalLexicalError> {
         icosian_inverse_witnesses_exact,
         serving_boundary,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_exact_spin_snapshot_view_is_read_only() -> Result<(), CanonicalLexicalError> {
+        let global_snapshot_units = vec![b"memory".to_vec(), b"memory".to_vec(), b"route".to_vec()];
+        let input = ConversationInput {
+            identity_scope: "canonical-global-exact-spin-view-test".to_owned(),
+            global_epoch: canonical_global_epoch(&global_snapshot_units)?,
+            global_snapshot_units,
+            turns: vec![TurnInput {
+                turn_id: "turn-0001".to_owned(),
+                paragraphs: vec![ParagraphInput {
+                    sentences: vec![b"memory route.".to_vec()],
+                }],
+            }],
+        };
+        let codec = CanonicalLexicalCodec::compile(&input)?;
+        let artifact = CanonicalRouteArtifact::ingest(&codec, &input)?;
+        let bytes_before = artifact.canonical_bytes()?;
+        let manifest_before = artifact.manifest_kappa().to_owned();
+
+        let view = artifact.global_exact_spin_snapshot_view()?;
+
+        assert_eq!(view.schema, GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_SCHEMA);
+        assert_eq!(view.domain, GLOBAL_EXACT_SPIN_SNAPSHOT_VIEW_DOMAIN);
+        assert_eq!(view.source_artifact_manifest_kappa, manifest_before);
+        assert_eq!(view.global_epoch, input.global_epoch);
+        assert_eq!(view.snapshot_kappa, input.global_epoch);
+        assert_eq!(
+            view.global_root_kappa,
+            artifact.attention_hierarchy_view().global
+        );
+        assert_eq!(view.entries.len(), 3);
+        assert_ne!(view.entries[0].entry_kappa, view.entries[1].entry_kappa);
+        assert_eq!(view.entries[0].address_kappa, view.entries[1].address_kappa);
+        assert_eq!(view.entries[0].payload_cid, view.entries[1].payload_cid);
+        assert_eq!(view.entries[0].payload_bytes, b"memory");
+        assert_eq!(
+            view.entries[0].shared_class_kappa,
+            view.entries[1].shared_class_kappa
+        );
+        assert_eq!(artifact.manifest_kappa(), manifest_before);
+        assert_eq!(artifact.canonical_bytes()?, bytes_before);
+        Ok(())
+    }
 }

--- a/crates/uor-r4-core/src/lib.rs
+++ b/crates/uor-r4-core/src/lib.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::f64::consts::PI;
 
+pub mod bounded_global_exact_spin_attention;
 pub mod canonical_lexical_ingestion;
 pub mod cayley_dickson;
 pub mod construction_causal_return_attention;

--- a/crates/uor-r4-core/tests/bounded_global_exact_spin_attention_973.rs
+++ b/crates/uor-r4-core/tests/bounded_global_exact_spin_attention_973.rs
@@ -1,0 +1,825 @@
+//! Frozen bounded-global exact-spin probe for #973.
+//!
+//! The target-free Gate 0 fixture preserves a valid repeated-class census but
+//! falsifies the proposed order separation: the swapped exact helix/prism
+//! states commute to one identical complete fold and cannot support opposite
+//! roles. It does not open decoded targets or establish global attention.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::Serialize;
+
+use uor_r4_core::bounded_global_exact_spin_attention::{
+    BoundedGlobalExactSpinCandidateEvidence, BoundedGlobalExactSpinHierarchyAudit,
+    BoundedGlobalExactSpinR4V1, MatchedBoundedGlobalExactSpinPrediction,
+    BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES, BOUNDED_GLOBAL_EXACT_SPIN_CLASSES,
+    BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES, BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS,
+    MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES, MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES,
+};
+use uor_r4_core::canonical_lexical_ingestion::{
+    canonical_lexical_piece_bytes, CanonicalRouteArtifact, GlobalExactSpinSnapshotView,
+};
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, BackoffOrder, MultiscaleCountRadiusR4V1, SourceDocument, SourceFreeTable,
+};
+
+const OBSERVED_PROMPT: &[u8] = b"The bounded global code is";
+const ID_49_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"helix", b"prism"];
+const ID_50_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"prism", b"helix"];
+const TARGET_COMMITMENT: &str =
+    "blake3:00fef74baee2785059d7be20a20fb07f9c5f5b18ae085c20503d3080019e13b1";
+const NEGATIVE_TERMINAL: &str =
+    "RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION";
+
+static TARGET_PREIMAGE_LOADS: AtomicUsize = AtomicUsize::new(0);
+
+fn construction_documents() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new(
+            "51",
+            b"Lena bound the helix class.\n\nThe bounded global code is bronze.".to_vec(),
+        ),
+        SourceDocument::new(
+            "52",
+            b"Pavel bound the prism class.\n\nThe bounded global code is teal.".to_vec(),
+        ),
+    ]
+}
+
+fn snapshot(units: [&[u8]; 4]) -> Vec<Vec<u8>> {
+    units.into_iter().map(<[u8]>::to_vec).collect()
+}
+
+fn decoded(table: &SourceFreeTable, token: u32) -> Vec<u8> {
+    table.decode_tokens(&[token]).unwrap()
+}
+
+fn decoded_support(table: &SourceFreeTable, tokens: &[u32]) -> Vec<Vec<u8>> {
+    tokens.iter().map(|token| decoded(table, *token)).collect()
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn direct_cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+#[derive(Serialize)]
+struct TargetFreeCensus<'a> {
+    schema: u32,
+    domain: &'static str,
+    decoded_target_commitment: &'static str,
+    table_cid: String,
+    base_overlay_cid: String,
+    operator_cid: String,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    route_manifest_kappa: String,
+    spin_map_kappa: String,
+    chart_profile_kappa: String,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    h4_root_table_kappa: String,
+    h4_multiplication_table_kappa: String,
+    base_lower_artifact_manifest_kappa: String,
+    hierarchy: &'a BoundedGlobalExactSpinHierarchyAudit,
+    snapshots: [&'a GlobalExactSpinSnapshotView; 2],
+    cases: Vec<TargetFreeCase<'a>>,
+    target_preimage_loads_observed: usize,
+    terminal: &'static str,
+}
+
+#[derive(Serialize)]
+struct TargetFreeCase<'a> {
+    partition_id: &'static str,
+    prompt_cid: String,
+    prediction: &'a MatchedBoundedGlobalExactSpinPrediction,
+}
+
+fn assert_snapshot_view(view: &GlobalExactSpinSnapshotView, expected: [&[u8]; 4]) {
+    assert_eq!(view.entries.len(), BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES);
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.ordinal)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2, 3]
+    );
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.payload_bytes.as_slice())
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert_eq!(view.global_epoch, view.snapshot_kappa);
+    assert!(view.source_artifact_manifest_kappa.starts_with("blake3:"));
+    assert!(view.snapshot_summary_kappa.starts_with("blake3:"));
+    assert!(view.global_root_kappa.starts_with("blake3:"));
+    assert!(view.global_exact_chain_kappa.starts_with("blake3:"));
+
+    let repeated = &view.entries[..2];
+    assert_ne!(repeated[0].ordinal, repeated[1].ordinal);
+    assert_ne!(repeated[0].entry_kappa, repeated[1].entry_kappa);
+    assert_eq!(repeated[0].address_index, repeated[1].address_index);
+    assert_eq!(repeated[0].address_kappa, repeated[1].address_kappa);
+    assert_eq!(repeated[0].payload_cid, repeated[1].payload_cid);
+    assert_eq!(repeated[0].payload_bytes, repeated[1].payload_bytes);
+    assert_eq!(repeated[0].spin, repeated[1].spin);
+    assert_eq!(
+        repeated[0].shared_class_kappa,
+        repeated[1].shared_class_kappa
+    );
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.shared_class_kappa.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CLASSES
+    );
+}
+
+fn candidate_for_anchor<'a>(
+    prediction: &'a MatchedBoundedGlobalExactSpinPrediction,
+    anchor: &[u8],
+) -> &'a BoundedGlobalExactSpinCandidateEvidence {
+    let anchor_hex = hex::encode(anchor);
+    prediction
+        .candidate_evidence
+        .iter()
+        .find(|candidate| candidate.prototype_anchor_hex == anchor_hex)
+        .unwrap()
+}
+
+fn assert_common_prediction(
+    table: &SourceFreeTable,
+    prediction: &MatchedBoundedGlobalExactSpinPrediction,
+) {
+    assert_eq!(prediction.local.order, BackoffOrder::Trigram);
+    assert_eq!(prediction.local.max_count, 1);
+    assert!(prediction.local.geometry_reachable);
+    assert_eq!(
+        decoded_support(table, &prediction.local.max_count_tie_tokens),
+        vec![b" bronze".to_vec(), b" teal".to_vec()]
+    );
+    assert_eq!(
+        prediction.local.baseline_support_tokens,
+        prediction.local.geometric_support_tokens
+    );
+    assert_eq!(
+        prediction.local.max_count_tie_tokens,
+        prediction.local.baseline_support_tokens
+    );
+    assert_eq!(
+        prediction.local.baseline_work,
+        prediction.local.geometric_work
+    );
+    assert_eq!(decoded(table, prediction.local.geometric_token), b" bronze");
+    assert_eq!(
+        prediction.snapshot_entries.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES
+    );
+    assert_eq!(
+        prediction.fold_steps.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES
+    );
+    assert_eq!(
+        prediction.class_evaluations.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CLASSES
+    );
+    assert_eq!(
+        prediction.candidate_evidence.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES
+    );
+    assert!(prediction.support_reversal_invariant);
+    assert_eq!(
+        prediction.support_reversed_real_token,
+        prediction.real.token
+    );
+    assert!(prediction.coherent_relabel_equivariant);
+    assert!(prediction.support_matched);
+    assert!(prediction.work_matched);
+    assert_eq!(prediction.operator_abstention, None);
+    assert_eq!(prediction.forbidden_reads.total(), 0);
+    assert_eq!(prediction.real.work, prediction.identity_disabled.work);
+    assert_eq!(
+        prediction.real.work,
+        prediction.class_operator_permuted.work
+    );
+    assert_eq!(
+        prediction.real.support_tokens,
+        prediction.identity_disabled.support_tokens
+    );
+    assert_eq!(
+        prediction.real.support_tokens,
+        prediction.class_operator_permuted.support_tokens
+    );
+    assert!(prediction.real.unique_minimum.is_some());
+    assert!(prediction.class_operator_permuted.unique_minimum.is_some());
+    assert_eq!(prediction.identity_disabled.unique_minimum, None);
+    assert_eq!(prediction.identity_disabled.minimum_cost, None);
+    assert_eq!(
+        prediction.identity_disabled.token,
+        prediction.local.geometric_token
+    );
+
+    let work = prediction.real.work;
+    assert_eq!(work.snapshot_entry_reads, 4);
+    assert_eq!(work.exact_class_comparisons, 4);
+    assert_eq!(work.unique_class_evaluations, 3);
+    assert_eq!(work.class_reuse_hits, BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS);
+    assert_eq!(work.class_result_applications, 4);
+    assert_eq!(work.h4_product_table_reads, 10);
+    assert_eq!(work.h4_inverse_table_reads, 6);
+    assert_eq!(work.phase_additions, 20);
+    assert_eq!(work.phase_distance_reads, 12);
+    assert_eq!(work.angular_shell_reads, 6);
+    assert_eq!(work.candidate_class_lookups, 2);
+    assert_eq!(work.cost_comparisons, 2);
+    assert_eq!(work.final_choice_operations, 1);
+
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.evaluation_count)
+            .sum::<u64>(),
+        3
+    );
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.reference_count)
+            .sum::<u64>(),
+        4
+    );
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.reuse_count)
+            .sum::<u64>(),
+        BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS
+    );
+    assert!(prediction
+        .class_evaluations
+        .iter()
+        .all(|class| class.cold_recomputation_equal && class.result_cid == class.cold_result_cid));
+
+    let repeated = prediction
+        .class_evaluations
+        .iter()
+        .find(|class| class.reference_count == 2)
+        .unwrap();
+    assert_eq!(repeated.reference_entry_kappas.len(), 2);
+    assert_ne!(
+        repeated.reference_entry_kappas[0],
+        repeated.reference_entry_kappas[1]
+    );
+    assert_eq!(repeated.evaluation_count, 1);
+    assert_eq!(repeated.reuse_count, 1);
+
+    let helix = prediction
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"helix"))
+        .unwrap();
+    let prism = prediction
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"prism"))
+        .unwrap();
+    assert_ne!(helix.shared_class_kappa, prism.shared_class_kappa);
+    assert_eq!(helix.diagnostic_sector, prism.diagnostic_sector);
+    assert!(prediction.snapshot_entries.iter().all(|entry| entry
+        .mapped_state
+        .h4_coordinate
+        .scaled_zphi_quaternion
+        .iter()
+        .all(|coordinate| coordinate[1] == 0)));
+
+    for candidate in &prediction.candidate_evidence {
+        assert_eq!(candidate.count, 1);
+        assert_eq!(
+            candidate.real_ranking_cost,
+            Some(candidate.real_measured_cost)
+        );
+        assert_eq!(candidate.identity_disabled_ranking_cost, None);
+        assert_eq!(
+            candidate.permuted_ranking_cost,
+            Some(candidate.permuted_measured_cost)
+        );
+        assert!(candidate.real_class_result_cid.starts_with("blake3:"));
+        assert!(candidate.permuted_class_result_cid.starts_with("blake3:"));
+        assert!(candidate.candidate_state_kappa.starts_with("blake3:"));
+    }
+}
+
+#[test]
+fn target_free_global_census_rejects_the_commuting_exact_spin_relation() {
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+
+    let construction = construction_documents();
+    assert_eq!(construction.len(), 2);
+    assert!(construction
+        .iter()
+        .all(|document| !d3_is_held_out(&document.id)));
+    assert!(d3_is_held_out("49"));
+    assert!(d3_is_held_out("50"));
+    let held_out = [
+        SourceDocument::new("49", OBSERVED_PROMPT.to_vec()),
+        SourceDocument::new("50", OBSERVED_PROMPT.to_vec()),
+    ];
+    for document in &held_out {
+        assert!(construction.iter().all(|source| {
+            source.id != document.id && source.text_cid() != document.text_cid()
+        }));
+        assert_eq!(document.text, OBSERVED_PROMPT);
+        assert!(!contains_bytes(&document.text, b" bronze"));
+        assert!(!contains_bytes(&document.text, b" teal"));
+    }
+    assert_eq!(held_out[0].text_cid(), held_out[1].text_cid());
+    assert!(OBSERVED_PROMPT.len() <= MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES);
+    let prompt_pieces = canonical_lexical_piece_bytes(OBSERVED_PROMPT).unwrap();
+    assert!(!prompt_pieces
+        .iter()
+        .any(|piece| piece == b"bronze" || piece == b"teal"));
+
+    let left_snapshot = snapshot(ID_49_SNAPSHOT);
+    let right_snapshot = snapshot(ID_50_SNAPSHOT);
+    let mut left_multiset = left_snapshot.clone();
+    let mut right_multiset = right_snapshot.clone();
+    left_multiset.sort();
+    right_multiset.sort();
+    assert_eq!(left_multiset, right_multiset);
+    assert_ne!(left_snapshot, right_snapshot);
+    for units in [&left_snapshot, &right_snapshot] {
+        assert_eq!(units.len(), BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES);
+        assert!(units
+            .iter()
+            .all(|unit| unit != b"bronze" && unit != b"teal"));
+    }
+
+    let table = SourceFreeTable::compile(&construction).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::compile(&table).unwrap();
+    let operator =
+        BoundedGlobalExactSpinR4V1::compile(&table, &base_overlay, &construction).unwrap();
+    let table_bytes = table.to_bytes();
+    let base_overlay_bytes = base_overlay.to_bytes();
+    let operator_bytes = operator.to_bytes().unwrap();
+    assert!(operator_bytes.len() <= MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES);
+    let operator_cid = operator.artifact_cid().unwrap();
+
+    let table = SourceFreeTable::from_bytes(&table_bytes).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::from_bytes(&table, &base_overlay_bytes).unwrap();
+    let oversized_operator = vec![0_u8; MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES + 1];
+    assert!(BoundedGlobalExactSpinR4V1::from_bytes(
+        &table,
+        &base_overlay,
+        &construction,
+        &oversized_operator,
+    )
+    .is_err());
+    let mut tampered_operator = operator_bytes.clone();
+    *tampered_operator.last_mut().unwrap() ^= 1;
+    assert!(BoundedGlobalExactSpinR4V1::from_bytes(
+        &table,
+        &base_overlay,
+        &construction,
+        &tampered_operator,
+    )
+    .is_err());
+    let operator = BoundedGlobalExactSpinR4V1::from_bytes(
+        &table,
+        &base_overlay,
+        &construction,
+        &operator_bytes,
+    )
+    .unwrap();
+    assert_eq!(table.to_bytes(), table_bytes);
+    assert_eq!(base_overlay.to_bytes(), base_overlay_bytes);
+    assert_eq!(operator.to_bytes().unwrap(), operator_bytes);
+    assert_eq!(operator.artifact_cid().unwrap(), operator_cid);
+    assert_eq!(operator.table_artifact_cid(), table.artifact_cid());
+    assert_eq!(
+        operator.base_overlay_artifact_cid(),
+        base_overlay.artifact_cid()
+    );
+
+    let prototypes = operator.prototype_traces().unwrap();
+    assert_eq!(prototypes.len(), BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES);
+    assert_eq!(
+        prototypes
+            .iter()
+            .map(|prototype| hex::decode(&prototype.candidate_hex).unwrap())
+            .collect::<Vec<_>>(),
+        vec![b" bronze".to_vec(), b" teal".to_vec()]
+    );
+    assert_eq!(
+        prototypes
+            .iter()
+            .map(|prototype| hex::decode(&prototype.anchor_hex).unwrap())
+            .collect::<Vec<_>>(),
+        vec![b"helix".to_vec(), b"prism".to_vec()]
+    );
+    assert_ne!(
+        prototypes[0].anchor_class_kappa,
+        prototypes[1].anchor_class_kappa
+    );
+    for prototype in &prototypes {
+        assert!(prototype.anchor_address_kappa.starts_with("blake3:"));
+        assert!(prototype.anchor_payload_cid.starts_with("blake3:"));
+        assert!(prototype.anchor_class_kappa.starts_with("blake3:"));
+        assert!(prototype
+            .anchor_state
+            .h4_coordinate
+            .scaled_zphi_quaternion
+            .iter()
+            .all(|coordinate| coordinate[1] == 0));
+    }
+
+    let base_artifact = operator.build_query_artifact(OBSERVED_PROMPT).unwrap();
+    assert!(operator.build_query_artifact(b"wrong prompt").is_err());
+    assert!(operator
+        .build_snapshot_artifact(
+            OBSERVED_PROMPT,
+            &[b"Pavel".to_vec(), b"helix".to_vec(), b"prism".to_vec()],
+        )
+        .is_err());
+    let left_artifact = operator
+        .build_snapshot_artifact(OBSERVED_PROMPT, &left_snapshot)
+        .unwrap();
+    let right_artifact = operator
+        .build_snapshot_artifact(OBSERVED_PROMPT, &right_snapshot)
+        .unwrap();
+    let base_artifact_bytes = base_artifact.canonical_bytes().unwrap();
+    let left_artifact_bytes = left_artifact.canonical_bytes().unwrap();
+    let right_artifact_bytes = right_artifact.canonical_bytes().unwrap();
+    let base_manifest = base_artifact.manifest_kappa().to_owned();
+    let left_manifest = left_artifact.manifest_kappa().to_owned();
+    let right_manifest = right_artifact.manifest_kappa().to_owned();
+    assert_ne!(base_manifest, left_manifest);
+    assert_ne!(base_manifest, right_manifest);
+    assert_ne!(left_manifest, right_manifest);
+    let left_view = left_artifact.global_exact_spin_snapshot_view().unwrap();
+    let right_view = right_artifact.global_exact_spin_snapshot_view().unwrap();
+    assert_eq!(
+        left_artifact.canonical_bytes().unwrap(),
+        left_artifact_bytes
+    );
+    assert_eq!(
+        right_artifact.canonical_bytes().unwrap(),
+        right_artifact_bytes
+    );
+    assert_eq!(left_artifact.manifest_kappa(), left_manifest);
+    assert_eq!(right_artifact.manifest_kappa(), right_manifest);
+    assert_snapshot_view(&left_view, ID_49_SNAPSHOT);
+    assert_snapshot_view(&right_view, ID_50_SNAPSHOT);
+    assert_eq!(left_view.source_artifact_manifest_kappa, left_manifest);
+    assert_eq!(right_view.source_artifact_manifest_kappa, right_manifest);
+    assert_ne!(left_view.snapshot_kappa, right_view.snapshot_kappa);
+    assert_ne!(left_view.global_root_kappa, right_view.global_root_kappa);
+
+    let hierarchy = operator
+        .audit_hierarchy_pair(&left_artifact, &right_artifact)
+        .unwrap();
+    assert_eq!(hierarchy.levels.len(), 7);
+    assert!(hierarchy.lower_through_conversation_ordered_state_equal);
+    assert!(hierarchy.global_identity_distinct);
+    assert!(hierarchy.global_ordered_state_distinct);
+    assert_ne!(
+        hierarchy.left_global_snapshot_kappa,
+        hierarchy.right_global_snapshot_kappa
+    );
+    for level in &hierarchy.levels[..6] {
+        assert!(level.ordered_state_equal);
+        assert_eq!(level.left_state, level.right_state);
+    }
+    assert_eq!(hierarchy.levels[6].level, "global");
+    assert!(!hierarchy.levels[6].identity_equal);
+    assert!(!hierarchy.levels[6].ordered_state_equal);
+
+    let left = operator
+        .predict_matched(
+            &table,
+            &base_overlay,
+            &base_artifact,
+            &left_artifact,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    let right = operator
+        .predict_matched(
+            &table,
+            &base_overlay,
+            &base_artifact,
+            &right_artifact,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    assert_common_prediction(&table, &left);
+    assert_common_prediction(&table, &right);
+    assert_eq!(left.local, right.local);
+    assert_eq!(left.real.work, right.real.work);
+    assert_eq!(left.real.support_tokens, right.real.support_tokens);
+    assert_ne!(left.global_epoch, right.global_epoch);
+    assert_ne!(left.global_root_kappa, right.global_root_kappa);
+    assert_eq!(left.global_result, right.global_result);
+    assert_eq!(left.base_lower_artifact_manifest_kappa, base_manifest);
+    assert_eq!(right.base_lower_artifact_manifest_kappa, base_manifest);
+    assert_eq!(left.source_snapshot_artifact_manifest_kappa, left_manifest);
+    assert_eq!(
+        right.source_snapshot_artifact_manifest_kappa,
+        right_manifest
+    );
+    assert_eq!(left.operator_cid, operator_cid);
+    assert_eq!(right.operator_cid, operator_cid);
+    assert_eq!(left.spin_map_kappa, operator.spin_map_kappa());
+    assert_eq!(right.spin_map_kappa, operator.spin_map_kappa());
+    assert_eq!(left.chart_profile_kappa, operator.chart_profile_kappa());
+    assert_eq!(right.chart_profile_kappa, operator.chart_profile_kappa());
+
+    let identity_coordinate = [[2, 0], [0, 0], [0, 0], [0, 0]];
+    let minus_one_coordinate = [[-2, 0], [0, 0], [0, 0], [0, 0]];
+    assert_eq!(
+        left.fold_steps[0]
+            .before
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        identity_coordinate
+    );
+    assert_eq!(
+        right.fold_steps[0]
+            .before
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        identity_coordinate
+    );
+    assert_eq!(left.fold_steps[0].before.fiber_q29, 0);
+    assert_eq!(left.fold_steps[0].before.torsion_q29, 0);
+    assert_eq!(
+        left.global_result.h4_coordinate.scaled_zphi_quaternion,
+        minus_one_coordinate
+    );
+    assert_eq!(
+        right.global_result.h4_coordinate.scaled_zphi_quaternion,
+        minus_one_coordinate
+    );
+    assert_eq!(left.global_result.fiber_q29, 110_444_176);
+    assert_eq!(right.global_result.fiber_q29, 110_444_176);
+    assert_eq!(left.global_result.torsion_q29, -10_509_096);
+    assert_eq!(right.global_result.torsion_q29, -10_509_096);
+    assert_eq!(left.fold_steps.last().unwrap().after, left.global_result);
+    assert_eq!(right.fold_steps.last().unwrap().after, right.global_result);
+    assert_eq!(left.fold_steps[1].after, right.fold_steps[1].after);
+    assert_ne!(left.fold_steps[2].after, right.fold_steps[2].after);
+    assert_eq!(left.fold_steps[3].after, right.fold_steps[3].after);
+
+    let left_helix_entry = left
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"helix"))
+        .unwrap();
+    let right_helix_entry = right
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"helix"))
+        .unwrap();
+    let left_prism_entry = left
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"prism"))
+        .unwrap();
+    let right_prism_entry = right
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"prism"))
+        .unwrap();
+    assert_eq!(
+        left_helix_entry.mapped_state,
+        right_helix_entry.mapped_state
+    );
+    assert_eq!(
+        left_prism_entry.mapped_state,
+        right_prism_entry.mapped_state
+    );
+    assert_ne!(left_helix_entry.mapped_state, left_prism_entry.mapped_state);
+
+    let left_helix = candidate_for_anchor(&left, b"helix");
+    let left_prism = candidate_for_anchor(&left, b"prism");
+    let right_helix = candidate_for_anchor(&right, b"helix");
+    let right_prism = candidate_for_anchor(&right, b"prism");
+    assert_eq!(left.real.minimum_cost, Some(left_helix.real_measured_cost));
+    assert_eq!(
+        right.real.minimum_cost,
+        Some(right_helix.real_measured_cost)
+    );
+    assert_eq!(
+        left_helix.real_measured_cost,
+        right_helix.real_measured_cost
+    );
+    assert_eq!(
+        left_prism.real_measured_cost,
+        right_prism.real_measured_cost
+    );
+    assert_ne!(left_helix.real_measured_cost, left_prism.real_measured_cost);
+    assert_eq!(decoded(&table, left.real.token), b" bronze");
+    assert_eq!(decoded(&table, right.real.token), b" bronze");
+    assert_eq!(decoded(&table, left.identity_disabled.token), b" bronze");
+    assert_eq!(decoded(&table, right.identity_disabled.token), b" bronze");
+    assert_eq!(
+        decoded(&table, left.class_operator_permuted.token),
+        b" teal"
+    );
+    assert_eq!(
+        decoded(&table, right.class_operator_permuted.token),
+        b" teal"
+    );
+    assert_eq!(left.real.token, right.real.token);
+    assert_eq!(
+        left.class_operator_permuted.token,
+        right.class_operator_permuted.token
+    );
+    let mut left_real_results = left
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.real_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    let mut left_permuted_results = left
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.permuted_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    left_real_results.sort();
+    left_permuted_results.sort();
+    assert_eq!(left_real_results, left_permuted_results);
+    let mut right_real_results = right
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.real_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    let mut right_permuted_results = right
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.permuted_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    right_real_results.sort();
+    right_permuted_results.sort();
+    assert_eq!(right_real_results, right_permuted_results);
+
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+    let target_free_census = TargetFreeCensus {
+        schema: 1,
+        domain: "uor-r4.bounded-global-exact-spin-target-free-census/1",
+        decoded_target_commitment: TARGET_COMMITMENT,
+        table_cid: table.artifact_cid(),
+        base_overlay_cid: base_overlay.artifact_cid(),
+        operator_cid: operator_cid.clone(),
+        codec_kappa: operator.codec_kappa().to_owned(),
+        vocabulary_kappa: operator.vocabulary_kappa().to_owned(),
+        route_manifest_kappa: operator.route_manifest_kappa().to_owned(),
+        spin_map_kappa: operator.spin_map_kappa().to_owned(),
+        chart_profile_kappa: operator.chart_profile_kappa().to_owned(),
+        grammar_kappa: operator.grammar_kappa().to_owned(),
+        routing_policy_kappa: operator.routing_policy_kappa().to_owned(),
+        h4_root_table_kappa: operator.h4_root_table_kappa().to_owned(),
+        h4_multiplication_table_kappa: operator.h4_multiplication_table_kappa().to_owned(),
+        base_lower_artifact_manifest_kappa: base_manifest.clone(),
+        hierarchy: &hierarchy,
+        snapshots: [&left_view, &right_view],
+        cases: vec![
+            TargetFreeCase {
+                partition_id: "49",
+                prompt_cid: direct_cid(OBSERVED_PROMPT),
+                prediction: &left,
+            },
+            TargetFreeCase {
+                partition_id: "50",
+                prompt_cid: direct_cid(OBSERVED_PROMPT),
+                prediction: &right,
+            },
+        ],
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+        terminal: NEGATIVE_TERMINAL,
+    };
+    let target_free_bytes = serde_json::to_vec(&target_free_census).unwrap();
+    let target_free_cid = direct_cid(&target_free_bytes);
+
+    let base_artifact_replay =
+        CanonicalRouteArtifact::decode_canonical(&base_artifact_bytes).unwrap();
+    let left_artifact_replay =
+        CanonicalRouteArtifact::decode_canonical(&left_artifact_bytes).unwrap();
+    let right_artifact_replay =
+        CanonicalRouteArtifact::decode_canonical(&right_artifact_bytes).unwrap();
+    assert_eq!(
+        base_artifact_replay.canonical_bytes().unwrap(),
+        base_artifact_bytes
+    );
+    assert_eq!(base_artifact_replay.manifest_kappa(), base_manifest);
+    assert_eq!(
+        left_artifact_replay.canonical_bytes().unwrap(),
+        left_artifact_bytes
+    );
+    assert_eq!(
+        right_artifact_replay.canonical_bytes().unwrap(),
+        right_artifact_bytes
+    );
+    let left_view_replay = left_artifact_replay
+        .global_exact_spin_snapshot_view()
+        .unwrap();
+    let right_view_replay = right_artifact_replay
+        .global_exact_spin_snapshot_view()
+        .unwrap();
+    assert_eq!(left_view_replay, left_view);
+    assert_eq!(right_view_replay, right_view);
+    let hierarchy_replay = operator
+        .audit_hierarchy_pair(&left_artifact_replay, &right_artifact_replay)
+        .unwrap();
+    let left_replay = operator
+        .predict_matched(
+            &table,
+            &base_overlay,
+            &base_artifact_replay,
+            &left_artifact_replay,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    let right_replay = operator
+        .predict_matched(
+            &table,
+            &base_overlay,
+            &base_artifact_replay,
+            &right_artifact_replay,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    assert_eq!(hierarchy_replay, hierarchy);
+    assert_eq!(left_replay, left);
+    assert_eq!(right_replay, right);
+    let replay_target_free_census = TargetFreeCensus {
+        schema: 1,
+        domain: "uor-r4.bounded-global-exact-spin-target-free-census/1",
+        decoded_target_commitment: TARGET_COMMITMENT,
+        table_cid: table.artifact_cid(),
+        base_overlay_cid: base_overlay.artifact_cid(),
+        operator_cid: operator_cid.clone(),
+        codec_kappa: operator.codec_kappa().to_owned(),
+        vocabulary_kappa: operator.vocabulary_kappa().to_owned(),
+        route_manifest_kappa: operator.route_manifest_kappa().to_owned(),
+        spin_map_kappa: operator.spin_map_kappa().to_owned(),
+        chart_profile_kappa: operator.chart_profile_kappa().to_owned(),
+        grammar_kappa: operator.grammar_kappa().to_owned(),
+        routing_policy_kappa: operator.routing_policy_kappa().to_owned(),
+        h4_root_table_kappa: operator.h4_root_table_kappa().to_owned(),
+        h4_multiplication_table_kappa: operator.h4_multiplication_table_kappa().to_owned(),
+        base_lower_artifact_manifest_kappa: base_manifest.clone(),
+        hierarchy: &hierarchy_replay,
+        snapshots: [&left_view_replay, &right_view_replay],
+        cases: vec![
+            TargetFreeCase {
+                partition_id: "49",
+                prompt_cid: direct_cid(OBSERVED_PROMPT),
+                prediction: &left_replay,
+            },
+            TargetFreeCase {
+                partition_id: "50",
+                prompt_cid: direct_cid(OBSERVED_PROMPT),
+                prediction: &right_replay,
+            },
+        ],
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+        terminal: NEGATIVE_TERMINAL,
+    };
+    let replay_target_free_bytes = serde_json::to_vec(&replay_target_free_census).unwrap();
+    assert_eq!(replay_target_free_bytes, target_free_bytes);
+    assert_eq!(direct_cid(&replay_target_free_bytes), target_free_cid);
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+
+    assert_eq!(operator.to_bytes().unwrap(), operator_bytes);
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+
+    println!(
+        "table_cid={}\nbase_overlay_cid={}\noperator_bytes={}\noperator_cid={operator_cid}\ncodec_kappa={}\nvocabulary_kappa={}\nroute_manifest_kappa={}\nspin_map_kappa={}\nchart_profile_kappa={}\ngrammar_kappa={}\nrouting_policy_kappa={}\nh4_root_table_kappa={}\nh4_multiplication_table_kappa={}\nleft_global_epoch={}\nright_global_epoch={}\ntarget_commitment={TARGET_COMMITMENT}\ntarget_free_census_cid={target_free_cid}\nleft_global_fold=-1\nright_global_fold=-1\nreal_roles=helix/helix\nclass_operator_permuted_roles=prism/prism\nsupport_mismatches=0\nwork_mismatches=0\ntarget_preimage_loads=0\nterminal={NEGATIVE_TERMINAL}",
+        table.artifact_cid(),
+        base_overlay.artifact_cid(),
+        operator_bytes.len(),
+        operator.codec_kappa(),
+        operator.vocabulary_kappa(),
+        operator.route_manifest_kappa(),
+        operator.spin_map_kappa(),
+        operator.chart_profile_kappa(),
+        operator.grammar_kappa(),
+        operator.routing_policy_kappa(),
+        operator.h4_root_table_kappa(),
+        operator.h4_multiplication_table_kappa(),
+        left.global_epoch,
+        right.global_epoch,
+    );
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,25 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
+> **Target-free #973 bounded-global negative, 2026-08-28.** The frozen
+> `BoundedGlobalExactSpinLeftFoldR4V1` contrast stopped at
+> `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
+> Detached left/right snapshot carriers reproduced distinct epochs and roots,
+> four references, three exact classes, one same-address repeated-class reuse,
+> exact cold-result bytes, one common lower artifact, equal support/work, and
+> zero forbidden score reads. The operative exact algebra falsified the frozen
+> premise: `Pavel` and `helix` map to the same H4 root, `prism` maps to identity,
+> and both orders therefore finish at the identical complete `-1`/fiber/torsion
+> state. Real roles were `helix/helix`; permuted roles were `prism/prism`.
+> Target loads were zero and decoded evaluation is `NOT_RUN`. The operator and
+> target-free census identities are
+> `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
+> and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
+> The retained paragraph/conversation results remain valid, but bounded-global
+> attention and corpus induction remain unqualified. #973 stays open for a
+> newly frozen noncommuting relation/population repair; #954 remains blocked.
+> See the [bounded-global record](bounded_global_exact_spin_attention_973.md).
+
 > **Retained #973 conversation mechanism, 2026-08-28.** The independently
 > frozen two-case synthetic contract retained `ConversationEntitySpinPathR4V1`
 > at `RETAIN_CONVERSATION_ENTITY_SPIN_PATH_ATTENTION_CONTINUE_BOUNDED_GLOBAL`.
@@ -33,8 +52,9 @@ assumptions, or objectives rather than measured results.
 > `blake3:343c961b06605f6ae9bb6160ac34a98224991715b706156349a8fd544b6dbb35`,
 > `blake3:649d733a194469aa648101a873d9e2ee323266b18872ced412d1da2cc6a56635`,
 > and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
-> #973 remains open for one independently frozen bounded-global contrast, then
-> corpus induction; #954 remains blocked. See the
+> The subsequent bounded-global contrast failed its target-free relation gate.
+> #973 remains open for a newly frozen relation/population repair before corpus
+> induction; #954 remains blocked. See the
 > [#973 conversation record](conversation_entity_spin_path_attention_973.md).
 
 > **Retained #973 paragraph mechanism, 2026-08-28.** The frozen two-case
@@ -58,8 +78,9 @@ assumptions, or objectives rather than measured results.
 > `blake3:515720686b96dbebc2f055f9a21d3f0684f76092018381c836b51abf47a4d197`,
 > and `blake3:0ba32e5fe26f1280ec2eef2b115023de52f2ef946882352311dcecc531d76a32`.
 > The subsequent independently frozen conversation-scope contrast has now
-> retained its bounded mechanism. #973 remains open for bounded-global
-> qualification and corpus induction; #954 remains blocked.
+> retained its bounded mechanism. The subsequent bounded-global relation failed
+> target-free. #973 remains open for its repair and later corpus induction;
+> #954 remains blocked.
 > See the [#973 paragraph record](paragraph_entity_spin_path_attention_973.md).
 
 > **Retained #973 Gate 0 mechanism, 2026-08-28.**
@@ -152,9 +173,10 @@ assumptions, or objectives rather than measured results.
 > accepted R4 table-tie result supersede that forward action: #953 closed at
 > its positive terminal; #973 has since retained one exact-candidate
 > prior-prefix copy mechanism plus bounded construction-bound exact-descriptor/
-> entity-binding path selectors at paragraph and conversation scope. One
-> independently frozen bounded-global contrast is next, followed by corpus
-> induction. #954 remains blocked
+> entity-binding path selectors at paragraph and conversation scope. The first
+> independently frozen bounded-global relation then failed target-free because
+> its swapped exact states commute. A fresh noncommuting relation/population
+> repair is next; corpus induction remains unauthorized. #954 remains blocked
 > behind #973.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
@@ -713,8 +735,10 @@ replay. External replay adjudication promoted the reports' pending verdict to
 then retained one exact-candidate prior-prefix copy mechanism, and its frozen
 paragraph and conversation slices retained construction-bound exact-descriptor/
 entity-binding path selectors at their respective scopes. These remain two-
-case synthetic results; one independently frozen bounded-global contrast is
-next, followed by corpus induction. Dependable broad coherent
+case synthetic results; the first independently frozen bounded-global relation
+failed target-free because its swapped exact states commute. A newly frozen
+noncommuting relation/population repair is next, and corpus induction remains
+unauthorized. Dependable broad coherent
 text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
@@ -1284,8 +1308,9 @@ External replay adjudication promoted the reports' pending verdict and #953
 closed at `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`.
 #973 has since retained one bounded exact-candidate prior-prefix copy mechanism
 plus bounded construction-bound exact-descriptor/entity-binding path selectors
-at paragraph and conversation scope. Bounded-global and corpus qualifications
-remain active in that order and continue to block #954.
+at paragraph and conversation scope. The first bounded-global relation is now
+target-free negative; a fresh bounded-global repair and later corpus
+qualification remain active in that order and continue to block #954.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/adr/0004-geometric-intelligence-route-hierarchy.md
+++ b/docs/adr/0004-geometric-intelligence-route-hierarchy.md
@@ -1,13 +1,16 @@
 # ADR-0004: Define a bounded geometric-intelligence route hierarchy
 
 - **Status:** Accepted as an architectural definition and evaluation boundary;
-  amended 2026-08-28 after #953's repaired admission and placement preflight,
-  #983's independent 0/6 construction-transfer negative, and #986's
-  `UNAVAILABLE_FRAME_OR_POPULATION` feasibility terminal. #986 produced no
-  placement, link state, or selector; #953 remains parked pending a freshly
-  frozen population/frame successor. #973 remains blocked and later owns
-  paragraph, conversation, global exact-spin, and corpus-scale qualification.
-  Harmonic qualification additionally requires a bound basis/mode contract.
+  amended 2026-08-28 after B0/#989, the accepted matched #953 R4 table-tie
+  intervention, and #973's retained prior-prefix, paragraph, and conversation
+  mechanisms. #973's first bounded-global exact-spin relation stopped
+  target-free at
+  `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`:
+  its detached snapshots and same-address class reuse were valid, but the
+  frozen swapped exact states commute to one identical complete fold. #973 is
+  active for a newly frozen noncommuting relation/population repair; corpus
+  induction is not authorized and #954 remains blocked. Harmonic qualification
+  additionally requires a bound basis/mode contract.
   Inference,
   correctness, and reasoning capability remain unproven.
 - **Date:** 2026-08-26
@@ -299,14 +302,22 @@ Consequently,
 “least energy” means least energy among admitted candidates unless an artifact
 explicitly scores the entire bounded union before admission.
 
-#969 qualified only its retained local S3 path cost. #953 continues to use that
-cost while repairing admission and keeps paragraph, conversation, global, and
-shared higher-scope operator action inert. After an accepted #953 loop, #973
-may qualify a global exact-spin overlay only under identical admitted support and work across
+#969 qualified only its retained local S3 path cost. The historical #953 path
+kept paragraph, conversation, global, and shared higher-scope action inert; the
+later accepted matched #953 R4 table-tie intervention exposed #973. #973 may
+qualify a global exact-spin overlay only under identical admitted support and work across
 real, identity-disabled, and deterministic class/operator-permuted arms. The
 real overlay must change the intended candidate and exact decoded output, while
 the disabled and permuted arms do not reproduce that predeclared effect. A
 changed shared-result trace or stored state alone is not attention.
+
+The first such #973 global overlay reached its target-free negative terminal.
+Both detached carriers had distinct epochs/roots and valid three-class/one-
+reuse populations, but `Pavel`/`helix` shared one H4 root and `prism` was the
+identity, so the swapped orders produced the same `-1`/fiber/torsion state and
+the same winner. Target data was not opened. This preserves the architectural
+overlay boundary while rejecting that relation/pair; any repair must establish
+noncommuting distinct exact folds before decoded or corpus work.
 
 For each already-admitted candidate `c`, the selector may clone the observed
 state, compute the deterministic provisional state
@@ -402,7 +413,9 @@ Delivery proceeds without skipping stages:
    unchanged after a fresh label-free preflight;
 6. in #973, qualify paragraph, conversation, and global influence through the
    accepted #953 loop, including the shared exact-spin operator overlay and
-   its matched disabled/permuted controls;
+   its matched disabled/permuted controls; paragraph and conversation are
+   retained, while the first global relation is negative and requires a newly
+   frozen noncommuting repair;
 7. within #973, after every required scope qualifies, activate a predeclared
    higher-scope/corpus-scale offline induction ladder with a frozen operator
    family and induction rule; assign every rung new artifact/operator identities

--- a/docs/bounded_global_exact_spin_attention_973.md
+++ b/docs/bounded_global_exact_spin_attention_973.md
@@ -1,0 +1,342 @@
+# #973 bounded-global exact-spin attention record
+
+- **Date:** 2026-08-28
+- **Issue:** #973
+- **Contract:** [frozen on the live issue](https://github.com/UOR-Foundation/uor-r4/issues/973#issuecomment-5456412251)
+  before implementation or outcome-bearing execution
+- **Isolation correction:** [frozen before execution](https://github.com/UOR-Foundation/uor-r4/issues/973#issuecomment-5456686701)
+  after discovering that snapshot epoch provenance otherwise changes lower
+  identities
+- **Mechanism:** `BoundedGlobalExactSpinLeftFoldR4V1`
+- **Contract status:** frozen
+- **Outcome:** `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`
+- **Decoded status:** `NOT_RUN`; target preimage loads `0`
+- **Issue state:** #973 remains open; #954 remains blocked
+
+## Decision
+
+Can one immutable ordered global snapshot act through exact stored lexical
+`SpinTorsionState` and causally change an already admitted #953 candidate and
+decoded output while the observed lower prompt, candidate support, payloads,
+base evidence, ceilings, and executed work remain fixed?
+
+This is the independently frozen bounded-global contrast authorized by the
+retained conversation-scope result. It owns no candidate admission, does not
+modify the source-free table or #953 overlay, and does not activate corpus
+induction, a neighbor kernel, correctness, reasoning, or release work.
+
+## Exact-class population boundary
+
+The current canonical registry assigns one prime and one complete stored spin
+state to each lexical unit. Consequently, two different lexical addresses do
+not share a full signed-S3/Hopf/fiber/torsion `shared_class_kappa` in this
+fixture. The required fan-out witness is instead exact and narrower:
+
+- two distinct immutable snapshot ordinals and entry kappas;
+- one unchanged lexical address and payload referenced twice;
+- one unchanged complete exact class;
+- one class evaluation reused by both references; and
+- a cold recomputation equal to the cached result bytes.
+
+The probe builds this census from global snapshot entries. It does not reuse
+the route-occurrence shared-class index as a surrogate. A result cannot support
+distinct-address class sharing; requiring two different address kappas would
+make the current population unavailable before decoded execution.
+
+## Frozen D3 split and bytes
+
+Construction uses exactly the D3-construction documents:
+
+```text
+51:
+Lena bound the helix class.
+
+The bounded global code is bronze.
+
+52:
+Pavel bound the prism class.
+
+The bounded global code is teal.
+```
+
+The independently identified D3-held-out cases are IDs 49 and 50. Both have
+the same complete observed lower prompt:
+
+```text
+The bounded global code is
+```
+
+The active trigram row must be a count-one tie over the fitted one-unit
+candidates ` bronze` and ` teal`. The global operator may rank only those
+`max_count_tie_tokens`; it cannot add, remove, rewrite, or discover support.
+Construction IDs and text CIDs, held-out IDs and prompt CID, table and overlay
+CIDs, codec and address registry, candidate payloads, base evidence, lower
+state, and work remain provenance or controls rather than score coordinates.
+
+The evaluation snapshots are not fitting documents or operator-family
+construction inputs. They contain no candidate continuation bytes. They use
+the same construction-registered lexical multiset in different order:
+
+```text
+ID 49: [Pavel, Pavel, helix, prism]
+ID 50: [Pavel, Pavel, prism, helix]
+```
+
+The pool `{Lena,Pavel,helix,prism}`, length-four multiset enumeration, and
+canonical lexical-unit/permutation order were fixed before target attachment.
+The pair is the first label-free exact-algebra population with both prototype
+anchors, a repeated exact class, nonidentity distinct folds, and incompatible
+unique prototype winners. This is synthetic execution-order separation, not a
+hidden-label or natural-distribution experiment.
+
+Each held-out case uses the same byte-identical lower query artifact, built
+once with the neutral registered global unit `global`. A second canonical
+artifact carries only the ordered evaluation snapshot. The operator reads the
+carrier's validated global root, epoch, ordered references, address inversion,
+payload inversion, complete stored spin, and exact-class identity; it forbids
+the carrier's lower identities, lower ordered state, global summary, and
+prime-derived hierarchy H4 fold as score inputs. This detached carrier keeps
+the lower artifact and its manifest fixed across the two cases while retaining
+canonical provenance for the global snapshot itself.
+
+## Frozen exact operator
+
+`CanonicalS3SpinToH4V1` maps a stored S3 raw coordinate only when every Q1.30
+component converts exactly to the scaled `Z[phi]` H4 table with zero phi
+coefficient and exactly one coordinate match. The artifact binds quaternion
+basis `(1,i,j,k)`, orientation, root order, quantization, identity, product and
+inverse tables, and mapping kappa. Prime-mod-120 route placement, nearest-root
+search, opaque-index arithmetic, hashes, and coarse spin sectors are forbidden.
+
+For snapshot entries `u_0..u_3`, define the ordered state
+
+```text
+G = G(u_0) o G(u_1) o G(u_2) o G(u_3)
+
+(h,f,t) o (h',f',t')
+  = (h*h', wrap_q29(f+f'), wrap_q29(t+t'))
+```
+
+starting from the exact identity. Every transition is recorded. Both frozen
+orders must finish at distinct nonidentity states. The existing global summary
+and prime-derived hierarchy H4 fold are not operator inputs or evidence.
+
+For every unique exact snapshot class `C`, compute once
+
+```text
+Delta(G,C) = C^-1 o G
+
+cost(G,C) = (H4S3AngularShell(Delta.h4),
+             circular_abs_q29(Delta.fiber),
+             circular_abs_q29(Delta.torsion))
+```
+
+and bind the result to the global epoch/root, operator, map/chart/table
+identities, and exact class. Repeated references reuse the byte-identical class
+result. Candidate identity only selects the construction-bound prototype row:
+`bronze -> helix` and `teal -> prism`. The unique lowest complete cost over the
+unchanged admitted support wins; an equal minimum abstains.
+
+The label-free algebra fixes:
+
+| Held-out state | Exact fold | Helix relation | Prism relation | Unique role |
+| --- | --- | --- | --- | --- |
+| ID 49 | `-1` | Orthogonal | Degrees120 | helix |
+| ID 50 | `+j` | Orthogonal | Degrees60 | prism |
+
+Fiber and torsion remain in the complete cost and trace, although the H4 shell
+is already strict in these two cases.
+
+## Firewall and controls
+
+The numeric path may read only exact stored S3/Hopf/fiber/torsion state and
+the bound exact tables. Class kappa is equality/cache identity only. Target,
+future, teacher, provider, corpus, candidate spelling/ID, digest, address,
+prime, payload, ordinal, coarse `SpinSector`, adjacent rows, and full-history
+IDs cannot contribute numerically.
+
+Every arm performs the same snapshot reads, class census, one reuse, exact
+fold, class evaluations, candidate relations, cost comparisons, support scan,
+and final-choice operation:
+
+- `real` ranks with the exact class-relative result;
+- `identity_disabled` performs the same work, masks global ranking, and returns
+  the unchanged #953 fallback; and
+- `class_operator_permuted` swaps the two prototype-class result assignments
+  after computing the identical result multiset.
+
+The target-free role matrix is:
+
+| Arm | ID 49 | ID 50 |
+| --- | --- | --- |
+| real | helix | prism |
+| identity disabled | #953 fallback | #953 fallback |
+| class/operator permuted | prism | helix |
+
+Physical support iteration reversal must leave the real result unchanged, and
+a coherent candidate/prototype relabel must be equivariant. Work is counted
+from executed operations rather than copied from a declared constant.
+
+## Sealed target and terminals
+
+Before the operator receives target data, the canonical decoded-target JSON is
+committed as
+`blake3:00fef74baee2785059d7be20a20fb07f9c5f5b18ae085c20503d3080019e13b1`.
+The preimage remains outside operator compilation and the target-free census.
+Only after exact serialization/reload/replay may the test reveal and verify the
+preimage once, attach the continuations, and run one decoded contrast.
+
+Typed terminals are:
+
+```text
+INVALID_BOUNDED_GLOBAL_EXACT_SPIN_CONTRACT
+UNAVAILABLE_BOUNDED_GLOBAL_EXACT_CLASS_POPULATION
+RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION
+RETAIN_BOUNDED_GLOBAL_STATE_ONLY_REDESIGN_BOUNDED_GLOBAL_READOUT
+RETAIN_BOUNDED_GLOBAL_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION
+```
+
+A positive requires the exact committed decoded matrix, real 2/2, weaker
+disabled behavior, permuted 0/2, deterministic period-and-EOS termination,
+zero support/work mismatch, and byte-identical replay. It would retain one
+bounded synthetic ordered exact-spin overlay with same-address reference reuse.
+It would not establish distinct-address sharing, semantic or natural/corpus
+transfer, a geometric advantage over direct order lookup, angular-neighbor or
+harmonic behavior, general global attention, coherence, correctness, or
+reasoning. #973 would remain open for corpus induction and final
+requalification, and #954 would remain blocked.
+
+## Run contract and activated checks
+
+```text
+metric to move:       exact decoded bounded-global matrix, current NOT_RUN
+reachability ceiling: 2/2 fixed decisions conditional on the target-free hard gate
+cheap instrument:     target-free support/class/fold/reuse/candidate census and exact replay
+instrument verdict:  real helix/prism; disabled common fallback; permuted prism/helix
+exit rule:            exact committed decoded matrix with zero support/work mismatch
+if positive:          retain bounded-global mechanism; freeze corpus induction inside #973
+if negative:          typed population, relation, or readout redesign terminal
+cost estimate:        focused probe expected under 5 minutes; 10-minute hard wall
+```
+
+Activated checks are the focused target-free/decoded test, binding/tamper/replay
+checks, touched-package compile, root WASM library compile for the public core
+module, Rust formatting, claim wording, and diff whitespace. Workspace-wide,
+BDD, model, no-std, Gate C, kappa, audit, fuzz, conformance, corpus, product,
+performance, formal, and release suites remain `NOT_RUN` because they cannot
+change this decision.
+
+## Observed target-free outcome
+
+The first blind execution stopped at the frozen distinct-fold assertion before
+any target load. The accepted target-free replay then encoded the observed
+negative without changing the construction documents, held-out IDs, snapshot
+orders, exact map, fold orientation, relative relation, cost, controls, or
+target commitment.
+
+The population and isolation checks passed:
+
+- both cases used one byte-identical base lower artifact and manifest;
+- the detached snapshot carriers had distinct manifests, epochs, roots, and
+  prime-derived hierarchy states;
+- each snapshot had four immutable references, three exact classes, and one
+  same-address `Pavel` reuse with distinct ordinals/entry kappas;
+- each cached class-result serialization equaled its cold recomputation;
+- candidate support, base evidence, lower fallback, and the complete named
+  operation ledger matched across real, disabled, and permuted arms; and
+- forbidden target/future/teacher/provider/corpus and provenance score reads
+  were zero.
+
+The label-free algebraic prediction failed. In the bound canonical codec,
+`Pavel` and `helix` both map to the exact H4 root
+`q = (1+i+j+k)/2`, while `prism` maps to the exact identity. Therefore:
+
+```text
+ID 49: q * q * q * 1 = -1
+ID 50: q * q * 1 * q = -1
+```
+
+The complete folds are identical, not merely their H4 component:
+
+| Field | ID 49 | ID 50 |
+| --- | ---: | ---: |
+| H4 coordinate | `-1` | `-1` |
+| fiber Q29 | `110444176` | `110444176` |
+| torsion Q29 | `-10509096` | `-10509096` |
+| real role | `helix` | `helix` |
+| identity-disabled role | #953 fallback | #953 fallback |
+| class/operator-permuted role | `prism` | `prism` |
+
+The order change is real at the carrier and at the forbidden prime-derived
+hierarchy audit, and the third intermediate fold step differs, but the fourth
+exact stored-spin step returns both orders to the same complete state. Those
+provenance differences cannot replace a distinct operative relation.
+
+The mapper and left-product convention semantically match the exact conversion
+used by the retained paragraph and conversation mechanisms. The result is therefore a
+frozen fixture/relation error, not an implementation orientation drift. The
+predeclared right `+j` state and `prism` winner were impossible for this exact
+registry. No alternative pair, chart, orientation, or readout was tried.
+
+Accepted identities:
+
+```text
+table:
+  blake3:a026549d331f071a3c6e70707f71a5dd0002855876f21d2cf0deb9ea4ac69b80
+#953 overlay:
+  blake3:c21ff09273062dc21baf87b6180fc5f224314858018c1e7aa6db4ff9fc25a422
+operator (3,228 bytes):
+  blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f
+target-free census:
+  blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a
+spin map:
+  blake3:5cc6d40c7b80e7c0519a08d95ea33ef6b079c9decfbd602c99c9937fabb7bb01
+chart profile:
+  blake3:38182fc770ce5ee5c717cd7e2ab4c54a81252dee7ce4995ab521340a8f34a0de
+H4 root table:
+  blake3:8d33d62a239fb8001fea2bd14a9a5ec7321d0f07d81c74a5715eaeb3df53aa76
+H4 product/inverse table:
+  blake3:90ee73a27ee2e8ba5bccd1507d7fb37ed1f044b1640772c86752bc0bb2111759
+```
+
+Named operations per principal arm were four snapshot reads, four exact-class
+comparisons, three unique-class evaluations, one reuse, four reference-result
+applications, ten H4 products, six H4 inverses, twenty phase additions, twelve
+phase-distance reads, six angular-shell reads, two candidate-class lookups, two
+cost comparisons, and one final choice, plus the unchanged #953 ledger. This
+is an equal named-operation schedule, not an exhaustive machine-instruction
+equality claim.
+
+The decoded commitment was never opened. There was no decoded output, period/
+EOS execution, decoded report, correctness count, or positive terminal. They
+remain `NOT_RUN`, not failed.
+
+The final hardened focused test passed `1/1` in `210.11s`, including canonical
+operator reload, oversized/operator-byte tamper rejection, malformed query/
+snapshot rejection, detached artifact reload, target-free census replay, and
+zero target loads. Touched-package compile, formatting, claim wording, and diff
+whitespace passed. The full strict clippy command was attempted but is blocked
+by pre-existing warnings in untouched model-source, graph-runtime, and core
+modules; no warning named this bounded-global module or test. Root WASM compile
+passed. All deliberately dormant suites listed in the frozen run contract
+remain `NOT_RUN`.
+
+The binding terminal is:
+
+```text
+RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION
+```
+
+This preserves the earlier paragraph/conversation results and establishes only
+the target-free population, canonical detached-carrier provenance, and exact
+same-address reuse mechanics. It rejects this particular bounded-global
+relation/pair. It does not establish bounded-global attention, general exact-
+spin attention, distinct-address sharing, semantic/natural/corpus transfer,
+angular-neighbor or harmonic behavior, a direct-lookup advantage, correctness,
+reasoning, coherence, performance, formal closure, or release readiness.
+
+#973 remains open and #954 remains blocked. Corpus induction is not authorized.
+The next decision is a newly frozen target-free bounded-global relation/
+population repair that proves noncommuting distinct exact folds before any
+decoded target join. The public result is recorded in
+[the live issue](https://github.com/UOR-Foundation/uor-r4/issues/973#issuecomment-5456901633).

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -31,9 +31,9 @@ emitted identical reports and artifacts. The binding record is
 This is an established statistical lexical prediction and bounded-decoding
 baseline, not semantics, attention, geometry, correctness, reasoning, chat,
 performance, or release evidence. Its exact artifact, corpus, support, decode,
-and work are frozen as the non-geometric reference for one later #953
-intervention. All unrelated geometric, attention, teacher, broad-QA, and
-release probes remain dormant; #973 remains blocked behind #953.
+and work were frozen as the non-geometric reference for the one later accepted
+#953 intervention. Unrelated geometric, teacher, broad-QA, and release probes
+remain dormant.
 
 Lexical ingestion, canonical serialization, registered-address membership,
 and rebuild witnesses are prerequisite plumbing, not inference. The delivery
@@ -64,8 +64,11 @@ selector or payload inversion and is now closed bounded negative evidence.
 #986 then closed `UNAVAILABLE_FRAME_OR_POPULATION` before placement because its
 exact population/codec commitment and complete lexical SpiralCore frame were
 unavailable. Gate 0, labels, selection, and #953 were `NOT_RUN`. The later
-established B0/#989 result now exposes one matched #953 intervention; #953
-continues to block #973 and #954, and #973 continues to block #954.
+established B0/#989 result exposed one matched #953 intervention, which has
+since been accepted. #973 then retained its bounded Gate 0, paragraph, and
+conversation mechanisms. Its first bounded-global exact-spin relation failed
+target-free because the frozen swapped states commute. #973 continues to block
+#954 while it owns a newly frozen relation/population repair.
 
 A negative result remains evidence about its declared mechanism and
 distribution. It does not erase a separately established storage, identity,
@@ -86,8 +89,8 @@ experiment nor a conditional issue number is automatically a serving consumer.
 0. **Source-free table baseline (B0/#989; established)** — construction-only
    integer lexical counts drove 22.261404% held-out top-1 versus 5.413561%
    unigram, exact decode, a bounded 16-unit continuation, and byte-identical
-   replay. Geometry was absent. The artifact is now the fixed reference for one
-   matched #953 intervention; all other later stages remain dormant or blocked.
+   replay. Geometry was absent. The artifact is the fixed reference used by the
+   one accepted matched #953 intervention; later stages remain sequenced.
 
 1. **Local route-attention mechanism (#969)** — natural schema-2 adjacency,
    causal ordered R4/S3 path state, retained prefix memory, and deterministic
@@ -818,7 +821,7 @@ it does not participate in admission. The existing adjacent-spin retrieval rows
 remain fallback/diagnostic data, not operator coefficients; any neighbor
 operator is compiled independently over exact classes and admitted candidates.
 
-The first global decision reuses one existing exact `shared_class_kappa` over
+The first global decision reused one existing exact `shared_class_kappa` over
 full signed S3 orientation, checked Hopf observation, fiber, and torsion.
 Hopf/S2 is not class identity by itself, and `q`/`-q` remain distinct. The
 fixture contains enough ordered global state to produce a witnessed
@@ -865,9 +868,27 @@ coefficients, quantization, and transition law before the prototype is called
 harmonic. #973 will freeze its own terminal literal before running this
 contract.
 
-A positive global subprobe cannot close #973. Paragraph and conversation still
-require their own matched load-bearing qualification through the accepted loop,
-or an explicit native revision of #973's scope and dependencies.
+A future positive global subprobe cannot close #973. Paragraph and conversation
+are retained, but corpus induction and final requalification still require
+their own frozen evidence or an explicit native scope revision.
+
+#### Observed bounded-global target-free terminal (2026-08-28)
+
+The first frozen global decision reached
+`RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION` before
+target attachment. Its detached snapshot carriers had distinct epochs/roots,
+four references, three exact classes, and one same-address result reuse, while
+one byte-identical lower artifact and equal support/work were preserved. The
+operative relation was nevertheless identical: `Pavel` and `helix` map to
+`q=(1+i+j+k)/2`, `prism` maps to identity, and both `q*q*q*1` and `q*q*1*q`
+finish at the same complete `-1`/fiber/torsion state. Real roles were
+`helix/helix`; permuted roles were `prism/prism`. Target loads were zero and
+decoded evaluation is `NOT_RUN`. See the
+[#973 bounded-global record](bounded_global_exact_spin_attention_973.md).
+
+This is a relation/population falsification, not a global-attention result. A
+fresh #973 contract must establish noncommuting distinct exact folds and
+incompatible target-free winners before any decoded join or corpus induction.
 
 ## 4. Matched controls
 
@@ -922,12 +943,15 @@ natural support and work. Do not carry #969's last-only arm or the obsolete
 six-comparator I1 matrix forward. A single grammar-disabled diagnostic is
 allowed only to localize an already observed output defect.
 
-For #973's global exact-spin operator decision, run real, identity-disabled, and
-deterministic class/operator-permuted arms with identical admission and work.
+For #973's global exact-spin operator decisions, run real, identity-disabled,
+and deterministic class/operator-permuted arms with identical admission and work.
 At least two references share one exact class so reuse is exercised; a different
 exact class in the same current `SpinSector` checks that the operator is not
 aliasing the coarse Hopf-octant/torsion bucket. A one-unit registration-only
 global snapshot or an identity transition cannot qualify the operator.
+The first frozen pair satisfied the class/reuse population but failed this gate
+because both complete order folds were identical; its decoded arm remains
+`NOT_RUN`.
 
 A working decoded intervention records
 `PROCEED_TO_I1_WITH_CAUSAL_R4_PATH_ATTENTION`. This establishes only a

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -83,8 +83,10 @@ coherence, correctness, reasoning, chat, performance, or release readiness.
 No second #953 formula, axis, prompt, corpus run, or representation is
 permitted. #973 has retained one bounded prior-prefix copy mechanism and one
 bounded construction-bound exact-descriptor selector at each of paragraph and
-conversation scope; bounded-global and corpus qualifications remain active and
-#954 remains blocked. No new H4,
+conversation scope. Its first bounded-global exact-spin relation then failed
+target-free because the frozen swapped states commute. A newly frozen
+noncommuting relation/population repair and later corpus qualification remain
+active; #954 remains blocked. No new H4,
 SpiralCore, harmonic, algebraic, placement, transport, or scale qualifier is
 eligible outside its exposed issue.
 
@@ -177,8 +179,9 @@ unavailable. Placement, Gate 0, labels, table/geometric arms, and #953 were
 table-tie intervention. That intervention passed, and #973 has since retained
 one bounded prior-prefix copy mechanism at Gate 0 plus one bounded
 construction-bound exact-descriptor selector at each of paragraph and
-conversation scope; bounded-global and corpus qualifications remain active and
-continue to block #954. Calling a later
+conversation scope. The first bounded-global exact-spin relation is now
+target-free negative; a fresh noncommuting relation/population repair and later
+corpus qualification continue to block #954. Calling a later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive
@@ -743,7 +746,8 @@ population/frame unavailable terminal. B0/#989 then supplied the frozen
 reference for the accepted matched #953 intervention. #973 has since retained
 one bounded exact-candidate prior-prefix copy mechanism plus bounded
 construction-bound exact-descriptor paragraph and conversation selectors;
-bounded-global and corpus qualifications remain active and continue to block
+the first bounded-global exact-spin relation failed target-free, and a fresh
+relation/population repair plus later corpus qualification continue to block
 #954**.
 
 The frozen A1.0 probe stopped before scorer implementation with
@@ -1150,7 +1154,8 @@ was `REVISE_I1_GENERATOR_IN_PLACE`. B0/#989 later permitted exactly one separate
 matched #953 intervention against its fixed table reference. That intervention
 is now accepted at the positive terminal after external replay adjudication.
 #973 has since retained only the bounded paragraph and conversation mechanisms
-recorded below; bounded-global selection remains unqualified.
+recorded below. Its first bounded-global relation failed target-free, so
+bounded-global selection remains unqualified.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
 identity-scoped hive-memory lifecycle remain #962 scope.
 
@@ -1382,13 +1387,45 @@ coherence, correctness, or reasoning.
 
 The retained terminal is
 `RETAIN_CONVERSATION_ENTITY_SPIN_PATH_ATTENTION_CONTINUE_BOUNDED_GLOBAL`.
-#973 remains open and continues to block #954. Its next decision is one
-independently frozen bounded-global exact-spin operator contrast. Only if the
-remaining bounded-global and later corpus-scale induction qualifications pass,
-or an explicit native revision changes #973's scope, may #973 reach its
-declared terminal and unblock #954.
+#973 remains open and continues to block #954. The independently frozen
+bounded-global exact-spin operator contrast that followed is recorded next.
 
-A later bounded-global qualification may use one exact-spin global operator
+#### #973 bounded-global target-free result — `BoundedGlobalExactSpinLeftFoldR4V1` (2026-08-28)
+
+The detached-carrier implementation preserved one byte-identical lower query
+artifact while giving the two same-multiset ordered global snapshots distinct
+canonical carrier manifests, epochs, and roots. Each snapshot exposed four
+immutable references, three complete exact classes, and one same-address
+`Pavel` class reuse. Cached result bytes reproduced under a cold computation;
+support, fallback, and named-operation work matched across real, disabled, and
+class/operator-permuted arms.
+
+The frozen label-free relation premise failed before target attachment. In the
+bound canonical registry, `Pavel` and `helix` map to the same exact H4 root
+`q = (1+i+j+k)/2`, while `prism` maps to the exact identity. Consequently the
+two proposed orders are `q*q*q*1` and `q*q*1*q`; both finish at `-1` with the
+same fiber `110444176` and torsion `-10509096`. Real roles were `helix/helix`,
+and class/operator-permuted roles were `prism/prism`, rather than the required
+incompatible pair. Distinct carrier provenance and the distinct prime-derived
+hierarchy state were audit-only and did not enter scoring.
+
+The target-free census replayed at
+`blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`
+against operator
+`blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`.
+Target loads were zero; decoded evaluation remains `NOT_RUN`. The binding
+terminal is
+`RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
+See the
+[#973 bounded-global exact-spin record](bounded_global_exact_spin_attention_973.md).
+
+This preserves the paragraph/conversation results and the exact snapshot/
+reuse machinery, but it does not establish bounded-global attention. #973
+remains open and #954 remains blocked. The next decision is a newly frozen,
+target-free relation/population repair that proves noncommuting distinct exact
+folds before any decoded join. Corpus induction is not authorized.
+
+A fresh bounded-global qualification may use one exact-spin global operator
 prototype, not a larger channel census. Freeze a construction-independent global snapshot with
 enough ordered state to produce a witnessed non-identity transition, at least
 two immutable references in one exact spin class, and one different
@@ -1431,7 +1468,7 @@ grammar, coherence, correctness, or reasoning. H4 group action alone is not a
 qualified spherical-harmonic field; fixed channels/modes and their transition
 law must be artifact-bound before that stronger description is earned.
 
-A positive global subprobe cannot close #973. The bounded construction-bound
+A future positive global subprobe cannot close #973. The bounded construction-bound
 paragraph and conversation slices are retained, but corpus-scale induction and
 final requalification remain required after the bounded-global decision, or an
 explicit native revision must change #973's scope and dependencies.
@@ -1605,7 +1642,8 @@ hours remains a hard kill ceiling, never an estimate.
   decoded-loop plumbing without qualifying natural grammar. The later, separate
   B0 table-tie intervention has qualified its bounded geometric increment and
   exposed #973. #973 has retained bounded paragraph and conversation
-  mechanisms and alone owns the remaining bounded-global qualification.
+  mechanisms; its first bounded-global relation failed target-free, and it
+  alone owns the newly frozen repair and remaining global qualification.
 - S3/R4 compute, Hopf S2/R3 observation, and an E8 action plane are distinct
   objects.
 - Exact recall, grammatical text, correct inference, and reasoning are separate


### PR DESCRIPTION
## Summary

- add a read-only canonical global exact-spin snapshot view and detached lower/snapshot artifact boundary
- implement the frozen bounded-global exact stored-spin left-fold operator with exact class reuse and matched controls
- preserve the binding target-free negative instead of opening decoded targets or tuning the fixture
- reconcile current #973 programme claims and append the full evidence record

## Observed decision

The frozen pair failed the target-free relation gate. `Pavel` and `helix` map to the same exact H4 root and `prism` maps to identity, so both swapped orders finish at the same complete `-1` state with identical fiber/torsion. Real roles are `helix/helix`; permuted roles are `prism/prism`.

Terminal:

`RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`

Target preimage loads are zero and decoded evaluation is `NOT_RUN`. This preserves the retained paragraph/conversation results but does not establish bounded-global attention. #973 remains open for a newly frozen noncommuting relation/population repair; corpus induction is not authorized and #954 remains blocked.

## Evidence

- operator, 3,228 bytes: `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
- target-free census: `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`
- focused test: 1 passed, 0 failed, 210.11s
- support mismatches: 0
- work mismatches: 0
- target loads: 0

## Verification

- `cargo test -p uor-r4-core --test bounded_global_exact_spin_attention_973 --offline -- --nocapture`
- `cargo check -p uor-r4-core --offline`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib --offline`
- `cargo fmt --all -- --check`
- `python3 scripts/check_claim_wording.py`
- `git diff --check`

The full strict clippy command was attempted and stopped on pre-existing warnings in untouched model-source, graph-runtime, and core modules; no diagnostic named the new bounded-global module or test. Workspace-wide, BDD, model, no-std, Gate C, kappa, audit, fuzz, conformance, corpus, product, performance, formal, and release suites remain `NOT_RUN` under the frozen decision boundary.

References #973