### PR TITLE
feat(core): qualify noncommuting global exact-spin attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ and reasoning can emerge from routes through a canonical geometric memory. The
 target serving engine uses no Ollama, hosted model, or source-model weights.
 
 > **Current bounded-global result (2026-08-28):** #973's independently frozen
+> `BoundedGlobalNoncommutingExactSpinR4V2` reached
+> `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
+> The canonical population repair witnesses exact stored-S3-to-H4
+> noncommutation, distinct nonidentity left-ordered folds, central Q29 phases,
+> same-address class-result reuse, and incompatible unique candidate-relative
+> winners under `C^-1*G` lexicographic least cost. With equal admitted support
+> and executed work, the decoded matrix was real 2/2, identity-disabled 1/2,
+> class/operator-permuted 0/2, and support-reversed real 2/2; support/work
+> mismatches were zero and exact period-plus-EOS termination was 6/6. The
+> target preimage was loaded once only after the target-free gate. Operator,
+> population-audit, target-free-census, and decoded-smoke identities are
+> `blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9`,
+> `blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c`,
+> `blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a`,
+> and `blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218`.
+> This establishes one bounded synthetic causal global geometric-attention
+> witness, not corpus induction, general semantics, reasoning, correctness, or
+> product readiness. #973 next independently freezes its corpus-induction gate;
+> #954 remains blocked. See the
+> [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
+
+> **Earlier bounded-global V1 negative (2026-08-28):** #973's independently frozen
 > exact-spin contrast stopped at the target-free relation gate with
 > `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
 > Both same-multiset snapshot carriers had distinct canonical epochs/roots,
@@ -27,12 +49,13 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > decoded smoke is `NOT_RUN`. Operator and target-free census identities are
 > `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
 > and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
-> This rejects one frozen global relation, not geometry generally. #973 remains
-> open for a newly frozen noncommuting relation/population repair before corpus
-> induction; #954 remains blocked. See the
+> This rejected one frozen global relation, not geometry generally. The V1
+> result remains append-only history; V2 supplied the noncommuting repair and
+> advanced #973 to an independently frozen corpus-induction gate. See the
 > [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
 
-> **Current retained bounded attention result (2026-08-28):** #973 retains three narrow
+> **Retained conversation-scope result (2026-08-28):** Before the global V2
+> qualification, #973 retained three narrow
 > mechanisms: Gate 0's exact-candidate prior-prefix copy mechanism, one
 > construction-bound exact-descriptor paragraph path selector, and now
 > `ConversationEntitySpinPathR4V1` at
@@ -55,9 +78,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `blake3:343c961b06605f6ae9bb6160ac34a98224991715b706156349a8fd544b6dbb35`,
 > `blake3:649d733a194469aa648101a873d9e2ee323266b18872ced412d1da2cc6a56635`,
 > and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
-> The subsequent independently frozen bounded-global contrast failed its
-> target-free relation gate. #973 stays open for a fresh bounded-global repair
-> before corpus induction; #954 remains blocked. See the
+> The subsequent V1 bounded-global contrast failed its target-free relation
+> gate; the independently frozen V2 repair later passed its bounded decoded
+> contract. #973 now proceeds to corpus induction; #954 remains blocked. See the
 > [conversation record](docs/conversation_entity_spin_path_attention_973.md).
 
 > **Current capability-first result (2026-08-28):** #953's frozen
@@ -104,7 +127,8 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > retained one construction-bound exact-descriptor cross-turn entity-role path
 > selector, each with the narrow boundary above. The first independent bounded-
 > global exact-spin relation failed target-free because its swapped states
-> commute; a fresh relation/population repair, then corpus qualification,
+> commute; the independently frozen V2 repair then established one bounded
+> noncommuting global mechanism. Corpus induction and final requalification
 > remain.
 > #954 remains blocked behind #973. General higher-scope attention, correct
 > answers, and reasoning do not exist yet. The
@@ -307,15 +331,15 @@ accepted a separate fixed-point R4 table-tie intervention and closed #953 at
 its positive terminal. #973 Gate 0 has since retained one bounded prior-prefix
 copy mechanism. Its frozen paragraph and conversation slices retained one
 exact-descriptor/entity-binding path selector apiece at their respective
-   scopes; the first bounded-global exact-spin relation failed target-free, so
-   a newly frozen noncommuting relation/population repair and corpus
-   qualification remain active while #954 stays blocked.
+   scopes. The first bounded-global exact-spin relation failed target-free; its
+   independently frozen V2 noncommuting repair then passed the bounded decoded
+   contract. Corpus induction is now the next #973 gate while #954 stays blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
 See the [#973 paragraph record](docs/paragraph_entity_spin_path_attention_973.md).
 See the [#973 conversation record](docs/conversation_entity_spin_path_attention_973.md).
-See the [#973 bounded-global negative record](docs/bounded_global_exact_spin_attention_973.md).
+See the [append-only #973 bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
 See the [#986 evidence record](docs/corpus_signed_transport_attention_986.md)
 for the exact feasibility boundary and deliberately unrun stages.
 Stored H4/Hopf/zeta/icosian and related route fields remain
@@ -399,12 +423,12 @@ not become substitutes for working intelligence:
    top-1, +4,242 correct choices over the unchanged table, a distinct bounded
    continuation, matched support and declared-work ledger, and byte-identical
    replay.
-3. **Repair higher-scope attention (#973)** — retain the positive Gate 0
+3. **Induce and requalify higher-scope attention (#973)** — retain the positive Gate 0
    exact-candidate prior-prefix mechanism and the bounded construction-bound
-   paragraph and conversation selectors. Preserve the first bounded-global
-   exact-spin contrast as a target-free negative: its frozen swapped states
-   commute. Freeze a noncommuting relation/population repair next; only a
-   positive bounded-global requalification may authorize corpus induction.
+   paragraph and conversation selectors. Preserve the first bounded-global V1
+   contrast as a target-free negative: its frozen swapped states commute.
+   Retain V2's positive bounded noncommuting exact-spin mechanism and freeze
+   the corpus-induction gate independently before any corpus outcome run.
    Historical placement and transport probes remain evidence, not current work.
 4. **Establish correctness** — relevance, contradiction handling, and honest
    abstention.
@@ -421,9 +445,10 @@ The active dependency chain is tracked in
 the frozen table reference, #953 established one matched R4 tie intervention
 over it, and #973 retained one bounded prior-prefix copy mechanism plus bounded
 exact-descriptor/entity-binding path selectors at paragraph and conversation
-scope. The first bounded-global relation is closed-negative within the still-open
-#973 track; its fresh repair and later corpus work remain active. #954 remains
-blocked behind #973.
+scope. Its first bounded-global relation remains closed-negative history; the
+independently frozen V2 repair passed its bounded contract. Corpus induction
+and final requalification remain active within #973. #954 remains blocked
+behind #973.
 
 ## Find your way around
 

--- a/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
+++ b/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
@@ -6,6 +6,8 @@
 //! torsion state; one query-specific result is evaluated per exact snapshot
 //! class and reused across repeated immutable references.
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 
 use crate::canonical_lexical_ingestion::{
@@ -26,10 +28,17 @@ use crate::source_free_table::{
 const OPERATOR_MAGIC: [u8; 8] = *b"BGESP001";
 const OPERATOR_SCHEMA: u32 = 1;
 const OPERATOR_DOMAIN: &str = "uor-r4.bounded-global-exact-spin-left-fold/1";
+const NONCOMMUTING_OPERATOR_MAGIC: [u8; 8] = *b"BGESP002";
+const NONCOMMUTING_OPERATOR_SCHEMA: u32 = 2;
+const NONCOMMUTING_OPERATOR_DOMAIN: &str =
+    "uor-r4.bounded-global-noncommuting-exact-spin-left-fold/2";
 const SPIN_MAP_DOMAIN: &str = "uor-r4.canonical-s3-spin-to-h4/1";
 const SPIN_MAP_RULE_IDENTITY: &str = "exact-s3-q30-components-divisible-by-2^29; arithmetic-right-shift-29-to-scaled-zphi-rational-coefficients; phi-coefficients-zero; unique-coordinate-membership-in-canonical-120-root-h4-table; reject-nonmultiple-nonmember-and-alias; no-prime-hash-candidate-or-nearest-root-placement";
 const GRAMMAR_IDENTITY_BYTES: &[u8] = b"uor-r4 bounded global exact spin grammar/1\nconstruction=<ENTITY> bound the <ANCHOR> class.\\n\\nThe bounded global code is <CANDIDATE>.\nactive-query=The bounded global code is\nprototype-bindings=bronze->helix,teal->prism\nevaluation-snapshots=Pavel,Pavel,helix,prism|Pavel,Pavel,prism,helix\nevaluation-snapshots-are-not-fitting-inputs=true";
 const ROUTING_POLICY_IDENTITY: &str = "uor-r4 bounded global exact spin routing policy/1\nmap=exact-stored-s3-to-canonical-h4-membership; q30-to-h4-shift=29; phi-coefficients=0\nfold=left-to-right exact H4 product with wrapped Q29 fiber/torsion addition\nphase-law=canonical interval [-1686629713,1686629713) with modulus 3373259426\nclass-result=C^-1*G with the same wrapped phase law\ncache-key=global-root,global-epoch,operator,map,chart,root-and-product-inverse-table,exact-class\ncost=lexicographic(h4-s3-angular-shell,fiber-circular-abs-q29,torsion-circular-abs-q29)\nselection=unique-minimum-or-abstain\ncontrols=real,identity-disabled,class-operator-permuted\nidentity-disabled=compute-all-then-return-bound-953-fallback\nclass-operator-permuted=swap-two-prototype-class-results\nscore-firewall=no-token-id,payload,address,prime,digest,ordinal,spin-sector,adjacent-row-or-target-numeric-input";
+const NONCOMMUTING_GRAMMAR_IDENTITY_BYTES: &[u8] = b"uor-r4 bounded global noncommuting exact spin grammar/2\nconstruction=<ENTITY> bound the <ANCHOR> class.\\n\\nThe bounded global code is <CANDIDATE>.\nactive-query=The bounded global code is\nprototype-bindings=bronze->helix,teal->prism\nevaluation-snapshots=Lena,Lena,helix,prism|Lena,helix,Lena,prism\nevaluation-snapshots-are-not-fitting-inputs=true\nheldout-document-identities-are-evaluation-only=true";
+const NONCOMMUTING_ROUTING_POLICY_IDENTITY: &str = "uor-r4 bounded global noncommuting exact spin routing policy/2\nmap=exact-stored-s3-to-canonical-h4-membership; q30-to-h4-shift=29; phi-coefficients=0\nfold=left-to-right exact H4 product with wrapped Q29 fiber/torsion addition\nphase-law=canonical interval [-1686629713,1686629713) with modulus 3373259426; phase-factors-are-central\nclass-result=C^-1*G with the same wrapped phase law\nnoncommutation-gate=direct exact H4 A*B!=B*A plus distinct nonidentity complete folds\ncache-key=global-root,global-epoch,operator,map,chart,root-and-product-inverse-table,exact-class\ncost=lexicographic(h4-s3-angular-shell,fiber-circular-abs-q29,torsion-circular-abs-q29)\nselection=unique-minimum-or-abstain\ncontrols=real,identity-disabled,class-operator-permuted\nidentity-disabled=compute-all-then-return-bound-953-fallback\nclass-operator-permuted=swap-two-prototype-class-results\nscore-firewall=no-token-id,payload,address,prime,digest,ordinal,spin-sector,adjacent-row-or-target-numeric-input";
+const NONCOMMUTING_POPULATION_POLICY_IDENTITY: &str = "uor-r4 bounded global noncommuting population policy/1\npool=exact registered one-unit noncandidate nonanchor construction lexemes ordered by canonical lexical-unit-id\npool-surfaces=.,Lena,Pavel,The,bound,bounded,class,code,global,is,the\nmultiset=[D,D,helix,prism]\npermutations=unique lexicographic lexical-unit-id vectors\npairs=lexicographic left-index,right-index with left-index<right-index\nrequirements=same-exact-multiset,one-exact-transposition,three-exact-classes,one-same-address-reuse,direct-noncommutation,distinct-nonidentity-complete-folds,incompatible-unique-C^-1G-prototype-winners\nselection=first qualifying pair; no target,continuation,partition-digest,candidate-id,payload,prime,address-ordinal-or-class-digest input";
 const CONSTRUCTION_IDENTITY_SCOPE: &str = "issue-973/bounded-global-exact-spin-construction-v1";
 const HELD_OUT_IDENTITY_SCOPE: &str = "issue-973/bounded-global-exact-spin-heldout-v1";
 const ACTIVE_TURN_ID: &str = "active-turn-0001";
@@ -47,6 +56,12 @@ const FROZEN_CONSTRUCTION: [(&str, &[u8]); 2] = [
 ];
 const LEFT_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"helix", b"prism"];
 const RIGHT_SNAPSHOT: [&[u8]; 4] = [b"Pavel", b"Pavel", b"prism", b"helix"];
+const NONCOMMUTING_LEFT_SNAPSHOT: [&[u8]; 4] = [b"Lena", b"Lena", b"helix", b"prism"];
+const NONCOMMUTING_RIGHT_SNAPSHOT: [&[u8]; 4] = [b"Lena", b"helix", b"Lena", b"prism"];
+const NONCOMMUTING_DUPLICATE_POOL: [&[u8]; 11] = [
+    b".", b"Lena", b"Pavel", b"The", b"bound", b"bounded", b"class", b"code", b"global", b"is",
+    b"the",
+];
 const PROTOTYPE_BINDINGS: [(&[u8], &[u8]); 2] = [(b"bronze", b"helix"), (b"teal", b"prism")];
 const PHASE_HALF_Q29: i64 = 1_686_629_713;
 const PHASE_MODULUS_Q29: i64 = 3_373_259_426;
@@ -185,6 +200,65 @@ pub struct BoundedGlobalExactSpinClassEvaluationTrace {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalNoncommutingPoolRowTrace {
+    pub duplicate_hex: String,
+    pub duplicate_lexical_unit_id: u32,
+    pub duplicate_address_kappa: String,
+    pub duplicate_class_kappa: String,
+    pub duplicate_state: BoundedGlobalExactSpinStateTrace,
+    pub direct_noncommutation: bool,
+    pub unique_permutations: u32,
+    pub permutation_pairs_examined: u32,
+    pub selected_pair_indices: Option<[u32; 2]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalNoncommutingWitnessTrace {
+    pub left_operand_hex: String,
+    pub right_operand_hex: String,
+    pub left_operand: BoundedGlobalExactSpinStateTrace,
+    pub right_operand: BoundedGlobalExactSpinStateTrace,
+    pub left_then_right: BoundedGlobalExactSpinStateTrace,
+    pub right_then_left: BoundedGlobalExactSpinStateTrace,
+    pub products_distinct: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalNoncommutingCandidateCostTrace {
+    pub prototype_anchor_hex: String,
+    pub prototype_class_kappa: String,
+    pub relative_state: BoundedGlobalExactSpinStateTrace,
+    pub cost: BoundedGlobalExactSpinCost,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundedGlobalNoncommutingPopulationAudit {
+    pub schema: u32,
+    pub domain: String,
+    pub population_policy_kappa: String,
+    pub duplicate_pool_hex: Vec<String>,
+    pub rows_examined: Vec<BoundedGlobalNoncommutingPoolRowTrace>,
+    pub selected_duplicate_hex: String,
+    pub selected_duplicate_lexical_unit_id: u32,
+    pub selected_duplicate_class_kappa: String,
+    pub selected_pair_indices: [u32; 2],
+    pub left_snapshot_hex: [String; 4],
+    pub right_snapshot_hex: [String; 4],
+    pub one_transposition: bool,
+    pub transposed_ordinals: [u16; 2],
+    pub noncommutation: BoundedGlobalNoncommutingWitnessTrace,
+    pub left_fold: BoundedGlobalExactSpinStateTrace,
+    pub right_fold: BoundedGlobalExactSpinStateTrace,
+    pub distinct_nonidentity_folds: bool,
+    pub complete_phase_totals_equal: bool,
+    pub left_candidate_costs: Vec<BoundedGlobalNoncommutingCandidateCostTrace>,
+    pub right_candidate_costs: Vec<BoundedGlobalNoncommutingCandidateCostTrace>,
+    pub left_winner_anchor_hex: String,
+    pub right_winner_anchor_hex: String,
+    pub incompatible_unique_winners: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BoundedGlobalExactSpinCandidateEvidence {
     pub token: u32,
     pub count: u64,
@@ -224,6 +298,12 @@ pub struct BoundedGlobalExactSpinWork {
     pub final_choice_operations: u64,
 }
 
+/// Structural score-firewall witness.
+///
+/// The exact scorer and winner selectors accept only exact geometric state or
+/// exact costs; the focused #973 source invariant rejects forbidden score
+/// capabilities. These zero fields record that boundary in the prediction
+/// trace; they are not dynamic machine-instruction counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 pub struct BoundedGlobalExactSpinForbiddenReads {
     pub target_reads: u64,
@@ -327,6 +407,26 @@ pub struct MatchedBoundedGlobalExactSpinContinuation {
     pub real: Continuation,
     pub identity_disabled: Continuation,
     pub class_operator_permuted: Continuation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedBoundedGlobalNoncommutingPairPrediction {
+    pub population_audit: BoundedGlobalNoncommutingPopulationAudit,
+    pub left: MatchedBoundedGlobalExactSpinPrediction,
+    pub right: MatchedBoundedGlobalExactSpinPrediction,
+    pub exact_fold_distinct: bool,
+    pub real_winners_incompatible: bool,
+    pub permuted_winners_incompatible: bool,
+    pub common_lower_artifact: bool,
+    pub support_matched_between_cases: bool,
+    pub work_matched_between_cases: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedBoundedGlobalNoncommutingPairContinuation {
+    pub first_pair: MatchedBoundedGlobalNoncommutingPairPrediction,
+    pub left: MatchedBoundedGlobalExactSpinContinuation,
+    pub right: MatchedBoundedGlobalExactSpinContinuation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -447,6 +547,21 @@ pub struct BoundedGlobalExactSpinR4V1 {
     prototypes: Vec<CandidatePrototype>,
 }
 
+/// Versioned successor to the target-free V1 relation failure.
+///
+/// V2 reuses the exact construction-bound codec, address registry, stored-spin
+/// map, prototype bindings, and `C^-1 * G` least-cost relation. Its additional
+/// population audit proves that the two detached global carriers differ by an
+/// actual noncommuting stored-H4 transposition before either case may decode.
+#[derive(Debug, Clone)]
+pub struct BoundedGlobalNoncommutingExactSpinR4V2 {
+    core: BoundedGlobalExactSpinR4V1,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    population_policy_kappa: String,
+    population_audit: BoundedGlobalNoncommutingPopulationAudit,
+}
+
 #[derive(Debug, Clone)]
 struct ArmEvaluation {
     entries: Vec<BoundedGlobalExactSpinSnapshotEntryTrace>,
@@ -464,6 +579,41 @@ struct ArmCandidateRow {
     relative_state: BoundedGlobalExactSpinStateTrace,
     measured_cost: BoundedGlobalExactSpinCost,
     ranking_cost: Option<BoundedGlobalExactSpinCost>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotContract {
+    FrozenCommutingV1,
+    FrozenNoncommutingV2,
+}
+
+#[derive(Debug, Clone)]
+struct PopulationLexeme {
+    bytes: Vec<u8>,
+    lexical_unit_id: u32,
+    address_kappa: String,
+    class_kappa: String,
+    spin: SpinTorsionStateTrace,
+    state: ExactSpinState,
+}
+
+#[derive(Debug, Clone)]
+struct PopulationSelection {
+    duplicate: PopulationLexeme,
+    left_index: usize,
+    right_index: usize,
+    left_ids: [u32; 4],
+    right_ids: [u32; 4],
+    left_fold: ExactSpinState,
+    right_fold: ExactSpinState,
+    left_costs: [BoundedGlobalNoncommutingCandidateCostTrace; 2],
+    right_costs: [BoundedGlobalNoncommutingCandidateCostTrace; 2],
+    left_winner: usize,
+    right_winner: usize,
+    left_operand: PopulationLexeme,
+    right_operand: PopulationLexeme,
+    left_then_right: ExactSpinState,
+    right_then_left: ExactSpinState,
 }
 
 impl BoundedGlobalExactSpinR4V1 {
@@ -535,14 +685,14 @@ impl BoundedGlobalExactSpinR4V1 {
             }
             let unit_id = encoded_anchor.units[0].unit_id;
             let address = construction_artifact
-                .lexical_route_address(unit_id)?
+                .lexical_route_address_from_validated_artifact(unit_id)?
                 .ok_or_else(|| {
                     BoundedGlobalExactSpinError::Invalid(
                         "prototype anchor has no registered address".to_owned(),
                     )
                 })?;
             let value = construction_artifact
-                .lexical_route_value_for_address(&address)?
+                .lexical_route_value_for_address_from_validated_artifact(&address)?
                 .ok_or_else(|| {
                     BoundedGlobalExactSpinError::Invalid(
                         "prototype anchor address has no payload inversion".to_owned(),
@@ -559,11 +709,7 @@ impl BoundedGlobalExactSpinR4V1 {
                 candidate_bytes,
                 anchor_bytes: anchor.to_vec(),
                 anchor_lexical_unit_id: unit_id,
-                anchor_address_kappa: address.canonical_kappa().map_err(|error| {
-                    BoundedGlobalExactSpinError::Invalid(format!(
-                        "prototype anchor address kappa failed: {error}"
-                    ))
-                })?,
+                anchor_address_kappa: value.address_kappa,
                 anchor_payload_cid: address.payload_cid.clone(),
                 anchor_class_kappa: shared_class_kappa(address.spin)?,
                 anchor_address: address,
@@ -763,8 +909,12 @@ impl BoundedGlobalExactSpinR4V1 {
         global_snapshot_units: &[Vec<u8>],
     ) -> Result<CanonicalRouteArtifact, BoundedGlobalExactSpinError> {
         validate_active_query(active_query)?;
-        validate_snapshot_units(global_snapshot_units)?;
-        let input = observed_global_input(active_query, global_snapshot_units)?;
+        validate_snapshot_units_for(global_snapshot_units, SnapshotContract::FrozenCommutingV1)?;
+        let input = observed_global_input_for(
+            active_query,
+            global_snapshot_units,
+            SnapshotContract::FrozenCommutingV1,
+        )?;
         Ok(CanonicalRouteArtifact::ingest(&self.codec, &input)?)
     }
 
@@ -775,6 +925,29 @@ impl BoundedGlobalExactSpinR4V1 {
         base_artifact: &CanonicalRouteArtifact,
         snapshot_artifact: &CanonicalRouteArtifact,
         active_query: &[u8],
+    ) -> Result<MatchedBoundedGlobalExactSpinPrediction, BoundedGlobalExactSpinError> {
+        let operator_cid = self.artifact_cid()?;
+        self.predict_matched_for(
+            table,
+            base_overlay,
+            base_artifact,
+            snapshot_artifact,
+            active_query,
+            SnapshotContract::FrozenCommutingV1,
+            &operator_cid,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn predict_matched_for(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        base_artifact: &CanonicalRouteArtifact,
+        snapshot_artifact: &CanonicalRouteArtifact,
+        active_query: &[u8],
+        snapshot_contract: SnapshotContract,
+        operator_cid: &str,
     ) -> Result<MatchedBoundedGlobalExactSpinPrediction, BoundedGlobalExactSpinError> {
         self.validate_binding(table, base_overlay)?;
         validate_active_query(active_query)?;
@@ -789,7 +962,11 @@ impl BoundedGlobalExactSpinR4V1 {
         }
         let snapshot_input = snapshot_artifact.reconstruct_input()?;
         if snapshot_input
-            != observed_global_input(active_query, &snapshot_input.global_snapshot_units)?
+            != observed_global_input_for(
+                active_query,
+                &snapshot_input.global_snapshot_units,
+                snapshot_contract,
+            )?
             || snapshot_artifact.codec_kappa() != self.codec.codec_kappa()
             || snapshot_artifact.vocabulary_kappa() != self.codec.vocabulary_kappa()
         {
@@ -797,7 +974,7 @@ impl BoundedGlobalExactSpinR4V1 {
                 "snapshot artifact is not an exact frozen global input".to_owned(),
             ));
         }
-        validate_snapshot_units(&snapshot_input.global_snapshot_units)?;
+        validate_snapshot_units_for(&snapshot_input.global_snapshot_units, snapshot_contract)?;
         let view = snapshot_artifact.global_exact_spin_snapshot_view()?;
         if view.global_epoch != snapshot_input.global_epoch
             || view.snapshot_kappa != snapshot_input.global_epoch
@@ -840,20 +1017,34 @@ impl BoundedGlobalExactSpinR4V1 {
             ));
         }
 
-        let real = self.evaluate_arm(&view, &local, BoundedGlobalExactSpinArm::Real, false)?;
+        let real = self.evaluate_arm(
+            &view,
+            &local,
+            BoundedGlobalExactSpinArm::Real,
+            false,
+            operator_cid,
+        )?;
         let disabled = self.evaluate_arm(
             &view,
             &local,
             BoundedGlobalExactSpinArm::IdentityDisabled,
             false,
+            operator_cid,
         )?;
         let permuted = self.evaluate_arm(
             &view,
             &local,
             BoundedGlobalExactSpinArm::ClassOperatorPermuted,
             false,
+            operator_cid,
         )?;
-        let reversed = self.evaluate_arm(&view, &local, BoundedGlobalExactSpinArm::Real, true)?;
+        let reversed = self.evaluate_arm(
+            &view,
+            &local,
+            BoundedGlobalExactSpinArm::Real,
+            true,
+            operator_cid,
+        )?;
 
         if real.entries != disabled.entries
             || real.entries != permuted.entries
@@ -940,7 +1131,7 @@ impl BoundedGlobalExactSpinR4V1 {
             global_epoch: view.global_epoch,
             global_snapshot_kappa: view.snapshot_kappa,
             global_root_kappa: view.global_root_kappa,
-            operator_cid: self.artifact_cid()?,
+            operator_cid: operator_cid.to_owned(),
             spin_map_kappa: self.spin_map_kappa.clone(),
             chart_profile_kappa: self.chart_profile_kappa.clone(),
             h4_root_table_kappa: self.h4_table.h4_root_table_kappa.clone(),
@@ -972,11 +1163,7 @@ impl BoundedGlobalExactSpinR4V1 {
         active_query: &[u8],
         max_units: usize,
     ) -> Result<MatchedBoundedGlobalExactSpinContinuation, BoundedGlobalExactSpinError> {
-        if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
-            return Err(BoundedGlobalExactSpinError::Invalid(format!(
-                "continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
-            )));
-        }
+        validate_continuation_bound(max_units)?;
         let first_decision = self.predict_matched(
             table,
             base_overlay,
@@ -984,63 +1171,7 @@ impl BoundedGlobalExactSpinR4V1 {
             snapshot_artifact,
             active_query,
         )?;
-        if first_decision.operator_abstention.is_some()
-            || !first_decision.support_matched
-            || !first_decision.work_matched
-            || !first_decision.support_reversal_invariant
-            || !first_decision.coherent_relabel_equivariant
-            || first_decision.real.unique_minimum.is_none()
-            || first_decision
-                .class_operator_permuted
-                .unique_minimum
-                .is_none()
-            || first_decision.identity_disabled.unique_minimum.is_some()
-            || first_decision.forbidden_reads.total() != 0
-        {
-            return Err(BoundedGlobalExactSpinError::Invalid(
-                "bounded-global hard gate stopped before decoding".to_owned(),
-            ));
-        }
-        let mut initial_context = vec![BOS_TOKEN];
-        initial_context.extend(table.encode_text(active_query)?);
-        let mut real = ContinuationState::new(initial_context.clone());
-        let mut disabled = ContinuationState::new(initial_context.clone());
-        let mut permuted = ContinuationState::new(initial_context);
-        real.accept(first_decision.real.token);
-        disabled.accept(first_decision.identity_disabled.token);
-        permuted.accept(first_decision.class_operator_permuted.token);
-        while real.can_step(max_units)
-            || disabled.can_step(max_units)
-            || permuted.can_step(max_units)
-        {
-            if real.can_step(max_units) {
-                real.accept(
-                    table
-                        .predict_multiscale_count_radius(&real.context, base_overlay)?
-                        .geometric_token,
-                );
-            }
-            if disabled.can_step(max_units) {
-                disabled.accept(
-                    table
-                        .predict_multiscale_count_radius(&disabled.context, base_overlay)?
-                        .geometric_token,
-                );
-            }
-            if permuted.can_step(max_units) {
-                permuted.accept(
-                    table
-                        .predict_multiscale_count_radius(&permuted.context, base_overlay)?
-                        .geometric_token,
-                );
-            }
-        }
-        Ok(MatchedBoundedGlobalExactSpinContinuation {
-            first_decision,
-            real: real.finish(table)?,
-            identity_disabled: disabled.finish(table)?,
-            class_operator_permuted: permuted.finish(table)?,
-        })
+        continue_from_prediction(table, base_overlay, active_query, max_units, first_decision)
     }
 
     pub fn audit_hierarchy_pair(
@@ -1127,6 +1258,7 @@ impl BoundedGlobalExactSpinR4V1 {
         local: &MatchedGeometricPrediction,
         arm: BoundedGlobalExactSpinArm,
         reverse_support_iteration: bool,
+        operator_cid: &str,
     ) -> Result<ArmEvaluation, BoundedGlobalExactSpinError> {
         let mut work = WorkCounter::new(local.geometric_work);
         let mut entries = Vec::with_capacity(view.entries.len());
@@ -1216,11 +1348,10 @@ impl BoundedGlobalExactSpinR4V1 {
             ));
         }
 
-        let operator_cid = self.artifact_cid()?;
         let result_binding = ClassResultBinding {
             global_root_kappa: &view.global_root_kappa,
             global_epoch: &view.global_epoch,
-            operator_cid: &operator_cid,
+            operator_cid,
             spin_map_kappa: &self.spin_map_kappa,
             chart_profile_kappa: &self.chart_profile_kappa,
             table: &self.h4_table,
@@ -1228,24 +1359,18 @@ impl BoundedGlobalExactSpinR4V1 {
         let mut class_results = Vec::<ClassResult>::with_capacity(unique.len());
         let mut class_traces = Vec::with_capacity(unique.len());
         for class in unique {
-            let relative = class
-                .state
-                .inverse(&self.h4_table)?
-                .compose(fold, &self.h4_table)?;
+            let (relative, cost) =
+                candidate_relative_exact_cost(class.state, fold, &self.h4_table)?;
             work.h4_inverse_table_reads += 1;
             work.h4_product_table_reads += 1;
             work.phase_additions += 2;
-            let cost = exact_cost(relative, &self.h4_table)?;
             work.angular_shell_reads += 1;
             work.phase_distance_reads += 2;
             work.unique_class_evaluations += 1;
             work.class_result_applications += u64::try_from(class.reference_entry_kappas.len())
                 .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?;
-            let cold = class
-                .state
-                .inverse(&self.h4_table)?
-                .compose(fold, &self.h4_table)?;
-            let cold_cost = exact_cost(cold, &self.h4_table)?;
+            let (cold, cold_cost) =
+                candidate_relative_exact_cost(class.state, fold, &self.h4_table)?;
             work.h4_inverse_table_reads += 1;
             work.h4_product_table_reads += 1;
             work.phase_additions += 2;
@@ -1318,7 +1443,15 @@ impl BoundedGlobalExactSpinR4V1 {
             .iter()
             .map(|prototype| prototype.candidate_token)
             .collect::<Vec<_>>();
-        let selection = select_candidate_rows(&candidate_rows)?;
+        let measured_costs = candidate_rows
+            .iter()
+            .map(|row| row.measured_cost)
+            .collect::<Vec<_>>();
+        let ranked_tokens = candidate_rows
+            .iter()
+            .map(|row| row.token)
+            .collect::<Vec<_>>();
+        let selection = select_exact_costs(&measured_costs)?;
         work.cost_comparisons = work
             .cost_comparisons
             .checked_add(selection.comparisons)
@@ -1331,6 +1464,7 @@ impl BoundedGlobalExactSpinR4V1 {
             arm,
             local.geometric_token,
             selection,
+            &ranked_tokens,
             support_tokens,
             work.finish(),
         );
@@ -1343,6 +1477,518 @@ impl BoundedGlobalExactSpinR4V1 {
             decision,
         })
     }
+}
+
+impl BoundedGlobalNoncommutingExactSpinR4V2 {
+    pub fn compile(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        let core = BoundedGlobalExactSpinR4V1::compile(table, base_overlay, construction)?;
+        let grammar_kappa = blake3_label(NONCOMMUTING_GRAMMAR_IDENTITY_BYTES);
+        let routing_policy_kappa = blake3_label(NONCOMMUTING_ROUTING_POLICY_IDENTITY.as_bytes());
+        let population_policy_kappa =
+            blake3_label(NONCOMMUTING_POPULATION_POLICY_IDENTITY.as_bytes());
+        let population_audit =
+            build_noncommuting_population_audit(&core, &population_policy_kappa)?;
+        let operator = Self {
+            core,
+            grammar_kappa,
+            routing_policy_kappa,
+            population_policy_kappa,
+            population_audit,
+        };
+        operator.validate_binding(table, base_overlay)?;
+        let audit = operator.population_audit()?;
+        if audit.left_snapshot_hex != NONCOMMUTING_LEFT_SNAPSHOT.map(hex::encode)
+            || audit.right_snapshot_hex != NONCOMMUTING_RIGHT_SNAPSHOT.map(hex::encode)
+            || !audit.noncommutation.products_distinct
+            || !audit.distinct_nonidentity_folds
+            || !audit.complete_phase_totals_equal
+            || !audit.incompatible_unique_winners
+            || !audit.one_transposition
+            || !frozen_noncommuting_population_matches(&audit)
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "canonical noncommuting population does not reproduce the frozen V2 pair"
+                    .to_owned(),
+            ));
+        }
+        if operator.to_bytes()?.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        Ok(operator)
+    }
+
+    pub fn from_bytes(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+        bytes: &[u8],
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        if bytes.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        if bytes.len() < NONCOMMUTING_OPERATOR_MAGIC.len()
+            || bytes[..NONCOMMUTING_OPERATOR_MAGIC.len()] != NONCOMMUTING_OPERATOR_MAGIC
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator magic is invalid".to_owned(),
+            ));
+        }
+        let expected = Self::compile(table, base_overlay, construction)?;
+        if expected.to_bytes()? != bytes {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator is noncanonical or binding-drifted"
+                    .to_owned(),
+            ));
+        }
+        Ok(expected)
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, BoundedGlobalExactSpinError> {
+        let wire = NoncommutingOperatorWire {
+            schema: NONCOMMUTING_OPERATOR_SCHEMA,
+            domain: NONCOMMUTING_OPERATOR_DOMAIN,
+            table_artifact_cid: self.core.table_artifact_cid.clone(),
+            base_overlay_artifact_cid: self.core.base_overlay_artifact_cid.clone(),
+            construction_ids: self.core.construction_ids.clone(),
+            construction_text_cids: self
+                .core
+                .construction_text_cids
+                .iter()
+                .map(hex::encode)
+                .collect(),
+            codec_kappa: self.core.codec_kappa().to_owned(),
+            vocabulary_kappa: self.core.vocabulary_kappa().to_owned(),
+            route_manifest_kappa: self.core.route_manifest_kappa().to_owned(),
+            h4_root_table_kappa: self.core.h4_root_table_kappa().to_owned(),
+            h4_multiplication_table_kappa: self.core.h4_multiplication_table_kappa().to_owned(),
+            grammar_kappa: self.grammar_kappa.clone(),
+            routing_policy_kappa: self.routing_policy_kappa.clone(),
+            spin_map_kappa: self.core.spin_map_kappa().to_owned(),
+            chart_profile_kappa: self.core.chart_profile_kappa().to_owned(),
+            population_policy_kappa: self.population_policy_kappa.clone(),
+            construction_identity_scope: CONSTRUCTION_IDENTITY_SCOPE,
+            held_out_identity_scope: HELD_OUT_IDENTITY_SCOPE,
+            active_turn_id: ACTIVE_TURN_ID,
+            active_query_hex: hex::encode(ACTIVE_QUERY_BYTES),
+            construction_global_unit_hex: hex::encode(CONSTRUCTION_GLOBAL_UNIT),
+            duplicate_pool_hex: NONCOMMUTING_DUPLICATE_POOL.map(hex::encode),
+            left_snapshot_hex: NONCOMMUTING_LEFT_SNAPSHOT.map(hex::encode),
+            right_snapshot_hex: NONCOMMUTING_RIGHT_SNAPSHOT.map(hex::encode),
+            candidates: BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES,
+            snapshot_entries: BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES,
+            snapshot_classes: BOUNDED_GLOBAL_EXACT_SPIN_CLASSES,
+            reuse_hits: BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS,
+            max_query_bytes: MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES,
+            max_operator_bytes: MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES,
+            prototypes: self.core.prototype_traces()?,
+            population_audit: self.population_audit.clone(),
+        };
+        let payload = serde_json::to_vec(&wire)
+            .map_err(|error| BoundedGlobalExactSpinError::Serialization(error.to_string()))?;
+        let mut bytes = Vec::with_capacity(NONCOMMUTING_OPERATOR_MAGIC.len() + payload.len());
+        bytes.extend_from_slice(&NONCOMMUTING_OPERATOR_MAGIC);
+        bytes.extend_from_slice(&payload);
+        if bytes.len() > MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    pub fn artifact_cid(&self) -> Result<String, BoundedGlobalExactSpinError> {
+        Ok(blake3_label(&self.to_bytes()?))
+    }
+
+    pub fn table_artifact_cid(&self) -> &str {
+        self.core.table_artifact_cid()
+    }
+
+    pub fn base_overlay_artifact_cid(&self) -> &str {
+        self.core.base_overlay_artifact_cid()
+    }
+
+    pub fn codec_kappa(&self) -> &str {
+        self.core.codec_kappa()
+    }
+
+    pub fn vocabulary_kappa(&self) -> &str {
+        self.core.vocabulary_kappa()
+    }
+
+    pub fn route_manifest_kappa(&self) -> &str {
+        self.core.route_manifest_kappa()
+    }
+
+    pub fn spin_map_kappa(&self) -> &str {
+        self.core.spin_map_kappa()
+    }
+
+    pub fn chart_profile_kappa(&self) -> &str {
+        self.core.chart_profile_kappa()
+    }
+
+    pub fn grammar_kappa(&self) -> &str {
+        &self.grammar_kappa
+    }
+
+    pub fn routing_policy_kappa(&self) -> &str {
+        &self.routing_policy_kappa
+    }
+
+    pub fn population_policy_kappa(&self) -> &str {
+        &self.population_policy_kappa
+    }
+
+    pub fn h4_root_table_kappa(&self) -> &str {
+        self.core.h4_root_table_kappa()
+    }
+
+    pub fn h4_multiplication_table_kappa(&self) -> &str {
+        self.core.h4_multiplication_table_kappa()
+    }
+
+    pub fn prototype_traces(
+        &self,
+    ) -> Result<Vec<BoundedGlobalExactSpinPrototypeTrace>, BoundedGlobalExactSpinError> {
+        self.core.prototype_traces()
+    }
+
+    pub fn population_audit(
+        &self,
+    ) -> Result<BoundedGlobalNoncommutingPopulationAudit, BoundedGlobalExactSpinError> {
+        Ok(self.population_audit.clone())
+    }
+
+    pub fn build_query_artifact(
+        &self,
+        active_query: &[u8],
+    ) -> Result<CanonicalRouteArtifact, BoundedGlobalExactSpinError> {
+        self.core.build_query_artifact(active_query)
+    }
+
+    pub fn build_snapshot_artifact(
+        &self,
+        active_query: &[u8],
+        global_snapshot_units: &[Vec<u8>],
+    ) -> Result<CanonicalRouteArtifact, BoundedGlobalExactSpinError> {
+        validate_active_query(active_query)?;
+        validate_snapshot_units_for(
+            global_snapshot_units,
+            SnapshotContract::FrozenNoncommutingV2,
+        )?;
+        let input = observed_global_input_for(
+            active_query,
+            global_snapshot_units,
+            SnapshotContract::FrozenNoncommutingV2,
+        )?;
+        Ok(CanonicalRouteArtifact::ingest(&self.core.codec, &input)?)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn predict_pair_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        base_artifact: &CanonicalRouteArtifact,
+        left_snapshot_artifact: &CanonicalRouteArtifact,
+        right_snapshot_artifact: &CanonicalRouteArtifact,
+        active_query: &[u8],
+    ) -> Result<MatchedBoundedGlobalNoncommutingPairPrediction, BoundedGlobalExactSpinError> {
+        self.validate_binding(table, base_overlay)?;
+        let population_audit = self.population_audit()?;
+        let operator_cid = self.artifact_cid()?;
+        let left = self.core.predict_matched_for(
+            table,
+            base_overlay,
+            base_artifact,
+            left_snapshot_artifact,
+            active_query,
+            SnapshotContract::FrozenNoncommutingV2,
+            &operator_cid,
+        )?;
+        let right = self.core.predict_matched_for(
+            table,
+            base_overlay,
+            base_artifact,
+            right_snapshot_artifact,
+            active_query,
+            SnapshotContract::FrozenNoncommutingV2,
+            &operator_cid,
+        )?;
+
+        let left_payloads = left
+            .snapshot_entries
+            .iter()
+            .map(|entry| entry.payload_hex.as_str())
+            .collect::<Vec<_>>();
+        let right_payloads = right
+            .snapshot_entries
+            .iter()
+            .map(|entry| entry.payload_hex.as_str())
+            .collect::<Vec<_>>();
+        let expected_left = NONCOMMUTING_LEFT_SNAPSHOT
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<_>>();
+        let expected_right = NONCOMMUTING_RIGHT_SNAPSHOT
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<_>>();
+        if left_payloads != expected_left.iter().map(String::as_str).collect::<Vec<_>>()
+            || right_payloads
+                != expected_right
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "paired global carriers are not in the canonical selected orientation".to_owned(),
+            ));
+        }
+
+        let left_winner =
+            self.candidate_token_for_anchor_hex(&population_audit.left_winner_anchor_hex)?;
+        let right_winner =
+            self.candidate_token_for_anchor_hex(&population_audit.right_winner_anchor_hex)?;
+        let left_permuted = self.other_candidate_token(left_winner)?;
+        let right_permuted = self.other_candidate_token(right_winner)?;
+        let exact_fold_distinct = left.global_result == population_audit.left_fold
+            && right.global_result == population_audit.right_fold
+            && left.global_result != right.global_result;
+        let real_winners_incompatible = left.real.token == left_winner
+            && right.real.token == right_winner
+            && left_winner != right_winner;
+        let permuted_winners_incompatible = left.class_operator_permuted.token == left_permuted
+            && right.class_operator_permuted.token == right_permuted
+            && left_permuted != right_permuted;
+        let common_lower_artifact =
+            left.base_lower_artifact_manifest_kappa == right.base_lower_artifact_manifest_kappa;
+        let support_matched_between_cases = left.real.support_tokens == right.real.support_tokens
+            && left.identity_disabled.support_tokens == right.identity_disabled.support_tokens
+            && left.class_operator_permuted.support_tokens
+                == right.class_operator_permuted.support_tokens;
+        let work_matched_between_cases = left.real.work == right.real.work
+            && left.identity_disabled.work == right.identity_disabled.work
+            && left.class_operator_permuted.work == right.class_operator_permuted.work;
+        let left_costs_reproduced =
+            prediction_reproduces_population_costs(&left, &population_audit.left_candidate_costs);
+        let right_costs_reproduced =
+            prediction_reproduces_population_costs(&right, &population_audit.right_candidate_costs);
+        let hard_gate = population_audit.noncommutation.products_distinct
+            && population_audit.distinct_nonidentity_folds
+            && population_audit.complete_phase_totals_equal
+            && population_audit.incompatible_unique_winners
+            && population_audit.one_transposition
+            && exact_fold_distinct
+            && real_winners_incompatible
+            && permuted_winners_incompatible
+            && common_lower_artifact
+            && support_matched_between_cases
+            && work_matched_between_cases
+            && left_costs_reproduced
+            && right_costs_reproduced
+            && left.source_snapshot_artifact_manifest_kappa
+                != right.source_snapshot_artifact_manifest_kappa
+            && left.global_epoch != right.global_epoch
+            && left.global_root_kappa != right.global_root_kappa
+            && left.identity_disabled.token == right.identity_disabled.token
+            && left.support_matched
+            && right.support_matched
+            && left.work_matched
+            && right.work_matched
+            && left.support_reversal_invariant
+            && right.support_reversal_invariant
+            && left.coherent_relabel_equivariant
+            && right.coherent_relabel_equivariant
+            && left.forbidden_reads.total() == 0
+            && right.forbidden_reads.total() == 0
+            && left.operator_abstention.is_none()
+            && right.operator_abstention.is_none()
+            && left.real.unique_minimum == Some(left.real.token)
+            && right.real.unique_minimum == Some(right.real.token)
+            && left.class_operator_permuted.unique_minimum
+                == Some(left.class_operator_permuted.token)
+            && right.class_operator_permuted.unique_minimum
+                == Some(right.class_operator_permuted.token)
+            && left.identity_disabled.unique_minimum.is_none()
+            && right.identity_disabled.unique_minimum.is_none();
+        if !hard_gate {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "paired noncommuting exact-spin hard gate stopped before decoding".to_owned(),
+            ));
+        }
+
+        Ok(MatchedBoundedGlobalNoncommutingPairPrediction {
+            population_audit,
+            left,
+            right,
+            exact_fold_distinct,
+            real_winners_incompatible,
+            permuted_winners_incompatible,
+            common_lower_artifact,
+            support_matched_between_cases,
+            work_matched_between_cases,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn continue_pair_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        base_artifact: &CanonicalRouteArtifact,
+        left_snapshot_artifact: &CanonicalRouteArtifact,
+        right_snapshot_artifact: &CanonicalRouteArtifact,
+        active_query: &[u8],
+        max_units: usize,
+    ) -> Result<MatchedBoundedGlobalNoncommutingPairContinuation, BoundedGlobalExactSpinError> {
+        validate_continuation_bound(max_units)?;
+        let first_pair = self.predict_pair_matched(
+            table,
+            base_overlay,
+            base_artifact,
+            left_snapshot_artifact,
+            right_snapshot_artifact,
+            active_query,
+        )?;
+        let left = continue_from_prediction(
+            table,
+            base_overlay,
+            active_query,
+            max_units,
+            first_pair.left.clone(),
+        )?;
+        let right = continue_from_prediction(
+            table,
+            base_overlay,
+            active_query,
+            max_units,
+            first_pair.right.clone(),
+        )?;
+        let continuations = [
+            &left.real,
+            &left.identity_disabled,
+            &left.class_operator_permuted,
+            &right.real,
+            &right.identity_disabled,
+            &right.class_operator_permuted,
+        ];
+        for continuation in continuations {
+            let exact_period = continuation.tokens.get(1).is_some_and(|token| {
+                table
+                    .decode_tokens(&[*token])
+                    .is_ok_and(|bytes| bytes == b".")
+            });
+            if continuation.stop != ContinuationStop::EndOfDocument
+                || continuation.tokens.len() != 2
+                || continuation.tokens[0] == continuation.tokens[1]
+                || !exact_period
+            {
+                return Err(BoundedGlobalExactSpinError::Invalid(
+                    "paired noncommuting exact-spin continuation did not append period and reach EOS"
+                        .to_owned(),
+                ));
+            }
+        }
+        Ok(MatchedBoundedGlobalNoncommutingPairContinuation {
+            first_pair,
+            left,
+            right,
+        })
+    }
+
+    fn validate_binding(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+    ) -> Result<(), BoundedGlobalExactSpinError> {
+        self.core.validate_binding(table, base_overlay)?;
+        if self.grammar_kappa != blake3_label(NONCOMMUTING_GRAMMAR_IDENTITY_BYTES)
+            || self.routing_policy_kappa
+                != blake3_label(NONCOMMUTING_ROUTING_POLICY_IDENTITY.as_bytes())
+            || self.population_policy_kappa
+                != blake3_label(NONCOMMUTING_POPULATION_POLICY_IDENTITY.as_bytes())
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "bounded-global noncommuting operator binding does not reproduce".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn candidate_token_for_anchor_hex(
+        &self,
+        anchor_hex: &str,
+    ) -> Result<u32, BoundedGlobalExactSpinError> {
+        self.core
+            .prototypes
+            .iter()
+            .find(|prototype| hex::encode(&prototype.anchor_bytes) == anchor_hex)
+            .map(|prototype| prototype.candidate_token)
+            .ok_or_else(|| {
+                BoundedGlobalExactSpinError::Invalid(
+                    "population audit winner is not a bound prototype anchor".to_owned(),
+                )
+            })
+    }
+
+    fn other_candidate_token(&self, token: u32) -> Result<u32, BoundedGlobalExactSpinError> {
+        let other = self
+            .core
+            .prototypes
+            .iter()
+            .filter(|prototype| prototype.candidate_token != token)
+            .map(|prototype| prototype.candidate_token)
+            .collect::<Vec<_>>();
+        if other.len() != 1 {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "noncommuting permutation requires exactly one other candidate".to_owned(),
+            ));
+        }
+        Ok(other[0])
+    }
+}
+
+fn prediction_reproduces_population_costs(
+    prediction: &MatchedBoundedGlobalExactSpinPrediction,
+    expected: &[BoundedGlobalNoncommutingCandidateCostTrace],
+) -> bool {
+    if prediction.candidate_evidence.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES
+        || expected.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES
+    {
+        return false;
+    }
+    prediction.candidate_evidence.iter().all(|evidence| {
+        let Some(real) = expected
+            .iter()
+            .find(|row| row.prototype_anchor_hex == evidence.prototype_anchor_hex)
+        else {
+            return false;
+        };
+        let Some(permuted) = expected
+            .iter()
+            .find(|row| row.prototype_anchor_hex != evidence.prototype_anchor_hex)
+        else {
+            return false;
+        };
+        evidence.real_relative_state == real.relative_state
+            && evidence.real_measured_cost == real.cost
+            && evidence.real_ranking_cost == Some(real.cost)
+            && evidence.identity_disabled_measured_cost == real.cost
+            && evidence.identity_disabled_ranking_cost.is_none()
+            && evidence.permuted_relative_state == permuted.relative_state
+            && evidence.permuted_measured_cost == permuted.cost
+            && evidence.permuted_ranking_cost == Some(permuted.cost)
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -1454,6 +2100,42 @@ struct OperatorWire {
 }
 
 #[derive(Serialize)]
+struct NoncommutingOperatorWire {
+    schema: u32,
+    domain: &'static str,
+    table_artifact_cid: String,
+    base_overlay_artifact_cid: String,
+    construction_ids: Vec<String>,
+    construction_text_cids: Vec<String>,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    route_manifest_kappa: String,
+    h4_root_table_kappa: String,
+    h4_multiplication_table_kappa: String,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    spin_map_kappa: String,
+    chart_profile_kappa: String,
+    population_policy_kappa: String,
+    construction_identity_scope: &'static str,
+    held_out_identity_scope: &'static str,
+    active_turn_id: &'static str,
+    active_query_hex: String,
+    construction_global_unit_hex: String,
+    duplicate_pool_hex: [String; 11],
+    left_snapshot_hex: [String; 4],
+    right_snapshot_hex: [String; 4],
+    candidates: usize,
+    snapshot_entries: usize,
+    snapshot_classes: usize,
+    reuse_hits: u64,
+    max_query_bytes: usize,
+    max_operator_bytes: usize,
+    prototypes: Vec<BoundedGlobalExactSpinPrototypeTrace>,
+    population_audit: BoundedGlobalNoncommutingPopulationAudit,
+}
+
+#[derive(Serialize)]
 struct SpinMapWire {
     schema: u32,
     domain: &'static str,
@@ -1524,12 +2206,13 @@ fn construction_geometry_input(
     })
 }
 
-fn observed_global_input(
+fn observed_global_input_for(
     active_query: &[u8],
     global_snapshot_units: &[Vec<u8>],
+    contract: SnapshotContract,
 ) -> Result<ConversationInput, BoundedGlobalExactSpinError> {
     validate_active_query(active_query)?;
-    validate_snapshot_units(global_snapshot_units)?;
+    validate_snapshot_units_for(global_snapshot_units, contract)?;
     Ok(ConversationInput {
         identity_scope: HELD_OUT_IDENTITY_SCOPE.to_owned(),
         global_epoch: canonical_global_epoch(global_snapshot_units)?,
@@ -1572,9 +2255,18 @@ fn validate_active_query(active_query: &[u8]) -> Result<(), BoundedGlobalExactSp
     Ok(())
 }
 
-fn validate_snapshot_units(units: &[Vec<u8>]) -> Result<(), BoundedGlobalExactSpinError> {
-    let left = LEFT_SNAPSHOT.map(<[u8]>::to_vec).to_vec();
-    let right = RIGHT_SNAPSHOT.map(<[u8]>::to_vec).to_vec();
+fn validate_snapshot_units_for(
+    units: &[Vec<u8>],
+    contract: SnapshotContract,
+) -> Result<(), BoundedGlobalExactSpinError> {
+    let (left, right) = match contract {
+        SnapshotContract::FrozenCommutingV1 => (LEFT_SNAPSHOT, RIGHT_SNAPSHOT),
+        SnapshotContract::FrozenNoncommutingV2 => {
+            (NONCOMMUTING_LEFT_SNAPSHOT, NONCOMMUTING_RIGHT_SNAPSHOT)
+        }
+    };
+    let left = left.map(<[u8]>::to_vec).to_vec();
+    let right = right.map(<[u8]>::to_vec).to_vec();
     if units != left && units != right {
         return Err(BoundedGlobalExactSpinError::Invalid(
             "global snapshot differs from both frozen order controls".to_owned(),
@@ -1603,6 +2295,533 @@ fn exact_state_from_entry(
         fiber_q29: i64::from(entry.spin.fiber_q29),
         torsion_q29: i64::from(entry.spin.torsion_q29),
     })
+}
+
+fn build_noncommuting_population_audit(
+    core: &BoundedGlobalExactSpinR4V1,
+    population_policy_kappa: &str,
+) -> Result<BoundedGlobalNoncommutingPopulationAudit, BoundedGlobalExactSpinError> {
+    if population_policy_kappa != blake3_label(NONCOMMUTING_POPULATION_POLICY_IDENTITY.as_bytes()) {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "noncommuting population policy identity does not reproduce".to_owned(),
+        ));
+    }
+
+    let helix = prototype_population_lexeme(core, b"helix")?;
+    let prism = prototype_population_lexeme(core, b"prism")?;
+    let mut pool = Vec::with_capacity(NONCOMMUTING_DUPLICATE_POOL.len());
+    for bytes in NONCOMMUTING_DUPLICATE_POOL {
+        if PROTOTYPE_BINDINGS
+            .iter()
+            .any(|(_, anchor)| *anchor == bytes)
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "noncommuting duplicate pool contains a prototype anchor".to_owned(),
+            ));
+        }
+        pool.push(resolve_population_lexeme(core, bytes)?);
+    }
+    if pool
+        .windows(2)
+        .any(|pair| pair[0].lexical_unit_id >= pair[1].lexical_unit_id)
+    {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "noncommuting duplicate pool is not in canonical lexical-unit order".to_owned(),
+        ));
+    }
+
+    let mut lexemes = BTreeMap::<u32, PopulationLexeme>::new();
+    for lexeme in pool.iter().chain([&helix, &prism]) {
+        if lexemes
+            .insert(lexeme.lexical_unit_id, lexeme.clone())
+            .is_some()
+        {
+            return Err(BoundedGlobalExactSpinError::Invalid(
+                "noncommuting population lexeme IDs alias".to_owned(),
+            ));
+        }
+    }
+
+    let mut rows_examined = Vec::new();
+    let mut selected = None;
+    for duplicate in &pool {
+        let direct_noncommutation =
+            population_has_direct_noncommutation([duplicate, &helix, &prism], &core.h4_table)?;
+        let permutations = unique_permutations_4([
+            duplicate.lexical_unit_id,
+            duplicate.lexical_unit_id,
+            helix.lexical_unit_id,
+            prism.lexical_unit_id,
+        ]);
+        let mut pairs_examined = 0_u32;
+        let mut selected_pair_indices = None;
+
+        if duplicate.spin != helix.spin
+            && duplicate.spin != prism.spin
+            && helix.spin != prism.spin
+            && direct_noncommutation
+        {
+            'pairs: for left_index in 0..permutations.len() {
+                for right_index in left_index + 1..permutations.len() {
+                    pairs_examined = pairs_examined
+                        .checked_add(1)
+                        .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?;
+                    let left_ids = permutations[left_index];
+                    let right_ids = permutations[right_index];
+                    let Some(transposed_ordinals) = one_transposition(left_ids, right_ids) else {
+                        continue;
+                    };
+                    let left_operand = lexemes
+                        .get(&left_ids[usize::from(transposed_ordinals[0])])
+                        .ok_or_else(|| {
+                            BoundedGlobalExactSpinError::Invalid(
+                                "population transposition references an unknown left operand"
+                                    .to_owned(),
+                            )
+                        })?;
+                    let right_operand = lexemes
+                        .get(&left_ids[usize::from(transposed_ordinals[1])])
+                        .ok_or_else(|| {
+                            BoundedGlobalExactSpinError::Invalid(
+                                "population transposition references an unknown right operand"
+                                    .to_owned(),
+                            )
+                        })?;
+                    let left_then_right = left_operand
+                        .state
+                        .compose(right_operand.state, &core.h4_table)?;
+                    let right_then_left = right_operand
+                        .state
+                        .compose(left_operand.state, &core.h4_table)?;
+                    let identity = ExactSpinState::identity(&core.h4_table)?;
+                    if left_operand.state.h4 == identity.h4
+                        || right_operand.state.h4 == identity.h4
+                        || left_then_right.h4 == right_then_left.h4
+                    {
+                        continue;
+                    }
+                    let left_fold = fold_population_ids(left_ids, &lexemes, &core.h4_table)?;
+                    let right_fold = fold_population_ids(right_ids, &lexemes, &core.h4_table)?;
+                    if left_fold == identity || right_fold == identity || left_fold == right_fold {
+                        continue;
+                    }
+                    let left_costs = [
+                        population_candidate_cost(core, &core.prototypes, b"helix", left_fold)?,
+                        population_candidate_cost(core, &core.prototypes, b"prism", left_fold)?,
+                    ];
+                    let right_costs = [
+                        population_candidate_cost(core, &core.prototypes, b"helix", right_fold)?,
+                        population_candidate_cost(core, &core.prototypes, b"prism", right_fold)?,
+                    ];
+                    let Some(left_winner) =
+                        unique_exact_cost_winner(&[left_costs[0].cost, left_costs[1].cost])
+                    else {
+                        continue;
+                    };
+                    let Some(right_winner) =
+                        unique_exact_cost_winner(&[right_costs[0].cost, right_costs[1].cost])
+                    else {
+                        continue;
+                    };
+                    if left_winner == right_winner {
+                        continue;
+                    }
+                    selected_pair_indices = Some([
+                        u32::try_from(left_index)
+                            .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+                        u32::try_from(right_index)
+                            .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+                    ]);
+                    selected = Some(PopulationSelection {
+                        duplicate: duplicate.clone(),
+                        left_index,
+                        right_index,
+                        left_ids,
+                        right_ids,
+                        left_fold,
+                        right_fold,
+                        left_costs,
+                        right_costs,
+                        left_winner,
+                        right_winner,
+                        left_operand: left_operand.clone(),
+                        right_operand: right_operand.clone(),
+                        left_then_right,
+                        right_then_left,
+                    });
+                    break 'pairs;
+                }
+            }
+        }
+
+        rows_examined.push(BoundedGlobalNoncommutingPoolRowTrace {
+            duplicate_hex: hex::encode(&duplicate.bytes),
+            duplicate_lexical_unit_id: duplicate.lexical_unit_id,
+            duplicate_address_kappa: duplicate.address_kappa.clone(),
+            duplicate_class_kappa: duplicate.class_kappa.clone(),
+            duplicate_state: duplicate.state.trace(&core.h4_table)?,
+            direct_noncommutation,
+            unique_permutations: u32::try_from(permutations.len())
+                .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            permutation_pairs_examined: pairs_examined,
+            selected_pair_indices,
+        });
+        if selected.is_some() {
+            break;
+        }
+    }
+
+    let selected = selected.ok_or_else(|| {
+        BoundedGlobalExactSpinError::Invalid(
+            "canonical construction pool has no noncommuting exact-spin population".to_owned(),
+        )
+    })?;
+    let left_snapshot = population_ids_to_hex(selected.left_ids, &lexemes)?;
+    let right_snapshot = population_ids_to_hex(selected.right_ids, &lexemes)?;
+    let transposed_ordinals =
+        one_transposition(selected.left_ids, selected.right_ids).ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "selected noncommuting pair is not one exact transposition".to_owned(),
+            )
+        })?;
+    let left_winner_anchor_hex = selected.left_costs[selected.left_winner]
+        .prototype_anchor_hex
+        .clone();
+    let right_winner_anchor_hex = selected.right_costs[selected.right_winner]
+        .prototype_anchor_hex
+        .clone();
+
+    Ok(BoundedGlobalNoncommutingPopulationAudit {
+        schema: 1,
+        domain: "uor-r4.bounded-global-noncommuting-population-audit/1".to_owned(),
+        population_policy_kappa: population_policy_kappa.to_owned(),
+        duplicate_pool_hex: NONCOMMUTING_DUPLICATE_POOL.map(hex::encode).to_vec(),
+        rows_examined,
+        selected_duplicate_hex: hex::encode(&selected.duplicate.bytes),
+        selected_duplicate_lexical_unit_id: selected.duplicate.lexical_unit_id,
+        selected_duplicate_class_kappa: selected.duplicate.class_kappa,
+        selected_pair_indices: [
+            u32::try_from(selected.left_index)
+                .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+            u32::try_from(selected.right_index)
+                .map_err(|_| BoundedGlobalExactSpinError::ArithmeticOverflow)?,
+        ],
+        left_snapshot_hex: left_snapshot,
+        right_snapshot_hex: right_snapshot,
+        one_transposition: true,
+        transposed_ordinals,
+        noncommutation: BoundedGlobalNoncommutingWitnessTrace {
+            left_operand_hex: hex::encode(&selected.left_operand.bytes),
+            right_operand_hex: hex::encode(&selected.right_operand.bytes),
+            left_operand: selected.left_operand.state.trace(&core.h4_table)?,
+            right_operand: selected.right_operand.state.trace(&core.h4_table)?,
+            left_then_right: selected.left_then_right.trace(&core.h4_table)?,
+            right_then_left: selected.right_then_left.trace(&core.h4_table)?,
+            products_distinct: selected.left_then_right.h4 != selected.right_then_left.h4,
+        },
+        left_fold: selected.left_fold.trace(&core.h4_table)?,
+        right_fold: selected.right_fold.trace(&core.h4_table)?,
+        distinct_nonidentity_folds: selected.left_fold != selected.right_fold
+            && selected.left_fold != ExactSpinState::identity(&core.h4_table)?
+            && selected.right_fold != ExactSpinState::identity(&core.h4_table)?,
+        complete_phase_totals_equal: selected.left_fold.fiber_q29 == selected.right_fold.fiber_q29
+            && selected.left_fold.torsion_q29 == selected.right_fold.torsion_q29,
+        left_candidate_costs: selected.left_costs.to_vec(),
+        right_candidate_costs: selected.right_costs.to_vec(),
+        left_winner_anchor_hex: left_winner_anchor_hex.clone(),
+        right_winner_anchor_hex: right_winner_anchor_hex.clone(),
+        incompatible_unique_winners: left_winner_anchor_hex != right_winner_anchor_hex,
+    })
+}
+
+fn frozen_noncommuting_population_matches(
+    audit: &BoundedGlobalNoncommutingPopulationAudit,
+) -> bool {
+    let state =
+        |scaled: [i64; 4], fiber_q29: i64, torsion_q29: i64| BoundedGlobalExactSpinStateTrace {
+            h4_coordinate: H4RootCoordinate {
+                scaled_zphi_quaternion: [
+                    [scaled[0], 0],
+                    [scaled[1], 0],
+                    [scaled[2], 0],
+                    [scaled[3], 0],
+                ],
+            },
+            fiber_q29,
+            torsion_q29,
+        };
+    let cost =
+        |angular_shell, fiber_distance_q29, torsion_distance_q29| BoundedGlobalExactSpinCost {
+            angular_shell,
+            fiber_distance_q29,
+            torsion_distance_q29,
+        };
+    let cost_matches = |row: &BoundedGlobalNoncommutingCandidateCostTrace,
+                        anchor: &[u8],
+                        relative_state: BoundedGlobalExactSpinStateTrace,
+                        expected_cost: BoundedGlobalExactSpinCost| {
+        row.prototype_anchor_hex == hex::encode(anchor)
+            && row.relative_state == relative_state
+            && row.cost == expected_cost
+    };
+
+    let left_costs_match = audit.left_candidate_costs.len() == 2
+        && cost_matches(
+            &audit.left_candidate_costs[0],
+            b"helix",
+            state([-2, 0, 0, 0], 61_239_177, -5_831_083),
+            cost(H4S3AngularShell::Antipodal, 61_239_177, 5_831_083),
+        )
+        && cost_matches(
+            &audit.left_candidate_costs[1],
+            b"prism",
+            state([-1, -1, -1, -1], 55_205_017, -5_262_467),
+            cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467),
+        );
+    let right_costs_match = audit.right_candidate_costs.len() == 2
+        && cost_matches(
+            &audit.right_candidate_costs[0],
+            b"helix",
+            state([0, 0, 2, 0], 61_239_177, -5_831_083),
+            cost(H4S3AngularShell::Orthogonal, 61_239_177, 5_831_083),
+        )
+        && cost_matches(
+            &audit.right_candidate_costs[1],
+            b"prism",
+            state([-1, -1, 1, 1], 55_205_017, -5_262_467),
+            cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467),
+        );
+    let rows_match = audit.rows_examined.len() == 2
+        && audit.rows_examined[0].duplicate_hex == hex::encode(b".")
+        && audit.rows_examined[0]
+            .duplicate_state
+            .h4_coordinate
+            .scaled_zphi_quaternion
+            == [[2, 0], [0, 0], [0, 0], [0, 0]]
+        && !audit.rows_examined[0].direct_noncommutation
+        && audit.rows_examined[0].selected_pair_indices.is_none()
+        && audit.rows_examined[1].duplicate_hex == hex::encode(b"Lena")
+        && audit.rows_examined[1].direct_noncommutation
+        && audit.rows_examined[1].selected_pair_indices == Some([0, 2]);
+
+    rows_match
+        && audit.selected_duplicate_hex == hex::encode(b"Lena")
+        && audit.selected_pair_indices == [0, 2]
+        && audit.left_snapshot_hex == NONCOMMUTING_LEFT_SNAPSHOT.map(hex::encode)
+        && audit.right_snapshot_hex == NONCOMMUTING_RIGHT_SNAPSHOT.map(hex::encode)
+        && audit.one_transposition
+        && audit.transposed_ordinals == [1, 2]
+        && audit.noncommutation.left_operand_hex == hex::encode(b"Lena")
+        && audit.noncommutation.right_operand_hex == hex::encode(b"helix")
+        && audit.noncommutation.left_operand == state([0, 2, 0, 0], 7_017_092, -673_944)
+        && audit.noncommutation.right_operand == state([1, 1, 1, 1], 41_170_833, -3_914_579)
+        && audit.noncommutation.left_then_right == state([-1, 1, -1, 1], 48_187_925, -4_588_523)
+        && audit.noncommutation.right_then_left == state([-1, 1, 1, -1], 48_187_925, -4_588_523)
+        && audit.noncommutation.products_distinct
+        && audit.left_fold == state([-1, -1, -1, -1], 102_410_010, -9_745_662)
+        && audit.right_fold == state([-1, -1, 1, 1], 102_410_010, -9_745_662)
+        && audit.distinct_nonidentity_folds
+        && audit.complete_phase_totals_equal
+        && left_costs_match
+        && right_costs_match
+        && audit.left_winner_anchor_hex == hex::encode(b"prism")
+        && audit.right_winner_anchor_hex == hex::encode(b"helix")
+        && audit.incompatible_unique_winners
+}
+
+fn resolve_population_lexeme(
+    core: &BoundedGlobalExactSpinR4V1,
+    bytes: &[u8],
+) -> Result<PopulationLexeme, BoundedGlobalExactSpinError> {
+    let encoded = core.codec.encode(0, 0, bytes)?;
+    if encoded.units.len() != 1 || !encoded.trailing_bytes.is_empty() {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "population pool surface is not one exact canonical lexical unit".to_owned(),
+        ));
+    }
+    let lexical_unit_id = encoded.units[0].unit_id;
+    let address = core
+        .construction_artifact
+        .lexical_route_address_from_validated_artifact(lexical_unit_id)?
+        .ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "population pool surface has no registered address".to_owned(),
+            )
+        })?;
+    let value = core
+        .construction_artifact
+        .lexical_route_value_for_address_from_validated_artifact(&address)?
+        .ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "population pool address has no payload inversion".to_owned(),
+            )
+        })?;
+    if value.payload_bytes != bytes {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "population pool address payload inversion mismatches".to_owned(),
+        ));
+    }
+    Ok(PopulationLexeme {
+        bytes: bytes.to_vec(),
+        lexical_unit_id,
+        address_kappa: value.address_kappa,
+        class_kappa: shared_class_kappa(address.spin)?,
+        spin: spin_trace(address.spin),
+        state: exact_state_from_address(&address, &core.h4_table)?,
+    })
+}
+
+fn prototype_population_lexeme(
+    core: &BoundedGlobalExactSpinR4V1,
+    anchor: &[u8],
+) -> Result<PopulationLexeme, BoundedGlobalExactSpinError> {
+    let prototype = core
+        .prototypes
+        .iter()
+        .find(|prototype| prototype.anchor_bytes == anchor)
+        .ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "noncommuting population omitted a prototype anchor".to_owned(),
+            )
+        })?;
+    Ok(PopulationLexeme {
+        bytes: prototype.anchor_bytes.clone(),
+        lexical_unit_id: prototype.anchor_lexical_unit_id,
+        address_kappa: prototype.anchor_address_kappa.clone(),
+        class_kappa: prototype.anchor_class_kappa.clone(),
+        spin: spin_trace(prototype.anchor_address.spin),
+        state: prototype.anchor_state,
+    })
+}
+
+fn population_has_direct_noncommutation(
+    factors: [&PopulationLexeme; 3],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<bool, BoundedGlobalExactSpinError> {
+    let identity = ExactSpinState::identity(table)?;
+    for left_index in 0..factors.len() {
+        for right_index in left_index + 1..factors.len() {
+            let left = factors[left_index].state;
+            let right = factors[right_index].state;
+            if left.h4 == identity.h4 || right.h4 == identity.h4 {
+                continue;
+            }
+            if left.compose(right, table)?.h4 != right.compose(left, table)?.h4 {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn unique_permutations_4(mut values: [u32; 4]) -> Vec<[u32; 4]> {
+    values.sort_unstable();
+    let mut permutations = vec![values];
+    while next_lexicographic_permutation(&mut values) {
+        permutations.push(values);
+    }
+    permutations
+}
+
+fn next_lexicographic_permutation(values: &mut [u32]) -> bool {
+    let Some(pivot) = (0..values.len().saturating_sub(1))
+        .rev()
+        .find(|index| values[*index] < values[index + 1])
+    else {
+        return false;
+    };
+    let Some(successor) = (pivot + 1..values.len())
+        .rev()
+        .find(|index| values[*index] > values[pivot])
+    else {
+        return false;
+    };
+    values.swap(pivot, successor);
+    values[pivot + 1..].reverse();
+    true
+}
+
+fn one_transposition(left: [u32; 4], right: [u32; 4]) -> Option<[u16; 2]> {
+    let changed = (0..left.len())
+        .filter(|index| left[*index] != right[*index])
+        .collect::<Vec<_>>();
+    if changed.len() != 2
+        || left[changed[0]] != right[changed[1]]
+        || left[changed[1]] != right[changed[0]]
+    {
+        return None;
+    }
+    Some([
+        u16::try_from(changed[0]).ok()?,
+        u16::try_from(changed[1]).ok()?,
+    ])
+}
+
+fn fold_population_ids(
+    ids: [u32; 4],
+    lexemes: &BTreeMap<u32, PopulationLexeme>,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
+    let mut fold = ExactSpinState::identity(table)?;
+    for id in ids {
+        let state = lexemes.get(&id).ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "population permutation references an unknown lexical unit".to_owned(),
+            )
+        })?;
+        fold = fold.compose(state.state, table)?;
+    }
+    Ok(fold)
+}
+
+fn population_candidate_cost(
+    core: &BoundedGlobalExactSpinR4V1,
+    prototypes: &[CandidatePrototype],
+    anchor: &[u8],
+    fold: ExactSpinState,
+) -> Result<BoundedGlobalNoncommutingCandidateCostTrace, BoundedGlobalExactSpinError> {
+    let prototype = prototypes
+        .iter()
+        .find(|prototype| prototype.anchor_bytes == anchor)
+        .ok_or_else(|| {
+            BoundedGlobalExactSpinError::Invalid(
+                "population cost omitted one prototype anchor".to_owned(),
+            )
+        })?;
+    let (relative, cost) =
+        candidate_relative_exact_cost(prototype.anchor_state, fold, &core.h4_table)?;
+    Ok(BoundedGlobalNoncommutingCandidateCostTrace {
+        prototype_anchor_hex: hex::encode(&prototype.anchor_bytes),
+        prototype_class_kappa: prototype.anchor_class_kappa.clone(),
+        relative_state: relative.trace(&core.h4_table)?,
+        cost,
+    })
+}
+
+fn unique_exact_cost_winner(costs: &[BoundedGlobalExactSpinCost; 2]) -> Option<usize> {
+    match costs[0].cmp(&costs[1]) {
+        std::cmp::Ordering::Less => Some(0),
+        std::cmp::Ordering::Greater => Some(1),
+        std::cmp::Ordering::Equal => None,
+    }
+}
+
+fn population_ids_to_hex(
+    ids: [u32; 4],
+    lexemes: &BTreeMap<u32, PopulationLexeme>,
+) -> Result<[String; 4], BoundedGlobalExactSpinError> {
+    let values = ids.map(|id| {
+        lexemes
+            .get(&id)
+            .map(|lexeme| hex::encode(&lexeme.bytes))
+            .ok_or_else(|| {
+                BoundedGlobalExactSpinError::Invalid(
+                    "population selection references an unknown lexical unit".to_owned(),
+                )
+            })
+    });
+    let [first, second, third, fourth] = values;
+    Ok([first?, second?, third?, fourth?])
 }
 
 fn exact_s3_spin_to_h4(
@@ -1679,6 +2898,16 @@ fn spin_map_kappa(
     Ok(blake3_label(&bytes))
 }
 
+fn candidate_relative_exact_cost(
+    class_state: ExactSpinState,
+    global_state: ExactSpinState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<(ExactSpinState, BoundedGlobalExactSpinCost), BoundedGlobalExactSpinError> {
+    let relative = class_state.inverse(table)?.compose(global_state, table)?;
+    let cost = exact_cost(relative, table)?;
+    Ok((relative, cost))
+}
+
 fn exact_cost(
     relative: ExactSpinState,
     table: &H4BinaryIcosahedralClosure,
@@ -1718,34 +2947,33 @@ impl ExactSpinState {
 
 #[derive(Debug, Clone, Copy)]
 struct SelectionOutcome {
-    unique_minimum: Option<u32>,
+    unique_minimum_index: Option<usize>,
     minimum_cost: Option<BoundedGlobalExactSpinCost>,
     comparisons: u64,
 }
 
-fn select_candidate_rows(
-    rows: &[ArmCandidateRow],
+fn select_exact_costs(
+    costs: &[BoundedGlobalExactSpinCost],
 ) -> Result<SelectionOutcome, BoundedGlobalExactSpinError> {
-    if rows.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES {
+    if costs.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES {
         return Err(BoundedGlobalExactSpinError::Invalid(
-            "bounded-global candidate row count differs from the frozen support".to_owned(),
+            "bounded-global exact-cost count differs from the frozen support".to_owned(),
         ));
     }
-    let mut minimum: Option<(u32, BoundedGlobalExactSpinCost)> = None;
+    let mut minimum: Option<(usize, BoundedGlobalExactSpinCost)> = None;
     let mut tied = false;
     let mut comparisons = 0_u64;
-    for row in rows {
+    for (index, cost) in costs.iter().copied().enumerate() {
         comparisons = comparisons
             .checked_add(1)
             .ok_or(BoundedGlobalExactSpinError::ArithmeticOverflow)?;
-        let cost = row.measured_cost;
         match minimum {
             None => {
-                minimum = Some((row.token, cost));
+                minimum = Some((index, cost));
                 tied = false;
             }
             Some((_, current)) if cost < current => {
-                minimum = Some((row.token, cost));
+                minimum = Some((index, cost));
                 tied = false;
             }
             Some((_, current)) if cost == current => tied = true,
@@ -1753,7 +2981,7 @@ fn select_candidate_rows(
         }
     }
     Ok(SelectionOutcome {
-        unique_minimum: (!tied).then_some(minimum.map(|value| value.0)).flatten(),
+        unique_minimum_index: (!tied).then_some(minimum.map(|value| value.0)).flatten(),
         minimum_cost: (!tied).then_some(minimum.map(|value| value.1)).flatten(),
         comparisons,
     })
@@ -1763,6 +2991,7 @@ fn decision_from_selection(
     arm: BoundedGlobalExactSpinArm,
     fallback: u32,
     selection: SelectionOutcome,
+    ranked_tokens: &[u32],
     support_tokens: Vec<u32>,
     work: BoundedGlobalExactSpinWork,
 ) -> BoundedGlobalExactSpinDecision {
@@ -1776,10 +3005,13 @@ fn decision_from_selection(
             work,
         };
     }
+    let unique_minimum = selection
+        .unique_minimum_index
+        .and_then(|index| ranked_tokens.get(index).copied());
     BoundedGlobalExactSpinDecision {
         arm,
-        token: selection.unique_minimum.unwrap_or(fallback),
-        unique_minimum: selection.unique_minimum,
+        token: unique_minimum.unwrap_or(fallback),
+        unique_minimum,
         minimum_cost: selection.minimum_cost,
         support_tokens,
         work,
@@ -1813,11 +3045,14 @@ fn coherent_relabel_equivariant(
             ..rows[1].clone()
         },
     ];
-    let selection = select_candidate_rows(&relabeled)?;
+    let measured_costs = [relabeled[0].measured_cost, relabeled[1].measured_cost];
+    let ranked_tokens = [relabeled[0].token, relabeled[1].token];
+    let selection = select_exact_costs(&measured_costs)?;
     let relabeled_decision = decision_from_selection(
         BoundedGlobalExactSpinArm::Real,
         tokens[1],
         selection,
+        &ranked_tokens,
         tokens.to_vec(),
         BoundedGlobalExactSpinWork {
             local: MultiscaleCountRadiusWork::default(),
@@ -1975,6 +3210,79 @@ fn contains_bytes(bytes: &[u8], needle: &[u8]) -> bool {
 
 fn blake3_label(bytes: &[u8]) -> String {
     format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn validate_continuation_bound(max_units: usize) -> Result<(), BoundedGlobalExactSpinError> {
+    if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
+        return Err(BoundedGlobalExactSpinError::Invalid(format!(
+            "continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
+        )));
+    }
+    Ok(())
+}
+
+fn continue_from_prediction(
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    active_query: &[u8],
+    max_units: usize,
+    first_decision: MatchedBoundedGlobalExactSpinPrediction,
+) -> Result<MatchedBoundedGlobalExactSpinContinuation, BoundedGlobalExactSpinError> {
+    validate_continuation_bound(max_units)?;
+    if first_decision.operator_abstention.is_some()
+        || !first_decision.support_matched
+        || !first_decision.work_matched
+        || !first_decision.support_reversal_invariant
+        || !first_decision.coherent_relabel_equivariant
+        || first_decision.real.unique_minimum.is_none()
+        || first_decision
+            .class_operator_permuted
+            .unique_minimum
+            .is_none()
+        || first_decision.identity_disabled.unique_minimum.is_some()
+        || first_decision.forbidden_reads.total() != 0
+    {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "bounded-global hard gate stopped before decoding".to_owned(),
+        ));
+    }
+    let mut initial_context = vec![BOS_TOKEN];
+    initial_context.extend(table.encode_text(active_query)?);
+    let mut real = ContinuationState::new(initial_context.clone());
+    let mut disabled = ContinuationState::new(initial_context.clone());
+    let mut permuted = ContinuationState::new(initial_context);
+    real.accept(first_decision.real.token);
+    disabled.accept(first_decision.identity_disabled.token);
+    permuted.accept(first_decision.class_operator_permuted.token);
+    while real.can_step(max_units) || disabled.can_step(max_units) || permuted.can_step(max_units) {
+        if real.can_step(max_units) {
+            real.accept(
+                table
+                    .predict_multiscale_count_radius(&real.context, base_overlay)?
+                    .geometric_token,
+            );
+        }
+        if disabled.can_step(max_units) {
+            disabled.accept(
+                table
+                    .predict_multiscale_count_radius(&disabled.context, base_overlay)?
+                    .geometric_token,
+            );
+        }
+        if permuted.can_step(max_units) {
+            permuted.accept(
+                table
+                    .predict_multiscale_count_radius(&permuted.context, base_overlay)?
+                    .geometric_token,
+            );
+        }
+    }
+    Ok(MatchedBoundedGlobalExactSpinContinuation {
+        first_decision,
+        real: real.finish(table)?,
+        identity_disabled: disabled.finish(table)?,
+        class_operator_permuted: permuted.finish(table)?,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
+++ b/crates/uor-r4-core/src/canonical_lexical_ingestion.rs
@@ -12,6 +12,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU16, NonZeroUsize};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -2155,6 +2156,11 @@ impl ClearProfileKappa for IcosianProfile {
 }
 
 fn fixed_h4_root_table() -> Result<H4RootTable, CanonicalLexicalError> {
+    static TABLE: OnceLock<Result<H4RootTable, CanonicalLexicalError>> = OnceLock::new();
+    TABLE.get_or_init(build_fixed_h4_root_table).clone()
+}
+
+fn build_fixed_h4_root_table() -> Result<H4RootTable, CanonicalLexicalError> {
     let zero = ZPhiWire { a: 0, b: 0 };
     let mut roots = BTreeSet::<[ZPhiWire; 4]>::new();
     for axis in 0..4 {
@@ -2391,6 +2397,15 @@ fn multiply_scaled_h4_roots(
 /// for S0's concrete scaled H4 root order.
 pub fn validate_h4_binary_icosahedral_closure(
 ) -> Result<H4BinaryIcosahedralClosure, CanonicalLexicalError> {
+    static CLOSURE: OnceLock<Result<H4BinaryIcosahedralClosure, CanonicalLexicalError>> =
+        OnceLock::new();
+    CLOSURE
+        .get_or_init(build_h4_binary_icosahedral_closure)
+        .clone()
+}
+
+fn build_h4_binary_icosahedral_closure() -> Result<H4BinaryIcosahedralClosure, CanonicalLexicalError>
+{
     let roots = fixed_h4_root_table()?;
     let root_count = roots.roots.len();
     if root_count != 120 || roots.roots.windows(2).any(|pair| pair[0] >= pair[1]) {

--- a/crates/uor-r4-core/tests/bounded_global_exact_spin_attention_973.rs
+++ b/crates/uor-r4-core/tests/bounded_global_exact_spin_attention_973.rs
@@ -376,6 +376,10 @@ fn target_free_global_census_rejects_the_commuting_exact_spin_relation() {
     let operator_bytes = operator.to_bytes().unwrap();
     assert!(operator_bytes.len() <= MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES);
     let operator_cid = operator.artifact_cid().unwrap();
+    assert_eq!(
+        operator_cid,
+        "blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f"
+    );
 
     let table = SourceFreeTable::from_bytes(&table_bytes).unwrap();
     let base_overlay = MultiscaleCountRadiusR4V1::from_bytes(&table, &base_overlay_bytes).unwrap();

--- a/crates/uor-r4-core/tests/bounded_global_noncommuting_exact_spin_attention_973.rs
+++ b/crates/uor-r4-core/tests/bounded_global_noncommuting_exact_spin_attention_973.rs
@@ -1,0 +1,1412 @@
+//! Frozen noncommuting bounded-global exact-spin successor probe for #973.
+//!
+//! This remains one bounded synthetic, construction-bound, same-address-reuse
+//! witness over fixed #953 support. It does not establish semantic placement,
+//! distinct-address sharing, a neighbor field, broad global attention, or any
+//! downstream correctness, reasoning, performance, or release claim.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use uor_r4_core::bounded_global_exact_spin_attention::{
+    BoundedGlobalExactSpinCandidateEvidence, BoundedGlobalExactSpinCost,
+    BoundedGlobalExactSpinForbiddenReads, BoundedGlobalNoncommutingExactSpinR4V2,
+    BoundedGlobalNoncommutingPopulationAudit, MatchedBoundedGlobalExactSpinPrediction,
+    MatchedBoundedGlobalNoncommutingPairPrediction, BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES,
+    BOUNDED_GLOBAL_EXACT_SPIN_CLASSES, BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES,
+    BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS, MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES,
+    MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES,
+};
+use uor_r4_core::canonical_lexical_ingestion::{
+    canonical_lexical_piece_bytes, CanonicalRouteArtifact, GlobalExactSpinSnapshotView,
+};
+use uor_r4_core::prime_route_geometric_attention::H4S3AngularShell;
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, BackoffOrder, ContinuationStop, MultiscaleCountRadiusR4V1, SourceDocument,
+    SourceFreeTable, MAX_CONTINUATION_UNITS,
+};
+
+const OBSERVED_PROMPT: &[u8] = b"The bounded global code is";
+const ID_53_SNAPSHOT: [&[u8]; 4] = [b"Lena", b"Lena", b"helix", b"prism"];
+const ID_54_SNAPSHOT: [&[u8]; 4] = [b"Lena", b"helix", b"Lena", b"prism"];
+const DUPLICATE_POOL: [&[u8]; 11] = [
+    b".", b"Lena", b"Pavel", b"The", b"bound", b"bounded", b"class", b"code", b"global", b"is",
+    b"the",
+];
+const TARGET_COMMITMENT: &str =
+    "blake3:b7340c776e005c32316de793b332e3f218b1fad757c77044b0fa2e70fc308354";
+const TARGET_PREIMAGE_BYTES: usize = 210;
+const POSITIVE_TERMINAL: &str =
+    "RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION";
+
+static TARGET_PREIMAGE_LOADS: AtomicUsize = AtomicUsize::new(0);
+
+fn construction_documents() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new(
+            "51",
+            b"Lena bound the helix class.\n\nThe bounded global code is bronze.".to_vec(),
+        ),
+        SourceDocument::new(
+            "52",
+            b"Pavel bound the prism class.\n\nThe bounded global code is teal.".to_vec(),
+        ),
+    ]
+}
+
+fn snapshot(units: [&[u8]; 4]) -> Vec<Vec<u8>> {
+    units.into_iter().map(<[u8]>::to_vec).collect()
+}
+
+fn decoded(table: &SourceFreeTable, token: u32) -> Vec<u8> {
+    table.decode_tokens(&[token]).unwrap()
+}
+
+fn decoded_support(table: &SourceFreeTable, tokens: &[u32]) -> Vec<Vec<u8>> {
+    tokens.iter().map(|token| decoded(table, *token)).collect()
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn direct_cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn source_function<'a>(source: &'a str, name: &str) -> &'a str {
+    let needle = format!("fn {name}(");
+    let start = source.find(&needle).unwrap();
+    let opening = start + source[start..].find('{').unwrap();
+    let mut depth = 0_u32;
+    for (offset, byte) in source.as_bytes()[opening..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[start..=opening + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated source function {name}")
+}
+
+fn exact_score_firewall_accepts(source: &str) -> bool {
+    const FORBIDDEN: [&str; 25] = [
+        "target",
+        "future_unit",
+        "teacher",
+        "provider",
+        "corpus",
+        "partition",
+        "payload",
+        "address",
+        "prime",
+        "digest",
+        "class_kappa",
+        "ordinal",
+        "spin_sector",
+        "adjacent",
+        "candidate_token",
+        "candidate_hex",
+        "construction_identity",
+        "prompt_identity",
+        "table_identity",
+        "base_evidence",
+        "lower_state",
+        "declared_work",
+        "global_summary",
+        "hierarchy_h4",
+        "result_cid",
+    ];
+    FORBIDDEN.iter().all(|needle| !source.contains(needle))
+}
+
+fn assert_typed_exact_score_firewall() {
+    let source = include_str!("../src/bounded_global_exact_spin_attention.rs");
+    let kernel = [
+        "candidate_relative_exact_cost",
+        "exact_cost",
+        "select_exact_costs",
+        "unique_exact_cost_winner",
+    ]
+    .into_iter()
+    .map(|name| source_function(source, name))
+    .collect::<Vec<_>>()
+    .join("\n");
+    assert!(exact_score_firewall_accepts(&kernel));
+
+    let injected_forbidden_read = format!("{kernel}\nlet payload_score_reads = 1_u64;");
+    assert!(!exact_score_firewall_accepts(&injected_forbidden_read));
+}
+
+fn reveal_target_preimage_once() -> &'static [u8] {
+    assert_eq!(TARGET_PREIMAGE_LOADS.fetch_add(1, Ordering::SeqCst), 0);
+    br#"{"schema":1,"domain":"uor-r4.bounded-global-noncommuting-exact-spin-decoded-targets/1","rows":[{"document_id":"53","continuation_hex":"207465616c2e"},{"document_id":"54","continuation_hex":"2062726f6e7a652e"}]}"#
+}
+
+fn parse_committed_targets(bytes: &[u8]) -> Result<DecodedTargets, String> {
+    if bytes.len() != TARGET_PREIMAGE_BYTES || direct_cid(bytes) != TARGET_COMMITMENT {
+        return Err("decoded-target commitment mismatch".to_owned());
+    }
+    let targets = serde_json::from_slice::<DecodedTargets>(bytes)
+        .map_err(|error| format!("decoded-target JSON: {error}"))?;
+    let replay = serde_json::to_vec(&targets)
+        .map_err(|error| format!("decoded-target replay JSON: {error}"))?;
+    if replay != bytes
+        || targets.schema != 1
+        || targets.domain != "uor-r4.bounded-global-noncommuting-exact-spin-decoded-targets/1"
+        || targets.rows.len() != 2
+        || targets.rows[0].document_id != "53"
+        || targets.rows[1].document_id != "54"
+        || targets
+            .rows
+            .iter()
+            .any(|target| hex::decode(&target.continuation_hex).is_err())
+    {
+        return Err("decoded-target preimage is noncanonical or malformed".to_owned());
+    }
+    Ok(targets)
+}
+
+fn cost(
+    angular_shell: H4S3AngularShell,
+    fiber_distance_q29: u64,
+    torsion_distance_q29: u64,
+) -> BoundedGlobalExactSpinCost {
+    BoundedGlobalExactSpinCost {
+        angular_shell,
+        fiber_distance_q29,
+        torsion_distance_q29,
+    }
+}
+
+fn tamper_bound_value(bytes: &[u8], needle: &[u8]) -> Vec<u8> {
+    let offset = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .unwrap();
+    let mut tampered = bytes.to_vec();
+    tampered[offset + needle.len() / 2] ^= 1;
+    tampered
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DecodedTargets {
+    schema: u32,
+    domain: String,
+    rows: Vec<DecodedTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DecodedTarget {
+    document_id: String,
+    continuation_hex: String,
+}
+
+#[derive(Serialize)]
+struct TargetFreeCensus<'a> {
+    schema: u32,
+    domain: &'static str,
+    decoded_target_commitment: &'static str,
+    table_cid: String,
+    base_overlay_cid: String,
+    operator_cid: String,
+    codec_kappa: String,
+    vocabulary_kappa: String,
+    route_manifest_kappa: String,
+    spin_map_kappa: String,
+    chart_profile_kappa: String,
+    grammar_kappa: String,
+    routing_policy_kappa: String,
+    population_policy_kappa: String,
+    h4_root_table_kappa: String,
+    h4_multiplication_table_kappa: String,
+    base_lower_artifact_manifest_kappa: String,
+    snapshot_artifact_manifest_kappas: [String; 2],
+    population_audit_cid: String,
+    population_audit: &'a BoundedGlobalNoncommutingPopulationAudit,
+    snapshots: [&'a GlobalExactSpinSnapshotView; 2],
+    pair: &'a MatchedBoundedGlobalNoncommutingPairPrediction,
+    held_out_document_ids: [&'static str; 2],
+    prompt_cid: String,
+    target_preimage_loads_observed: usize,
+}
+
+#[derive(Serialize)]
+struct DecodedSmoke<'a> {
+    schema: u32,
+    domain: &'static str,
+    operator_cid: String,
+    decoded_target_commitment: &'static str,
+    target_preimage_loads_observed: usize,
+    rows: Vec<DecodedCase<'a>>,
+    real_correct: u32,
+    identity_disabled_correct: u32,
+    class_operator_permuted_correct: u32,
+    support_reversed_real_correct: u32,
+    support_mismatches: u32,
+    work_mismatches: u32,
+    period_and_eos_terminations: u32,
+    terminal: &'static str,
+}
+
+#[derive(Serialize)]
+struct DecodedCase<'a> {
+    document_id: &'static str,
+    target_hex: String,
+    continuation: &'a uor_r4_core::bounded_global_exact_spin_attention::MatchedBoundedGlobalExactSpinContinuation,
+}
+
+fn assert_snapshot_view(
+    view: &GlobalExactSpinSnapshotView,
+    expected: [&[u8]; 4],
+    duplicate: &[u8],
+) {
+    assert_eq!(view.entries.len(), BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES);
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.ordinal)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2, 3]
+    );
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.payload_bytes.as_slice())
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert_eq!(view.global_epoch, view.snapshot_kappa);
+    assert!(view.source_artifact_manifest_kappa.starts_with("blake3:"));
+    assert!(view.snapshot_summary_kappa.starts_with("blake3:"));
+    assert!(view.global_root_kappa.starts_with("blake3:"));
+    assert!(view.global_exact_chain_kappa.starts_with("blake3:"));
+
+    let repeated = view
+        .entries
+        .iter()
+        .filter(|entry| entry.payload_bytes == duplicate)
+        .collect::<Vec<_>>();
+    assert_eq!(repeated.len(), 2);
+    assert_ne!(repeated[0].ordinal, repeated[1].ordinal);
+    assert_ne!(repeated[0].entry_kappa, repeated[1].entry_kappa);
+    assert_eq!(repeated[0].address_index, repeated[1].address_index);
+    assert_eq!(repeated[0].address_kappa, repeated[1].address_kappa);
+    assert_eq!(repeated[0].payload_cid, repeated[1].payload_cid);
+    assert_eq!(repeated[0].payload_bytes, repeated[1].payload_bytes);
+    assert_eq!(repeated[0].spin, repeated[1].spin);
+    assert_eq!(
+        repeated[0].shared_class_kappa,
+        repeated[1].shared_class_kappa
+    );
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.shared_class_kappa.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CLASSES
+    );
+}
+
+fn candidate_for_anchor<'a>(
+    prediction: &'a MatchedBoundedGlobalExactSpinPrediction,
+    anchor: &[u8],
+) -> &'a BoundedGlobalExactSpinCandidateEvidence {
+    let anchor_hex = hex::encode(anchor);
+    prediction
+        .candidate_evidence
+        .iter()
+        .find(|candidate| candidate.prototype_anchor_hex == anchor_hex)
+        .unwrap()
+}
+
+fn assert_candidate_result_permutation(prediction: &MatchedBoundedGlobalExactSpinPrediction) {
+    let mut real = prediction
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.real_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    let mut permuted = prediction
+        .candidate_evidence
+        .iter()
+        .map(|candidate| candidate.permuted_class_result_cid.clone())
+        .collect::<Vec<_>>();
+    real.sort();
+    permuted.sort();
+    assert_eq!(real, permuted);
+}
+
+fn assert_common_prediction(
+    table: &SourceFreeTable,
+    prediction: &MatchedBoundedGlobalExactSpinPrediction,
+) {
+    assert_eq!(prediction.local.order, BackoffOrder::Trigram);
+    assert_eq!(prediction.local.max_count, 1);
+    assert!(prediction.local.geometry_reachable);
+    assert_eq!(
+        decoded_support(table, &prediction.local.max_count_tie_tokens),
+        vec![b" bronze".to_vec(), b" teal".to_vec()]
+    );
+    assert_eq!(
+        prediction.local.baseline_support_tokens,
+        prediction.local.geometric_support_tokens
+    );
+    assert_eq!(
+        prediction.local.max_count_tie_tokens,
+        prediction.local.baseline_support_tokens
+    );
+    assert_eq!(
+        prediction.local.baseline_work,
+        prediction.local.geometric_work
+    );
+    assert_eq!(decoded(table, prediction.local.geometric_token), b" bronze");
+    assert_eq!(
+        prediction.snapshot_entries.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES
+    );
+    assert_eq!(
+        prediction.fold_steps.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES
+    );
+    assert_eq!(
+        prediction.class_evaluations.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CLASSES
+    );
+    assert_eq!(
+        prediction.candidate_evidence.len(),
+        BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES
+    );
+    assert!(prediction.support_reversal_invariant);
+    assert_eq!(
+        prediction.support_reversed_real_token,
+        prediction.real.token
+    );
+    assert!(prediction.coherent_relabel_equivariant);
+    assert!(prediction.support_matched);
+    assert!(prediction.work_matched);
+    assert_eq!(prediction.operator_abstention, None);
+    assert_eq!(
+        prediction.forbidden_reads,
+        BoundedGlobalExactSpinForbiddenReads::default()
+    );
+    assert_eq!(prediction.real.work, prediction.identity_disabled.work);
+    assert_eq!(
+        prediction.real.work,
+        prediction.class_operator_permuted.work
+    );
+    assert_eq!(
+        prediction.real.support_tokens,
+        prediction.identity_disabled.support_tokens
+    );
+    assert_eq!(
+        prediction.real.support_tokens,
+        prediction.class_operator_permuted.support_tokens
+    );
+    assert!(prediction.real.unique_minimum.is_some());
+    assert!(prediction.class_operator_permuted.unique_minimum.is_some());
+    assert_eq!(prediction.identity_disabled.unique_minimum, None);
+    assert_eq!(prediction.identity_disabled.minimum_cost, None);
+    assert_eq!(
+        prediction.identity_disabled.token,
+        prediction.local.geometric_token
+    );
+
+    let work = prediction.real.work;
+    assert_eq!(work.snapshot_entry_reads, 4);
+    assert_eq!(work.exact_class_comparisons, 4);
+    assert_eq!(work.unique_class_evaluations, 3);
+    assert_eq!(work.class_reuse_hits, BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS);
+    assert_eq!(work.class_result_applications, 4);
+    assert_eq!(work.h4_product_table_reads, 10);
+    assert_eq!(work.h4_inverse_table_reads, 6);
+    assert_eq!(work.phase_additions, 20);
+    assert_eq!(work.phase_distance_reads, 12);
+    assert_eq!(work.angular_shell_reads, 6);
+    assert_eq!(work.candidate_class_lookups, 2);
+    assert_eq!(work.cost_comparisons, 2);
+    assert_eq!(work.final_choice_operations, 1);
+
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.evaluation_count)
+            .sum::<u64>(),
+        3
+    );
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.reference_count)
+            .sum::<u64>(),
+        4
+    );
+    assert_eq!(
+        prediction
+            .class_evaluations
+            .iter()
+            .map(|class| class.reuse_count)
+            .sum::<u64>(),
+        BOUNDED_GLOBAL_EXACT_SPIN_REUSE_HITS
+    );
+    assert!(prediction.class_evaluations.iter().all(|class| {
+        class.cold_recomputation_equal && class.result_cid == class.cold_result_cid
+    }));
+    let repeated = prediction
+        .class_evaluations
+        .iter()
+        .find(|class| class.reference_count == 2)
+        .unwrap();
+    assert_eq!(repeated.reference_entry_kappas.len(), 2);
+    assert_ne!(
+        repeated.reference_entry_kappas[0],
+        repeated.reference_entry_kappas[1]
+    );
+    assert_eq!(repeated.evaluation_count, 1);
+    assert_eq!(repeated.reuse_count, 1);
+
+    let helix = prediction
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"helix"))
+        .unwrap();
+    let prism = prediction
+        .snapshot_entries
+        .iter()
+        .find(|entry| entry.payload_hex == hex::encode(b"prism"))
+        .unwrap();
+    assert_ne!(helix.shared_class_kappa, prism.shared_class_kappa);
+    assert_eq!(helix.diagnostic_sector, prism.diagnostic_sector);
+    assert!(prediction.snapshot_entries.iter().all(|entry| entry
+        .mapped_state
+        .h4_coordinate
+        .scaled_zphi_quaternion
+        .iter()
+        .all(|coordinate| coordinate[1] == 0)));
+
+    for candidate in &prediction.candidate_evidence {
+        assert_eq!(candidate.count, 1);
+        assert_eq!(
+            candidate.real_ranking_cost,
+            Some(candidate.real_measured_cost)
+        );
+        assert_eq!(candidate.identity_disabled_ranking_cost, None);
+        assert_eq!(
+            candidate.permuted_ranking_cost,
+            Some(candidate.permuted_measured_cost)
+        );
+        assert!(candidate.real_class_result_cid.starts_with("blake3:"));
+        assert!(candidate.permuted_class_result_cid.starts_with("blake3:"));
+        assert!(candidate.candidate_state_kappa.starts_with("blake3:"));
+    }
+    assert_candidate_result_permutation(prediction);
+}
+
+fn assert_population_audit(
+    operator: &BoundedGlobalNoncommutingExactSpinR4V2,
+    audit: &BoundedGlobalNoncommutingPopulationAudit,
+) {
+    assert_eq!(audit.schema, 1);
+    assert_eq!(
+        audit.domain,
+        "uor-r4.bounded-global-noncommuting-population-audit/1"
+    );
+    assert_eq!(
+        audit.population_policy_kappa,
+        operator.population_policy_kappa()
+    );
+    assert_eq!(
+        audit
+            .duplicate_pool_hex
+            .iter()
+            .map(|value| hex::decode(value).unwrap())
+            .collect::<Vec<_>>(),
+        DUPLICATE_POOL
+            .iter()
+            .map(|value| value.to_vec())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(audit.rows_examined.len(), 2);
+    assert_eq!(
+        hex::decode(&audit.rows_examined[0].duplicate_hex).unwrap(),
+        b"."
+    );
+    assert!(!audit.rows_examined[0].direct_noncommutation);
+    assert_eq!(audit.rows_examined[0].selected_pair_indices, None);
+    assert_eq!(
+        audit.rows_examined[0]
+            .duplicate_state
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        [[2, 0], [0, 0], [0, 0], [0, 0]]
+    );
+    assert_eq!(
+        hex::decode(&audit.rows_examined[1].duplicate_hex).unwrap(),
+        b"Lena"
+    );
+    assert!(audit.rows_examined[1].direct_noncommutation);
+    assert_eq!(audit.rows_examined[1].unique_permutations, 12);
+    assert_eq!(audit.rows_examined[1].selected_pair_indices, Some([0, 2]));
+    assert_eq!(audit.selected_duplicate_hex, hex::encode(b"Lena"));
+    assert_eq!(audit.selected_pair_indices, [0, 2]);
+    assert_eq!(audit.left_snapshot_hex, ID_53_SNAPSHOT.map(hex::encode));
+    assert_eq!(audit.right_snapshot_hex, ID_54_SNAPSHOT.map(hex::encode));
+    assert!(audit.one_transposition);
+    assert_eq!(audit.transposed_ordinals, [1, 2]);
+    assert!(audit.noncommutation.products_distinct);
+    assert_eq!(
+        hex::decode(&audit.noncommutation.left_operand_hex).unwrap(),
+        b"Lena"
+    );
+    assert_eq!(
+        hex::decode(&audit.noncommutation.right_operand_hex).unwrap(),
+        b"helix"
+    );
+    assert_eq!(
+        audit
+            .noncommutation
+            .left_operand
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        [[0, 0], [2, 0], [0, 0], [0, 0]]
+    );
+    assert_eq!(
+        audit
+            .noncommutation
+            .right_operand
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        [[1, 0], [1, 0], [1, 0], [1, 0]]
+    );
+    assert_eq!(
+        audit
+            .noncommutation
+            .left_then_right
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        [[-1, 0], [1, 0], [-1, 0], [1, 0]]
+    );
+    assert_eq!(
+        audit
+            .noncommutation
+            .right_then_left
+            .h4_coordinate
+            .scaled_zphi_quaternion,
+        [[-1, 0], [1, 0], [1, 0], [-1, 0]]
+    );
+    assert_ne!(
+        audit.noncommutation.left_then_right,
+        audit.noncommutation.right_then_left
+    );
+    assert_eq!(
+        audit.noncommutation.left_then_right.fiber_q29,
+        audit.noncommutation.right_then_left.fiber_q29
+    );
+    assert_eq!(
+        audit.noncommutation.left_then_right.torsion_q29,
+        audit.noncommutation.right_then_left.torsion_q29
+    );
+    assert!(audit.distinct_nonidentity_folds);
+    assert!(audit.complete_phase_totals_equal);
+    assert_ne!(audit.left_fold, audit.right_fold);
+    assert_eq!(
+        audit.left_fold.h4_coordinate.scaled_zphi_quaternion,
+        [[-1, 0], [-1, 0], [-1, 0], [-1, 0]]
+    );
+    assert_eq!(
+        audit.right_fold.h4_coordinate.scaled_zphi_quaternion,
+        [[-1, 0], [-1, 0], [1, 0], [1, 0]]
+    );
+    for fold in [audit.left_fold, audit.right_fold] {
+        assert_eq!(fold.fiber_q29, 102_410_010);
+        assert_eq!(fold.torsion_q29, -9_745_662);
+    }
+
+    let left_helix = audit
+        .left_candidate_costs
+        .iter()
+        .find(|row| row.prototype_anchor_hex == hex::encode(b"helix"))
+        .unwrap();
+    let left_prism = audit
+        .left_candidate_costs
+        .iter()
+        .find(|row| row.prototype_anchor_hex == hex::encode(b"prism"))
+        .unwrap();
+    let right_helix = audit
+        .right_candidate_costs
+        .iter()
+        .find(|row| row.prototype_anchor_hex == hex::encode(b"helix"))
+        .unwrap();
+    let right_prism = audit
+        .right_candidate_costs
+        .iter()
+        .find(|row| row.prototype_anchor_hex == hex::encode(b"prism"))
+        .unwrap();
+    assert_eq!(
+        left_helix.cost,
+        cost(H4S3AngularShell::Antipodal, 61_239_177, 5_831_083)
+    );
+    assert_eq!(
+        left_prism.cost,
+        cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467)
+    );
+    assert_eq!(
+        right_helix.cost,
+        cost(H4S3AngularShell::Orthogonal, 61_239_177, 5_831_083)
+    );
+    assert_eq!(
+        right_prism.cost,
+        cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467)
+    );
+    assert_eq!(audit.left_winner_anchor_hex, hex::encode(b"prism"));
+    assert_eq!(audit.right_winner_anchor_hex, hex::encode(b"helix"));
+    assert!(audit.incompatible_unique_winners);
+}
+
+#[test]
+fn noncommuting_global_relation_is_load_bearing_before_the_committed_decode() {
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+    assert_typed_exact_score_firewall();
+
+    let construction = construction_documents();
+    assert_eq!(construction.len(), 2);
+    assert!(construction
+        .iter()
+        .all(|document| !d3_is_held_out(&document.id)));
+    assert!(d3_is_held_out("53"));
+    assert!(d3_is_held_out("54"));
+    let held_out = [
+        SourceDocument::new("53", OBSERVED_PROMPT.to_vec()),
+        SourceDocument::new("54", OBSERVED_PROMPT.to_vec()),
+    ];
+    for document in &held_out {
+        assert!(construction.iter().all(|source| {
+            source.id != document.id && source.text_cid() != document.text_cid()
+        }));
+        assert_eq!(document.text, OBSERVED_PROMPT);
+        assert!(!contains_bytes(&document.text, b" bronze"));
+        assert!(!contains_bytes(&document.text, b" teal"));
+    }
+    assert_eq!(held_out[0].text_cid(), held_out[1].text_cid());
+    assert!(OBSERVED_PROMPT.len() <= MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES);
+    let prompt_pieces = canonical_lexical_piece_bytes(OBSERVED_PROMPT).unwrap();
+    assert!(!prompt_pieces
+        .iter()
+        .any(|piece| piece == b"bronze" || piece == b"teal"));
+
+    let left_snapshot = snapshot(ID_53_SNAPSHOT);
+    let right_snapshot = snapshot(ID_54_SNAPSHOT);
+    let mut left_multiset = left_snapshot.clone();
+    let mut right_multiset = right_snapshot.clone();
+    left_multiset.sort();
+    right_multiset.sort();
+    assert_eq!(left_multiset, right_multiset);
+    assert_ne!(left_snapshot, right_snapshot);
+    for units in [&left_snapshot, &right_snapshot] {
+        assert_eq!(units.len(), BOUNDED_GLOBAL_EXACT_SPIN_ENTRIES);
+        assert!(units
+            .iter()
+            .all(|unit| unit != b"bronze" && unit != b"teal"));
+    }
+
+    let table = SourceFreeTable::compile(&construction).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::compile(&table).unwrap();
+    let operator =
+        BoundedGlobalNoncommutingExactSpinR4V2::compile(&table, &base_overlay, &construction)
+            .unwrap();
+    let table_bytes = table.to_bytes();
+    let base_overlay_bytes = base_overlay.to_bytes();
+    let operator_bytes = operator.to_bytes().unwrap();
+    assert!(operator_bytes.len() <= MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES);
+    let operator_wire: serde_json::Value = serde_json::from_slice(&operator_bytes[8..]).unwrap();
+    assert!(operator_wire.get("held_out_document_ids").is_none());
+    assert!(operator_wire.get("decoded_targets").is_none());
+    assert!(operator_wire.get("decoded_target_commitment").is_none());
+    assert!(!contains_bytes(
+        &operator_bytes,
+        TARGET_COMMITMENT.as_bytes()
+    ));
+    let operator_cid = operator.artifact_cid().unwrap();
+
+    let table = SourceFreeTable::from_bytes(&table_bytes).unwrap();
+    let base_overlay = MultiscaleCountRadiusR4V1::from_bytes(&table, &base_overlay_bytes).unwrap();
+    let operator = BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+        &table,
+        &base_overlay,
+        &construction,
+        &operator_bytes,
+    )
+    .unwrap();
+    assert_eq!(table.to_bytes(), table_bytes);
+    assert_eq!(base_overlay.to_bytes(), base_overlay_bytes);
+    assert_eq!(operator.to_bytes().unwrap(), operator_bytes);
+    assert_eq!(operator.artifact_cid().unwrap(), operator_cid);
+    assert_eq!(operator.table_artifact_cid(), table.artifact_cid());
+    assert_eq!(
+        operator.base_overlay_artifact_cid(),
+        base_overlay.artifact_cid()
+    );
+
+    let prototypes = operator.prototype_traces().unwrap();
+    assert_eq!(prototypes.len(), BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES);
+    assert_eq!(
+        prototypes
+            .iter()
+            .map(|prototype| hex::decode(&prototype.candidate_hex).unwrap())
+            .collect::<Vec<_>>(),
+        vec![b" bronze".to_vec(), b" teal".to_vec()]
+    );
+    assert_eq!(
+        prototypes
+            .iter()
+            .map(|prototype| hex::decode(&prototype.anchor_hex).unwrap())
+            .collect::<Vec<_>>(),
+        vec![b"helix".to_vec(), b"prism".to_vec()]
+    );
+    assert_ne!(
+        prototypes[0].anchor_class_kappa,
+        prototypes[1].anchor_class_kappa
+    );
+
+    let population_audit = operator.population_audit().unwrap();
+    assert_population_audit(&operator, &population_audit);
+    let population_audit_bytes = serde_json::to_vec(&population_audit).unwrap();
+    let population_audit_cid = direct_cid(&population_audit_bytes);
+    let population_audit_replay = operator.population_audit().unwrap();
+    assert_eq!(population_audit_replay, population_audit);
+    assert_eq!(
+        serde_json::to_vec(&population_audit_replay).unwrap(),
+        population_audit_bytes
+    );
+
+    let [base_carrier, left_carrier, right_carrier] = std::thread::scope(|scope| {
+        [
+            scope.spawn(|| {
+                let artifact = operator.build_query_artifact(OBSERVED_PROMPT).unwrap();
+                let bytes = artifact.canonical_bytes().unwrap();
+                (artifact, bytes)
+            }),
+            scope.spawn(|| {
+                let artifact = operator
+                    .build_snapshot_artifact(OBSERVED_PROMPT, &left_snapshot)
+                    .unwrap();
+                let bytes = artifact.canonical_bytes().unwrap();
+                (artifact, bytes)
+            }),
+            scope.spawn(|| {
+                let artifact = operator
+                    .build_snapshot_artifact(OBSERVED_PROMPT, &right_snapshot)
+                    .unwrap();
+                let bytes = artifact.canonical_bytes().unwrap();
+                (artifact, bytes)
+            }),
+        ]
+        .map(|handle| handle.join().unwrap())
+    });
+    let (base_artifact, base_artifact_bytes) = base_carrier;
+    let (left_artifact, left_artifact_bytes) = left_carrier;
+    let (right_artifact, right_artifact_bytes) = right_carrier;
+    let base_manifest = base_artifact.manifest_kappa().to_owned();
+    let left_manifest = left_artifact.manifest_kappa().to_owned();
+    let right_manifest = right_artifact.manifest_kappa().to_owned();
+    assert_ne!(base_manifest, left_manifest);
+    assert_ne!(base_manifest, right_manifest);
+    assert_ne!(left_manifest, right_manifest);
+    let left_view = left_artifact.global_exact_spin_snapshot_view().unwrap();
+    let right_view = right_artifact.global_exact_spin_snapshot_view().unwrap();
+    assert_snapshot_view(&left_view, ID_53_SNAPSHOT, b"Lena");
+    assert_snapshot_view(&right_view, ID_54_SNAPSHOT, b"Lena");
+    assert_eq!(left_view.source_artifact_manifest_kappa, left_manifest);
+    assert_eq!(right_view.source_artifact_manifest_kappa, right_manifest);
+    assert_ne!(left_view.snapshot_kappa, right_view.snapshot_kappa);
+    assert_ne!(left_view.global_root_kappa, right_view.global_root_kappa);
+
+    let pair = operator
+        .predict_pair_matched(
+            &table,
+            &base_overlay,
+            &base_artifact,
+            &left_artifact,
+            &right_artifact,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    assert_eq!(pair.population_audit, population_audit);
+    assert!(pair.exact_fold_distinct);
+    assert!(pair.real_winners_incompatible);
+    assert!(pair.permuted_winners_incompatible);
+    assert!(pair.common_lower_artifact);
+    assert!(pair.support_matched_between_cases);
+    assert!(pair.work_matched_between_cases);
+    assert_common_prediction(&table, &pair.left);
+    assert_common_prediction(&table, &pair.right);
+    assert_eq!(pair.left.local, pair.right.local);
+    assert_eq!(pair.left.real.work, pair.right.real.work);
+    assert_eq!(
+        pair.left.real.support_tokens,
+        pair.right.real.support_tokens
+    );
+    assert_eq!(pair.left.base_lower_artifact_manifest_kappa, base_manifest);
+    assert_eq!(pair.right.base_lower_artifact_manifest_kappa, base_manifest);
+    assert_eq!(
+        pair.left.source_snapshot_artifact_manifest_kappa,
+        left_manifest
+    );
+    assert_eq!(
+        pair.right.source_snapshot_artifact_manifest_kappa,
+        right_manifest
+    );
+    assert_ne!(pair.left.global_epoch, pair.right.global_epoch);
+    assert_ne!(pair.left.global_root_kappa, pair.right.global_root_kappa);
+    assert_eq!(pair.left.global_result, population_audit.left_fold);
+    assert_eq!(pair.right.global_result, population_audit.right_fold);
+    assert_ne!(pair.left.global_result, pair.right.global_result);
+    assert_eq!(pair.left.operator_cid, operator_cid);
+    assert_eq!(pair.right.operator_cid, operator_cid);
+    assert_eq!(pair.left.spin_map_kappa, operator.spin_map_kappa());
+    assert_eq!(pair.right.spin_map_kappa, operator.spin_map_kappa());
+    assert_eq!(
+        pair.left.chart_profile_kappa,
+        operator.chart_profile_kappa()
+    );
+    assert_eq!(
+        pair.right.chart_profile_kappa,
+        operator.chart_profile_kappa()
+    );
+
+    let left_helix = candidate_for_anchor(&pair.left, b"helix");
+    let left_prism = candidate_for_anchor(&pair.left, b"prism");
+    let right_helix = candidate_for_anchor(&pair.right, b"helix");
+    let right_prism = candidate_for_anchor(&pair.right, b"prism");
+    assert_eq!(
+        left_helix.real_measured_cost,
+        cost(H4S3AngularShell::Antipodal, 61_239_177, 5_831_083)
+    );
+    assert_eq!(
+        left_prism.real_measured_cost,
+        cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467)
+    );
+    assert_eq!(
+        right_helix.real_measured_cost,
+        cost(H4S3AngularShell::Orthogonal, 61_239_177, 5_831_083)
+    );
+    assert_eq!(
+        right_prism.real_measured_cost,
+        cost(H4S3AngularShell::Degrees120, 55_205_017, 5_262_467)
+    );
+    assert_eq!(
+        pair.left.real.minimum_cost,
+        Some(left_prism.real_measured_cost)
+    );
+    assert_eq!(
+        pair.right.real.minimum_cost,
+        Some(right_helix.real_measured_cost)
+    );
+    assert_eq!(decoded(&table, pair.left.real.token), b" teal");
+    assert_eq!(decoded(&table, pair.right.real.token), b" bronze");
+    assert_eq!(
+        decoded(&table, pair.left.identity_disabled.token),
+        b" bronze"
+    );
+    assert_eq!(
+        decoded(&table, pair.right.identity_disabled.token),
+        b" bronze"
+    );
+    assert_eq!(
+        decoded(&table, pair.left.class_operator_permuted.token),
+        b" bronze"
+    );
+    assert_eq!(
+        decoded(&table, pair.right.class_operator_permuted.token),
+        b" teal"
+    );
+    assert_ne!(pair.left.real.token, pair.right.real.token);
+    assert_ne!(
+        pair.left.class_operator_permuted.token,
+        pair.right.class_operator_permuted.token
+    );
+
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+    let target_free_census = TargetFreeCensus {
+        schema: 1,
+        domain: "uor-r4.bounded-global-noncommuting-exact-spin-target-free-census/1",
+        decoded_target_commitment: TARGET_COMMITMENT,
+        table_cid: table.artifact_cid(),
+        base_overlay_cid: base_overlay.artifact_cid(),
+        operator_cid: operator_cid.clone(),
+        codec_kappa: operator.codec_kappa().to_owned(),
+        vocabulary_kappa: operator.vocabulary_kappa().to_owned(),
+        route_manifest_kappa: operator.route_manifest_kappa().to_owned(),
+        spin_map_kappa: operator.spin_map_kappa().to_owned(),
+        chart_profile_kappa: operator.chart_profile_kappa().to_owned(),
+        grammar_kappa: operator.grammar_kappa().to_owned(),
+        routing_policy_kappa: operator.routing_policy_kappa().to_owned(),
+        population_policy_kappa: operator.population_policy_kappa().to_owned(),
+        h4_root_table_kappa: operator.h4_root_table_kappa().to_owned(),
+        h4_multiplication_table_kappa: operator.h4_multiplication_table_kappa().to_owned(),
+        base_lower_artifact_manifest_kappa: base_manifest.clone(),
+        snapshot_artifact_manifest_kappas: [left_manifest.clone(), right_manifest.clone()],
+        population_audit_cid: population_audit_cid.clone(),
+        population_audit: &population_audit,
+        snapshots: [&left_view, &right_view],
+        pair: &pair,
+        held_out_document_ids: ["53", "54"],
+        prompt_cid: direct_cid(OBSERVED_PROMPT),
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+    };
+    let target_free_bytes = serde_json::to_vec(&target_free_census).unwrap();
+    let target_free_cid = direct_cid(&target_free_bytes);
+
+    let [base_artifact_replay, left_artifact_replay, right_artifact_replay] =
+        std::thread::scope(|scope| {
+            [
+                scope.spawn(|| CanonicalRouteArtifact::decode_canonical(&base_artifact_bytes)),
+                scope.spawn(|| CanonicalRouteArtifact::decode_canonical(&left_artifact_bytes)),
+                scope.spawn(|| CanonicalRouteArtifact::decode_canonical(&right_artifact_bytes)),
+            ]
+            .map(|handle| handle.join().unwrap().unwrap())
+        });
+    let left_view_replay = left_artifact_replay
+        .global_exact_spin_snapshot_view()
+        .unwrap();
+    let right_view_replay = right_artifact_replay
+        .global_exact_spin_snapshot_view()
+        .unwrap();
+    assert_eq!(left_view_replay, left_view);
+    assert_eq!(right_view_replay, right_view);
+    let pair_replay = operator
+        .predict_pair_matched(
+            &table,
+            &base_overlay,
+            &base_artifact_replay,
+            &left_artifact_replay,
+            &right_artifact_replay,
+            OBSERVED_PROMPT,
+        )
+        .unwrap();
+    assert_eq!(pair_replay, pair);
+    let replay_population_audit = operator.population_audit().unwrap();
+    assert_eq!(
+        serde_json::to_vec(&replay_population_audit).unwrap(),
+        population_audit_bytes
+    );
+    let replay_target_free_census = TargetFreeCensus {
+        schema: 1,
+        domain: "uor-r4.bounded-global-noncommuting-exact-spin-target-free-census/1",
+        decoded_target_commitment: TARGET_COMMITMENT,
+        table_cid: table.artifact_cid(),
+        base_overlay_cid: base_overlay.artifact_cid(),
+        operator_cid: operator_cid.clone(),
+        codec_kappa: operator.codec_kappa().to_owned(),
+        vocabulary_kappa: operator.vocabulary_kappa().to_owned(),
+        route_manifest_kappa: operator.route_manifest_kappa().to_owned(),
+        spin_map_kappa: operator.spin_map_kappa().to_owned(),
+        chart_profile_kappa: operator.chart_profile_kappa().to_owned(),
+        grammar_kappa: operator.grammar_kappa().to_owned(),
+        routing_policy_kappa: operator.routing_policy_kappa().to_owned(),
+        population_policy_kappa: operator.population_policy_kappa().to_owned(),
+        h4_root_table_kappa: operator.h4_root_table_kappa().to_owned(),
+        h4_multiplication_table_kappa: operator.h4_multiplication_table_kappa().to_owned(),
+        base_lower_artifact_manifest_kappa: base_manifest.clone(),
+        snapshot_artifact_manifest_kappas: [left_manifest.clone(), right_manifest.clone()],
+        population_audit_cid: population_audit_cid.clone(),
+        population_audit: &replay_population_audit,
+        snapshots: [&left_view_replay, &right_view_replay],
+        pair: &pair_replay,
+        held_out_document_ids: ["53", "54"],
+        prompt_cid: direct_cid(OBSERVED_PROMPT),
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+    };
+    let replay_target_free_bytes = serde_json::to_vec(&replay_target_free_census).unwrap();
+    assert_eq!(replay_target_free_bytes, target_free_bytes);
+    assert_eq!(direct_cid(&replay_target_free_bytes), target_free_cid);
+    assert_eq!(operator.to_bytes().unwrap(), operator_bytes);
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+
+    let oversized_operator = vec![0_u8; MAX_BOUNDED_GLOBAL_EXACT_SPIN_OPERATOR_BYTES + 1];
+    assert!(BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+        &table,
+        &base_overlay,
+        &construction,
+        &oversized_operator,
+    )
+    .is_err());
+    let tampered_operator = tamper_bound_value(
+        &tamper_bound_value(
+            &tamper_bound_value(
+                &tamper_bound_value(&operator_bytes, operator.spin_map_kappa().as_bytes()),
+                operator.h4_root_table_kappa().as_bytes(),
+            ),
+            operator.population_policy_kappa().as_bytes(),
+        ),
+        b"4c656e61",
+    );
+    let drifted_construction = vec![
+        SourceDocument::new(
+            "51",
+            b"Lena bound the helix class.\n\nThe bounded global code is brass.".to_vec(),
+        ),
+        construction[1].clone(),
+    ];
+    let unrelated = vec![
+        SourceDocument::new("51", b"alpha beta gamma.".to_vec()),
+        SourceDocument::new("52", b"delta epsilon zeta.".to_vec()),
+    ];
+    let drifted_table = SourceFreeTable::compile(&unrelated).unwrap();
+    let drifted_overlay = MultiscaleCountRadiusR4V1::compile(&drifted_table).unwrap();
+    let binding_rejections = std::thread::scope(|scope| {
+        let tampered = scope.spawn(|| {
+            BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+                &table,
+                &base_overlay,
+                &construction,
+                &tampered_operator,
+            )
+            .is_err()
+        });
+        let construction_drift = scope.spawn(|| {
+            BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+                &table,
+                &base_overlay,
+                &drifted_construction,
+                &operator_bytes,
+            )
+            .is_err()
+        });
+        let table_drift = scope.spawn(|| {
+            BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+                &drifted_table,
+                &drifted_overlay,
+                &construction,
+                &operator_bytes,
+            )
+            .is_err()
+        });
+        let overlay_drift = scope.spawn(|| {
+            BoundedGlobalNoncommutingExactSpinR4V2::from_bytes(
+                &table,
+                &drifted_overlay,
+                &construction,
+                &operator_bytes,
+            )
+            .is_err()
+        });
+        [
+            tampered.join().unwrap(),
+            construction_drift.join().unwrap(),
+            table_drift.join().unwrap(),
+            overlay_drift.join().unwrap(),
+        ]
+    });
+    assert!(binding_rejections.into_iter().all(|rejected| rejected));
+    assert!(operator.build_query_artifact(b"wrong prompt").is_err());
+    assert!(operator
+        .build_query_artifact(&vec![b'x'; MAX_BOUNDED_GLOBAL_EXACT_SPIN_QUERY_BYTES + 1])
+        .is_err());
+    assert!(operator
+        .build_snapshot_artifact(
+            OBSERVED_PROMPT,
+            &[b"Lena".to_vec(), b"helix".to_vec(), b"prism".to_vec()],
+        )
+        .is_err());
+    assert!(operator
+        .build_snapshot_artifact(
+            OBSERVED_PROMPT,
+            &snapshot([b"Lena", b"Lena", b"prism", b"helix"]),
+        )
+        .is_err());
+    let carrier_rejections = std::thread::scope(|scope| {
+        let reversed = scope.spawn(|| {
+            operator
+                .predict_pair_matched(
+                    &table,
+                    &base_overlay,
+                    &base_artifact,
+                    &right_artifact,
+                    &left_artifact,
+                    OBSERVED_PROMPT,
+                )
+                .is_err()
+        });
+        let aliased = scope.spawn(|| {
+            operator
+                .predict_pair_matched(
+                    &table,
+                    &base_overlay,
+                    &base_artifact,
+                    &left_artifact,
+                    &left_artifact,
+                    OBSERVED_PROMPT,
+                )
+                .is_err()
+        });
+        let wrong_lower = scope.spawn(|| {
+            operator
+                .predict_pair_matched(
+                    &table,
+                    &base_overlay,
+                    &left_artifact,
+                    &left_artifact,
+                    &right_artifact,
+                    OBSERVED_PROMPT,
+                )
+                .is_err()
+        });
+        [
+            reversed.join().unwrap(),
+            aliased.join().unwrap(),
+            wrong_lower.join().unwrap(),
+        ]
+    });
+    assert!(carrier_rejections.into_iter().all(|rejected| rejected));
+    let mut tampered_carrier = left_artifact_bytes.clone();
+    *tampered_carrier.last_mut().unwrap() ^= 1;
+    assert!(CanonicalRouteArtifact::decode_canonical(&tampered_carrier).is_err());
+    for invalid_bound in [0, MAX_CONTINUATION_UNITS + 1] {
+        assert!(operator
+            .continue_pair_matched(
+                &table,
+                &base_overlay,
+                &base_artifact,
+                &left_artifact,
+                &right_artifact,
+                OBSERVED_PROMPT,
+                invalid_bound,
+            )
+            .is_err());
+    }
+    let operator_ref = &operator;
+    let table_ref = &table;
+    let base_overlay_ref = &base_overlay;
+    let base_artifact_ref = &base_artifact;
+    let left_artifact_ref = &left_artifact;
+    let right_artifact_ref = &right_artifact;
+    let truncation_rejections = std::thread::scope(|scope| {
+        [1, 2]
+            .map(|invalid_bound| {
+                scope.spawn(move || {
+                    operator_ref
+                        .continue_pair_matched(
+                            table_ref,
+                            base_overlay_ref,
+                            base_artifact_ref,
+                            left_artifact_ref,
+                            right_artifact_ref,
+                            OBSERVED_PROMPT,
+                            invalid_bound,
+                        )
+                        .is_err()
+                })
+            })
+            .map(|handle| handle.join().unwrap())
+    });
+    assert!(truncation_rejections.into_iter().all(|rejected| rejected));
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 0);
+
+    let target_preimage = reveal_target_preimage_once();
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 1);
+    assert_eq!(target_preimage.len(), TARGET_PREIMAGE_BYTES);
+    assert_eq!(direct_cid(target_preimage), TARGET_COMMITMENT);
+    let sealed_targets = parse_committed_targets(target_preimage).unwrap();
+    assert_eq!(
+        serde_json::to_vec(&sealed_targets).unwrap(),
+        target_preimage
+    );
+    let decoded_targets = sealed_targets
+        .rows
+        .iter()
+        .map(|target| hex::decode(&target.continuation_hex).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        decoded_targets,
+        vec![b" teal.".to_vec(), b" bronze.".to_vec()]
+    );
+    let mut tampered_target = target_preimage.to_vec();
+    *tampered_target.last_mut().unwrap() ^= 1;
+    assert!(parse_committed_targets(&tampered_target).is_err());
+    let mut target_with_newline = target_preimage.to_vec();
+    target_with_newline.push(b'\n');
+    assert!(parse_committed_targets(&target_with_newline).is_err());
+    let mut target_with_unknown = target_preimage[..target_preimage.len() - 1].to_vec();
+    target_with_unknown.extend_from_slice(br#","unknown":0}"#);
+    assert!(serde_json::from_slice::<DecodedTargets>(&target_with_unknown).is_err());
+
+    let continuation = operator
+        .continue_pair_matched(
+            &table,
+            &base_overlay,
+            &base_artifact_replay,
+            &left_artifact_replay,
+            &right_artifact_replay,
+            OBSERVED_PROMPT,
+            3,
+        )
+        .unwrap();
+    assert_eq!(continuation.first_pair, pair);
+    assert_eq!(
+        continuation.first_pair.left,
+        continuation.left.first_decision
+    );
+    assert_eq!(
+        continuation.first_pair.right,
+        continuation.right.first_decision
+    );
+    let cases = [&continuation.left, &continuation.right];
+    let mut real_correct = 0_u32;
+    let mut identity_disabled_correct = 0_u32;
+    let mut class_operator_permuted_correct = 0_u32;
+    let mut support_reversed_real_correct = 0_u32;
+    let mut period_and_eos_terminations = 0_u32;
+    for (index, case) in cases.iter().enumerate() {
+        let target = &decoded_targets[index];
+        real_correct += u32::from(case.real.decoded == *target);
+        identity_disabled_correct += u32::from(case.identity_disabled.decoded == *target);
+        class_operator_permuted_correct +=
+            u32::from(case.class_operator_permuted.decoded == *target);
+        support_reversed_real_correct += u32::from(
+            case.first_decision.support_reversal_invariant
+                && case.first_decision.support_reversed_real_token
+                    == case.first_decision.real.token
+                && case.real.decoded == *target,
+        );
+        for arm in [
+            &case.real,
+            &case.identity_disabled,
+            &case.class_operator_permuted,
+        ] {
+            assert_eq!(arm.stop, ContinuationStop::EndOfDocument);
+            assert_eq!(arm.tokens.len(), 2);
+            assert_ne!(arm.tokens[0], arm.tokens[1]);
+            assert_eq!(decoded(&table, arm.tokens[1]), b".");
+            assert!(arm.decoded.ends_with(b"."));
+            period_and_eos_terminations += 1;
+        }
+        assert!(case.first_decision.support_matched);
+        assert!(case.first_decision.work_matched);
+        assert_eq!(case.first_decision.forbidden_reads.total(), 0);
+    }
+    assert_eq!(continuation.left.real.decoded, b" teal.");
+    assert_eq!(continuation.right.real.decoded, b" bronze.");
+    assert_eq!(continuation.left.identity_disabled.decoded, b" bronze.");
+    assert_eq!(continuation.right.identity_disabled.decoded, b" bronze.");
+    assert_eq!(
+        continuation.left.class_operator_permuted.decoded,
+        b" bronze."
+    );
+    assert_eq!(
+        continuation.right.class_operator_permuted.decoded,
+        b" teal."
+    );
+    assert_eq!(real_correct, 2);
+    assert_eq!(identity_disabled_correct, 1);
+    assert_eq!(class_operator_permuted_correct, 0);
+    assert_eq!(support_reversed_real_correct, 2);
+    assert_eq!(period_and_eos_terminations, 6);
+
+    let decoded_smoke = DecodedSmoke {
+        schema: 1,
+        domain: "uor-r4.bounded-global-noncommuting-exact-spin-decoded-smoke/1",
+        operator_cid: operator_cid.clone(),
+        decoded_target_commitment: TARGET_COMMITMENT,
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+        rows: vec![
+            DecodedCase {
+                document_id: "53",
+                target_hex: sealed_targets.rows[0].continuation_hex.clone(),
+                continuation: &continuation.left,
+            },
+            DecodedCase {
+                document_id: "54",
+                target_hex: sealed_targets.rows[1].continuation_hex.clone(),
+                continuation: &continuation.right,
+            },
+        ],
+        real_correct,
+        identity_disabled_correct,
+        class_operator_permuted_correct,
+        support_reversed_real_correct,
+        support_mismatches: 0,
+        work_mismatches: 0,
+        period_and_eos_terminations,
+        terminal: POSITIVE_TERMINAL,
+    };
+    let decoded_smoke_bytes = serde_json::to_vec(&decoded_smoke).unwrap();
+    let decoded_smoke_cid = direct_cid(&decoded_smoke_bytes);
+    let continuation_replay = operator
+        .continue_pair_matched(
+            &table,
+            &base_overlay,
+            &base_artifact_replay,
+            &left_artifact_replay,
+            &right_artifact_replay,
+            OBSERVED_PROMPT,
+            3,
+        )
+        .unwrap();
+    assert_eq!(continuation_replay, continuation);
+    let replay_decoded_smoke = DecodedSmoke {
+        schema: 1,
+        domain: "uor-r4.bounded-global-noncommuting-exact-spin-decoded-smoke/1",
+        operator_cid: operator_cid.clone(),
+        decoded_target_commitment: TARGET_COMMITMENT,
+        target_preimage_loads_observed: TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst),
+        rows: vec![
+            DecodedCase {
+                document_id: "53",
+                target_hex: sealed_targets.rows[0].continuation_hex.clone(),
+                continuation: &continuation_replay.left,
+            },
+            DecodedCase {
+                document_id: "54",
+                target_hex: sealed_targets.rows[1].continuation_hex.clone(),
+                continuation: &continuation_replay.right,
+            },
+        ],
+        real_correct,
+        identity_disabled_correct,
+        class_operator_permuted_correct,
+        support_reversed_real_correct,
+        support_mismatches: 0,
+        work_mismatches: 0,
+        period_and_eos_terminations,
+        terminal: POSITIVE_TERMINAL,
+    };
+    assert_eq!(
+        serde_json::to_vec(&replay_decoded_smoke).unwrap(),
+        decoded_smoke_bytes
+    );
+    assert_eq!(TARGET_PREIMAGE_LOADS.load(Ordering::SeqCst), 1);
+
+    println!(
+        "table_cid={}\nbase_overlay_cid={}\noperator_bytes={}\noperator_cid={operator_cid}\npopulation_audit_cid={population_audit_cid}\ntarget_free_census_cid={target_free_cid}\ndecoded_smoke_cid={decoded_smoke_cid}\ncodec_kappa={}\nvocabulary_kappa={}\nroute_manifest_kappa={}\nspin_map_kappa={}\nchart_profile_kappa={}\ngrammar_kappa={}\nrouting_policy_kappa={}\npopulation_policy_kappa={}\nh4_root_table_kappa={}\nh4_multiplication_table_kappa={}\nleft_global_epoch={}\nright_global_epoch={}\ntarget_commitment={TARGET_COMMITMENT}\ntarget_preimage_loads=1\nreal=2/2\nidentity_disabled=1/2\nclass_operator_permuted=0/2\nsupport_reversed_real=2/2\nperiod_and_eos_terminations=6/6\nsupport_mismatches=0\nwork_mismatches=0\nterminal={POSITIVE_TERMINAL}",
+        table.artifact_cid(),
+        base_overlay.artifact_cid(),
+        operator_bytes.len(),
+        operator.codec_kappa(),
+        operator.vocabulary_kappa(),
+        operator.route_manifest_kappa(),
+        operator.spin_map_kappa(),
+        operator.chart_profile_kappa(),
+        operator.grammar_kappa(),
+        operator.routing_policy_kappa(),
+        operator.population_policy_kappa(),
+        operator.h4_root_table_kappa(),
+        operator.h4_multiplication_table_kappa(),
+        pair.left.global_epoch,
+        pair.right.global_epoch,
+    );
+}

--- a/crates/uor-r4-core/tests/h4_exact_table_cache_973.rs
+++ b/crates/uor-r4-core/tests/h4_exact_table_cache_973.rs
@@ -1,0 +1,44 @@
+//! Cold-start concurrency regression for #973's immutable exact-H4 caches.
+
+use std::sync::{Arc, Barrier};
+
+use uor_r4_core::canonical_lexical_ingestion::validate_h4_binary_icosahedral_closure;
+
+const WORKERS: usize = 4;
+const ROOT_TABLE_KAPPA: &str =
+    "blake3:8d33d62a239fb8001fea2bd14a9a5ec7321d0f07d81c74a5715eaeb3df53aa76";
+const MULTIPLICATION_TABLE_KAPPA: &str =
+    "blake3:90ee73a27ee2e8ba5bccd1507d7fb37ed1f044b1640772c86752bc0bb2111759";
+
+#[test]
+fn concurrent_cold_h4_table_initialization_is_byte_identical() {
+    let barrier = Arc::new(Barrier::new(WORKERS));
+    let handles = (0..WORKERS)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                let table = validate_h4_binary_icosahedral_closure().unwrap();
+                assert_eq!(table.root_count, 120);
+                assert_eq!(table.product_count, 14_400);
+                assert_eq!(table.h4_root_table_kappa, ROOT_TABLE_KAPPA);
+                assert_eq!(table.multiplication_table_kappa, MULTIPLICATION_TABLE_KAPPA);
+                assert!(table.unique_closure_exact);
+                assert!(table.identity_exact);
+                assert!(table.inverses_exact);
+                assert!(table.associativity_exact);
+                assert!(table.integer_only_no_rounding);
+                serde_json::to_vec(&table).unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+    assert!(results.windows(2).all(|pair| pair[0] == pair[1]));
+    assert_eq!(
+        serde_json::to_vec(&validate_h4_binary_icosahedral_closure().unwrap()).unwrap(),
+        results[0]
+    );
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,7 +14,31 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
-> **Target-free #973 bounded-global negative, 2026-08-28.** The frozen
+> **Positive #973 bounded-global V2 result, 2026-08-28.** The independently
+> frozen `BoundedGlobalNoncommutingExactSpinR4V2` contract reached
+> `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
+> Canonical label-free population enumeration selected one exact stored-S3-to-
+> H4 pair with `A*B != B*A`, distinct nonidentity complete left folds, central
+> Q29 phases, one same-address class-result reuse, and incompatible strict
+> prototype winners under candidate-relative `C^-1*G` lexicographic least cost.
+> The decoded matrix was real 2/2, identity-disabled 1/2,
+> class/operator-permuted 0/2, and support-reversed real 2/2; support/work
+> mismatches were zero and exact period-plus-EOS termination was 6/6. The target
+> preimage loaded once only after the target-free gate. The zero forbidden-read
+> trace is backed by a typed/source score firewall with a negative injection
+> control, not dynamic instruction counting. Operator, population-audit,
+> target-free-census, and decoded-smoke identities are
+> `blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9`,
+> `blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c`,
+> `blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a`,
+> and `blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218`.
+> This establishes one bounded synthetic causal global geometric-attention
+> witness only. Corpus induction, general semantics, correctness, reasoning,
+> and product readiness remain unestablished. #973 next freezes an independent
+> corpus-induction gate; #954 remains blocked. See the
+> [bounded-global record](bounded_global_exact_spin_attention_973.md).
+
+> **Earlier target-free #973 bounded-global V1 negative, 2026-08-28.** The frozen
 > `BoundedGlobalExactSpinLeftFoldR4V1` contrast stopped at
 > `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION`.
 > Detached left/right snapshot carriers reproduced distinct epochs and roots,
@@ -28,9 +52,9 @@ assumptions, or objectives rather than measured results.
 > target-free census identities are
 > `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
 > and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
-> The retained paragraph/conversation results remain valid, but bounded-global
-> attention and corpus induction remain unqualified. #973 stays open for a
-> newly frozen noncommuting relation/population repair; #954 remains blocked.
+> The retained paragraph/conversation results remain valid. This V1 negative
+> is append-only history; the independently frozen V2 repair above subsequently
+> qualified one bounded-global mechanism while leaving corpus induction open.
 > See the [bounded-global record](bounded_global_exact_spin_attention_973.md).
 
 > **Retained #973 conversation mechanism, 2026-08-28.** The independently
@@ -52,9 +76,9 @@ assumptions, or objectives rather than measured results.
 > `blake3:343c961b06605f6ae9bb6160ac34a98224991715b706156349a8fd544b6dbb35`,
 > `blake3:649d733a194469aa648101a873d9e2ee323266b18872ced412d1da2cc6a56635`,
 > and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
-> The subsequent bounded-global contrast failed its target-free relation gate.
-> #973 remains open for a newly frozen relation/population repair before corpus
-> induction; #954 remains blocked. See the
+> The subsequent V1 bounded-global contrast failed its target-free relation
+> gate; the independently frozen V2 repair later passed its bounded decoded
+> contract. #973 now proceeds to corpus induction; #954 remains blocked. See the
 > [#973 conversation record](conversation_entity_spin_path_attention_973.md).
 
 > **Retained #973 paragraph mechanism, 2026-08-28.** The frozen two-case
@@ -78,9 +102,10 @@ assumptions, or objectives rather than measured results.
 > `blake3:515720686b96dbebc2f055f9a21d3f0684f76092018381c836b51abf47a4d197`,
 > and `blake3:0ba32e5fe26f1280ec2eef2b115023de52f2ef946882352311dcecc531d76a32`.
 > The subsequent independently frozen conversation-scope contrast has now
-> retained its bounded mechanism. The subsequent bounded-global relation failed
-> target-free. #973 remains open for its repair and later corpus induction;
-> #954 remains blocked.
+> retained its bounded mechanism. The subsequent bounded-global V1 relation
+> failed target-free; its independently frozen V2 repair later passed the
+> bounded decoded contract. Corpus induction remains inside #973; #954 remains
+> blocked.
 > See the [#973 paragraph record](paragraph_entity_spin_path_attention_973.md).
 
 > **Retained #973 Gate 0 mechanism, 2026-08-28.**
@@ -174,10 +199,10 @@ assumptions, or objectives rather than measured results.
 > its positive terminal; #973 has since retained one exact-candidate
 > prior-prefix copy mechanism plus bounded construction-bound exact-descriptor/
 > entity-binding path selectors at paragraph and conversation scope. The first
-> independently frozen bounded-global relation then failed target-free because
-> its swapped exact states commute. A fresh noncommuting relation/population
-> repair is next; corpus induction remains unauthorized. #954 remains blocked
-> behind #973.
+> independently frozen bounded-global V1 relation then failed target-free
+> because its swapped exact states commute. The independently frozen V2 repair
+> passed its bounded noncommuting decoded contract. Corpus induction is now the
+> next #973 gate; #954 remains blocked behind #973.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -734,11 +759,11 @@ replay. External replay adjudication promoted the reports' pending verdict to
 `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`. #973 Gate 0
 then retained one exact-candidate prior-prefix copy mechanism, and its frozen
 paragraph and conversation slices retained construction-bound exact-descriptor/
-entity-binding path selectors at their respective scopes. These remain two-
-case synthetic results; the first independently frozen bounded-global relation
-failed target-free because its swapped exact states commute. A newly frozen
-noncommuting relation/population repair is next, and corpus induction remains
-unauthorized. Dependable broad coherent
+entity-binding path selectors at their respective scopes. The first
+independently frozen bounded-global V1 relation failed target-free because its
+swapped exact states commute; the independently frozen V2 repair then retained
+one bounded synthetic noncommuting exact-spin mechanism. Corpus induction and
+final requalification remain. Dependable broad coherent
 text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
@@ -1308,9 +1333,10 @@ External replay adjudication promoted the reports' pending verdict and #953
 closed at `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`.
 #973 has since retained one bounded exact-candidate prior-prefix copy mechanism
 plus bounded construction-bound exact-descriptor/entity-binding path selectors
-at paragraph and conversation scope. The first bounded-global relation is now
-target-free negative; a fresh bounded-global repair and later corpus
-qualification remain active in that order and continue to block #954.
+at paragraph and conversation scope. The first bounded-global V1 relation
+remains target-free negative history; its V2 noncommuting repair passed the
+bounded decoded contract. Corpus induction and final requalification remain
+active in that order and continue to block #954.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/bounded_global_exact_spin_attention_973.md
+++ b/docs/bounded_global_exact_spin_attention_973.md
@@ -340,3 +340,147 @@ The next decision is a newly frozen target-free bounded-global relation/
 population repair that proves noncommuting distinct exact folds before any
 decoded target join. The public result is recorded in
 [the live issue](https://github.com/UOR-Foundation/uor-r4/issues/973#issuecomment-5456901633).
+
+## V2 noncommuting population repair — positive bounded result
+
+- **Date:** 2026-08-28
+- **Immutable contract:** [frozen on the live issue](https://github.com/UOR-Foundation/uor-r4/issues/973#issuecomment-5457282665)
+  before the V2 outcome-bearing run
+- **Mechanism:** `BoundedGlobalNoncommutingExactSpinR4V2`
+- **Outcome:** `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`
+- **Target-free status:** passed before one target-preimage load
+- **Decoded status:** real `2/2`; identity-disabled `1/2`;
+  class/operator-permuted `0/2`; support-reversed real `2/2`
+- **Issue state:** #973 remains open for an independently frozen
+  corpus-induction gate; #954 remains blocked
+
+This addendum does not revise the V1 negative above. V1 correctly rejected its
+commuting `Pavel` population. V2 implements the next independently frozen
+repair: it canonically enumerates the available construction population before
+target attachment and accepts only the first population/permutation satisfying
+the paired target-free gates.
+
+### Canonical noncommuting witness and exact cost
+
+The enumeration first examined `.` and rejected its identity H4 state. It then
+selected duplicate `Lena`, pair indices `[0,2]`, and the one-transposition
+snapshot pair
+
+```text
+left:  [Lena, Lena,  helix, prism]
+right: [Lena, helix, Lena,  prism]
+```
+
+The two `Lena` references are one byte-identical lexical address and complete
+stored-spin class at distinct immutable ordinals, so the evaluation performs
+one class computation and one exact same-address reuse. The transposed
+operands are the exact canonical H4 states
+
+```text
+Lena  = i                 = [ 0, 2,  0,  0] / 2
+helix = (1+i+j+k)/2       = [ 1, 1,  1,  1] / 2
+i * helix                 = [-1, 1, -1,  1] / 2
+helix * i                 = [-1, 1,  1, -1] / 2
+```
+
+Thus the operative H4 products genuinely do not commute. The Q29 fiber and
+torsion phases are central additions, so they remain equal across the two
+operand products without erasing the H4 distinction. The complete left-ordered
+folds are distinct and nonidentity:
+
+```text
+left fold:  [-1,-1,-1,-1] / 2, fiber 102410010, torsion -9745662
+right fold: [-1,-1, 1, 1] / 2, fiber 102410010, torsion -9745662
+```
+
+Candidate spelling does not enter the score. It selects only the frozen
+construction prototype binding `bronze -> helix`, `teal -> prism`. For each
+candidate-relative prototype state `C` and global fold `G`, V2 computes
+`C^-1 * G` and the lexicographic least exact cost
+
+```text
+(H4S3AngularShell, circular_abs_q29(fiber), circular_abs_q29(torsion)).
+```
+
+The target-free costs and unique winners were:
+
+| Snapshot | Helix cost | Prism cost | Unique prototype/candidate winner |
+| --- | --- | --- | --- |
+| left | `(Antipodal, 61239177, 5831083)` | `(Degrees120, 55205017, 5262467)` | prism / ` teal` |
+| right | `(Orthogonal, 61239177, 5831083)` | `(Degrees120, 55205017, 5262467)` | helix / ` bronze` |
+
+The same-address reuse, direct `A*B != B*A` witness, distinct nonidentity
+complete folds, and incompatible strict candidate-relative winners all had to
+hold together. Any absent, tied, commuting, identity, mismatched, or
+non-reproducible condition fails closed before decoded target access.
+
+### Firewall, sealed target, and observed matrix
+
+The exact score kernel accepts only exact geometric state/cost values. A
+focused typed/source firewall covers the candidate-relative cost, exact cost,
+selection, and unique-winner functions and rejects forbidden scoring
+capabilities; its negative control injects a forbidden payload-score read and
+must be rejected. The zero forbidden-read trace is therefore a structural
+typed/source witness, **not** dynamic machine-instruction counting.
+
+The target-free census, canonical operator reload, population replay, paired
+hard gates, common lower artifact, equal admitted support/work, carrier
+separation, support reversal, and coherent relabel control all passed while the
+target-preimage load counter remained zero. Only then was the committed target
+preimage loaded exactly once:
+
+```text
+target commitment:
+  blake3:b7340c776e005c32316de793b332e3f218b1fad757c77044b0fa2e70fc308354
+target preimage loads before target-free gate: 0
+target preimage loads after target-free gate:  1
+```
+
+The decoded contrast was:
+
+| Arm | left | right | Correct |
+| --- | --- | --- | ---: |
+| real | ` teal.` | ` bronze.` | 2/2 |
+| identity disabled | ` bronze.` | ` bronze.` | 1/2 |
+| class/operator permuted | ` bronze.` | ` teal.` | 0/2 |
+| support-reversed real | ` teal.` | ` bronze.` | 2/2 |
+
+Support mismatches were `0`; executed-work mismatches were `0`; all six arm
+continuations produced an exact period token followed by EOS (`6/6`). Exact
+serialization/replay identities are:
+
+```text
+operator:
+  blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9
+population audit:
+  blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c
+target-free census:
+  blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a
+decoded smoke:
+  blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218
+```
+
+The focused debug test passed `1/1` in `47.67s`. Its multicore execution of
+independent artifact construction/reload work is an engineering efficiency
+detail, not attention evidence. No broader suite was needed to decide this
+frozen result.
+
+### Binding claim and next action
+
+The binding terminal is:
+
+```text
+RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION
+```
+
+This establishes one bounded synthetic causal global geometric-attention
+witness using exact stored S3-to-H4 state, central Q29 phases, a left ordered
+fold, `C^-1*G` lexicographic least-cost routing, and same-address result reuse.
+It does **not** establish corpus induction, semantic or natural-distribution
+transfer, general/global recursive attention, broad coherence, correctness,
+reasoning, chat, performance or energy advantage, formal closure, or product
+readiness.
+
+The next action is to freeze #973's corpus-induction gate independently before
+any outcome-bearing corpus execution. #954 remains blocked until #973 completes
+that induction and final requalification.

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -67,8 +67,10 @@ unavailable. Gate 0, labels, selection, and #953 were `NOT_RUN`. The later
 established B0/#989 result exposed one matched #953 intervention, which has
 since been accepted. #973 then retained its bounded Gate 0, paragraph, and
 conversation mechanisms. Its first bounded-global exact-spin relation failed
-target-free because the frozen swapped states commute. #973 continues to block
-#954 while it owns a newly frozen relation/population repair.
+target-free because the frozen swapped states commute. The independently
+frozen V2 repair then passed its bounded noncommuting decoded contract. #973
+continues to block #954 while it owns corpus induction and final
+requalification.
 
 A negative result remains evidence about its declared mechanism and
 distribution. It does not erase a separately established storage, identity,
@@ -812,7 +814,12 @@ outcome identities are bound in the
 append-only. #953's fixture, overlay, generator, and records remain untouched
 under #986; #973 and downstream #954 remain blocked.
 
-### A1Q-H/#973 exact-spin global operator prototype
+### A1Q-H/#973 exact-spin global operator qualification
+
+The V1 contract and negative below remain append-only evidence. The
+independently frozen V2 repair subsequently satisfied the bounded-global
+decision without changing V1. The current evaluation action is to freeze the
+corpus-induction gate independently before any corpus outcome-bearing run.
 
 #973 owns paragraph, conversation, and bounded-global influence only after the
 one #989-matched #953 intervention qualifies the decoded loop.
@@ -868,11 +875,11 @@ coefficients, quantization, and transition law before the prototype is called
 harmonic. #973 will freeze its own terminal literal before running this
 contract.
 
-A future positive global subprobe cannot close #973. Paragraph and conversation
-are retained, but corpus induction and final requalification still require
+The now-positive bounded V2 subprobe cannot close #973. Paragraph and
+conversation are retained, but corpus induction and final requalification still require
 their own frozen evidence or an explicit native scope revision.
 
-#### Observed bounded-global target-free terminal (2026-08-28)
+#### Observed bounded-global V1 target-free terminal (2026-08-28)
 
 The first frozen global decision reached
 `RETAIN_CONVERSATION_ONLY_REDESIGN_BOUNDED_GLOBAL_EXACT_SPIN_RELATION` before
@@ -886,9 +893,44 @@ finish at the same complete `-1`/fiber/torsion state. Real roles were
 decoded evaluation is `NOT_RUN`. See the
 [#973 bounded-global record](bounded_global_exact_spin_attention_973.md).
 
-This is a relation/population falsification, not a global-attention result. A
-fresh #973 contract must establish noncommuting distinct exact folds and
-incompatible target-free winners before any decoded join or corpus induction.
+This is a relation/population falsification, not a global-attention result. It
+remains V1 history; the independently frozen V2 repair below supplied the
+required noncommuting distinct folds and incompatible target-free winners.
+
+#### Observed bounded-global V2 positive terminal (2026-08-28)
+
+`BoundedGlobalNoncommutingExactSpinR4V2` canonically enumerated the
+construction population and selected the first pair jointly satisfying direct
+exact H4 `A*B != B*A`, distinct nonidentity complete left folds, central Q29
+phase composition, one same-address exact-class reuse, and incompatible strict
+candidate-relative winners under `C^-1*G` lexicographic least cost. The exact
+score path is protected by a typed/source firewall and an injected forbidden-
+read falsifier. Its zero forbidden-read trace is structural evidence, not
+dynamic instruction counting.
+
+The target-free gate completed with zero target loads. The committed target
+preimage
+`blake3:b7340c776e005c32316de793b332e3f218b1fad757c77044b0fa2e70fc308354`
+was then loaded exactly once. Real decoded behavior was 2/2,
+identity-disabled 1/2, class/operator-permuted 0/2, and support-reversed real
+2/2; support/work mismatches were zero and exact period-plus-EOS termination
+was 6/6. Exact replay identities are:
+
+```text
+operator:         blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9
+population audit: blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c
+target-free:      blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a
+decoded smoke:    blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218
+```
+
+The binding terminal is
+`RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
+This establishes one bounded synthetic causal global geometric-attention
+witness only. It does not establish corpus induction, semantic or natural
+transfer, general attention, correctness, reasoning, or product readiness.
+The next #973 decision is an independently frozen corpus-induction gate; #954
+remains blocked. See the
+[#973 bounded-global record](bounded_global_exact_spin_attention_973.md).
 
 ## 4. Matched controls
 

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -84,9 +84,10 @@ No second #953 formula, axis, prompt, corpus run, or representation is
 permitted. #973 has retained one bounded prior-prefix copy mechanism and one
 bounded construction-bound exact-descriptor selector at each of paragraph and
 conversation scope. Its first bounded-global exact-spin relation then failed
-target-free because the frozen swapped states commute. A newly frozen
-noncommuting relation/population repair and later corpus qualification remain
-active; #954 remains blocked. No new H4,
+target-free because the frozen swapped states commute. The independently
+frozen V2 repair subsequently retained one bounded noncommuting exact-spin
+mechanism. Corpus induction and final requalification remain active; #954
+remains blocked. No new H4,
 SpiralCore, harmonic, algebraic, placement, transport, or scale qualifier is
 eligible outside its exposed issue.
 
@@ -180,8 +181,9 @@ table-tie intervention. That intervention passed, and #973 has since retained
 one bounded prior-prefix copy mechanism at Gate 0 plus one bounded
 construction-bound exact-descriptor selector at each of paragraph and
 conversation scope. The first bounded-global exact-spin relation is now
-target-free negative; a fresh noncommuting relation/population repair and later
-corpus qualification continue to block #954. Calling a later
+preserved target-free negative history; the independently frozen V2 repair
+passed its bounded decoded contract. Corpus induction and final
+requalification continue to block #954. Calling a later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive
@@ -746,9 +748,9 @@ population/frame unavailable terminal. B0/#989 then supplied the frozen
 reference for the accepted matched #953 intervention. #973 has since retained
 one bounded exact-candidate prior-prefix copy mechanism plus bounded
 construction-bound exact-descriptor paragraph and conversation selectors;
-the first bounded-global exact-spin relation failed target-free, and a fresh
-relation/population repair plus later corpus qualification continue to block
-#954**.
+the first bounded-global V1 relation failed target-free, while the independently
+frozen V2 noncommuting repair passed its bounded decoded contract. Corpus
+induction and final requalification continue to block #954**.
 
 The frozen A1.0 probe stopped before scorer implementation with
 `REDESIGN_ORDERED_ROUTE_SUMMARY`. Across three matched contrasts, all 21
@@ -1153,9 +1155,10 @@ The historical positive terminal was
 was `REVISE_I1_GENERATOR_IN_PLACE`. B0/#989 later permitted exactly one separate
 matched #953 intervention against its fixed table reference. That intervention
 is now accepted at the positive terminal after external replay adjudication.
-#973 has since retained only the bounded paragraph and conversation mechanisms
-recorded below. Its first bounded-global relation failed target-free, so
-bounded-global selection remains unqualified.
+#973 has since retained the bounded Gate 0, paragraph, conversation, and V2
+noncommuting global mechanisms recorded below. Its first bounded-global V1
+relation remains negative history; V2 qualified one bounded-global selection
+mechanism while leaving corpus induction open.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
 identity-scoped hive-memory lifecycle remain #962 scope.
 
@@ -1420,10 +1423,51 @@ See the
 [#973 bounded-global exact-spin record](bounded_global_exact_spin_attention_973.md).
 
 This preserves the paragraph/conversation results and the exact snapshot/
-reuse machinery, but it does not establish bounded-global attention. #973
-remains open and #954 remains blocked. The next decision is a newly frozen,
-target-free relation/population repair that proves noncommuting distinct exact
-folds before any decoded join. Corpus induction is not authorized.
+reuse machinery, but V1 did not establish bounded-global attention. Its
+negative remains append-only history. The independently frozen V2 repair below
+supersedes V1's forward action without changing that evidence.
+
+#### #973 bounded-global V2 positive — `BoundedGlobalNoncommutingExactSpinR4V2` (2026-08-28)
+
+Canonical construction-population enumeration rejected the identity `.` row
+and selected duplicate `Lena` with snapshots `[Lena,Lena,helix,prism]` and
+`[Lena,helix,Lena,prism]`. The transposed exact H4 operands satisfy
+`i*q != q*i`, where `q=(1+i+j+k)/2`; their left-ordered complete folds are
+distinct and nonidentity while the Q29 fiber/torsion phase additions remain
+central. One `Lena` class result is reused by two immutable same-address
+references.
+
+For each construction-bound candidate prototype `C`, the operator ranks the
+exact relation `C^-1*G` by lexicographic least
+`(H4S3AngularShell,fiber_distance_q29,torsion_distance_q29)` cost. This produced
+strict incompatible target-free winners: prism/`teal` for the left fold and
+helix/`bronze` for the right. Real decoded behavior was 2/2,
+identity-disabled 1/2, class/operator-permuted 0/2, and support-reversed real
+2/2. Support/work mismatches were zero and exact period-plus-EOS termination
+was 6/6. The target preimage was loaded exactly once, only after the target-free
+hard gate.
+
+The exact-score forbidden-read trace is a structural witness backed by a
+typed/source firewall and a forbidden-read injection falsifier; it is not a
+dynamic machine-instruction count. Exact replay identities are:
+
+```text
+operator:         blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9
+population audit: blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c
+target-free:      blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a
+decoded smoke:    blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218
+target commitment: blake3:b7340c776e005c32316de793b332e3f218b1fad757c77044b0fa2e70fc308354
+```
+
+The binding terminal is
+`RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
+This establishes one bounded synthetic causal global geometric-attention
+witness, not corpus induction, general semantics, correctness, reasoning, or
+product readiness. #973 next independently freezes its corpus-induction gate;
+#954 remains blocked. See the
+[#973 bounded-global exact-spin record](bounded_global_exact_spin_attention_973.md).
+
+##### Historical V1 repair direction, superseded by V2
 
 A fresh bounded-global qualification may use one exact-spin global operator
 prototype, not a larger channel census. Freeze a construction-independent global snapshot with
@@ -1468,17 +1512,18 @@ grammar, coherence, correctness, or reasoning. H4 group action alone is not a
 qualified spherical-harmonic field; fixed channels/modes and their transition
 law must be artifact-bound before that stronger description is earned.
 
-A future positive global subprobe cannot close #973. The bounded construction-bound
+A positive global subprobe cannot close #973. The bounded construction-bound
 paragraph and conversation slices are retained, but corpus-scale induction and
 final requalification remain required after the bounded-global decision, or an
 explicit native revision must change #973's scope and dependencies.
 
 #### #973 higher-scope/corpus-scale induction qualification and handoff to #954
 
-Within #973, only after the accepted bounded local selector and #953 qualify
-and every required #973 higher-scope intervention qualifies, or an explicit
-native revision changes that scope, may
-the programme activate controlled higher-scope/corpus-scale offline induction.
+The accepted bounded local selector, #953, and the required bounded #973
+higher-scope interventions now qualify at their declared narrow scopes. The
+next authorized action is to freeze the corpus-induction gate independently;
+only after that immutable contract exists may the programme execute controlled
+higher-scope/corpus-scale offline induction.
 This ladder and its final requalification are part of #973's definition of done
 and terminal; #973 cannot close and #954 cannot start without them. The one
 separation permitted inside #953 was a tiny construction-only, same-frame,
@@ -1642,8 +1687,9 @@ hours remains a hard kill ceiling, never an estimate.
   decoded-loop plumbing without qualifying natural grammar. The later, separate
   B0 table-tie intervention has qualified its bounded geometric increment and
   exposed #973. #973 has retained bounded paragraph and conversation
-  mechanisms; its first bounded-global relation failed target-free, and it
-  alone owns the newly frozen repair and remaining global qualification.
+  mechanisms; its first bounded-global V1 relation failed target-free, and its
+  independently frozen V2 repair retained one bounded noncommuting global
+  mechanism. It alone owns corpus induction and final requalification.
 - S3/R4 compute, Hopf S2/R3 observation, and an E8 action plane are distinct
   objects.
 - Exact recall, grammatical text, correct inference, and reasoning are separate


### PR DESCRIPTION
## Summary

- add `BoundedGlobalNoncommutingExactSpinR4V2`, preserving the exact stored-S3-to-H4 map, central Q29 phases, left-ordered fold, `C^-1*G` candidate-relative relation, and lexicographic least-cost routing
- freeze and bind a label-free construction-population census whose first qualifier is the one-transposition `Lena` pair with genuinely noncommuting H4 products and incompatible unique winners
- harden target exclusion with a typed/source score firewall, canonical operator/carrier bindings, target-free replay, causal controls, and exact continuation termination
- cache immutable exact H4 tables and the bound population audit; parallelize independent carrier/tamper checks while preserving the serial gate -> reveal -> decode dependency
- preserve the V1 negative append-only and record the bounded V2 positive plus its narrow claim boundary

## Result

Terminal: `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`

- real: 2/2
- identity disabled: 1/2
- class/operator permuted: 0/2
- support-reversed real: 2/2
- support mismatches: 0
- work mismatches: 0
- exact period plus EOS: 6/6
- target preimage loads: 0 through the target-free gate, exactly 1 after reveal

Exact identities:

- operator: `blake3:1cf08604fb4a1c545984f4cab41194e0ffcf1d7551b6e438ed57b49a0066a6e9`
- population audit: `blake3:16ebc6d36f01e4cb324d3c46fc059aca4ffea84ba467e860b55f983cd83f4a9c`
- target-free census: `blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a`
- decoded smoke: `blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218`

This establishes one bounded synthetic causal global geometric-attention witness. It does not establish corpus induction, general semantics, correctness, reasoning, broad coherence, performance/energy advantage, or product readiness. #973 remains open for an independently frozen corpus-induction gate; #954 remains blocked.

## Verification

- PASS: focused V2 target-free plus committed decoded causal test, final replay 1/1 in 48.24s with identical CIDs
- PASS: historical V1 regression 1/1 with unchanged operator CID `blake3:f6b36cdf3e6cf96e1e9a345980843ee9eaffd25f5b864d4b4ed45a30ae6f746f`
- PASS: isolated four-thread cold H4-cache initialization, byte-identical across workers
- PASS: `cargo check -p uor-r4-core --offline`
- PASS: root WASM library check
- PASS: touched-core all-target Clippy after allowing only known untouched live-main lint classes
- PASS: formatting, claim wording, and diff hygiene
- NOT PASS / untouched main: the full workspace release-QA Clippy command stops on pre-existing lints in `uor-r4-model-source/src/geometric_decoder.rs` and `uor-r4-graph-runtime/src/vp_tree.rs`; those paths are unchanged here and PR/merge required-check jobs are currently transport-only
- NOT_RUN: broad workspace tests and release QA, per the frozen scoped run contract

References #973
