### PR TITLE
feat(core): qualify corpus-induced document spin placement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,10 +35,13 @@ closed as negative evidence. A1Q-L3/#986 then stopped
 `UNAVAILABLE_FRAME_OR_POPULATION`: the raw corpus reproduced, but no exact
 corpus-scale codec/three-way pair commitment or complete same-frame lexical
 SpiralCore operator map was available. Placement, diffusion, Gate 0, labels,
-selection, and #953 were `NOT_RUN`. #986 is closed; parked, unassigned,
-untouched #953 is now limited to one matched intervention against the
-established B0/#989 table baseline and continues to block #973 and #954. #989
-closed its frozen decision at `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`._
+selection, and #953 were `NOT_RUN`. #986 is closed. B0/#989 then established
+the table baseline, and the one matched #953 intervention closed positive.
+#973 retained bounded Gate 0, paragraph, conversation, and noncommuting-global
+mechanisms. Its first document-scope corpus-induced placement passed target-free
+qualification but scored 2,931/35,028 versus 4,281/35,028 for unchanged #953;
+it terminated `RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`.
+#973 is active on replacement placement and continues to block #954._
 
 > **Project priority:** build source-free geometric intelligence in which the
 > route is the data location. A pinned lexical codec supplies text boundaries;
@@ -78,9 +81,11 @@ closed its frozen decision at `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`._
 > before placement or labels; no table or geometric arm transferred. A new
 > local attempt must freeze a population/frame successor rather than retry
 > #986. That pre-reset handoff is retained as history; B0/#989 now supersedes
-> it. Once #953 is accepted and every required #973 scope
-> qualifies, a separately frozen higher-scope/corpus-scale offline induction
-> ladder may compile causal prefix-to-observed-next-route examples, multiscale
+> it. #953 is now accepted, and #973's first separately frozen document-scope
+> corpus placement passed target-free qualification but failed its held-out
+> promotion gate. The next rung must change the construction-only placement
+> objective, not merely add rows or documents. A replacement may compile causal
+> prefix-to-observed-next-route examples, multiscale
 > route summaries, versioned placement overlays that preserve immutable
 > route/payload identity, and operator statistics. More rows, hits, or trace activity are
 > recall/capacity, not attention. Promotion requires a held-out anti-recall
@@ -109,19 +114,19 @@ closed its frozen decision at `ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`._
 
 Native GitHub relationships are the source of truth:
 
-The current priority view is **Established baseline:** #989 at
-`ESTABLISH_TABLE_NATIVE_LEXICAL_BASELINE`; **Next permitted:** exactly one #953
-geometric intervention against that frozen reference; **Blocked:** #973 → #954;
-**Later:** #955 → #962 → #963 → #964 → #965.
+The current priority view is **Established:** #989 table baseline and accepted
+#953 bounded source-free geometric generation; **Active:** #973 replacement
+corpus spin placement after the first document-scope rule failed; **Blocked:**
+#954; **Later:** #955 → #962 → #963 → #964 → #965.
 
 This capability-first reset supersedes the old forward action implied by the
 numbered evidence ladder below without rewriting that history. #989 scored
 99,362/446,342 (22.261404%) held-out top-1 versus 24,163/446,342 (5.413561%)
 for unigram, an uplift of +16.847843 percentage points, with byte-identical
-double execution. Freeze its non-geometric table engine, corpus, support,
-decode, and work budget. Do not start another attention, H4, SpiralCore,
-harmonic, algebraic, placement, transport, higher-scope, or scale probe outside
-the one matched #953 intervention. See the
+double execution. Its non-geometric table engine, corpus, support, decode, and
+work budget remain the frozen reference inherited by accepted #953 and active
+#973. Do not broaden scale while #973's placement objective is the measured
+failure. See the
 [#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
 feasibility boundary remains in the
 [#986 evidence](docs/corpus_signed_transport_attention_986.md).
@@ -328,31 +333,24 @@ feasibility boundary remains in the
    reference under matched corpus, support, decode, and work. Harmonic
    influence remains dormant in #953. See the
    [#953 record](docs/local_geometric_generation_953.md).
-9. **GI-2 A1Q-H / #973 — higher-scope attention:** after the accepted local
-   semantic selector and #953 qualify, test paragraph, conversation, and
-   bounded global state through the
-   real decoded loop. The first global mechanism is a deterministic exact-spin
-   operator prototype
-   overlay bound by global root/epoch kappa, operator and chart/table
-   identities, and the existing exact spin class. It acts
-   only on already-admitted candidate-relative state and is compared with
-   identity-disabled and deterministic class/operator-permuted controls under
-   identical support and work. Exact-class sharing comes first; a finite
-   orientation-aware angular-neighbor kernel is a later #973 subprobe. Those
-   scopes remain serialized but inert before #973. A global positive alone
-   cannot close #973; paragraph and conversation still require matched
-   qualification or an explicit native scope revision. The operator is called
-   harmonic only after its identity binds basis, mode order, coefficients,
-   quantization, and transition law. After all bounded #973 scope gates are
-   positive, #973 activates a separately predeclared higher-scope/corpus-scale
-   induction ladder as part of its terminal and handoff to #954. Freeze the
-   operator family, objective, scope semantics, neighborhood contract, and
-   induction rule; vary only declared corpus-derived parameters under a new
-   artifact/operator kappa per rung, and rerun the bounded gate for every
-   structural or placement epoch.
-   Match support/work between controls within each rung, report support changes
-   across rungs separately, and stop if scale only raises exact/backoff recall or
-   table density.
+9. **GI-2 A1Q-H / #973 — higher-scope attention:** Gate 0, paragraph,
+   conversation, and the V2 bounded-global noncommuting exact-spin mechanism
+   are retained at their narrow scopes. The first independently frozen
+   document-scope `CorpusInducedDocumentSpinPlacementR4V1` gate was genuinely
+   operative on 36,533 anti-recall positions and changed a bounded decoded
+   continuation, but failed every held-out promotion comparison: real was
+   2,931/35,028, unchanged #953 was 4,281/35,028, order-shuffled was
+   2,934/35,028, and operator-permuted was 2,966/35,028. Retain bounded-global
+   V2 and reject the componentwise Frechet placement.
+
+   The next #973 rung freezes a new construction-only, candidate-relative
+   discriminative placement objective in exact R4 state. It preserves immutable
+   route/payload identity, #953 admission/support, `C^-1*G` least-cost routing,
+   target-free anti-recall qualification, equal-work controls, and one held-out
+   target join. Every structural or placement epoch receives a new kappa and
+   reruns its owning gate. More documents, table density, or trace activity are
+   capacity, not attention. #973 cannot close and #954 cannot begin until a
+   replacement passes and the final #973 requalification succeeds.
 10. **GI-4 / #954 — correctness and abstention:** test held-out answer
    correctness, relevance, abstention, and causal use of required context only
    through the accepted selector/#953/#973 artifact while binding evidence
@@ -385,10 +383,10 @@ plumbing and tiered admission remain preserved, but its known placement
 population is quarantined after 0/2 real versus 2/2 placement-permuted and
 decoded generation/replay `NOT_RUN`. #983 is closed bounded negative evidence
 after its independent Gate 0 transferred on 0/6 decisions. #986 is also closed
-at its pre-sealed population/frame unavailable terminal. #989 has now
-established the frozen table reference. The live sequence is established #989
-→ exactly one matched #953 intervention → blocked #973 → blocked #954 → #955 →
-#962–#965. #953 continues to block #973 and #954; #973 continues to block #954.
+at its pre-sealed population/frame unavailable terminal. #989 established the
+frozen table reference; the later matched #953 intervention closed positive.
+The live sequence is established #989 → accepted #953 → active #973 replacement
+placement → blocked #954 → #955 → #962–#965. #973 continues to block #954.
 Legacy tracker #949 is closed as
 superseded; #958 is retained directly under programme root #820 as GI-0
 foundation.
@@ -407,9 +405,11 @@ historical evidence and comparators.
   16 valid UTF-8 units without a period-1/2 cycle, and full replay was byte
   identical. This establishes statistical lexical prediction and decoding
   only.
-- [ ] **#953 — exactly one matched geometric intervention.** Hold #989's
-  corpus, support, decode, table artifact, and work fixed. No broader geometry
-  or attention programme is eligible; #973 remains blocked.
+- [x] **#953 — accepted matched geometric intervention.**
+  `MultiscaleCountRadiusR4V1` improved the frozen held-out table result by 4,242
+  correct routes (+0.950392 pp), retained support/work equality and deterministic
+  replay, and closed at
+  `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`.
 
 ## Completed negative
 
@@ -426,13 +426,12 @@ historical evidence and comparators.
   inversion, and #953 were `NOT_RUN`. Its successor handoff is #986; the failed
   #983 representation and evidence remain unchanged.
 
-## Parked
+## Active
 
-- [ ] **#953 bounded source-free geometric generation loop** — preserved at
-  historical terminal `REVISE_I1_GENERATOR_IN_PLACE`, open and unassigned.
-  Established B0/#989 authorizes exactly one intervention against its frozen
-  table reference under matched corpus, support, decode, and work. #953
-  continues to block #973 and #954.
+- [ ] **#973 corpus-induced geometric attention** — retain its bounded positive
+  mechanisms and the first document-scope placement as negative evidence. The
+  active action is a separately frozen candidate-relative discriminative exact-
+  R4 placement objective; #954 remains blocked.
 
 ## Landed
 
@@ -550,8 +549,9 @@ historical evidence and comparators.
   frozen union. #969 then qualified one local causal selector, and #953 has
   implemented its decoded-loop plumbing while the tiered policy passed its
   frozen preflight. The repaired natural agreement run still made the same
-  full-path choice for both prompts, so `REVISE_I1_GENERATOR_IN_PLACE` remains
-  active. Its first bounded construction-induced placement preflight then
+  full-path choice for both prompts, producing the historical
+  `REVISE_I1_GENERATOR_IN_PLACE` terminal. Its first bounded
+  construction-induced placement preflight then
   failed at a frozen-contract real-placement ceiling of 0/2 while the cyclic
   placement-permuted control reached 2/2; generation and replay were `NOT_RUN`.
   #983 then tested `ConstructionCausalReturnV1` on an independent natural
@@ -559,8 +559,11 @@ historical evidence and comparators.
   before its deployed selector. #986 then stopped
   `UNAVAILABLE_FRAME_OR_POPULATION` before geometry because its exact
   population/codec commitment and complete lexical SpiralCore frame were
-  unavailable. #953 remains an untouched parked integration
-  regression; #973 and #954 are still blocked.
+  unavailable. B0/#989 and the later accepted #953 intervention then exposed
+  #973. Its bounded paragraph, conversation, and V2 global mechanisms are
+  retained; its first document-scope corpus placement passed target-free but
+  failed held-out promotion, so replacement placement is active and #954 is
+  still blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See

--- a/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
+++ b/crates/uor-r4-core/src/bounded_global_exact_spin_attention.rs
@@ -452,14 +452,53 @@ pub struct BoundedGlobalExactSpinHierarchyAudit {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ExactSpinState {
+pub(crate) struct ExactSpinState {
     h4: OrderedH4FoldState,
     fiber_q29: i64,
     torsion_q29: i64,
 }
 
 impl ExactSpinState {
-    fn identity(table: &H4BinaryIcosahedralClosure) -> Result<Self, BoundedGlobalExactSpinError> {
+    pub(crate) fn from_parts(
+        h4: OrderedH4FoldState,
+        fiber_q29: i64,
+        torsion_q29: i64,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        h4.root_coordinate(table)?;
+        Ok(Self {
+            h4,
+            fiber_q29: wrap_phase_q29(fiber_q29),
+            torsion_q29: wrap_phase_q29(torsion_q29),
+        })
+    }
+
+    pub(crate) fn from_table_index_and_phases(
+        table_index: OpaqueH4TableIndex,
+        fiber_q29: i64,
+        torsion_q29: i64,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        let h4 = OrderedH4FoldState::from_table_index(table_index, table)?;
+        Self::from_parts(h4, fiber_q29, torsion_q29, table)
+    }
+
+    pub(crate) fn from_spin_trace(
+        spin: SpinTorsionStateTrace,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
+        let h4 = exact_s3_spin_to_h4(spin.s3_q30, table)?;
+        Self::from_parts(
+            h4,
+            i64::from(spin.fiber_q29),
+            i64::from(spin.torsion_q29),
+            table,
+        )
+    }
+
+    pub(crate) fn identity(
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, BoundedGlobalExactSpinError> {
         Ok(Self {
             h4: OrderedH4FoldState::identity(table)?,
             fiber_q29: 0,
@@ -467,7 +506,7 @@ impl ExactSpinState {
         })
     }
 
-    fn compose(
+    pub(crate) fn compose(
         self,
         right: Self,
         table: &H4BinaryIcosahedralClosure,
@@ -487,7 +526,7 @@ impl ExactSpinState {
         })
     }
 
-    fn inverse(
+    pub(crate) fn inverse(
         self,
         table: &H4BinaryIcosahedralClosure,
     ) -> Result<Self, BoundedGlobalExactSpinError> {
@@ -506,7 +545,7 @@ impl ExactSpinState {
         })
     }
 
-    fn trace(
+    pub(crate) fn trace(
         self,
         table: &H4BinaryIcosahedralClosure,
     ) -> Result<BoundedGlobalExactSpinStateTrace, BoundedGlobalExactSpinError> {
@@ -515,6 +554,32 @@ impl ExactSpinState {
             fiber_q29: self.fiber_q29,
             torsion_q29: self.torsion_q29,
         })
+    }
+
+    pub(crate) const fn table_index(self) -> OpaqueH4TableIndex {
+        self.h4.table_index()
+    }
+
+    pub(crate) fn root_coordinate(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<H4RootCoordinate, BoundedGlobalExactSpinError> {
+        Ok(self.h4.root_coordinate(table)?)
+    }
+
+    pub(crate) const fn fiber_q29(self) -> i64 {
+        self.fiber_q29
+    }
+
+    pub(crate) const fn torsion_q29(self) -> i64 {
+        self.torsion_q29
+    }
+
+    pub(crate) fn root_real(
+        self,
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<[i64; 2], BoundedGlobalExactSpinError> {
+        Ok(self.root_coordinate(table)?.scaled_zphi_quaternion[0])
     }
 }
 
@@ -2275,26 +2340,23 @@ fn validate_snapshot_units_for(
     Ok(())
 }
 
-fn exact_state_from_address(
+pub(crate) fn exact_state_from_address(
     address: &GeometricAddress,
     table: &H4BinaryIcosahedralClosure,
 ) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
-    Ok(ExactSpinState {
-        h4: exact_s3_spin_to_h4(address.spin.s3.raw(), table)?,
-        fiber_q29: i64::from(address.spin.fiber.raw()),
-        torsion_q29: i64::from(address.spin.torsion.raw()),
-    })
+    ExactSpinState::from_parts(
+        exact_s3_spin_to_h4(address.spin.s3.raw(), table)?,
+        i64::from(address.spin.fiber.raw()),
+        i64::from(address.spin.torsion.raw()),
+        table,
+    )
 }
 
-fn exact_state_from_entry(
+pub(crate) fn exact_state_from_entry(
     entry: &GlobalExactSpinSnapshotEntry,
     table: &H4BinaryIcosahedralClosure,
 ) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
-    Ok(ExactSpinState {
-        h4: exact_s3_spin_to_h4(entry.spin.s3_q30, table)?,
-        fiber_q29: i64::from(entry.spin.fiber_q29),
-        torsion_q29: i64::from(entry.spin.torsion_q29),
-    })
+    ExactSpinState::from_spin_trace(entry.spin, table)
 }
 
 fn build_noncommuting_population_audit(
@@ -2414,12 +2476,12 @@ fn build_noncommuting_population_audit(
                         population_candidate_cost(core, &core.prototypes, b"prism", right_fold)?,
                     ];
                     let Some(left_winner) =
-                        unique_exact_cost_winner(&[left_costs[0].cost, left_costs[1].cost])
+                        unique_exact_cost_winner(&[left_costs[0].cost, left_costs[1].cost])?
                     else {
                         continue;
                     };
                     let Some(right_winner) =
-                        unique_exact_cost_winner(&[right_costs[0].cost, right_costs[1].cost])
+                        unique_exact_cost_winner(&[right_costs[0].cost, right_costs[1].cost])?
                     else {
                         continue;
                     };
@@ -2762,16 +2824,17 @@ fn fold_population_ids(
     lexemes: &BTreeMap<u32, PopulationLexeme>,
     table: &H4BinaryIcosahedralClosure,
 ) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
-    let mut fold = ExactSpinState::identity(table)?;
-    for id in ids {
-        let state = lexemes.get(&id).ok_or_else(|| {
-            BoundedGlobalExactSpinError::Invalid(
-                "population permutation references an unknown lexical unit".to_owned(),
-            )
-        })?;
-        fold = fold.compose(state.state, table)?;
-    }
-    Ok(fold)
+    let states = ids
+        .into_iter()
+        .map(|id| {
+            lexemes.get(&id).map(|state| state.state).ok_or_else(|| {
+                BoundedGlobalExactSpinError::Invalid(
+                    "population permutation references an unknown lexical unit".to_owned(),
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    fold_exact_spin_states(states, table)
 }
 
 fn population_candidate_cost(
@@ -2798,12 +2861,10 @@ fn population_candidate_cost(
     })
 }
 
-fn unique_exact_cost_winner(costs: &[BoundedGlobalExactSpinCost; 2]) -> Option<usize> {
-    match costs[0].cmp(&costs[1]) {
-        std::cmp::Ordering::Less => Some(0),
-        std::cmp::Ordering::Greater => Some(1),
-        std::cmp::Ordering::Equal => None,
-    }
+fn unique_exact_cost_winner(
+    costs: &[BoundedGlobalExactSpinCost; 2],
+) -> Result<Option<usize>, BoundedGlobalExactSpinError> {
+    Ok(select_unique_minimum_exact_costs(costs)?.unique_minimum_index)
 }
 
 fn population_ids_to_hex(
@@ -2824,7 +2885,7 @@ fn population_ids_to_hex(
     Ok([first?, second?, third?, fourth?])
 }
 
-fn exact_s3_spin_to_h4(
+pub(crate) fn exact_s3_spin_to_h4(
     raw: [i32; 4],
     table: &H4BinaryIcosahedralClosure,
 ) -> Result<OrderedH4FoldState, BoundedGlobalExactSpinError> {
@@ -2898,7 +2959,18 @@ fn spin_map_kappa(
     Ok(blake3_label(&bytes))
 }
 
-fn candidate_relative_exact_cost(
+pub(crate) fn fold_exact_spin_states(
+    states: impl IntoIterator<Item = ExactSpinState>,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactSpinState, BoundedGlobalExactSpinError> {
+    let mut fold = ExactSpinState::identity(table)?;
+    for state in states {
+        fold = fold.compose(state, table)?;
+    }
+    Ok(fold)
+}
+
+pub(crate) fn candidate_relative_exact_cost(
     class_state: ExactSpinState,
     global_state: ExactSpinState,
     table: &H4BinaryIcosahedralClosure,
@@ -2908,7 +2980,7 @@ fn candidate_relative_exact_cost(
     Ok((relative, cost))
 }
 
-fn exact_cost(
+pub(crate) fn exact_cost(
     relative: ExactSpinState,
     table: &H4BinaryIcosahedralClosure,
 ) -> Result<BoundedGlobalExactSpinCost, BoundedGlobalExactSpinError> {
@@ -2931,33 +3003,24 @@ fn exact_cost(
     };
     Ok(BoundedGlobalExactSpinCost {
         angular_shell,
-        fiber_distance_q29: relative.fiber_q29.unsigned_abs(),
-        torsion_distance_q29: relative.torsion_q29.unsigned_abs(),
+        fiber_distance_q29: circular_abs_q29(relative.fiber_q29),
+        torsion_distance_q29: circular_abs_q29(relative.torsion_q29),
     })
 }
 
-impl ExactSpinState {
-    fn root_real(
-        self,
-        table: &H4BinaryIcosahedralClosure,
-    ) -> Result<[i64; 2], BoundedGlobalExactSpinError> {
-        Ok(self.h4.root_coordinate(table)?.scaled_zphi_quaternion[0])
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
-struct SelectionOutcome {
-    unique_minimum_index: Option<usize>,
-    minimum_cost: Option<BoundedGlobalExactSpinCost>,
-    comparisons: u64,
+pub(crate) struct SelectionOutcome {
+    pub(crate) unique_minimum_index: Option<usize>,
+    pub(crate) minimum_cost: Option<BoundedGlobalExactSpinCost>,
+    pub(crate) comparisons: u64,
 }
 
-fn select_exact_costs(
+pub(crate) fn select_unique_minimum_exact_costs(
     costs: &[BoundedGlobalExactSpinCost],
 ) -> Result<SelectionOutcome, BoundedGlobalExactSpinError> {
-    if costs.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES {
+    if costs.is_empty() {
         return Err(BoundedGlobalExactSpinError::Invalid(
-            "bounded-global exact-cost count differs from the frozen support".to_owned(),
+            "exact-spin cost selection requires nonempty support".to_owned(),
         ));
     }
     let mut minimum: Option<(usize, BoundedGlobalExactSpinCost)> = None;
@@ -2985,6 +3048,17 @@ fn select_exact_costs(
         minimum_cost: (!tied).then_some(minimum.map(|value| value.1)).flatten(),
         comparisons,
     })
+}
+
+fn select_exact_costs(
+    costs: &[BoundedGlobalExactSpinCost],
+) -> Result<SelectionOutcome, BoundedGlobalExactSpinError> {
+    if costs.len() != BOUNDED_GLOBAL_EXACT_SPIN_CANDIDATES {
+        return Err(BoundedGlobalExactSpinError::Invalid(
+            "bounded-global exact-cost count differs from the frozen support".to_owned(),
+        ));
+    }
+    select_unique_minimum_exact_costs(costs)
 }
 
 fn decision_from_selection(
@@ -3144,7 +3218,7 @@ fn spin_trace(spin: crate::prime_route_attention::SpinTorsionState) -> SpinTorsi
     }
 }
 
-fn wrap_phase_q29(mut value: i64) -> i64 {
+pub(crate) fn wrap_phase_q29(mut value: i64) -> i64 {
     while value >= PHASE_HALF_Q29 {
         value -= PHASE_MODULUS_Q29;
     }
@@ -3152,6 +3226,10 @@ fn wrap_phase_q29(mut value: i64) -> i64 {
         value += PHASE_MODULUS_Q29;
     }
     value
+}
+
+pub(crate) fn circular_abs_q29(value: i64) -> u64 {
+    wrap_phase_q29(value).unsigned_abs()
 }
 
 const HIERARCHY_LEVELS: [&str; 7] = [

--- a/crates/uor-r4-core/src/corpus_induced_spin_placement.rs
+++ b/crates/uor-r4-core/src/corpus_induced_spin_placement.rs
@@ -1,0 +1,3937 @@
+//! Construction-induced exact document-spin placement for issue #973.
+//!
+//! `CorpusInducedDocumentSpinPlacementR4V1` is an additive, source-free
+//! placement overlay over the unchanged `SFTBL001` table and #953
+//! `MultiscaleCountRadiusR4V1` admission path.  Compilation may observe only
+//! D3-construction causal prefix -> observed-next-route pairs.  The serialized
+//! artifact retains one aggregate exact prototype per usable candidate and no
+//! source text, prefix row, continuation, target, or anti-recall index.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::bounded_global_exact_spin_attention::{
+    candidate_relative_exact_cost, exact_s3_spin_to_h4, select_unique_minimum_exact_costs,
+    BoundedGlobalExactSpinCost, BoundedGlobalExactSpinError, BoundedGlobalExactSpinStateTrace,
+    ExactSpinState,
+};
+use crate::canonical_lexical_ingestion::{
+    validate_h4_binary_icosahedral_closure, H4BinaryIcosahedralClosure, OpaqueH4TableIndex,
+};
+use crate::prime_route_geometric_attention::H4S3AngularShell;
+use crate::source_free_table::{
+    BackoffOrder, Continuation, ContinuationStop, MatchedGeometricPrediction,
+    MultiscaleCountRadiusR4V1, MultiscaleCountRadiusWork, SourceDocument, SourceFreeTable,
+    SourceFreeTableError, BOS_TOKEN, EOS_TOKEN, MAX_CONTINUATION_UNITS,
+};
+
+const ARTIFACT_MAGIC: [u8; 8] = *b"CIDSP001";
+const ARTIFACT_SCHEMA: u32 = 1;
+const ARTIFACT_DOMAIN: &str = "uor-r4.corpus-induced-document-spin-placement/1";
+const LEAF_BASIS_DOMAIN: &str = "uor-r4.sftbl001-exact-spin-identity-leaf/1";
+const INDUCTION_POLICY_DOMAIN: &str = "uor-r4.document-prefix-componentwise-frechet-placement/1";
+const QUERY_POLICY_DOMAIN: &str = "uor-r4.document-spin-c-inverse-g-lexicographic-minimum/1";
+const SCORE_FIREWALL_DOMAIN: &str = "uor-r4.document-spin-score-firewall/1";
+const SCORE_FIREWALL_POLICY: &str = "schema=1\ncapability=causal-prefix-frame-only\nallowed-score-inputs=exact-query-state,aggregate-prototype-state\nforbidden=heldout-target,compiler-future,teacher,provider,source-weight,runtime-corpus,token,payload,prime,rank,digest,support,provenance\ncertificate=BLAKE3(policy,operator,prefix-units,candidate-count,four-executed-query-states,forbidden-mask)";
+const ANTI_RECALL_DOMAIN: &str = "uor-r4.document-spin-operative-anti-recall/1";
+const ANTI_RECALL_POLICY_IDENTITY: &str = "schema=1\nfull-prefix-cid=BLAKE3(PREFIX_DOMAIN || each causal SFTBL001 token as fixed-width u32 little-endian)\ncanonical-witness-order=(active-row,canonical-support-cid,full-prefix-cid,document-id,target-index)\nwitness=first-operative-real-non-EOS-real-differs-from-each-control";
+const PREFIX_DOMAIN: &[u8] = b"uor-r4.document-spin-prefix/1\0";
+const ROW_DOMAIN: &[u8] = b"uor-r4.document-spin-active-row/1\0";
+const SUPPORT_DOMAIN: &[u8] = b"uor-r4.document-spin-support/1\0";
+const PREDICTION_DOMAIN: &[u8] = b"uor-r4.document-spin-prediction/1\0";
+const CONSTRUCTION_SET_DOMAIN: &[u8] = b"uor-r4.document-spin-construction-set/1\0";
+const HELD_OUT_SET_DOMAIN: &[u8] = b"uor-r4.document-spin-heldout-set/1\0";
+const FROZEN_CORPUS_CID: &str =
+    "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf";
+const FROZEN_TABLE_CID: &str =
+    "blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297";
+const FROZEN_OVERLAY_CID: &str =
+    "blake3:914126a311c3984d1482258a8f0a7fa2e34896540d502d19f1d9076fbd4a9b76";
+const FROZEN_CONSTRUCTION_SET_KAPPA: &str =
+    "blake3:af2a2d7d49db55279e7ea40947a3259ac0a100aa56e8d920951e7c27eaf6df5c";
+const FROZEN_HELD_OUT_SET_KAPPA: &str =
+    "blake3:7a7558e96aa86aa2d8965972b69ddce02222c6eccc8ca560df2141fc0ac4170e";
+const PHASE_MODULUS_Q29: i64 = 3_373_259_426;
+const PHASE_HALF_Q29: i64 = 1_686_629_713;
+const MAX_ARTIFACT_BYTES: usize = 64 * 1024 * 1024;
+const MIN_PROTOTYPE_DOCUMENTS: u32 = 2;
+const MIN_DISTINCT_PROTOTYPE_STATES: u32 = 2;
+const FROZEN_HELD_OUT_DOCUMENTS: u64 = 596;
+const FROZEN_TARGET_FREE_ADMISSIONS: u64 = 81_177;
+#[cfg(not(target_arch = "wasm32"))]
+const MAX_NATIVE_DOCUMENT_SCAN_WORKERS: usize = 8;
+pub const MIN_OPERATIVE_ANTI_RECALL_POSITIONS: u64 = 1_024;
+pub const POSITIVE_TERMINAL: &str =
+    "RETAIN_CORPUS_INDUCED_DOCUMENT_SPIN_ATTENTION_CONTINUE_FINAL_973_REQUALIFICATION";
+pub const NEGATIVE_TERMINAL: &str = "RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT";
+pub const UNAVAILABLE_TERMINAL: &str = "UNAVAILABLE_OPERATIVE_ANTI_RECALL_OR_REACHABILITY";
+
+const LEAF_BASIS_IDENTITY: &str = "schema=1\ndomain=uor-r4.sftbl001-exact-spin-identity-leaf/1\ntoken=SFTBL001-u32-token-id\nprime=zero-based-rth-prime,p_0=2\nh4-row=r-mod-4 over exact V2 roots [(1,0,0,0),(0,1,0,0),(1/2,1/2,1/2,1/2),(1/2,-1/2,1/2,-1/2)]\nfiber=wrap_M(p_r*1000003+r*17071)\ntorsion=wrap_M(-p_r*97409+r*7919)\nM=3373259426\nBOS=identity-reset";
+const INDUCTION_POLICY_IDENTITY: &str = "schema=1\ndomain=uor-r4.document-prefix-componentwise-frechet-placement/1\nscope=document-only\nexamples=construction-only max-count trigram/bigram ties whose observed next route is admitted\ncap=earliest eligible occurrence per candidate/document\nminimum=two-distinct-documents-and-two-distinct-exact-prefix-states\nh4=minimum-summed-angular-shell-rank-over-all-120-roots\nphase=minimum-summed-circular-Q29-distance-over-observed-values\nties=canonical-H4-table-order-then-ascending-signed-Q29";
+const QUERY_POLICY_IDENTITY: &str = "schema=1\ndomain=uor-r4.document-spin-c-inverse-g-lexicographic-minimum/1\nadmission=unchanged-953-max-count-tie\nrelative=C^-1*G\ncost=lexicographic(H4S3AngularShell,circular-abs-fiber-Q29,circular-abs-torsion-Q29)\nselection=unique-minimum-else-953-fallback\ncontrols=real,scope-disabled,reverse-order,cyclic-operator-permutation\nforbidden-score-inputs=token,payload,prime,rank,digest,support,provenance,target,future,teacher,provider,source-weight";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorpusInducedDocumentSpinError {
+    Invalid(String),
+    SourceFree(String),
+    ExactSpin(String),
+    Serialization(String),
+    ArithmeticOverflow,
+}
+
+impl std::fmt::Display for CorpusInducedDocumentSpinError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(reason) => formatter.write_str(reason),
+            Self::SourceFree(reason) => write!(formatter, "source-free table: {reason}"),
+            Self::ExactSpin(reason) => write!(formatter, "exact spin: {reason}"),
+            Self::Serialization(reason) => write!(formatter, "serialization: {reason}"),
+            Self::ArithmeticOverflow => {
+                formatter.write_str("corpus-induced document-spin arithmetic overflow")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CorpusInducedDocumentSpinError {}
+
+impl From<SourceFreeTableError> for CorpusInducedDocumentSpinError {
+    fn from(error: SourceFreeTableError) -> Self {
+        Self::SourceFree(error.to_string())
+    }
+}
+
+impl From<BoundedGlobalExactSpinError> for CorpusInducedDocumentSpinError {
+    fn from(error: BoundedGlobalExactSpinError) -> Self {
+        Self::ExactSpin(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CorpusInducedDocumentSpinArm {
+    Real,
+    ScopeDisabled,
+    OrderShuffled,
+    OperatorPermuted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CorpusInducedDocumentSpinAbstention {
+    NotMaximumCountTie,
+    MissingPrototype,
+    CostTie,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub struct CorpusInducedDocumentSpinForbiddenReads {
+    pub held_out_target_reads: u64,
+    pub compiler_future_reads: u64,
+    pub teacher_calls: u64,
+    pub provider_calls: u64,
+    pub source_weight_reads: u64,
+    pub runtime_corpus_reads: u64,
+    pub token_score_reads: u64,
+    pub payload_score_reads: u64,
+    pub prime_score_reads: u64,
+    pub rank_score_reads: u64,
+    pub digest_score_reads: u64,
+    pub support_score_reads: u64,
+    pub provenance_score_reads: u64,
+}
+
+impl CorpusInducedDocumentSpinForbiddenReads {
+    pub fn total(self) -> u64 {
+        [
+            self.held_out_target_reads,
+            self.compiler_future_reads,
+            self.teacher_calls,
+            self.provider_calls,
+            self.source_weight_reads,
+            self.runtime_corpus_reads,
+            self.token_score_reads,
+            self.payload_score_reads,
+            self.prime_score_reads,
+            self.rank_score_reads,
+            self.digest_score_reads,
+            self.support_score_reads,
+            self.provenance_score_reads,
+        ]
+        .into_iter()
+        .fold(0_u64, u64::saturating_add)
+    }
+
+    fn saturating_accumulate(&mut self, other: Self) {
+        self.held_out_target_reads = self
+            .held_out_target_reads
+            .saturating_add(other.held_out_target_reads);
+        self.compiler_future_reads = self
+            .compiler_future_reads
+            .saturating_add(other.compiler_future_reads);
+        self.teacher_calls = self.teacher_calls.saturating_add(other.teacher_calls);
+        self.provider_calls = self.provider_calls.saturating_add(other.provider_calls);
+        self.source_weight_reads = self
+            .source_weight_reads
+            .saturating_add(other.source_weight_reads);
+        self.runtime_corpus_reads = self
+            .runtime_corpus_reads
+            .saturating_add(other.runtime_corpus_reads);
+        self.token_score_reads = self
+            .token_score_reads
+            .saturating_add(other.token_score_reads);
+        self.payload_score_reads = self
+            .payload_score_reads
+            .saturating_add(other.payload_score_reads);
+        self.prime_score_reads = self
+            .prime_score_reads
+            .saturating_add(other.prime_score_reads);
+        self.rank_score_reads = self.rank_score_reads.saturating_add(other.rank_score_reads);
+        self.digest_score_reads = self
+            .digest_score_reads
+            .saturating_add(other.digest_score_reads);
+        self.support_score_reads = self
+            .support_score_reads
+            .saturating_add(other.support_score_reads);
+        self.provenance_score_reads = self
+            .provenance_score_reads
+            .saturating_add(other.provenance_score_reads);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinScoreFirewallCertificate {
+    pub schema: u32,
+    pub domain: String,
+    pub policy_kappa: String,
+    pub operator_cid: String,
+    pub causal_prefix_units: u64,
+    pub candidate_count: u64,
+    pub query_state_kappa: String,
+    pub forbidden_dependency_mask: u16,
+    pub certificate_cid: String,
+}
+
+impl CorpusInducedDocumentSpinScoreFirewallCertificate {
+    pub fn validate(&self) -> bool {
+        self.schema == ARTIFACT_SCHEMA
+            && self.domain == SCORE_FIREWALL_DOMAIN
+            && self.policy_kappa == identity_kappa(&[SCORE_FIREWALL_POLICY])
+            && self.forbidden_dependency_mask == 0
+            && self.certificate_cid == score_firewall_certificate_cid(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinWork {
+    pub local: MultiscaleCountRadiusWork,
+    pub prefix_leaf_reads: u64,
+    pub prefix_h4_product_reads: u64,
+    pub prefix_phase_additions: u64,
+    pub prototype_reads: u64,
+    pub prototype_inverse_reads: u64,
+    pub relative_h4_product_reads: u64,
+    pub relative_phase_additions: u64,
+    pub angular_shell_reads: u64,
+    pub phase_distance_reads: u64,
+    pub cost_comparisons: u64,
+    pub final_choice_operations: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinDecision {
+    pub arm: CorpusInducedDocumentSpinArm,
+    pub token: u32,
+    pub unique_minimum: Option<u32>,
+    pub minimum_cost: Option<BoundedGlobalExactSpinCost>,
+    pub abstention: Option<CorpusInducedDocumentSpinAbstention>,
+    pub support_tokens: Vec<u32>,
+    pub work: CorpusInducedDocumentSpinWork,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinCandidateEvidence {
+    pub token: u32,
+    pub prototype_state: BoundedGlobalExactSpinStateTrace,
+    pub prototype_document_support: u32,
+    pub prototype_distinct_state_support: u32,
+    pub real_relative_state: BoundedGlobalExactSpinStateTrace,
+    pub real_cost: BoundedGlobalExactSpinCost,
+    pub order_shuffled_relative_state: BoundedGlobalExactSpinStateTrace,
+    pub order_shuffled_cost: BoundedGlobalExactSpinCost,
+    pub permuted_from_token: u32,
+    pub permuted_prototype_state: BoundedGlobalExactSpinStateTrace,
+    pub operator_permuted_relative_state: BoundedGlobalExactSpinStateTrace,
+    pub operator_permuted_cost: BoundedGlobalExactSpinCost,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedCorpusInducedDocumentSpinPrediction {
+    pub local: MatchedGeometricPrediction,
+    pub operator_cid: String,
+    pub natural_state: BoundedGlobalExactSpinStateTrace,
+    pub reverse_state: BoundedGlobalExactSpinStateTrace,
+    pub candidate_evidence: Vec<CorpusInducedDocumentSpinCandidateEvidence>,
+    pub real: CorpusInducedDocumentSpinDecision,
+    pub scope_disabled: CorpusInducedDocumentSpinDecision,
+    pub order_shuffled: CorpusInducedDocumentSpinDecision,
+    pub operator_permuted: CorpusInducedDocumentSpinDecision,
+    pub prototype_complete: bool,
+    pub natural_reverse_distinct: bool,
+    pub permutation_cost_vector_changed: bool,
+    pub support_matched: bool,
+    pub work_matched: bool,
+    pub score_firewall_certificate: CorpusInducedDocumentSpinScoreFirewallCertificate,
+    pub forbidden_reads: CorpusInducedDocumentSpinForbiddenReads,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatchedCorpusInducedDocumentSpinContinuation {
+    pub first_decision: MatchedCorpusInducedDocumentSpinPrediction,
+    pub real: Continuation,
+    pub scope_disabled: Continuation,
+    pub order_shuffled: Continuation,
+    pub operator_permuted: Continuation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub struct CorpusInducedDocumentSpinArtifactStats {
+    pub construction_documents: u64,
+    pub eligible_construction_positions: u64,
+    pub retained_document_exemplars: u64,
+    pub observed_candidate_tokens: u64,
+    pub usable_prototypes: u64,
+    pub rejected_single_document_prototypes: u64,
+    pub rejected_single_state_prototypes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinPrototypeTrace {
+    pub token: u32,
+    pub payload_cid: String,
+    pub state: BoundedGlobalExactSpinStateTrace,
+    pub construction_document_support: u32,
+    pub distinct_state_support: u32,
+    pub h4_minimum_objective_sum: u128,
+    pub h4_minimizer_count: u16,
+    pub fiber_minimum_objective_sum: u128,
+    pub fiber_minimizer_count: u32,
+    pub torsion_minimum_objective_sum: u128,
+    pub torsion_minimizer_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinCensusPosition {
+    pub document_id: String,
+    pub target_index: u32,
+    pub prefix_cid: String,
+    pub row_cid: String,
+    pub support_cid: String,
+    pub prediction_cid: String,
+    pub real_token: u32,
+    pub scope_disabled_token: u32,
+    pub order_shuffled_token: u32,
+    pub operator_permuted_token: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CorpusInducedDocumentSpinTargetFreeCensus {
+    pub schema: u32,
+    pub domain: String,
+    pub operator_cid: String,
+    pub anti_recall_index_kappa: String,
+    pub held_out_set_kappa: String,
+    pub held_out_documents: u64,
+    /// Every target-blind trigram/bigram maximum-count-tie prefix.  The frozen
+    /// corpus value is 81,177; the 76,641 known-target count is attached only
+    /// by [`CorpusInducedDocumentSpinPlacementR4V1::evaluate_held_out`].
+    pub admission_opportunities: u64,
+    /// Admission positions whose active row occurs in at least two held-out
+    /// documents (a position count, not a distinct-row count).
+    pub rows_in_multiple_held_out_documents: u64,
+    pub prototype_complete_positions: u64,
+    pub full_prefix_construction_hits: u64,
+    pub natural_state_construction_hits: u64,
+    pub operative_signature_construction_hits: u64,
+    pub natural_reverse_equal_positions: u64,
+    pub permutation_inert_positions: u64,
+    pub support_mismatches: u64,
+    pub work_mismatches: u64,
+    pub invalid_score_firewall_certificates: u64,
+    pub score_firewall_policy_kappa: String,
+    pub meets_frozen_preflight: bool,
+    pub operative_positions: Vec<CorpusInducedDocumentSpinCensusPosition>,
+    pub frozen_decoded_witness: Option<CorpusInducedDocumentSpinCensusPosition>,
+    pub forbidden_reads: CorpusInducedDocumentSpinForbiddenReads,
+}
+
+impl CorpusInducedDocumentSpinTargetFreeCensus {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, CorpusInducedDocumentSpinError> {
+        serde_json::to_vec(self)
+            .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))
+    }
+
+    pub fn artifact_cid(&self) -> Result<String, CorpusInducedDocumentSpinError> {
+        Ok(blake3_label(&self.canonical_bytes()?))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CorpusInducedDocumentSpinComparatorEvaluation {
+    pub wins: u64,
+    pub losses: u64,
+    pub ties: u64,
+    pub discordant: u64,
+    pub one_sided_exact_sign_test: String,
+    pub passes: bool,
+    pub terminal: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CorpusInducedDocumentSpinEvaluation {
+    pub schema: u32,
+    pub domain: String,
+    pub decision: String,
+    pub operator_cid: String,
+    pub census_cid: String,
+    pub held_out_set_kappa: String,
+    pub held_out_documents: u64,
+    pub post_join_admission_opportunities: u64,
+    pub post_join_known_target_admission_opportunities: u64,
+    pub operative_positions: u64,
+    pub operative_known_target_positions: u64,
+    pub real_correct: u64,
+    pub scope_disabled_correct: u64,
+    pub order_shuffled_correct: u64,
+    pub operator_permuted_correct: u64,
+    pub witness_continuation_contrast: bool,
+    pub witness_continuation: Option<MatchedCorpusInducedDocumentSpinContinuation>,
+    pub witness_continuation_cid: Option<String>,
+    pub versus_scope_disabled: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub versus_order_shuffled: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub versus_operator_permuted: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub document_blocked_versus_scope_disabled: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub document_blocked_versus_order_shuffled: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub document_blocked_versus_operator_permuted: CorpusInducedDocumentSpinComparatorEvaluation,
+    pub target_reads: u64,
+    pub forbidden_reads: CorpusInducedDocumentSpinForbiddenReads,
+}
+
+impl CorpusInducedDocumentSpinEvaluation {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, CorpusInducedDocumentSpinError> {
+        serde_json::to_vec(self)
+            .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))
+    }
+
+    pub fn report_cid(&self) -> Result<String, CorpusInducedDocumentSpinError> {
+        Ok(blake3_label(&self.canonical_bytes()?))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+struct ExactStateWire {
+    h4_table_offset: u16,
+    h4_coordinate: [[i64; 2]; 4],
+    fiber_q29: i64,
+    torsion_q29: i64,
+}
+
+#[derive(Debug, Clone)]
+struct Prototype {
+    token: u32,
+    payload_cid: String,
+    state: ExactSpinState,
+    construction_document_support: u32,
+    distinct_state_support: u32,
+    fit_audit: PrototypeFitAudit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct PrototypeFitAudit {
+    h4_minimum_objective_sum: u128,
+    h4_minimizer_count: u16,
+    fiber_minimum_objective_sum: u128,
+    fiber_minimizer_count: u32,
+    torsion_minimum_objective_sum: u128,
+    torsion_minimizer_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PrototypeWire {
+    token: u32,
+    payload_cid: String,
+    state: ExactStateWire,
+    construction_document_support: u32,
+    distinct_state_support: u32,
+    fit_audit: PrototypeFitAudit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ArtifactWire {
+    schema: u32,
+    domain: String,
+    corpus_cid: String,
+    table_artifact_cid: String,
+    base_overlay_artifact_cid: String,
+    construction_set_kappa: String,
+    leaf_basis_kappa: String,
+    induction_policy_kappa: String,
+    query_policy_kappa: String,
+    h4_root_table_kappa: String,
+    h4_multiplication_table_kappa: String,
+    phase_modulus_q29: i64,
+    phase_half_q29: i64,
+    max_artifact_bytes: usize,
+    stats: ArtifactStatsWire,
+    prototypes: Vec<PrototypeWire>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct ArtifactStatsWire {
+    construction_documents: u64,
+    eligible_construction_positions: u64,
+    retained_document_exemplars: u64,
+    observed_candidate_tokens: u64,
+    usable_prototypes: u64,
+    rejected_single_document_prototypes: u64,
+    rejected_single_state_prototypes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CorpusInducedDocumentSpinPlacementR4V1 {
+    operator_cid: String,
+    corpus_cid: String,
+    table_artifact_cid: String,
+    base_overlay_artifact_cid: String,
+    construction_set_kappa: String,
+    leaf_basis_kappa: String,
+    induction_policy_kappa: String,
+    query_policy_kappa: String,
+    h4_table: H4BinaryIcosahedralClosure,
+    max_token_id: u32,
+    leaves: Vec<ExactSpinState>,
+    prototypes: BTreeMap<u32, Prototype>,
+    stats: CorpusInducedDocumentSpinArtifactStats,
+}
+
+#[derive(Debug, Clone)]
+pub struct CorpusInducedDocumentSpinAntiRecallIndex {
+    operator_cid: String,
+    construction_set_kappa: String,
+    full_prefix_cids: BTreeSet<[u8; 32]>,
+    natural_states: BTreeSet<ExactStateWire>,
+    operative_signature_cids: BTreeSet<[u8; 32]>,
+    index_kappa: String,
+}
+
+#[cfg(test)]
+#[derive(Serialize)]
+struct AntiRecallIndexWire<'a> {
+    schema: u32,
+    domain: &'static str,
+    operator_cid: &'a str,
+    construction_set_kappa: &'a str,
+    full_prefix_cids: &'a BTreeSet<[u8; 32]>,
+    natural_states: &'a BTreeSet<ExactStateWire>,
+    operative_signature_cids: &'a BTreeSet<[u8; 32]>,
+    index_kappa: &'a str,
+}
+
+#[derive(Debug, Default)]
+struct AntiRecallDocumentScan {
+    full_prefix_cids: BTreeSet<[u8; 32]>,
+    natural_states: BTreeSet<ExactStateWire>,
+    operative_signature_cids: BTreeSet<[u8; 32]>,
+}
+
+#[derive(Debug, Clone)]
+struct ConstructionExemplar {
+    document_id: String,
+    state: ExactSpinState,
+}
+
+#[derive(Debug)]
+struct DocumentCompilation {
+    eligible_positions: u64,
+    exemplars: Vec<(u32, ConstructionExemplar)>,
+}
+
+#[derive(Debug)]
+enum CandidateCompilation {
+    Usable(Prototype),
+    RejectedSingleDocument,
+    RejectedSingleState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ActiveRowKey {
+    order: u8,
+    previous_two: u32,
+    previous_one: u32,
+}
+
+#[derive(Debug, Clone)]
+struct TargetFreeCandidate {
+    position: CorpusInducedDocumentSpinCensusPosition,
+    row: ActiveRowKey,
+    prediction: MatchedCorpusInducedDocumentSpinPrediction,
+    natural_state: ExactStateWire,
+    omega_cid: [u8; 32],
+    prefix_cid: [u8; 32],
+}
+
+#[derive(Debug)]
+struct TargetFreeDocumentScan {
+    document_id: String,
+    admission_opportunities: u64,
+    rows_seen: BTreeSet<ActiveRowKey>,
+    candidates: Vec<TargetFreeCandidate>,
+}
+
+#[derive(Debug, Default)]
+struct TargetFreeScanAggregate {
+    admission_opportunities: u64,
+    row_documents: BTreeMap<ActiveRowKey, BTreeSet<String>>,
+    candidates: Vec<TargetFreeCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScoreFrameOrigin {
+    CausalPrefix,
+    #[cfg(test)]
+    InjectedHeldOutTarget,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ExecutedQueryState {
+    state: ExactSpinState,
+    prefix_leaf_reads: u64,
+    prefix_h4_product_reads: u64,
+    prefix_phase_additions: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CausalScoreFrame {
+    origin: ScoreFrameOrigin,
+    prefix_units: u64,
+    real: ExecutedQueryState,
+    scope_disabled: ExecutedQueryState,
+    order_shuffled: ExecutedQueryState,
+    operator_permuted: ExecutedQueryState,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CausalPrefixCursor {
+    frame: CausalScoreFrame,
+}
+
+impl CausalPrefixCursor {
+    fn new(table: &H4BinaryIcosahedralClosure) -> Result<Self, CorpusInducedDocumentSpinError> {
+        let identity = ExactSpinState::identity(table)?;
+        let query = ExecutedQueryState {
+            state: identity,
+            prefix_leaf_reads: 0,
+            prefix_h4_product_reads: 0,
+            prefix_phase_additions: 0,
+        };
+        Ok(Self {
+            frame: CausalScoreFrame {
+                origin: ScoreFrameOrigin::CausalPrefix,
+                prefix_units: 0,
+                real: query,
+                scope_disabled: query,
+                order_shuffled: query,
+                operator_permuted: query,
+            },
+        })
+    }
+
+    fn from_prefix(
+        prefix: &[u32],
+        leaves: &[ExactSpinState],
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        let mut cursor = Self::new(table)?;
+        for &token in prefix {
+            cursor.advance(token, leaves, table)?;
+        }
+        Ok(cursor)
+    }
+
+    fn advance(
+        &mut self,
+        token: u32,
+        leaves: &[ExactSpinState],
+        table: &H4BinaryIcosahedralClosure,
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        self.frame.prefix_units = checked_add_u64(self.frame.prefix_units, 1)?;
+        advance_executed_query(&mut self.frame.real, token, leaves, table, false)?;
+        advance_executed_query(&mut self.frame.scope_disabled, token, leaves, table, false)?;
+        advance_executed_query(&mut self.frame.order_shuffled, token, leaves, table, true)?;
+        advance_executed_query(
+            &mut self.frame.operator_permuted,
+            token,
+            leaves,
+            table,
+            false,
+        )?;
+        Ok(())
+    }
+
+    const fn frame(self) -> CausalScoreFrame {
+        self.frame
+    }
+}
+
+fn advance_executed_query(
+    query: &mut ExecutedQueryState,
+    token: u32,
+    leaves: &[ExactSpinState],
+    table: &H4BinaryIcosahedralClosure,
+    reverse: bool,
+) -> Result<(), CorpusInducedDocumentSpinError> {
+    let leaf = leaf_for_token(leaves, token)?;
+    query.prefix_leaf_reads = checked_add_u64(query.prefix_leaf_reads, 1)?;
+    query.state = if reverse {
+        leaf.compose(query.state, table)?
+    } else {
+        query.state.compose(leaf, table)?
+    };
+    query.prefix_h4_product_reads = checked_add_u64(query.prefix_h4_product_reads, 1)?;
+    query.prefix_phase_additions = checked_add_u64(query.prefix_phase_additions, 2)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ExecutedCandidateScore {
+    support_token: u32,
+    prototype_token: u32,
+    prototype_state: ExactSpinState,
+    relative_state: ExactSpinState,
+    cost: BoundedGlobalExactSpinCost,
+}
+
+#[derive(Debug)]
+struct ExecutedArm {
+    decision: CorpusInducedDocumentSpinDecision,
+    candidates: Vec<ExecutedCandidateScore>,
+}
+
+#[derive(Clone)]
+struct PrefixDigestState(blake3::Hasher);
+
+impl PrefixDigestState {
+    fn new() -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(PREFIX_DOMAIN);
+        Self(hasher)
+    }
+
+    fn append(&mut self, token: u32) {
+        self.0.update(&token.to_le_bytes());
+    }
+
+    fn digest(&self) -> [u8; 32] {
+        *self.0.clone().finalize().as_bytes()
+    }
+}
+
+impl From<CorpusInducedDocumentSpinArtifactStats> for ArtifactStatsWire {
+    fn from(stats: CorpusInducedDocumentSpinArtifactStats) -> Self {
+        Self {
+            construction_documents: stats.construction_documents,
+            eligible_construction_positions: stats.eligible_construction_positions,
+            retained_document_exemplars: stats.retained_document_exemplars,
+            observed_candidate_tokens: stats.observed_candidate_tokens,
+            usable_prototypes: stats.usable_prototypes,
+            rejected_single_document_prototypes: stats.rejected_single_document_prototypes,
+            rejected_single_state_prototypes: stats.rejected_single_state_prototypes,
+        }
+    }
+}
+
+impl From<ArtifactStatsWire> for CorpusInducedDocumentSpinArtifactStats {
+    fn from(stats: ArtifactStatsWire) -> Self {
+        Self {
+            construction_documents: stats.construction_documents,
+            eligible_construction_positions: stats.eligible_construction_positions,
+            retained_document_exemplars: stats.retained_document_exemplars,
+            observed_candidate_tokens: stats.observed_candidate_tokens,
+            usable_prototypes: stats.usable_prototypes,
+            rejected_single_document_prototypes: stats.rejected_single_document_prototypes,
+            rejected_single_state_prototypes: stats.rejected_single_state_prototypes,
+        }
+    }
+}
+
+impl CorpusInducedDocumentSpinPlacementR4V1 {
+    /// Compile the aggregate-only placement from the exact construction set
+    /// that produced `table`.  Held-out documents are rejected by the table's
+    /// binding check and are not accepted by this API.
+    pub fn compile(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        Self::compile_with_worker_count(table, base_overlay, construction, None)
+    }
+
+    fn compile_with_worker_count(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+        worker_count: Option<usize>,
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        if !table.is_bound_to_construction_documents(construction) {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement compiler is not bound to the table's exact construction set".to_owned(),
+            ));
+        }
+        if base_overlay.table_artifact_cid() != table.artifact_cid() {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "#953 overlay is not bound to the supplied source-free table".to_owned(),
+            ));
+        }
+        if construction.is_empty() {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement construction set is empty".to_owned(),
+            ));
+        }
+
+        let h4_table = validate_h4_binary_icosahedral_closure()
+            .map_err(|error| CorpusInducedDocumentSpinError::ExactSpin(error.to_string()))?;
+        let max_token_id = table.maximum_token_id();
+        let leaves = compile_identity_leaves(max_token_id, &h4_table)?;
+        let table_artifact_cid = table.artifact_cid();
+        let base_overlay_artifact_cid = base_overlay.artifact_cid();
+        let construction_set_kappa = document_set_kappa(CONSTRUCTION_SET_DOMAIN, construction)?;
+        if table_artifact_cid == FROZEN_TABLE_CID
+            && base_overlay_artifact_cid == FROZEN_OVERLAY_CID
+            && construction_set_kappa != FROZEN_CONSTRUCTION_SET_KAPPA
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "frozen construction-set kappa does not reproduce".to_owned(),
+            ));
+        }
+        let corpus_cid = if table_artifact_cid == FROZEN_TABLE_CID
+            && base_overlay_artifact_cid == FROZEN_OVERLAY_CID
+        {
+            FROZEN_CORPUS_CID.to_owned()
+        } else {
+            construction_set_kappa.clone()
+        };
+        let leaf_basis_kappa = identity_kappa(&[
+            LEAF_BASIS_DOMAIN,
+            LEAF_BASIS_IDENTITY,
+            table_artifact_cid.as_str(),
+            h4_table.h4_root_table_kappa.as_str(),
+            h4_table.multiplication_table_kappa.as_str(),
+        ]);
+        let induction_policy_kappa = identity_kappa(&[
+            INDUCTION_POLICY_DOMAIN,
+            INDUCTION_POLICY_IDENTITY,
+            table_artifact_cid.as_str(),
+            base_overlay_artifact_cid.as_str(),
+        ]);
+        let query_policy_kappa = identity_kappa(&[
+            QUERY_POLICY_DOMAIN,
+            QUERY_POLICY_IDENTITY,
+            table_artifact_cid.as_str(),
+            base_overlay_artifact_cid.as_str(),
+        ]);
+
+        let mut ordered_documents = construction.iter().collect::<Vec<_>>();
+        ordered_documents.sort_by(|left, right| left.id.cmp(&right.id));
+        if ordered_documents
+            .windows(2)
+            .any(|pair| pair[0].id == pair[1].id)
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement construction contains duplicate document IDs".to_owned(),
+            ));
+        }
+
+        let document_compilations = compile_construction_documents(
+            table,
+            base_overlay,
+            &ordered_documents,
+            &leaves,
+            &h4_table,
+            worker_count,
+        )?;
+        let mut exemplars = BTreeMap::<u32, Vec<ConstructionExemplar>>::new();
+        let mut eligible_construction_positions = 0_u64;
+        for compilation in document_compilations {
+            eligible_construction_positions = checked_add_u64(
+                eligible_construction_positions,
+                compilation.eligible_positions,
+            )?;
+            for (token, exemplar) in compilation.exemplars {
+                exemplars.entry(token).or_default().push(exemplar);
+            }
+        }
+
+        let observed_candidate_tokens = usize_u64(exemplars.len())?;
+        let retained_document_exemplars = exemplars.values().try_fold(0_u64, |total, rows| {
+            checked_add_u64(total, usize_u64(rows.len())?)
+        })?;
+        let exemplar_rows = exemplars.into_iter().collect::<Vec<_>>();
+        let candidate_compilations =
+            compile_candidate_prototypes(table, &exemplar_rows, &h4_table, worker_count)?;
+        let mut rejected_single_document_prototypes = 0_u64;
+        let mut rejected_single_state_prototypes = 0_u64;
+        let mut prototypes = BTreeMap::new();
+        for compilation in candidate_compilations {
+            match compilation {
+                CandidateCompilation::Usable(prototype) => {
+                    prototypes.insert(prototype.token, prototype);
+                }
+                CandidateCompilation::RejectedSingleDocument => {
+                    rejected_single_document_prototypes =
+                        checked_add_u64(rejected_single_document_prototypes, 1)?;
+                }
+                CandidateCompilation::RejectedSingleState => {
+                    rejected_single_state_prototypes =
+                        checked_add_u64(rejected_single_state_prototypes, 1)?;
+                }
+            }
+        }
+
+        let stats = CorpusInducedDocumentSpinArtifactStats {
+            construction_documents: usize_u64(ordered_documents.len())?,
+            eligible_construction_positions,
+            retained_document_exemplars,
+            observed_candidate_tokens,
+            usable_prototypes: usize_u64(prototypes.len())?,
+            rejected_single_document_prototypes,
+            rejected_single_state_prototypes,
+        };
+        let mut operator = Self {
+            operator_cid: String::new(),
+            corpus_cid,
+            table_artifact_cid,
+            base_overlay_artifact_cid,
+            construction_set_kappa,
+            leaf_basis_kappa,
+            induction_policy_kappa,
+            query_policy_kappa,
+            h4_table,
+            max_token_id,
+            leaves,
+            prototypes,
+            stats,
+        };
+        operator.validate_binding(table, base_overlay)?;
+        let artifact_bytes = operator.to_bytes()?;
+        if artifact_bytes.len() > MAX_ARTIFACT_BYTES {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "corpus-induced placement artifact exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        operator.operator_cid = blake3_label(&artifact_bytes);
+        Ok(operator)
+    }
+
+    pub fn from_bytes(
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        expected_operator_cid: &str,
+        bytes: &[u8],
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        if bytes.len() < ARTIFACT_MAGIC.len()
+            || bytes.len() > MAX_ARTIFACT_BYTES
+            || bytes[..ARTIFACT_MAGIC.len()] != ARTIFACT_MAGIC
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "corpus-induced placement artifact magic or size is invalid".to_owned(),
+            ));
+        }
+        if blake3_label(bytes) != expected_operator_cid {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement artifact does not match its trusted expected CID".to_owned(),
+            ));
+        }
+        let wire: ArtifactWire = serde_json::from_slice(&bytes[ARTIFACT_MAGIC.len()..])
+            .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+        let h4_table = validate_h4_binary_icosahedral_closure()
+            .map_err(|error| CorpusInducedDocumentSpinError::ExactSpin(error.to_string()))?;
+        if wire.schema != ARTIFACT_SCHEMA
+            || wire.domain != ARTIFACT_DOMAIN
+            || wire.phase_modulus_q29 != PHASE_MODULUS_Q29
+            || wire.phase_half_q29 != PHASE_HALF_Q29
+            || wire.max_artifact_bytes != MAX_ARTIFACT_BYTES
+            || wire.h4_root_table_kappa != h4_table.h4_root_table_kappa
+            || wire.h4_multiplication_table_kappa != h4_table.multiplication_table_kappa
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement artifact schema, constants, or exact H4 table binding is invalid"
+                    .to_owned(),
+            ));
+        }
+        if wire
+            .prototypes
+            .windows(2)
+            .any(|pair| pair[0].token >= pair[1].token)
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement prototype rows are not in unique canonical token order".to_owned(),
+            ));
+        }
+        let max_token_id = table.maximum_token_id();
+        let leaves = compile_identity_leaves(max_token_id, &h4_table)?;
+        let mut prototypes = BTreeMap::new();
+        for row in &wire.prototypes {
+            if row.token > max_token_id
+                || !table.is_fitted_lexical_token(row.token)
+                || prototypes.contains_key(&row.token)
+            {
+                return Err(CorpusInducedDocumentSpinError::Invalid(
+                    "placement prototype token is duplicated or out of range".to_owned(),
+                ));
+            }
+            let state = exact_state_from_wire(&row.state, &h4_table)?;
+            let payload_cid = blake3_label(&table.decode_tokens(&[row.token])?);
+            if row.payload_cid != payload_cid
+                || row.construction_document_support < MIN_PROTOTYPE_DOCUMENTS
+                || row.distinct_state_support < MIN_DISTINCT_PROTOTYPE_STATES
+                || row.fit_audit.h4_minimizer_count == 0
+                || usize::from(row.fit_audit.h4_minimizer_count) > h4_table.root_count
+                || row.fit_audit.fiber_minimizer_count == 0
+                || row.fit_audit.fiber_minimizer_count > row.distinct_state_support
+                || row.fit_audit.torsion_minimizer_count == 0
+                || row.fit_audit.torsion_minimizer_count > row.distinct_state_support
+            {
+                return Err(CorpusInducedDocumentSpinError::Invalid(
+                    "placement prototype payload or support witness is invalid".to_owned(),
+                ));
+            }
+            prototypes.insert(
+                row.token,
+                Prototype {
+                    token: row.token,
+                    payload_cid: row.payload_cid.clone(),
+                    state,
+                    construction_document_support: row.construction_document_support,
+                    distinct_state_support: row.distinct_state_support,
+                    fit_audit: row.fit_audit,
+                },
+            );
+        }
+        let stats: CorpusInducedDocumentSpinArtifactStats = wire.stats.into();
+        let classified = stats
+            .usable_prototypes
+            .checked_add(stats.rejected_single_document_prototypes)
+            .and_then(|value| value.checked_add(stats.rejected_single_state_prototypes))
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        if stats.construction_documents == 0
+            || stats.usable_prototypes != usize_u64(prototypes.len())?
+            || stats.observed_candidate_tokens != classified
+            || prototypes.values().any(|prototype| {
+                u64::from(prototype.construction_document_support) > stats.construction_documents
+                    || prototype.distinct_state_support > prototype.construction_document_support
+            })
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement artifact aggregate statistics are inconsistent".to_owned(),
+            ));
+        }
+        let expected_table_cid = table.artifact_cid();
+        let expected_overlay_cid = base_overlay.artifact_cid();
+        let expected_corpus_cid = if expected_table_cid == FROZEN_TABLE_CID
+            && expected_overlay_cid == FROZEN_OVERLAY_CID
+        {
+            FROZEN_CORPUS_CID
+        } else {
+            wire.construction_set_kappa.as_str()
+        };
+        if wire.table_artifact_cid != expected_table_cid
+            || wire.base_overlay_artifact_cid != expected_overlay_cid
+            || wire.corpus_cid != expected_corpus_cid
+            || (wire.table_artifact_cid == FROZEN_TABLE_CID
+                && wire.base_overlay_artifact_cid == FROZEN_OVERLAY_CID
+                && wire.construction_set_kappa != FROZEN_CONSTRUCTION_SET_KAPPA)
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement artifact corpus, table, or overlay identity is invalid".to_owned(),
+            ));
+        }
+        let operator = Self {
+            operator_cid: blake3_label(bytes),
+            corpus_cid: wire.corpus_cid,
+            table_artifact_cid: wire.table_artifact_cid,
+            base_overlay_artifact_cid: wire.base_overlay_artifact_cid,
+            construction_set_kappa: wire.construction_set_kappa,
+            leaf_basis_kappa: wire.leaf_basis_kappa,
+            induction_policy_kappa: wire.induction_policy_kappa,
+            query_policy_kappa: wire.query_policy_kappa,
+            h4_table,
+            max_token_id,
+            leaves,
+            prototypes,
+            stats,
+        };
+        operator.validate_binding(table, base_overlay)?;
+        if operator.to_bytes()? != bytes {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement artifact is noncanonical or binding-drifted".to_owned(),
+            ));
+        }
+        Ok(operator)
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, CorpusInducedDocumentSpinError> {
+        let prototypes = self
+            .prototypes
+            .values()
+            .map(|prototype| {
+                Ok(PrototypeWire {
+                    token: prototype.token,
+                    payload_cid: prototype.payload_cid.clone(),
+                    state: exact_state_wire(prototype.state, &self.h4_table)?,
+                    construction_document_support: prototype.construction_document_support,
+                    distinct_state_support: prototype.distinct_state_support,
+                    fit_audit: prototype.fit_audit,
+                })
+            })
+            .collect::<Result<Vec<_>, CorpusInducedDocumentSpinError>>()?;
+        let wire = ArtifactWire {
+            schema: ARTIFACT_SCHEMA,
+            domain: ARTIFACT_DOMAIN.to_owned(),
+            corpus_cid: self.corpus_cid.clone(),
+            table_artifact_cid: self.table_artifact_cid.clone(),
+            base_overlay_artifact_cid: self.base_overlay_artifact_cid.clone(),
+            construction_set_kappa: self.construction_set_kappa.clone(),
+            leaf_basis_kappa: self.leaf_basis_kappa.clone(),
+            induction_policy_kappa: self.induction_policy_kappa.clone(),
+            query_policy_kappa: self.query_policy_kappa.clone(),
+            h4_root_table_kappa: self.h4_table.h4_root_table_kappa.clone(),
+            h4_multiplication_table_kappa: self.h4_table.multiplication_table_kappa.clone(),
+            phase_modulus_q29: PHASE_MODULUS_Q29,
+            phase_half_q29: PHASE_HALF_Q29,
+            max_artifact_bytes: MAX_ARTIFACT_BYTES,
+            stats: self.stats.into(),
+            prototypes,
+        };
+        let payload = serde_json::to_vec(&wire)
+            .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+        let mut bytes = Vec::with_capacity(ARTIFACT_MAGIC.len() + payload.len());
+        bytes.extend_from_slice(&ARTIFACT_MAGIC);
+        bytes.extend_from_slice(&payload);
+        if bytes.len() > MAX_ARTIFACT_BYTES {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "corpus-induced placement artifact exceeds its byte ceiling".to_owned(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    pub fn artifact_cid(&self) -> Result<String, CorpusInducedDocumentSpinError> {
+        Ok(self.operator_cid.clone())
+    }
+
+    pub fn table_artifact_cid(&self) -> &str {
+        &self.table_artifact_cid
+    }
+
+    pub fn base_overlay_artifact_cid(&self) -> &str {
+        &self.base_overlay_artifact_cid
+    }
+
+    pub fn construction_set_kappa(&self) -> &str {
+        &self.construction_set_kappa
+    }
+
+    pub fn leaf_basis_kappa(&self) -> &str {
+        &self.leaf_basis_kappa
+    }
+
+    pub fn induction_policy_kappa(&self) -> &str {
+        &self.induction_policy_kappa
+    }
+
+    pub fn query_policy_kappa(&self) -> &str {
+        &self.query_policy_kappa
+    }
+
+    pub fn stats(&self) -> CorpusInducedDocumentSpinArtifactStats {
+        self.stats
+    }
+
+    pub fn prototype_traces(
+        &self,
+    ) -> Result<Vec<CorpusInducedDocumentSpinPrototypeTrace>, CorpusInducedDocumentSpinError> {
+        self.prototypes
+            .values()
+            .map(|prototype| {
+                Ok(CorpusInducedDocumentSpinPrototypeTrace {
+                    token: prototype.token,
+                    payload_cid: prototype.payload_cid.clone(),
+                    state: prototype.state.trace(&self.h4_table)?,
+                    construction_document_support: prototype.construction_document_support,
+                    distinct_state_support: prototype.distinct_state_support,
+                    h4_minimum_objective_sum: prototype.fit_audit.h4_minimum_objective_sum,
+                    h4_minimizer_count: prototype.fit_audit.h4_minimizer_count,
+                    fiber_minimum_objective_sum: prototype.fit_audit.fiber_minimum_objective_sum,
+                    fiber_minimizer_count: prototype.fit_audit.fiber_minimizer_count,
+                    torsion_minimum_objective_sum: prototype
+                        .fit_audit
+                        .torsion_minimum_objective_sum,
+                    torsion_minimizer_count: prototype.fit_audit.torsion_minimizer_count,
+                })
+            })
+            .collect()
+    }
+
+    fn validate_binding(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        if self.table_artifact_cid != table.artifact_cid()
+            || self.base_overlay_artifact_cid != base_overlay.artifact_cid()
+            || base_overlay.table_artifact_cid() != table.artifact_cid()
+            || self.max_token_id != table.maximum_token_id()
+            || self.leaves.len()
+                != usize::try_from(self.max_token_id)
+                    .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+                    .checked_add(1)
+                    .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement table, overlay, token namespace, or leaf binding mismatches".to_owned(),
+            ));
+        }
+        let expected_leaf_basis = identity_kappa(&[
+            LEAF_BASIS_DOMAIN,
+            LEAF_BASIS_IDENTITY,
+            self.table_artifact_cid.as_str(),
+            self.h4_table.h4_root_table_kappa.as_str(),
+            self.h4_table.multiplication_table_kappa.as_str(),
+        ]);
+        let expected_induction = identity_kappa(&[
+            INDUCTION_POLICY_DOMAIN,
+            INDUCTION_POLICY_IDENTITY,
+            self.table_artifact_cid.as_str(),
+            self.base_overlay_artifact_cid.as_str(),
+        ]);
+        let expected_query = identity_kappa(&[
+            QUERY_POLICY_DOMAIN,
+            QUERY_POLICY_IDENTITY,
+            self.table_artifact_cid.as_str(),
+            self.base_overlay_artifact_cid.as_str(),
+        ]);
+        if self.leaf_basis_kappa != expected_leaf_basis
+            || self.induction_policy_kappa != expected_induction
+            || self.query_policy_kappa != expected_query
+            || self.stats.usable_prototypes != usize_u64(self.prototypes.len())?
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "placement policy identity or prototype census does not reproduce".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parallel_construction_fixture() -> Vec<SourceDocument> {
+        const CANDIDATES: usize = 12;
+        const DOCUMENTS_PER_CANDIDATE: usize = 2;
+
+        let mut documents = Vec::with_capacity(CANDIDATES * DOCUMENTS_PER_CANDIDATE);
+        let mut next_id = 0_u64;
+        for candidate in 0..CANDIDATES {
+            for replica in 0..DOCUMENTS_PER_CANDIDATE {
+                let id = loop {
+                    let id = format!("worker-fixture-{next_id}");
+                    next_id += 1;
+                    if !crate::source_free_table::d3_is_held_out(&id) {
+                        break id;
+                    }
+                };
+                documents.push(SourceDocument::new(
+                    id,
+                    format!("Prelude{replica} common anchor choice{candidate}.").into_bytes(),
+                ));
+            }
+        }
+        documents
+    }
+
+    fn parallel_held_out_fixture() -> Vec<SourceDocument> {
+        const DOCUMENTS: usize = 16;
+
+        let mut held_out = Vec::with_capacity(DOCUMENTS);
+        let mut next_id = 0_u64;
+        while held_out.len() < DOCUMENTS {
+            let id = format!("heldout-worker-fixture-{next_id}");
+            next_id += 1;
+            if crate::source_free_table::d3_is_held_out(&id) {
+                let document = held_out.len();
+                held_out.push(SourceDocument::new(
+                    id,
+                    format!("Heldout{document} common anchor choice{}.", document % 12)
+                        .into_bytes(),
+                ));
+            }
+        }
+        held_out
+    }
+
+    fn target_mutation_fixture() -> [SourceDocument; 2] {
+        let mut ids = Vec::with_capacity(2);
+        let mut next_id = 0_u64;
+        while ids.len() < 2 {
+            let id = format!("heldout-target-mutation-{next_id}");
+            next_id += 1;
+            if crate::source_free_table::d3_is_held_out(&id) {
+                ids.push(id);
+            }
+        }
+        [
+            SourceDocument::new(ids.remove(0), b"Probe common anchor choice0.".to_vec()),
+            SourceDocument::new(ids.remove(0), b"Probe common anchor choice1.".to_vec()),
+        ]
+    }
+
+    fn small_construction_fixture() -> Vec<SourceDocument> {
+        [
+            ("14", "The red fox rests."),
+            ("657", "At noon the red fox rests."),
+            ("4579", "The red fox runs."),
+            ("5121", "At dusk the red fox runs."),
+        ]
+        .into_iter()
+        .map(|(id, text)| SourceDocument::new(id, text.as_bytes().to_vec()))
+        .collect()
+    }
+
+    fn brute_force_circular_medoid(values: &[i64]) -> (i64, u128, u32) {
+        let mut candidates = values.to_vec();
+        candidates.sort_unstable();
+        candidates.dedup();
+        let mut best = None;
+        for candidate in candidates {
+            let objective = values.iter().fold(0_u128, |sum, &value| {
+                sum + u128::from(
+                    crate::bounded_global_exact_spin_attention::circular_abs_q29(value - candidate),
+                )
+            });
+            match best {
+                None => best = Some((candidate, objective, 1_u32)),
+                Some((_, current, _)) if objective < current => {
+                    best = Some((candidate, objective, 1));
+                }
+                Some((selected, current, count)) if objective == current => {
+                    best = Some((selected, current, count + 1));
+                }
+                Some(_) => {}
+            }
+        }
+        best.expect("nonempty medoid fixture")
+    }
+
+    #[test]
+    fn one_and_eight_worker_compiles_have_identical_canonical_bytes(
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        let construction = parallel_construction_fixture();
+        let table = SourceFreeTable::compile(&construction)?;
+        let overlay = MultiscaleCountRadiusR4V1::compile(&table)?;
+        let serial = CorpusInducedDocumentSpinPlacementR4V1::compile_with_worker_count(
+            &table,
+            &overlay,
+            &construction,
+            Some(1),
+        )?;
+        let parallel = CorpusInducedDocumentSpinPlacementR4V1::compile_with_worker_count(
+            &table,
+            &overlay,
+            &construction,
+            Some(8),
+        )?;
+
+        assert!(
+            serial.stats().usable_prototypes >= 8,
+            "fixture must exercise candidate parallelism"
+        );
+        assert_eq!(serial.to_bytes()?, parallel.to_bytes()?);
+        assert_eq!(serial.artifact_cid()?, parallel.artifact_cid()?);
+        Ok(())
+    }
+
+    #[test]
+    fn one_and_eight_worker_document_scans_are_canonical(
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        let construction = parallel_construction_fixture();
+        let held_out = parallel_held_out_fixture();
+        let table = SourceFreeTable::compile(&construction)?;
+        let overlay = MultiscaleCountRadiusR4V1::compile(&table)?;
+        let operator =
+            CorpusInducedDocumentSpinPlacementR4V1::compile(&table, &overlay, &construction)?;
+        let serial_index = CorpusInducedDocumentSpinAntiRecallIndex::compile_with_worker_count(
+            &operator,
+            &table,
+            &overlay,
+            &construction,
+            Some(1),
+        )?;
+        let parallel_index = CorpusInducedDocumentSpinAntiRecallIndex::compile_with_worker_count(
+            &operator,
+            &table,
+            &overlay,
+            &construction,
+            Some(8),
+        )?;
+        assert_eq!(serial_index.index_kappa(), parallel_index.index_kappa());
+        assert_eq!(
+            serial_index.canonical_bytes()?,
+            parallel_index.canonical_bytes()?
+        );
+
+        let serial_census = operator.target_free_census_with_worker_count(
+            &table,
+            &overlay,
+            &serial_index,
+            &held_out,
+            Some(1),
+        )?;
+        let parallel_census = operator.target_free_census_with_worker_count(
+            &table,
+            &overlay,
+            &parallel_index,
+            &held_out,
+            Some(8),
+        )?;
+        assert!(serial_census.admission_opportunities > 0);
+        assert_eq!(
+            serial_census.canonical_bytes()?,
+            parallel_census.canonical_bytes()?
+        );
+        assert_eq!(
+            serial_census.artifact_cid()?,
+            parallel_census.artifact_cid()?
+        );
+        assert_eq!(serial_census.forbidden_reads.held_out_target_reads, 0);
+        assert_eq!(parallel_census.forbidden_reads.held_out_target_reads, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn target_free_scan_freezes_prediction_before_current_target(
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        let construction = parallel_construction_fixture();
+        let table = SourceFreeTable::compile(&construction)?;
+        let overlay = MultiscaleCountRadiusR4V1::compile(&table)?;
+        let operator =
+            CorpusInducedDocumentSpinPlacementR4V1::compile(&table, &overlay, &construction)?;
+        let documents = target_mutation_fixture();
+        let left_stream = table.encode_document_stream(&documents[0])?;
+        let right_stream = table.encode_document_stream(&documents[1])?;
+        let target_index = left_stream
+            .iter()
+            .zip(&right_stream)
+            .position(|(left, right)| left != right)
+            .expect("mutation fixture must contain one distinct current target");
+        assert_eq!(&left_stream[..target_index], &right_stream[..target_index]);
+
+        let left = scan_one_target_free_document(&operator, &table, &overlay, &documents[0])?;
+        let right = scan_one_target_free_document(&operator, &table, &overlay, &documents[1])?;
+        let left_candidate = left
+            .candidates
+            .iter()
+            .find(|candidate| candidate.position.target_index as usize == target_index)
+            .expect("left mutation target must be an admitted maximum-count tie");
+        let right_candidate = right
+            .candidates
+            .iter()
+            .find(|candidate| candidate.position.target_index as usize == target_index)
+            .expect("right mutation target must be an admitted maximum-count tie");
+
+        assert_eq!(left_candidate.prefix_cid, right_candidate.prefix_cid);
+        assert_eq!(left_candidate.natural_state, right_candidate.natural_state);
+        assert_eq!(left_candidate.omega_cid, right_candidate.omega_cid);
+        assert_eq!(left_candidate.prediction, right_candidate.prediction);
+        assert_eq!(
+            left_candidate.position.prediction_cid,
+            right_candidate.position.prediction_cid
+        );
+        assert_eq!(
+            left_candidate
+                .prediction
+                .forbidden_reads
+                .held_out_target_reads,
+            0
+        );
+        assert_eq!(
+            right_candidate
+                .prediction
+                .forbidden_reads
+                .held_out_target_reads,
+            0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn trusted_cid_and_single_byte_tamper_are_rejected(
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        let construction = small_construction_fixture();
+        let table = SourceFreeTable::compile(&construction)?;
+        let overlay = MultiscaleCountRadiusR4V1::compile(&table)?;
+        let operator =
+            CorpusInducedDocumentSpinPlacementR4V1::compile(&table, &overlay, &construction)?;
+        let bytes = operator.to_bytes()?;
+        let expected_cid = operator.artifact_cid()?;
+        let wrong_cid = format!("blake3:{}", "00".repeat(32));
+
+        let wrong_cid_error = CorpusInducedDocumentSpinPlacementR4V1::from_bytes(
+            &table, &overlay, &wrong_cid, &bytes,
+        )
+        .expect_err("trusted CID mismatch must reject canonical bytes");
+        assert!(wrong_cid_error.to_string().contains("trusted expected CID"));
+
+        let mut tampered = bytes.clone();
+        tampered[ARTIFACT_MAGIC.len()] ^= 1;
+        let trusted_tamper_error = CorpusInducedDocumentSpinPlacementR4V1::from_bytes(
+            &table,
+            &overlay,
+            &expected_cid,
+            &tampered,
+        )
+        .expect_err("single-byte tamper must fail the trusted CID");
+        assert!(trusted_tamper_error
+            .to_string()
+            .contains("trusted expected CID"));
+
+        let tampered_cid = blake3_label(&tampered);
+        assert!(CorpusInducedDocumentSpinPlacementR4V1::from_bytes(
+            &table,
+            &overlay,
+            &tampered_cid,
+            &tampered,
+        )
+        .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn target_derived_score_frame_is_rejected() {
+        let error = injected_target_score_firewall_control()
+            .expect_err("target-derived query state must not receive a score certificate");
+        assert!(error.to_string().contains("score firewall rejected"));
+    }
+
+    #[test]
+    fn imbalanced_executed_prefix_work_is_rejected() {
+        let error = imbalanced_work_score_firewall_control()
+            .expect_err("imbalanced executed-prefix work must not receive a score certificate");
+        assert!(error.to_string().contains("imbalanced executed-prefix"));
+    }
+
+    #[test]
+    fn optimized_circular_medoid_matches_brute_force_at_boundaries(
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        let mut cases = vec![
+            vec![0],
+            vec![-PHASE_HALF_Q29, PHASE_HALF_Q29 - 1],
+            vec![-PHASE_HALF_Q29, 0, PHASE_HALF_Q29 - 1],
+            vec![-PHASE_HALF_Q29, -PHASE_HALF_Q29, PHASE_HALF_Q29 - 1],
+            vec![-1, 0, 1],
+            vec![-7, -7, 11, 11],
+        ];
+        let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+        for length in 1..=32_usize {
+            let mut values = Vec::with_capacity(length);
+            for _ in 0..length {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                values.push(
+                    i64::try_from(state % PHASE_MODULUS_Q29 as u64)
+                        .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+                        - PHASE_HALF_Q29,
+                );
+            }
+            cases.push(values);
+        }
+
+        for values in cases {
+            assert_eq!(
+                circular_medoid(values.iter().copied())?,
+                brute_force_circular_medoid(&values),
+                "optimized circular medoid drifted for {values:?}",
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct ComparatorAccumulator {
+    wins: u64,
+    losses: u64,
+    ties: u64,
+}
+
+impl ComparatorAccumulator {
+    fn observe(
+        &mut self,
+        real_correct: bool,
+        comparator_correct: bool,
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        match (real_correct, comparator_correct) {
+            (true, false) => self.wins = checked_add_u64(self.wins, 1)?,
+            (false, true) => self.losses = checked_add_u64(self.losses, 1)?,
+            _ => self.ties = checked_add_u64(self.ties, 1)?,
+        }
+        Ok(())
+    }
+
+    fn observe_counts(
+        &mut self,
+        real_correct: u64,
+        comparator_correct: u64,
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        match real_correct.cmp(&comparator_correct) {
+            std::cmp::Ordering::Greater => self.wins = checked_add_u64(self.wins, 1)?,
+            std::cmp::Ordering::Less => self.losses = checked_add_u64(self.losses, 1)?,
+            std::cmp::Ordering::Equal => self.ties = checked_add_u64(self.ties, 1)?,
+        }
+        Ok(())
+    }
+
+    fn finish(
+        self,
+    ) -> Result<CorpusInducedDocumentSpinComparatorEvaluation, CorpusInducedDocumentSpinError> {
+        let discordant = checked_add_u64(self.wins, self.losses)?;
+        let exact_threshold_passes = exact_one_sided_sign_test_passes(self.wins, self.losses)?;
+        let passes = self.wins > self.losses && exact_threshold_passes;
+        Ok(CorpusInducedDocumentSpinComparatorEvaluation {
+            wins: self.wins,
+            losses: self.losses,
+            ties: self.ties,
+            discordant,
+            one_sided_exact_sign_test: format!(
+                "20*sum_{{k=0}}^{{{}}} C({discordant},k) <= 2^{discordant}: {exact_threshold_passes}",
+                self.losses,
+            ),
+            passes,
+            terminal: if passes {
+                "PASS_DIRECTIONAL_EXACT_SIGN_TEST"
+            } else {
+                "FAIL_DIRECTIONAL_EXACT_SIGN_TEST"
+            }
+            .to_owned(),
+        })
+    }
+}
+
+impl CorpusInducedDocumentSpinPlacementR4V1 {
+    /// Perform the single authorized next-route join against an already-frozen
+    /// target-free census.
+    pub fn evaluate_held_out(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        anti_recall: &CorpusInducedDocumentSpinAntiRecallIndex,
+        census: &CorpusInducedDocumentSpinTargetFreeCensus,
+        held_out: &[SourceDocument],
+    ) -> Result<CorpusInducedDocumentSpinEvaluation, CorpusInducedDocumentSpinError> {
+        self.validate_binding(table, base_overlay)?;
+        if !table.is_disjoint_d3_held_out_documents(held_out)
+            || census.schema != ARTIFACT_SCHEMA
+            || census.domain != ANTI_RECALL_DOMAIN
+            || census.operator_cid != self.operator_cid
+            || census.held_out_set_kappa != document_set_kappa(HELD_OUT_SET_DOMAIN, held_out)?
+            || census.held_out_documents != usize_u64(held_out.len())?
+            || census.invalid_score_firewall_certificates != 0
+            || census.score_firewall_policy_kappa != identity_kappa(&[SCORE_FIREWALL_POLICY])
+            || census.forbidden_reads.total() != 0
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "held-out evaluation is not bound to the frozen target-free census".to_owned(),
+            ));
+        }
+        let reproduced = self.target_free_census(table, base_overlay, anti_recall, held_out)?;
+        if reproduced.canonical_bytes()? != census.canonical_bytes()? {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "target-free census does not reproduce byte-identically before target join"
+                    .to_owned(),
+            ));
+        }
+        if !census.meets_frozen_preflight {
+            let empty = ComparatorAccumulator::default().finish()?;
+            return Ok(CorpusInducedDocumentSpinEvaluation {
+                schema: ARTIFACT_SCHEMA,
+                domain: "uor-r4.corpus-induced-document-spin-evaluation/1".to_owned(),
+                decision: UNAVAILABLE_TERMINAL.to_owned(),
+                operator_cid: self.operator_cid.clone(),
+                census_cid: census.artifact_cid()?,
+                held_out_set_kappa: census.held_out_set_kappa.clone(),
+                held_out_documents: census.held_out_documents,
+                post_join_admission_opportunities: 0,
+                post_join_known_target_admission_opportunities: 0,
+                operative_positions: usize_u64(census.operative_positions.len())?,
+                operative_known_target_positions: 0,
+                real_correct: 0,
+                scope_disabled_correct: 0,
+                order_shuffled_correct: 0,
+                operator_permuted_correct: 0,
+                witness_continuation_contrast: false,
+                witness_continuation: None,
+                witness_continuation_cid: None,
+                versus_scope_disabled: empty.clone(),
+                versus_order_shuffled: empty.clone(),
+                versus_operator_permuted: empty.clone(),
+                document_blocked_versus_scope_disabled: empty.clone(),
+                document_blocked_versus_order_shuffled: empty.clone(),
+                document_blocked_versus_operator_permuted: empty,
+                target_reads: 0,
+                forbidden_reads: census.forbidden_reads,
+            });
+        }
+        let mut operative =
+            BTreeMap::<(String, u32), &CorpusInducedDocumentSpinCensusPosition>::new();
+        for position in &census.operative_positions {
+            if operative
+                .insert(
+                    (position.document_id.clone(), position.target_index),
+                    position,
+                )
+                .is_some()
+            {
+                return Err(CorpusInducedDocumentSpinError::Invalid(
+                    "target-free census contains a duplicate operative position".to_owned(),
+                ));
+            }
+        }
+        let census_cid = census.artifact_cid()?;
+        let witness_key = census
+            .frozen_decoded_witness
+            .as_ref()
+            .map(|position| (position.document_id.clone(), position.target_index));
+        let mut witness_prefix = None;
+        let mut documents = held_out.iter().collect::<Vec<_>>();
+        documents.sort_by(|left, right| left.id.cmp(&right.id));
+        let mut post_join_admission_opportunities = 0_u64;
+        let mut post_join_known_target_admission_opportunities = 0_u64;
+        let mut operative_positions = 0_u64;
+        let mut operative_known_target_positions = 0_u64;
+        let mut real_correct = 0_u64;
+        let mut scope_disabled_correct = 0_u64;
+        let mut order_shuffled_correct = 0_u64;
+        let mut operator_permuted_correct = 0_u64;
+        let mut target_reads = 0_u64;
+        let mut evaluation_forbidden_reads = CorpusInducedDocumentSpinForbiddenReads::default();
+        let mut versus_scope_disabled = ComparatorAccumulator::default();
+        let mut versus_order_shuffled = ComparatorAccumulator::default();
+        let mut versus_operator_permuted = ComparatorAccumulator::default();
+        let mut document_blocked_versus_scope_disabled = ComparatorAccumulator::default();
+        let mut document_blocked_versus_order_shuffled = ComparatorAccumulator::default();
+        let mut document_blocked_versus_operator_permuted = ComparatorAccumulator::default();
+        for document in &documents {
+            let mut document_real_correct = 0_u64;
+            let mut document_scope_disabled_correct = 0_u64;
+            let mut document_order_shuffled_correct = 0_u64;
+            let mut document_operator_permuted_correct = 0_u64;
+            let stream = table.encode_document_stream(document)?;
+            let mut cursor = CausalPrefixCursor::new(&self.h4_table)?;
+            cursor.advance(BOS_TOKEN, &self.leaves, &self.h4_table)?;
+            let mut prefix_hash = PrefixDigestState::new();
+            prefix_hash.append(BOS_TOKEN);
+            for target_index in 1..stream.len() {
+                let prefix = &stream[..target_index];
+                let local = table.predict_multiscale_count_radius(prefix, base_overlay)?;
+                let prediction = active_maximum_tie(&local)
+                    .then(|| self.predict_from_frame(local, cursor.frame()))
+                    .transpose()?;
+                // This is the only label-bearing held-out read in this API.
+                let target = stream[target_index];
+                target_reads = checked_add_u64(target_reads, 1)?;
+                if let Some(prediction) = prediction {
+                    evaluation_forbidden_reads.saturating_accumulate(prediction.forbidden_reads);
+                    post_join_admission_opportunities =
+                        checked_add_u64(post_join_admission_opportunities, 1)?;
+                    let fitted_target = table.is_fitted_lexical_token(target);
+                    if fitted_target {
+                        post_join_known_target_admission_opportunities =
+                            checked_add_u64(post_join_known_target_admission_opportunities, 1)?;
+                    }
+                    let target_index_u32 = u32::try_from(target_index)
+                        .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+                    if let Some(expected) = operative.get(&(document.id.clone(), target_index_u32))
+                    {
+                        let row = active_row_key(prefix, prediction.local.order)?;
+                        let actual = CorpusInducedDocumentSpinCensusPosition {
+                            document_id: document.id.clone(),
+                            target_index: target_index_u32,
+                            prefix_cid: digest_label(prefix_hash.digest()),
+                            row_cid: row_label(&row),
+                            support_cid: support_label(&prediction.real.support_tokens),
+                            prediction_cid: prediction_label(&prediction)?,
+                            real_token: prediction.real.token,
+                            scope_disabled_token: prediction.scope_disabled.token,
+                            order_shuffled_token: prediction.order_shuffled.token,
+                            operator_permuted_token: prediction.operator_permuted.token,
+                        };
+                        if actual != **expected {
+                            return Err(CorpusInducedDocumentSpinError::Invalid(
+                                "operative prediction drifted after target attachment".to_owned(),
+                            ));
+                        }
+                        if witness_key.as_ref() == Some(&(document.id.clone(), target_index_u32)) {
+                            witness_prefix = Some(prefix.to_vec());
+                        }
+                        operative_positions = checked_add_u64(operative_positions, 1)?;
+                        if fitted_target {
+                            operative_known_target_positions =
+                                checked_add_u64(operative_known_target_positions, 1)?;
+                            let real_hit = prediction.real.token == target;
+                            let scope_hit = prediction.scope_disabled.token == target;
+                            let order_hit = prediction.order_shuffled.token == target;
+                            let permuted_hit = prediction.operator_permuted.token == target;
+                            if real_hit {
+                                real_correct = checked_add_u64(real_correct, 1)?;
+                                document_real_correct = checked_add_u64(document_real_correct, 1)?;
+                            }
+                            if scope_hit {
+                                scope_disabled_correct =
+                                    checked_add_u64(scope_disabled_correct, 1)?;
+                                document_scope_disabled_correct =
+                                    checked_add_u64(document_scope_disabled_correct, 1)?;
+                            }
+                            if order_hit {
+                                order_shuffled_correct =
+                                    checked_add_u64(order_shuffled_correct, 1)?;
+                                document_order_shuffled_correct =
+                                    checked_add_u64(document_order_shuffled_correct, 1)?;
+                            }
+                            if permuted_hit {
+                                operator_permuted_correct =
+                                    checked_add_u64(operator_permuted_correct, 1)?;
+                                document_operator_permuted_correct =
+                                    checked_add_u64(document_operator_permuted_correct, 1)?;
+                            }
+                            versus_scope_disabled.observe(real_hit, scope_hit)?;
+                            versus_order_shuffled.observe(real_hit, order_hit)?;
+                            versus_operator_permuted.observe(real_hit, permuted_hit)?;
+                        }
+                    }
+                } else if operative.contains_key(&(
+                    document.id.clone(),
+                    u32::try_from(target_index)
+                        .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+                )) {
+                    return Err(CorpusInducedDocumentSpinError::Invalid(
+                        "operative census position is no longer admitted".to_owned(),
+                    ));
+                }
+                cursor.advance(target, &self.leaves, &self.h4_table)?;
+                prefix_hash.append(target);
+            }
+            document_blocked_versus_scope_disabled
+                .observe_counts(document_real_correct, document_scope_disabled_correct)?;
+            document_blocked_versus_order_shuffled
+                .observe_counts(document_real_correct, document_order_shuffled_correct)?;
+            document_blocked_versus_operator_permuted
+                .observe_counts(document_real_correct, document_operator_permuted_correct)?;
+        }
+        if operative_positions != usize_u64(census.operative_positions.len())?
+            || post_join_admission_opportunities != census.admission_opportunities
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "post-join structural population differs from the target-free census".to_owned(),
+            ));
+        }
+        if witness_key.is_some() && witness_prefix.is_none() {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "frozen decoded witness was not reproduced during target join".to_owned(),
+            ));
+        }
+        let frozen_identity = self.corpus_cid == FROZEN_CORPUS_CID
+            && self.table_artifact_cid == FROZEN_TABLE_CID
+            && self.base_overlay_artifact_cid == FROZEN_OVERLAY_CID;
+        if frozen_identity
+            && (post_join_admission_opportunities != FROZEN_TARGET_FREE_ADMISSIONS
+                || post_join_known_target_admission_opportunities != 76_641
+                || usize_u64(documents.len())? != FROZEN_HELD_OUT_DOCUMENTS)
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "frozen 81,177/76,641 post-join population did not reproduce".to_owned(),
+            ));
+        }
+        let versus_scope_disabled = versus_scope_disabled.finish()?;
+        let versus_order_shuffled = versus_order_shuffled.finish()?;
+        let versus_operator_permuted = versus_operator_permuted.finish()?;
+        let document_blocked_versus_scope_disabled =
+            document_blocked_versus_scope_disabled.finish()?;
+        let document_blocked_versus_order_shuffled =
+            document_blocked_versus_order_shuffled.finish()?;
+        let document_blocked_versus_operator_permuted =
+            document_blocked_versus_operator_permuted.finish()?;
+        let witness_continuation = if let Some(prefix) = witness_prefix {
+            Some(self.continue_matched(table, base_overlay, &prefix, MAX_CONTINUATION_UNITS)?)
+        } else {
+            None
+        };
+        let witness_continuation_contrast = if let Some(continuation) = &witness_continuation {
+            continuation.real.decoded != continuation.scope_disabled.decoded
+                && continuation.real.decoded != continuation.order_shuffled.decoded
+                && continuation.real.decoded != continuation.operator_permuted.decoded
+        } else {
+            false
+        };
+        let witness_continuation_cid = witness_continuation
+            .as_ref()
+            .map(|continuation| {
+                serde_json::to_vec(continuation)
+                    .map(|bytes| blake3_label(&bytes))
+                    .map_err(|error| {
+                        CorpusInducedDocumentSpinError::Serialization(error.to_string())
+                    })
+            })
+            .transpose()?;
+        let decision = if versus_scope_disabled.passes
+            && versus_order_shuffled.passes
+            && versus_operator_permuted.passes
+            && document_blocked_versus_scope_disabled.passes
+            && document_blocked_versus_order_shuffled.passes
+            && document_blocked_versus_operator_permuted.passes
+            && witness_continuation_contrast
+        {
+            POSITIVE_TERMINAL
+        } else {
+            NEGATIVE_TERMINAL
+        };
+        Ok(CorpusInducedDocumentSpinEvaluation {
+            schema: ARTIFACT_SCHEMA,
+            domain: "uor-r4.corpus-induced-document-spin-evaluation/1".to_owned(),
+            decision: decision.to_owned(),
+            operator_cid: self.operator_cid.clone(),
+            census_cid,
+            held_out_set_kappa: census.held_out_set_kappa.clone(),
+            held_out_documents: usize_u64(documents.len())?,
+            post_join_admission_opportunities,
+            post_join_known_target_admission_opportunities,
+            operative_positions,
+            operative_known_target_positions,
+            real_correct,
+            scope_disabled_correct,
+            order_shuffled_correct,
+            operator_permuted_correct,
+            witness_continuation_contrast,
+            witness_continuation,
+            witness_continuation_cid,
+            versus_scope_disabled,
+            versus_order_shuffled,
+            versus_operator_permuted,
+            document_blocked_versus_scope_disabled,
+            document_blocked_versus_order_shuffled,
+            document_blocked_versus_operator_permuted,
+            target_reads,
+            forbidden_reads: evaluation_forbidden_reads,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct UnsignedLimbs(Vec<u32>);
+
+impl UnsignedLimbs {
+    fn one() -> Self {
+        Self(vec![1])
+    }
+
+    fn power_of_two(exponent: u64) -> Result<Self, CorpusInducedDocumentSpinError> {
+        let word = usize::try_from(exponent / 32)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let mut limbs = vec![
+            0_u32;
+            word.checked_add(1)
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+        ];
+        limbs[word] = 1_u32 << (exponent % 32);
+        Ok(Self(limbs))
+    }
+
+    fn multiply_small(&mut self, factor: u64) -> Result<(), CorpusInducedDocumentSpinError> {
+        let mut carry = 0_u128;
+        for limb in &mut self.0 {
+            let product = u128::from(*limb)
+                .checked_mul(u128::from(factor))
+                .and_then(|value| value.checked_add(carry))
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+            *limb = product as u32;
+            carry = product >> 32;
+        }
+        while carry != 0 {
+            self.0.push(carry as u32);
+            carry >>= 32;
+        }
+        Ok(())
+    }
+
+    fn divide_small_exact(&mut self, divisor: u64) -> Result<(), CorpusInducedDocumentSpinError> {
+        if divisor == 0 {
+            return Err(CorpusInducedDocumentSpinError::ArithmeticOverflow);
+        }
+        let mut remainder = 0_u128;
+        for limb in self.0.iter_mut().rev() {
+            let dividend = (remainder << 32) | u128::from(*limb);
+            let quotient = dividend / u128::from(divisor);
+            remainder = dividend % u128::from(divisor);
+            *limb = u32::try_from(quotient)
+                .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        }
+        if remainder != 0 {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "binomial recurrence division was not exact".to_owned(),
+            ));
+        }
+        self.normalize();
+        Ok(())
+    }
+
+    fn add_assign(&mut self, other: &Self) -> Result<(), CorpusInducedDocumentSpinError> {
+        if self.0.len() < other.0.len() {
+            self.0.resize(other.0.len(), 0);
+        }
+        let mut carry = 0_u64;
+        for index in 0..self.0.len() {
+            let right = other.0.get(index).copied().unwrap_or(0);
+            let sum = u64::from(self.0[index]) + u64::from(right) + carry;
+            self.0[index] = sum as u32;
+            carry = sum >> 32;
+        }
+        if carry != 0 {
+            self.0.push(
+                u32::try_from(carry)
+                    .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+            );
+        }
+        Ok(())
+    }
+
+    fn normalize(&mut self) {
+        while self.0.len() > 1 && self.0.last() == Some(&0) {
+            self.0.pop();
+        }
+    }
+}
+
+impl PartialOrd for UnsignedLimbs {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UnsignedLimbs {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .len()
+            .cmp(&other.0.len())
+            .then_with(|| self.0.iter().rev().cmp(other.0.iter().rev()))
+    }
+}
+
+fn exact_one_sided_sign_test_passes(
+    wins: u64,
+    losses: u64,
+) -> Result<bool, CorpusInducedDocumentSpinError> {
+    let n = checked_add_u64(wins, losses)?;
+    if n == 0 || wins <= losses {
+        return Ok(false);
+    }
+    // By symmetry P[X >= wins] = sum_{k=0}^{losses} C(n,k) / 2^n.
+    // Compare to 1/20 with an exact little-endian unsigned limb integer.
+    let mut term = UnsignedLimbs::one();
+    let mut cumulative = term.clone();
+    for k in 1..=losses {
+        term.multiply_small(n - k + 1)?;
+        term.divide_small_exact(k)?;
+        cumulative.add_assign(&term)?;
+    }
+    cumulative.multiply_small(20)?;
+    Ok(cumulative <= UnsignedLimbs::power_of_two(n)?)
+}
+
+fn continue_arm(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    prefix: &[u32],
+    max_units: usize,
+    arm: CorpusInducedDocumentSpinArm,
+) -> Result<Continuation, CorpusInducedDocumentSpinError> {
+    let mut context = prefix.to_vec();
+    let mut generated = Vec::new();
+    let mut stop = ContinuationStop::Bound;
+    while generated.len() < max_units {
+        let prediction = operator.predict_matched_bound(table, base_overlay, &context)?;
+        let token = match arm {
+            CorpusInducedDocumentSpinArm::Real => prediction.real.token,
+            CorpusInducedDocumentSpinArm::ScopeDisabled => prediction.scope_disabled.token,
+            CorpusInducedDocumentSpinArm::OrderShuffled => prediction.order_shuffled.token,
+            CorpusInducedDocumentSpinArm::OperatorPermuted => prediction.operator_permuted.token,
+        };
+        if token == EOS_TOKEN {
+            stop = ContinuationStop::EndOfDocument;
+            break;
+        }
+        if generated.last() == Some(&token) {
+            stop = ContinuationStop::PeriodOneCycle;
+            break;
+        }
+        if generated.len() >= 3
+            && generated[generated.len() - 2] == token
+            && generated[generated.len() - 3] == generated[generated.len() - 1]
+        {
+            stop = ContinuationStop::PeriodTwoCycle;
+            break;
+        }
+        generated.push(token);
+        context.push(token);
+    }
+    let decoded = table.decode_tokens(&generated)?;
+    Ok(Continuation {
+        tokens: generated,
+        decoded,
+        stop,
+    })
+}
+
+#[derive(Serialize)]
+struct OmegaCandidateWire<'a> {
+    token: u32,
+    relative_state: &'a BoundedGlobalExactSpinStateTrace,
+    cost: BoundedGlobalExactSpinCost,
+}
+
+#[derive(Serialize)]
+struct OmegaWire<'a> {
+    order: u8,
+    support: &'a [u32],
+    natural_state: &'a BoundedGlobalExactSpinStateTrace,
+    candidates: Vec<OmegaCandidateWire<'a>>,
+}
+
+fn digest_label(digest: [u8; 32]) -> String {
+    format!("blake3:{}", hex::encode(digest))
+}
+
+fn active_row_key(
+    prefix: &[u32],
+    order: BackoffOrder,
+) -> Result<ActiveRowKey, CorpusInducedDocumentSpinError> {
+    match order {
+        BackoffOrder::Trigram if prefix.len() >= 2 => Ok(ActiveRowKey {
+            order: 2,
+            previous_two: prefix[prefix.len() - 2],
+            previous_one: prefix[prefix.len() - 1],
+        }),
+        BackoffOrder::Bigram if !prefix.is_empty() => Ok(ActiveRowKey {
+            order: 1,
+            previous_two: BOS_TOKEN,
+            previous_one: prefix[prefix.len() - 1],
+        }),
+        _ => Err(CorpusInducedDocumentSpinError::Invalid(
+            "active document-spin row lacks its causal context".to_owned(),
+        )),
+    }
+}
+
+fn row_label(row: &ActiveRowKey) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ROW_DOMAIN);
+    hasher.update(&[row.order]);
+    hasher.update(&row.previous_two.to_le_bytes());
+    hasher.update(&row.previous_one.to_le_bytes());
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn support_label(support: &[u32]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(SUPPORT_DOMAIN);
+    hasher.update(&(support.len() as u64).to_le_bytes());
+    for token in support {
+        hasher.update(&token.to_le_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn prediction_label(
+    prediction: &MatchedCorpusInducedDocumentSpinPrediction,
+) -> Result<String, CorpusInducedDocumentSpinError> {
+    let bytes = serde_json::to_vec(prediction)
+        .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(PREDICTION_DOMAIN);
+    hasher.update(&bytes);
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+fn omega_digest(
+    prediction: &MatchedCorpusInducedDocumentSpinPrediction,
+) -> Result<[u8; 32], CorpusInducedDocumentSpinError> {
+    let candidates = prediction
+        .candidate_evidence
+        .iter()
+        .map(|candidate| OmegaCandidateWire {
+            token: candidate.token,
+            relative_state: &candidate.real_relative_state,
+            cost: candidate.real_cost,
+        })
+        .collect();
+    let wire = OmegaWire {
+        order: match prediction.local.order {
+            BackoffOrder::Unigram => 0,
+            BackoffOrder::Bigram => 1,
+            BackoffOrder::Trigram => 2,
+        },
+        support: &prediction.real.support_tokens,
+        natural_state: &prediction.natural_state,
+        candidates,
+    };
+    let bytes = serde_json::to_vec(&wire)
+        .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ANTI_RECALL_DOMAIN.as_bytes());
+    hasher.update(ANTI_RECALL_POLICY_IDENTITY.as_bytes());
+    hasher.update(&bytes);
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn anti_recall_kappa(
+    operator_cid: &str,
+    construction_set_kappa: &str,
+    prefixes: &BTreeSet<[u8; 32]>,
+    states: &BTreeSet<ExactStateWire>,
+    signatures: &BTreeSet<[u8; 32]>,
+) -> Result<String, CorpusInducedDocumentSpinError> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ANTI_RECALL_DOMAIN.as_bytes());
+    hasher.update(ANTI_RECALL_POLICY_IDENTITY.as_bytes());
+    hasher.update(operator_cid.as_bytes());
+    hasher.update(construction_set_kappa.as_bytes());
+    hasher.update(&usize_u64(prefixes.len())?.to_le_bytes());
+    for prefix in prefixes {
+        hasher.update(prefix);
+    }
+    let states = serde_json::to_vec(states)
+        .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+    hasher.update(&states);
+    hasher.update(&usize_u64(signatures.len())?.to_le_bytes());
+    for signature in signatures {
+        hasher.update(signature);
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+fn compile_identity_leaves(
+    max_token_id: u32,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<Vec<ExactSpinState>, CorpusInducedDocumentSpinError> {
+    let count = usize::try_from(max_token_id)
+        .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+        .checked_add(1)
+        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+    let primes = first_primes(count)?;
+    let one = 1_i32 << 30;
+    let half = 1_i32 << 29;
+    let roots = [
+        exact_s3_spin_to_h4([one, 0, 0, 0], table)?,
+        exact_s3_spin_to_h4([0, one, 0, 0], table)?,
+        exact_s3_spin_to_h4([half, half, half, half], table)?,
+        exact_s3_spin_to_h4([half, -half, half, -half], table)?,
+    ];
+    let mut leaves = Vec::with_capacity(count);
+    for token in 0..=max_token_id {
+        if token == BOS_TOKEN {
+            leaves.push(ExactSpinState::identity(table)?);
+            continue;
+        }
+        let index = usize::try_from(token)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let prime = i64::try_from(primes[index])
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let rank = i64::from(token);
+        let fiber = prime
+            .checked_mul(1_000_003)
+            .and_then(|value| {
+                rank.checked_mul(17_071)
+                    .and_then(|add| value.checked_add(add))
+            })
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let torsion = prime
+            .checked_mul(-97_409)
+            .and_then(|value| {
+                rank.checked_mul(7_919)
+                    .and_then(|add| value.checked_add(add))
+            })
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        leaves.push(ExactSpinState::from_parts(
+            roots[index % roots.len()],
+            wrap_phase_for_compile(fiber)?,
+            wrap_phase_for_compile(torsion)?,
+            table,
+        )?);
+    }
+    Ok(leaves)
+}
+
+fn compile_one_construction_document(
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    document: &SourceDocument,
+    leaves: &[ExactSpinState],
+    h4_table: &H4BinaryIcosahedralClosure,
+) -> Result<DocumentCompilation, CorpusInducedDocumentSpinError> {
+    let stream = table.encode_document_stream(document)?;
+    let mut natural = ExactSpinState::identity(h4_table)?;
+    let mut retained_in_document = BTreeSet::<u32>::new();
+    let mut eligible_positions = 0_u64;
+    let mut exemplars = Vec::new();
+    for target_index in 1..stream.len() {
+        let local = table.predict_multiscale_count_radius(&stream[..target_index], base_overlay)?;
+        let target = stream[target_index];
+        if active_maximum_tie(&local)
+            && table.is_fitted_lexical_token(target)
+            && local.max_count_tie_tokens.binary_search(&target).is_ok()
+        {
+            eligible_positions = checked_add_u64(eligible_positions, 1)?;
+            if retained_in_document.insert(target) {
+                exemplars.push((
+                    target,
+                    ConstructionExemplar {
+                        document_id: document.id.clone(),
+                        state: natural,
+                    },
+                ));
+            }
+        }
+        natural = natural.compose(leaf_for_token(leaves, target)?, h4_table)?;
+    }
+    Ok(DocumentCompilation {
+        eligible_positions,
+        exemplars,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn compile_construction_documents(
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    leaves: &[ExactSpinState],
+    h4_table: &H4BinaryIcosahedralClosure,
+    _worker_count: Option<usize>,
+) -> Result<Vec<DocumentCompilation>, CorpusInducedDocumentSpinError> {
+    documents
+        .iter()
+        .map(|document| {
+            compile_one_construction_document(table, base_overlay, document, leaves, h4_table)
+        })
+        .collect()
+}
+
+fn compile_one_candidate_prototype(
+    table: &SourceFreeTable,
+    token: u32,
+    rows: &[ConstructionExemplar],
+    h4_table: &H4BinaryIcosahedralClosure,
+) -> Result<CandidateCompilation, CorpusInducedDocumentSpinError> {
+    let document_support = rows
+        .iter()
+        .map(|row| row.document_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    if document_support
+        < usize::try_from(MIN_PROTOTYPE_DOCUMENTS)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+    {
+        return Ok(CandidateCompilation::RejectedSingleDocument);
+    }
+    let distinct_states = rows
+        .iter()
+        .map(|row| exact_state_wire(row.state, h4_table))
+        .collect::<Result<BTreeSet<_>, _>>()?
+        .len();
+    if distinct_states
+        < usize::try_from(MIN_DISTINCT_PROTOTYPE_STATES)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?
+    {
+        return Ok(CandidateCompilation::RejectedSingleState);
+    }
+    let states = rows.iter().map(|row| row.state).collect::<Vec<_>>();
+    let (state, fit_audit) = fit_componentwise_frechet_prototype(&states, h4_table)?;
+    let payload = table.decode_tokens(&[token])?;
+    Ok(CandidateCompilation::Usable(Prototype {
+        token,
+        payload_cid: blake3_label(&payload),
+        state,
+        construction_document_support: u32::try_from(document_support)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+        distinct_state_support: u32::try_from(distinct_states)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+        fit_audit,
+    }))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn compile_candidate_prototypes(
+    table: &SourceFreeTable,
+    rows: &[(u32, Vec<ConstructionExemplar>)],
+    h4_table: &H4BinaryIcosahedralClosure,
+    _worker_count: Option<usize>,
+) -> Result<Vec<CandidateCompilation>, CorpusInducedDocumentSpinError> {
+    rows.iter()
+        .map(|(token, exemplars)| {
+            compile_one_candidate_prototype(table, *token, exemplars, h4_table)
+        })
+        .collect()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn compile_candidate_prototypes(
+    table: &SourceFreeTable,
+    rows: &[(u32, Vec<ConstructionExemplar>)],
+    h4_table: &H4BinaryIcosahedralClosure,
+    worker_count: Option<usize>,
+) -> Result<Vec<CandidateCompilation>, CorpusInducedDocumentSpinError> {
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+    let available = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1);
+    let workers = worker_count
+        .unwrap_or(available)
+        .min(MAX_NATIVE_DOCUMENT_SCAN_WORKERS)
+        .min(rows.len())
+        .max(1);
+    let chunk_size = rows.len().div_ceil(workers);
+    std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (chunk_index, chunk) in rows.chunks(chunk_size).enumerate() {
+            let handle = std::thread::Builder::new()
+                .name(format!("uor-r4-candidate-compile-{chunk_index}"))
+                .spawn_scoped(scope, move || {
+                    chunk
+                        .iter()
+                        .map(|(token, exemplars)| {
+                            compile_one_candidate_prototype(table, *token, exemplars, h4_table)
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .map_err(|error| {
+                    CorpusInducedDocumentSpinError::Invalid(format!(
+                        "failed to spawn document-spin candidate worker: {error}"
+                    ))
+                })?;
+            handles.push(handle);
+        }
+        let mut compiled = Vec::with_capacity(rows.len());
+        for handle in handles {
+            let mut chunk = handle.join().map_err(|_| {
+                CorpusInducedDocumentSpinError::Invalid(
+                    "document-spin candidate worker panicked".to_owned(),
+                )
+            })??;
+            compiled.append(&mut chunk);
+        }
+        Ok(compiled)
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn compile_construction_documents(
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    leaves: &[ExactSpinState],
+    h4_table: &H4BinaryIcosahedralClosure,
+    worker_count: Option<usize>,
+) -> Result<Vec<DocumentCompilation>, CorpusInducedDocumentSpinError> {
+    if documents.is_empty() {
+        return Ok(Vec::new());
+    }
+    let available = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1);
+    let workers = worker_count
+        .unwrap_or(available)
+        .min(MAX_NATIVE_DOCUMENT_SCAN_WORKERS)
+        .min(documents.len())
+        .max(1);
+    let chunk_size = documents.len().div_ceil(workers);
+    std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (chunk_index, chunk) in documents.chunks(chunk_size).enumerate() {
+            let handle = std::thread::Builder::new()
+                .name(format!("uor-r4-construction-compile-{chunk_index}"))
+                .spawn_scoped(scope, move || {
+                    chunk
+                        .iter()
+                        .map(|document| {
+                            compile_one_construction_document(
+                                table,
+                                base_overlay,
+                                document,
+                                leaves,
+                                h4_table,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .map_err(|error| {
+                    CorpusInducedDocumentSpinError::Invalid(format!(
+                        "failed to spawn document-spin construction worker: {error}"
+                    ))
+                })?;
+            handles.push(handle);
+        }
+        let mut compiled = Vec::with_capacity(documents.len());
+        for handle in handles {
+            let mut chunk = handle.join().map_err(|_| {
+                CorpusInducedDocumentSpinError::Invalid(
+                    "document-spin construction worker panicked".to_owned(),
+                )
+            })??;
+            compiled.append(&mut chunk);
+        }
+        Ok(compiled)
+    })
+}
+
+fn first_primes(count: usize) -> Result<Vec<u64>, CorpusInducedDocumentSpinError> {
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+    let mut limit = 32_usize;
+    loop {
+        let mut composite = vec![
+            false;
+            limit
+                .checked_add(1)
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow,)?
+        ];
+        let mut candidate = 2_usize;
+        while candidate <= limit / candidate {
+            if !composite[candidate] {
+                let mut multiple = candidate
+                    .checked_mul(candidate)
+                    .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+                while multiple <= limit {
+                    composite[multiple] = true;
+                    multiple = multiple
+                        .checked_add(candidate)
+                        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+                }
+            }
+            candidate += 1;
+        }
+        let primes = (2..=limit)
+            .filter(|&value| !composite[value])
+            .map(|value| {
+                u64::try_from(value).map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if primes.len() >= count {
+            return Ok(primes.into_iter().take(count).collect());
+        }
+        limit = limit
+            .checked_mul(2)
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+    }
+}
+
+fn wrap_phase_for_compile(value: i64) -> Result<i64, CorpusInducedDocumentSpinError> {
+    value
+        .checked_add(PHASE_HALF_Q29)
+        .map(|shifted| shifted.rem_euclid(PHASE_MODULUS_Q29) - PHASE_HALF_Q29)
+        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)
+}
+
+fn fit_componentwise_frechet_prototype(
+    states: &[ExactSpinState],
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<(ExactSpinState, PrototypeFitAudit), CorpusInducedDocumentSpinError> {
+    if states.is_empty() {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "cannot fit an empty document-spin prototype".to_owned(),
+        ));
+    }
+    let mut best_h4: Option<(u128, OpaqueH4TableIndex, u16)> = None;
+    for offset in 0..table.root_count {
+        let offset = u16::try_from(offset)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let index = OpaqueH4TableIndex::from_table_offset(offset, table).ok_or_else(|| {
+            CorpusInducedDocumentSpinError::Invalid(
+                "H4 Frechet search addressed outside the exact root table".to_owned(),
+            )
+        })?;
+        let candidate = ExactSpinState::from_table_index_and_phases(index, 0, 0, table)?;
+        let total = states.iter().try_fold(0_u128, |sum, &state| {
+            let rank = u128::from(shell_rank(
+                candidate_relative_exact_cost(candidate, state, table)?
+                    .1
+                    .angular_shell,
+            ));
+            sum.checked_add(rank)
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)
+        })?;
+        match best_h4 {
+            None => best_h4 = Some((total, index, 1)),
+            Some((best, _, _)) if total < best => best_h4 = Some((total, index, 1)),
+            Some((best, selected, count)) if total == best => {
+                best_h4 = Some((
+                    best,
+                    selected,
+                    count
+                        .checked_add(1)
+                        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    let (h4_minimum_objective_sum, h4, h4_minimizer_count) = best_h4.ok_or_else(|| {
+        CorpusInducedDocumentSpinError::Invalid("exact H4 root table is empty".to_owned())
+    })?;
+    let (fiber, fiber_minimum_objective_sum, fiber_minimizer_count) =
+        circular_medoid(states.iter().map(|state| state.fiber_q29()))?;
+    let (torsion, torsion_minimum_objective_sum, torsion_minimizer_count) =
+        circular_medoid(states.iter().map(|state| state.torsion_q29()))?;
+    Ok((
+        ExactSpinState::from_table_index_and_phases(h4, fiber, torsion, table)?,
+        PrototypeFitAudit {
+            h4_minimum_objective_sum,
+            h4_minimizer_count,
+            fiber_minimum_objective_sum,
+            fiber_minimizer_count,
+            torsion_minimum_objective_sum,
+            torsion_minimizer_count,
+        },
+    ))
+}
+
+fn circular_medoid(
+    values: impl IntoIterator<Item = i64>,
+) -> Result<(i64, u128, u32), CorpusInducedDocumentSpinError> {
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    if values.is_empty() {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "circular medoid input is empty".to_owned(),
+        ));
+    }
+    values.sort_unstable();
+    let mut candidates = values.clone();
+    candidates.dedup();
+    let modulus = i128::from(PHASE_MODULUS_Q29);
+    let half = i128::from(PHASE_HALF_Q29);
+    let mut points = values
+        .iter()
+        .map(|&value| {
+            let value = i128::from(value);
+            if value < 0 {
+                value + modulus
+            } else {
+                value
+            }
+        })
+        .collect::<Vec<_>>();
+    points.sort_unstable();
+    let mut prefix_sums = Vec::with_capacity(points.len() + 1);
+    prefix_sums.push(0_i128);
+    for &point in &points {
+        let next = prefix_sums
+            .last()
+            .copied()
+            .and_then(|sum| sum.checked_add(point))
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        prefix_sums.push(next);
+    }
+    let total_sum = *prefix_sums.last().ok_or_else(|| {
+        CorpusInducedDocumentSpinError::Invalid("circular medoid input is empty".to_owned())
+    })?;
+    let mut best: Option<(u128, i64, u32)> = None;
+    for &candidate in &candidates {
+        let candidate_unsigned = {
+            let value = i128::from(candidate);
+            if value < 0 {
+                value + modulus
+            } else {
+                value
+            }
+        };
+        let split = points.partition_point(|&point| point < candidate_unsigned);
+        let split_i128 = i128::try_from(split)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let right_count = i128::try_from(points.len() - split)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let mut total = candidate_unsigned
+            .checked_mul(split_i128)
+            .and_then(|value| value.checked_sub(prefix_sums[split]))
+            .and_then(|value| {
+                total_sum
+                    .checked_sub(prefix_sums[split])
+                    .and_then(|right_sum| {
+                        candidate_unsigned
+                            .checked_mul(right_count)
+                            .and_then(|right_center| right_sum.checked_sub(right_center))
+                    })
+                    .and_then(|right| value.checked_add(right))
+            })
+            .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        let left_boundary = candidate_unsigned - half;
+        if left_boundary > 0 {
+            let count = points.partition_point(|&point| point < left_boundary);
+            let count_i128 = i128::try_from(count)
+                .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+            let correction = modulus
+                .checked_mul(count_i128)
+                .and_then(|base| {
+                    candidate_unsigned
+                        .checked_mul(count_i128)
+                        .and_then(|center| center.checked_sub(prefix_sums[count]))
+                        .and_then(|distance| distance.checked_mul(2))
+                        .and_then(|twice| base.checked_sub(twice))
+                })
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+            total = total
+                .checked_add(correction)
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        }
+        let right_boundary = candidate_unsigned + half;
+        if right_boundary < modulus {
+            let start = points.partition_point(|&point| point <= right_boundary);
+            let count = points.len() - start;
+            let count_i128 = i128::try_from(count)
+                .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+            let correction = modulus
+                .checked_mul(count_i128)
+                .and_then(|base| {
+                    total_sum
+                        .checked_sub(prefix_sums[start])
+                        .and_then(|right_sum| {
+                            candidate_unsigned
+                                .checked_mul(count_i128)
+                                .and_then(|center| right_sum.checked_sub(center))
+                        })
+                        .and_then(|distance| distance.checked_mul(2))
+                        .and_then(|twice| base.checked_sub(twice))
+                })
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+            total = total
+                .checked_add(correction)
+                .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        }
+        let total = u128::try_from(total)
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        match best {
+            None => best = Some((total, candidate, 1)),
+            Some((current, _, _)) if total < current => best = Some((total, candidate, 1)),
+            Some((current, selected, count)) if total == current => {
+                best = Some((
+                    current,
+                    selected,
+                    count
+                        .checked_add(1)
+                        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    best.map(|(objective, candidate, count)| (candidate, objective, count))
+        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)
+}
+
+fn shell_rank(shell: H4S3AngularShell) -> u8 {
+    match shell {
+        H4S3AngularShell::Coincident => 0,
+        H4S3AngularShell::Degrees36 => 1,
+        H4S3AngularShell::Degrees60 => 2,
+        H4S3AngularShell::Degrees72 => 3,
+        H4S3AngularShell::Orthogonal => 4,
+        H4S3AngularShell::Degrees108 => 5,
+        H4S3AngularShell::Degrees120 => 6,
+        H4S3AngularShell::Degrees144 => 7,
+        H4S3AngularShell::Antipodal => 8,
+    }
+}
+
+fn leaf_for_token(
+    leaves: &[ExactSpinState],
+    token: u32,
+) -> Result<ExactSpinState, CorpusInducedDocumentSpinError> {
+    let index =
+        usize::try_from(token).map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+    leaves.get(index).copied().ok_or_else(|| {
+        CorpusInducedDocumentSpinError::Invalid(
+            "document-spin prefix token is outside the fitted namespace".to_owned(),
+        )
+    })
+}
+
+fn exact_state_wire(
+    state: ExactSpinState,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactStateWire, CorpusInducedDocumentSpinError> {
+    Ok(ExactStateWire {
+        h4_table_offset: state.table_index().table_offset(),
+        h4_coordinate: state.root_coordinate(table)?.scaled_zphi_quaternion,
+        fiber_q29: state.fiber_q29(),
+        torsion_q29: state.torsion_q29(),
+    })
+}
+
+fn exact_state_from_wire(
+    wire: &ExactStateWire,
+    table: &H4BinaryIcosahedralClosure,
+) -> Result<ExactSpinState, CorpusInducedDocumentSpinError> {
+    if wire.fiber_q29 < -PHASE_HALF_Q29
+        || wire.fiber_q29 >= PHASE_HALF_Q29
+        || wire.torsion_q29 < -PHASE_HALF_Q29
+        || wire.torsion_q29 >= PHASE_HALF_Q29
+    {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "serialized document-spin phase is noncanonical".to_owned(),
+        ));
+    }
+    let index =
+        OpaqueH4TableIndex::from_table_offset(wire.h4_table_offset, table).ok_or_else(|| {
+            CorpusInducedDocumentSpinError::Invalid("serialized H4 offset is invalid".to_owned())
+        })?;
+    let state = ExactSpinState::from_table_index_and_phases(
+        index,
+        wire.fiber_q29,
+        wire.torsion_q29,
+        table,
+    )?;
+    if state.root_coordinate(table)?.scaled_zphi_quaternion != wire.h4_coordinate {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "serialized H4 offset and coordinate disagree".to_owned(),
+        ));
+    }
+    Ok(state)
+}
+
+fn active_maximum_tie(local: &MatchedGeometricPrediction) -> bool {
+    local.geometry_reachable
+        && local.max_count_tie_tokens.len() > 1
+        && matches!(local.order, BackoffOrder::Trigram | BackoffOrder::Bigram)
+}
+
+fn work_from_executed_query(
+    local: &MatchedGeometricPrediction,
+    query: ExecutedQueryState,
+) -> CorpusInducedDocumentSpinWork {
+    CorpusInducedDocumentSpinWork {
+        local: local.geometric_work,
+        prefix_leaf_reads: query.prefix_leaf_reads,
+        prefix_h4_product_reads: query.prefix_h4_product_reads,
+        prefix_phase_additions: query.prefix_phase_additions,
+        prototype_reads: 0,
+        prototype_inverse_reads: 0,
+        relative_h4_product_reads: 0,
+        relative_phase_additions: 0,
+        angular_shell_reads: 0,
+        phase_distance_reads: 0,
+        cost_comparisons: 0,
+        final_choice_operations: 0,
+    }
+}
+
+fn execute_arm(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    arm: CorpusInducedDocumentSpinArm,
+    local: &MatchedGeometricPrediction,
+    query: ExecutedQueryState,
+    rotate_prototypes: bool,
+) -> Result<ExecutedArm, CorpusInducedDocumentSpinError> {
+    let mut support = Vec::with_capacity(local.max_count_tie_tokens.len());
+    for &token in &local.max_count_tie_tokens {
+        support.push(token);
+    }
+    let mut work = work_from_executed_query(local, query);
+    if !active_maximum_tie(local) {
+        work.final_choice_operations = checked_add_u64(work.final_choice_operations, 1)?;
+        return Ok(ExecutedArm {
+            decision: fallback_decision(
+                arm,
+                local.geometric_token,
+                &support,
+                work,
+                CorpusInducedDocumentSpinAbstention::NotMaximumCountTie,
+            ),
+            candidates: Vec::new(),
+        });
+    }
+    let mut assigned = Vec::with_capacity(support.len());
+    let mut complete = true;
+    for index in 0..support.len() {
+        let prototype_token = if rotate_prototypes {
+            support[(index + 1) % support.len()]
+        } else {
+            support[index]
+        };
+        work.prototype_reads = checked_add_u64(work.prototype_reads, 1)?;
+        if !operator.prototypes.contains_key(&prototype_token) {
+            complete = false;
+        }
+        assigned.push(prototype_token);
+    }
+    if !complete {
+        work.final_choice_operations = checked_add_u64(work.final_choice_operations, 1)?;
+        return Ok(ExecutedArm {
+            decision: fallback_decision(
+                arm,
+                local.geometric_token,
+                &support,
+                work,
+                CorpusInducedDocumentSpinAbstention::MissingPrototype,
+            ),
+            candidates: Vec::new(),
+        });
+    }
+    let mut candidates = Vec::with_capacity(support.len());
+    let mut costs = Vec::with_capacity(support.len());
+    for (&support_token, &prototype_token) in support.iter().zip(&assigned) {
+        let prototype = operator.prototypes.get(&prototype_token).ok_or_else(|| {
+            CorpusInducedDocumentSpinError::Invalid(
+                "independently admitted prototype disappeared during scoring".to_owned(),
+            )
+        })?;
+        let (relative_state, cost) =
+            candidate_relative_exact_cost(prototype.state, query.state, &operator.h4_table)?;
+        work.prototype_inverse_reads = checked_add_u64(work.prototype_inverse_reads, 1)?;
+        work.relative_h4_product_reads = checked_add_u64(work.relative_h4_product_reads, 1)?;
+        work.relative_phase_additions = checked_add_u64(work.relative_phase_additions, 2)?;
+        work.angular_shell_reads = checked_add_u64(work.angular_shell_reads, 1)?;
+        work.phase_distance_reads = checked_add_u64(work.phase_distance_reads, 2)?;
+        costs.push(cost);
+        candidates.push(ExecutedCandidateScore {
+            support_token,
+            prototype_token,
+            prototype_state: prototype.state,
+            relative_state,
+            cost,
+        });
+    }
+    let decision = select_decision(arm, local.geometric_token, &support, &costs, work)?;
+    Ok(ExecutedArm {
+        decision,
+        candidates,
+    })
+}
+
+fn issue_score_firewall_certificate(
+    operator_cid: &str,
+    frame: CausalScoreFrame,
+    table: &H4BinaryIcosahedralClosure,
+    candidate_count: usize,
+) -> Result<CorpusInducedDocumentSpinScoreFirewallCertificate, CorpusInducedDocumentSpinError> {
+    let expected_phase_additions = frame
+        .prefix_units
+        .checked_mul(2)
+        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+    let executed_queries = [
+        frame.real,
+        frame.scope_disabled,
+        frame.order_shuffled,
+        frame.operator_permuted,
+    ];
+    if executed_queries.iter().any(|query| {
+        query.prefix_leaf_reads != frame.prefix_units
+            || query.prefix_h4_product_reads != frame.prefix_units
+            || query.prefix_phase_additions != expected_phase_additions
+    }) || frame.real.state != frame.scope_disabled.state
+        || frame.real.state != frame.operator_permuted.state
+    {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "score firewall rejected an imbalanced executed-prefix capability".to_owned(),
+        ));
+    }
+    let forbidden_dependency_mask = match frame.origin {
+        ScoreFrameOrigin::CausalPrefix => 0,
+        #[cfg(test)]
+        ScoreFrameOrigin::InjectedHeldOutTarget => 1,
+    };
+    let state_bytes = serde_json::to_vec(
+        &executed_queries
+            .map(|query| {
+                Ok::<_, CorpusInducedDocumentSpinError>((
+                    exact_state_wire(query.state, table)?,
+                    query.prefix_leaf_reads,
+                    query.prefix_h4_product_reads,
+                    query.prefix_phase_additions,
+                ))
+            })
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?,
+    )
+    .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))?;
+    let mut certificate = CorpusInducedDocumentSpinScoreFirewallCertificate {
+        schema: ARTIFACT_SCHEMA,
+        domain: SCORE_FIREWALL_DOMAIN.to_owned(),
+        policy_kappa: identity_kappa(&[SCORE_FIREWALL_POLICY]),
+        operator_cid: operator_cid.to_owned(),
+        causal_prefix_units: frame.prefix_units,
+        candidate_count: usize_u64(candidate_count)?,
+        query_state_kappa: blake3_label(&state_bytes),
+        forbidden_dependency_mask,
+        certificate_cid: String::new(),
+    };
+    certificate.certificate_cid = score_firewall_certificate_cid(&certificate);
+    if !certificate.validate() {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "score firewall rejected a forbidden or noncanonical input capability".to_owned(),
+        ));
+    }
+    Ok(certificate)
+}
+
+#[cfg(test)]
+fn injected_target_score_firewall_control() -> Result<(), CorpusInducedDocumentSpinError> {
+    let table = validate_h4_binary_icosahedral_closure()
+        .map_err(|error| CorpusInducedDocumentSpinError::ExactSpin(error.to_string()))?;
+    let identity = ExactSpinState::identity(&table)?;
+    let query = ExecutedQueryState {
+        state: identity,
+        prefix_leaf_reads: 1,
+        prefix_h4_product_reads: 1,
+        prefix_phase_additions: 2,
+    };
+    let frame = CausalScoreFrame {
+        origin: ScoreFrameOrigin::InjectedHeldOutTarget,
+        prefix_units: 1,
+        real: query,
+        scope_disabled: query,
+        order_shuffled: query,
+        operator_permuted: query,
+    };
+    issue_score_firewall_certificate("blake3:injected-target", frame, &table, 2).map(|_| ())
+}
+
+#[cfg(test)]
+fn imbalanced_work_score_firewall_control() -> Result<(), CorpusInducedDocumentSpinError> {
+    let table = validate_h4_binary_icosahedral_closure()
+        .map_err(|error| CorpusInducedDocumentSpinError::ExactSpin(error.to_string()))?;
+    let identity = ExactSpinState::identity(&table)?;
+    let balanced = ExecutedQueryState {
+        state: identity,
+        prefix_leaf_reads: 1,
+        prefix_h4_product_reads: 1,
+        prefix_phase_additions: 2,
+    };
+    let mut imbalanced = balanced;
+    imbalanced.prefix_h4_product_reads = 0;
+    let frame = CausalScoreFrame {
+        origin: ScoreFrameOrigin::CausalPrefix,
+        prefix_units: 1,
+        real: balanced,
+        scope_disabled: balanced,
+        order_shuffled: imbalanced,
+        operator_permuted: balanced,
+    };
+    issue_score_firewall_certificate("blake3:imbalanced-work", frame, &table, 2).map(|_| ())
+}
+
+fn score_firewall_certificate_cid(
+    certificate: &CorpusInducedDocumentSpinScoreFirewallCertificate,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(SCORE_FIREWALL_DOMAIN.as_bytes());
+    hasher.update(certificate.policy_kappa.as_bytes());
+    hasher.update(certificate.operator_cid.as_bytes());
+    hasher.update(&certificate.causal_prefix_units.to_le_bytes());
+    hasher.update(&certificate.candidate_count.to_le_bytes());
+    hasher.update(certificate.query_state_kappa.as_bytes());
+    hasher.update(&certificate.forbidden_dependency_mask.to_le_bytes());
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn forbidden_reads_from_mask(mask: u16) -> CorpusInducedDocumentSpinForbiddenReads {
+    let set = |bit: u32| u64::from((mask & (1_u16 << bit)) != 0);
+    CorpusInducedDocumentSpinForbiddenReads {
+        held_out_target_reads: set(0),
+        compiler_future_reads: set(1),
+        teacher_calls: set(2),
+        provider_calls: set(3),
+        source_weight_reads: set(4),
+        runtime_corpus_reads: set(5),
+        token_score_reads: set(6),
+        payload_score_reads: set(7),
+        prime_score_reads: set(8),
+        rank_score_reads: set(9),
+        digest_score_reads: set(10),
+        support_score_reads: set(11),
+        provenance_score_reads: set(12),
+    }
+}
+
+fn fallback_decision(
+    arm: CorpusInducedDocumentSpinArm,
+    fallback: u32,
+    support: &[u32],
+    work: CorpusInducedDocumentSpinWork,
+    abstention: CorpusInducedDocumentSpinAbstention,
+) -> CorpusInducedDocumentSpinDecision {
+    CorpusInducedDocumentSpinDecision {
+        arm,
+        token: fallback,
+        unique_minimum: None,
+        minimum_cost: None,
+        abstention: Some(abstention),
+        support_tokens: support.to_vec(),
+        work,
+    }
+}
+
+fn select_decision(
+    arm: CorpusInducedDocumentSpinArm,
+    fallback: u32,
+    support: &[u32],
+    costs: &[BoundedGlobalExactSpinCost],
+    mut work: CorpusInducedDocumentSpinWork,
+) -> Result<CorpusInducedDocumentSpinDecision, CorpusInducedDocumentSpinError> {
+    let selection = select_unique_minimum_exact_costs(costs)?;
+    work.cost_comparisons = selection.comparisons;
+    work.final_choice_operations = checked_add_u64(work.final_choice_operations, 1)?;
+    let unique_minimum = selection.unique_minimum_index.map(|index| support[index]);
+    Ok(CorpusInducedDocumentSpinDecision {
+        arm,
+        token: unique_minimum.unwrap_or(fallback),
+        unique_minimum,
+        minimum_cost: selection.minimum_cost,
+        abstention: unique_minimum
+            .is_none()
+            .then_some(CorpusInducedDocumentSpinAbstention::CostTie),
+        support_tokens: support.to_vec(),
+        work,
+    })
+}
+
+fn blake3_label(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn identity_kappa(parts: &[&str]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for part in parts {
+        hasher.update(&(part.len() as u64).to_le_bytes());
+        hasher.update(part.as_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn document_set_kappa(
+    domain: &[u8],
+    documents: &[SourceDocument],
+) -> Result<String, CorpusInducedDocumentSpinError> {
+    let mut documents = documents.iter().collect::<Vec<_>>();
+    documents.sort_by(|left, right| left.id.cmp(&right.id));
+    if documents.windows(2).any(|pair| pair[0].id == pair[1].id) {
+        return Err(CorpusInducedDocumentSpinError::Invalid(
+            "document set has duplicate IDs".to_owned(),
+        ));
+    }
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(domain);
+    for document in documents {
+        let id_len = u64::try_from(document.id.len())
+            .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?;
+        hasher.update(&id_len.to_le_bytes());
+        hasher.update(document.id.as_bytes());
+        hasher.update(&document.text_cid());
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+fn checked_add_u64(left: u64, right: u64) -> Result<u64, CorpusInducedDocumentSpinError> {
+    left.checked_add(right)
+        .ok_or(CorpusInducedDocumentSpinError::ArithmeticOverflow)
+}
+
+fn usize_u64(value: usize) -> Result<u64, CorpusInducedDocumentSpinError> {
+    u64::try_from(value).map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)
+}
+
+impl AntiRecallDocumentScan {
+    fn merge(&mut self, other: Self) {
+        self.full_prefix_cids.extend(other.full_prefix_cids);
+        self.natural_states.extend(other.natural_states);
+        self.operative_signature_cids
+            .extend(other.operative_signature_cids);
+    }
+}
+
+impl TargetFreeScanAggregate {
+    fn merge_document(
+        &mut self,
+        document: TargetFreeDocumentScan,
+    ) -> Result<(), CorpusInducedDocumentSpinError> {
+        self.admission_opportunities = checked_add_u64(
+            self.admission_opportunities,
+            document.admission_opportunities,
+        )?;
+        for row in document.rows_seen {
+            self.row_documents
+                .entry(row)
+                .or_default()
+                .insert(document.document_id.clone());
+        }
+        self.candidates.extend(document.candidates);
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn merge(&mut self, other: Self) -> Result<(), CorpusInducedDocumentSpinError> {
+        self.admission_opportunities =
+            checked_add_u64(self.admission_opportunities, other.admission_opportunities)?;
+        for (row, documents) in other.row_documents {
+            self.row_documents.entry(row).or_default().extend(documents);
+        }
+        self.candidates.extend(other.candidates);
+        Ok(())
+    }
+}
+
+fn scan_one_anti_recall_document(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    document: &SourceDocument,
+) -> Result<AntiRecallDocumentScan, CorpusInducedDocumentSpinError> {
+    let stream = table.encode_document_stream(document)?;
+    let mut cursor = CausalPrefixCursor::new(&operator.h4_table)?;
+    cursor.advance(BOS_TOKEN, &operator.leaves, &operator.h4_table)?;
+    let mut prefix_hash = PrefixDigestState::new();
+    prefix_hash.append(BOS_TOKEN);
+    let mut scan = AntiRecallDocumentScan::default();
+    for target_index in 1..stream.len() {
+        let prefix = &stream[..target_index];
+        let local = table.predict_multiscale_count_radius(prefix, base_overlay)?;
+        scan.full_prefix_cids.insert(prefix_hash.digest());
+        scan.natural_states.insert(exact_state_wire(
+            cursor.frame().real.state,
+            &operator.h4_table,
+        )?);
+        if active_maximum_tie(&local) {
+            let prediction = operator.predict_from_frame(local, cursor.frame())?;
+            if prediction.prototype_complete {
+                scan.operative_signature_cids
+                    .insert(omega_digest(&prediction)?);
+            }
+        }
+        cursor.advance(stream[target_index], &operator.leaves, &operator.h4_table)?;
+        prefix_hash.append(stream[target_index]);
+    }
+    Ok(scan)
+}
+
+fn scan_one_target_free_document(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    document: &SourceDocument,
+) -> Result<TargetFreeDocumentScan, CorpusInducedDocumentSpinError> {
+    let stream = table.encode_document_stream(document)?;
+    let mut cursor = CausalPrefixCursor::new(&operator.h4_table)?;
+    cursor.advance(BOS_TOKEN, &operator.leaves, &operator.h4_table)?;
+    let mut prefix_hash = PrefixDigestState::new();
+    prefix_hash.append(BOS_TOKEN);
+    let mut admission_opportunities = 0_u64;
+    let mut rows_seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+    for target_index in 1..stream.len() {
+        let prefix = &stream[..target_index];
+        let local = table.predict_multiscale_count_radius(prefix, base_overlay)?;
+        if active_maximum_tie(&local) {
+            admission_opportunities = checked_add_u64(admission_opportunities, 1)?;
+            let row = active_row_key(prefix, local.order)?;
+            rows_seen.insert(row.clone());
+            let prediction = operator.predict_from_frame(local, cursor.frame())?;
+            let prefix_cid = prefix_hash.digest();
+            let omega_cid = omega_digest(&prediction)?;
+            let position = CorpusInducedDocumentSpinCensusPosition {
+                document_id: document.id.clone(),
+                target_index: u32::try_from(target_index)
+                    .map_err(|_| CorpusInducedDocumentSpinError::ArithmeticOverflow)?,
+                prefix_cid: digest_label(prefix_cid),
+                row_cid: row_label(&row),
+                support_cid: support_label(&prediction.real.support_tokens),
+                prediction_cid: prediction_label(&prediction)?,
+                real_token: prediction.real.token,
+                scope_disabled_token: prediction.scope_disabled.token,
+                order_shuffled_token: prediction.order_shuffled.token,
+                operator_permuted_token: prediction.operator_permuted.token,
+            };
+            candidates.push(TargetFreeCandidate {
+                position,
+                row,
+                prediction,
+                natural_state: exact_state_wire(cursor.frame().real.state, &operator.h4_table)?,
+                omega_cid,
+                prefix_cid,
+            });
+        }
+        cursor.advance(stream[target_index], &operator.leaves, &operator.h4_table)?;
+        prefix_hash.append(stream[target_index]);
+    }
+    Ok(TargetFreeDocumentScan {
+        document_id: document.id.clone(),
+        admission_opportunities,
+        rows_seen,
+        candidates,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn scan_anti_recall_documents(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    _worker_count: Option<usize>,
+) -> Result<AntiRecallDocumentScan, CorpusInducedDocumentSpinError> {
+    let mut aggregate = AntiRecallDocumentScan::default();
+    for document in documents {
+        aggregate.merge(scan_one_anti_recall_document(
+            operator,
+            table,
+            base_overlay,
+            document,
+        )?);
+    }
+    Ok(aggregate)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn scan_anti_recall_documents(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    worker_count: Option<usize>,
+) -> Result<AntiRecallDocumentScan, CorpusInducedDocumentSpinError> {
+    if documents.is_empty() {
+        return Ok(AntiRecallDocumentScan::default());
+    }
+    let available = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1);
+    let workers = worker_count
+        .unwrap_or(available)
+        .min(MAX_NATIVE_DOCUMENT_SCAN_WORKERS)
+        .min(documents.len())
+        .max(1);
+    let chunk_size = documents.len().div_ceil(workers);
+    std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (chunk_index, chunk) in documents.chunks(chunk_size).enumerate() {
+            let handle = std::thread::Builder::new()
+                .name(format!("uor-r4-anti-recall-{chunk_index}"))
+                .spawn_scoped(scope, move || {
+                    let mut aggregate = AntiRecallDocumentScan::default();
+                    for document in chunk {
+                        aggregate.merge(scan_one_anti_recall_document(
+                            operator,
+                            table,
+                            base_overlay,
+                            document,
+                        )?);
+                    }
+                    Ok::<_, CorpusInducedDocumentSpinError>(aggregate)
+                })
+                .map_err(|error| {
+                    CorpusInducedDocumentSpinError::Invalid(format!(
+                        "failed to spawn document-spin anti-recall worker: {error}"
+                    ))
+                })?;
+            handles.push(handle);
+        }
+        let mut aggregate = AntiRecallDocumentScan::default();
+        for handle in handles {
+            let chunk = handle.join().map_err(|_| {
+                CorpusInducedDocumentSpinError::Invalid(
+                    "document-spin anti-recall worker panicked".to_owned(),
+                )
+            })??;
+            aggregate.merge(chunk);
+        }
+        Ok(aggregate)
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn scan_target_free_documents(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    _worker_count: Option<usize>,
+) -> Result<TargetFreeScanAggregate, CorpusInducedDocumentSpinError> {
+    let mut aggregate = TargetFreeScanAggregate::default();
+    for document in documents {
+        aggregate.merge_document(scan_one_target_free_document(
+            operator,
+            table,
+            base_overlay,
+            document,
+        )?)?;
+    }
+    Ok(aggregate)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn scan_target_free_documents(
+    operator: &CorpusInducedDocumentSpinPlacementR4V1,
+    table: &SourceFreeTable,
+    base_overlay: &MultiscaleCountRadiusR4V1,
+    documents: &[&SourceDocument],
+    worker_count: Option<usize>,
+) -> Result<TargetFreeScanAggregate, CorpusInducedDocumentSpinError> {
+    if documents.is_empty() {
+        return Ok(TargetFreeScanAggregate::default());
+    }
+    let available = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1);
+    let workers = worker_count
+        .unwrap_or(available)
+        .min(MAX_NATIVE_DOCUMENT_SCAN_WORKERS)
+        .min(documents.len())
+        .max(1);
+    let chunk_size = documents.len().div_ceil(workers);
+    std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+        for (chunk_index, chunk) in documents.chunks(chunk_size).enumerate() {
+            let handle = std::thread::Builder::new()
+                .name(format!("uor-r4-target-free-{chunk_index}"))
+                .spawn_scoped(scope, move || {
+                    let mut aggregate = TargetFreeScanAggregate::default();
+                    for document in chunk {
+                        aggregate.merge_document(scan_one_target_free_document(
+                            operator,
+                            table,
+                            base_overlay,
+                            document,
+                        )?)?;
+                    }
+                    Ok::<_, CorpusInducedDocumentSpinError>(aggregate)
+                })
+                .map_err(|error| {
+                    CorpusInducedDocumentSpinError::Invalid(format!(
+                        "failed to spawn document-spin target-free worker: {error}"
+                    ))
+                })?;
+            handles.push(handle);
+        }
+        let mut aggregate = TargetFreeScanAggregate::default();
+        for handle in handles {
+            let chunk = handle.join().map_err(|_| {
+                CorpusInducedDocumentSpinError::Invalid(
+                    "document-spin target-free worker panicked".to_owned(),
+                )
+            })??;
+            aggregate.merge(chunk)?;
+        }
+        Ok(aggregate)
+    })
+}
+
+impl CorpusInducedDocumentSpinAntiRecallIndex {
+    /// Build the audit-only construction replay index. It is intentionally a
+    /// separate value and has no serialization path into the runtime artifact.
+    pub fn compile(
+        operator: &CorpusInducedDocumentSpinPlacementR4V1,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        Self::compile_with_worker_count(operator, table, base_overlay, construction, None)
+    }
+
+    fn compile_with_worker_count(
+        operator: &CorpusInducedDocumentSpinPlacementR4V1,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        construction: &[SourceDocument],
+        worker_count: Option<usize>,
+    ) -> Result<Self, CorpusInducedDocumentSpinError> {
+        operator.validate_binding(table, base_overlay)?;
+        if !table.is_bound_to_construction_documents(construction)
+            || document_set_kappa(CONSTRUCTION_SET_DOMAIN, construction)?
+                != operator.construction_set_kappa
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "anti-recall replay is not the operator's exact construction set".to_owned(),
+            ));
+        }
+        let mut documents = construction.iter().collect::<Vec<_>>();
+        documents.sort_by(|left, right| left.id.cmp(&right.id));
+        let scan =
+            scan_anti_recall_documents(operator, table, base_overlay, &documents, worker_count)?;
+        let index_kappa = anti_recall_kappa(
+            &operator.operator_cid,
+            &operator.construction_set_kappa,
+            &scan.full_prefix_cids,
+            &scan.natural_states,
+            &scan.operative_signature_cids,
+        )?;
+        Ok(Self {
+            operator_cid: operator.operator_cid.clone(),
+            construction_set_kappa: operator.construction_set_kappa.clone(),
+            full_prefix_cids: scan.full_prefix_cids,
+            natural_states: scan.natural_states,
+            operative_signature_cids: scan.operative_signature_cids,
+            index_kappa,
+        })
+    }
+
+    #[cfg(test)]
+    fn canonical_bytes(&self) -> Result<Vec<u8>, CorpusInducedDocumentSpinError> {
+        serde_json::to_vec(&AntiRecallIndexWire {
+            schema: ARTIFACT_SCHEMA,
+            domain: ANTI_RECALL_DOMAIN,
+            operator_cid: &self.operator_cid,
+            construction_set_kappa: &self.construction_set_kappa,
+            full_prefix_cids: &self.full_prefix_cids,
+            natural_states: &self.natural_states,
+            operative_signature_cids: &self.operative_signature_cids,
+            index_kappa: &self.index_kappa,
+        })
+        .map_err(|error| CorpusInducedDocumentSpinError::Serialization(error.to_string()))
+    }
+
+    pub fn index_kappa(&self) -> &str {
+        &self.index_kappa
+    }
+
+    pub fn full_prefix_count(&self) -> usize {
+        self.full_prefix_cids.len()
+    }
+
+    pub fn natural_state_count(&self) -> usize {
+        self.natural_states.len()
+    }
+
+    pub fn operative_signature_count(&self) -> usize {
+        self.operative_signature_cids.len()
+    }
+}
+
+impl CorpusInducedDocumentSpinPlacementR4V1 {
+    /// Census the held-out structural population without attaching any next
+    /// route. The stream element at `target_index` is used only after that
+    /// prefix has been frozen, when it becomes causal history for the next
+    /// prefix.
+    pub fn target_free_census(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        anti_recall: &CorpusInducedDocumentSpinAntiRecallIndex,
+        held_out: &[SourceDocument],
+    ) -> Result<CorpusInducedDocumentSpinTargetFreeCensus, CorpusInducedDocumentSpinError> {
+        self.target_free_census_with_worker_count(table, base_overlay, anti_recall, held_out, None)
+    }
+
+    fn target_free_census_with_worker_count(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        anti_recall: &CorpusInducedDocumentSpinAntiRecallIndex,
+        held_out: &[SourceDocument],
+        worker_count: Option<usize>,
+    ) -> Result<CorpusInducedDocumentSpinTargetFreeCensus, CorpusInducedDocumentSpinError> {
+        self.validate_binding(table, base_overlay)?;
+        if anti_recall.operator_cid != self.operator_cid
+            || anti_recall.construction_set_kappa != self.construction_set_kappa
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "anti-recall index is not bound to this operator".to_owned(),
+            ));
+        }
+        let reproduced_index_kappa = anti_recall_kappa(
+            &anti_recall.operator_cid,
+            &anti_recall.construction_set_kappa,
+            &anti_recall.full_prefix_cids,
+            &anti_recall.natural_states,
+            &anti_recall.operative_signature_cids,
+        )?;
+        if reproduced_index_kappa != anti_recall.index_kappa {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "anti-recall index does not reproduce its canonical kappa".to_owned(),
+            ));
+        }
+        if !table.is_disjoint_d3_held_out_documents(held_out) {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "target-free census requires a pristine disjoint D3 held-out set".to_owned(),
+            ));
+        }
+        let held_out_set_kappa = document_set_kappa(HELD_OUT_SET_DOMAIN, held_out)?;
+        if self.corpus_cid == FROZEN_CORPUS_CID && held_out_set_kappa != FROZEN_HELD_OUT_SET_KAPPA {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "frozen held-out-set kappa does not reproduce".to_owned(),
+            ));
+        }
+        let mut documents = held_out.iter().collect::<Vec<_>>();
+        documents.sort_by(|left, right| left.id.cmp(&right.id));
+        let TargetFreeScanAggregate {
+            admission_opportunities,
+            row_documents,
+            mut candidates,
+        } = scan_target_free_documents(self, table, base_overlay, &documents, worker_count)?;
+        candidates.sort_by(|left, right| {
+            left.row
+                .cmp(&right.row)
+                .then_with(|| left.position.support_cid.cmp(&right.position.support_cid))
+                .then_with(|| left.position.prefix_cid.cmp(&right.position.prefix_cid))
+                .then_with(|| left.position.document_id.cmp(&right.position.document_id))
+                .then_with(|| left.position.target_index.cmp(&right.position.target_index))
+        });
+        let mut rows_in_multiple_held_out_documents = 0_u64;
+        let mut prototype_complete_positions = 0_u64;
+        let mut full_prefix_construction_hits = 0_u64;
+        let mut natural_state_construction_hits = 0_u64;
+        let mut operative_signature_construction_hits = 0_u64;
+        let mut natural_reverse_equal_positions = 0_u64;
+        let mut permutation_inert_positions = 0_u64;
+        let mut support_mismatches = 0_u64;
+        let mut work_mismatches = 0_u64;
+        let mut invalid_score_firewall_certificates = 0_u64;
+        let mut forbidden_reads = CorpusInducedDocumentSpinForbiddenReads::default();
+        let mut operative_positions = Vec::new();
+        let mut frozen_decoded_witness = None;
+        for candidate in candidates {
+            let multi_document = row_documents
+                .get(&candidate.row)
+                .is_some_and(|documents| documents.len() >= 2);
+            if multi_document {
+                rows_in_multiple_held_out_documents =
+                    checked_add_u64(rows_in_multiple_held_out_documents, 1)?;
+            }
+            if candidate.prediction.prototype_complete {
+                prototype_complete_positions = checked_add_u64(prototype_complete_positions, 1)?;
+            }
+            let prefix_hit = anti_recall.full_prefix_cids.contains(&candidate.prefix_cid);
+            let state_hit = anti_recall
+                .natural_states
+                .contains(&candidate.natural_state);
+            let omega_hit = anti_recall
+                .operative_signature_cids
+                .contains(&candidate.omega_cid);
+            if prefix_hit {
+                full_prefix_construction_hits = checked_add_u64(full_prefix_construction_hits, 1)?;
+            }
+            if state_hit {
+                natural_state_construction_hits =
+                    checked_add_u64(natural_state_construction_hits, 1)?;
+            }
+            if omega_hit {
+                operative_signature_construction_hits =
+                    checked_add_u64(operative_signature_construction_hits, 1)?;
+            }
+            if !candidate.prediction.natural_reverse_distinct {
+                natural_reverse_equal_positions =
+                    checked_add_u64(natural_reverse_equal_positions, 1)?;
+            }
+            if !candidate.prediction.permutation_cost_vector_changed {
+                permutation_inert_positions = checked_add_u64(permutation_inert_positions, 1)?;
+            }
+            if !candidate.prediction.support_matched {
+                support_mismatches = checked_add_u64(support_mismatches, 1)?;
+            }
+            if !candidate.prediction.work_matched {
+                work_mismatches = checked_add_u64(work_mismatches, 1)?;
+            }
+            let firewall_valid = candidate.prediction.score_firewall_certificate.validate();
+            if !firewall_valid {
+                invalid_score_firewall_certificates =
+                    checked_add_u64(invalid_score_firewall_certificates, 1)?;
+            }
+            forbidden_reads.saturating_accumulate(candidate.prediction.forbidden_reads);
+            let operative = multi_document
+                && candidate.prediction.prototype_complete
+                && !prefix_hit
+                && !state_hit
+                && !omega_hit
+                && candidate.prediction.natural_reverse_distinct
+                && candidate.prediction.permutation_cost_vector_changed
+                && candidate.prediction.support_matched
+                && candidate.prediction.work_matched
+                && firewall_valid
+                && candidate.prediction.forbidden_reads.total() == 0;
+            if operative {
+                let all_control_contrast = candidate.position.real_token != EOS_TOKEN
+                    && candidate.position.real_token != candidate.position.scope_disabled_token
+                    && candidate.position.real_token != candidate.position.order_shuffled_token
+                    && candidate.position.real_token != candidate.position.operator_permuted_token;
+                if frozen_decoded_witness.is_none() && all_control_contrast {
+                    frozen_decoded_witness = Some(candidate.position.clone());
+                }
+                operative_positions.push(candidate.position);
+            }
+        }
+        let frozen_identity = self.corpus_cid == FROZEN_CORPUS_CID
+            && self.table_artifact_cid == FROZEN_TABLE_CID
+            && self.base_overlay_artifact_cid == FROZEN_OVERLAY_CID;
+        let frozen_population_reproduced = !frozen_identity
+            || (usize_u64(documents.len())? == FROZEN_HELD_OUT_DOCUMENTS
+                && admission_opportunities == FROZEN_TARGET_FREE_ADMISSIONS);
+        let meets_frozen_preflight = frozen_population_reproduced
+            && usize_u64(operative_positions.len())? >= MIN_OPERATIVE_ANTI_RECALL_POSITIONS
+            && frozen_decoded_witness.is_some()
+            && support_mismatches == 0
+            && work_mismatches == 0
+            && invalid_score_firewall_certificates == 0
+            && forbidden_reads.total() == 0;
+        Ok(CorpusInducedDocumentSpinTargetFreeCensus {
+            schema: ARTIFACT_SCHEMA,
+            domain: ANTI_RECALL_DOMAIN.to_owned(),
+            operator_cid: self.operator_cid.clone(),
+            anti_recall_index_kappa: anti_recall.index_kappa.clone(),
+            held_out_set_kappa,
+            held_out_documents: usize_u64(documents.len())?,
+            admission_opportunities,
+            rows_in_multiple_held_out_documents,
+            prototype_complete_positions,
+            full_prefix_construction_hits,
+            natural_state_construction_hits,
+            operative_signature_construction_hits,
+            natural_reverse_equal_positions,
+            permutation_inert_positions,
+            support_mismatches,
+            work_mismatches,
+            invalid_score_firewall_certificates,
+            score_firewall_policy_kappa: identity_kappa(&[SCORE_FIREWALL_POLICY]),
+            meets_frozen_preflight,
+            operative_positions,
+            frozen_decoded_witness,
+            forbidden_reads,
+        })
+    }
+}
+
+impl CorpusInducedDocumentSpinPlacementR4V1 {
+    /// Predict all four frozen, equal-support arms from one causal prefix.
+    pub fn predict_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        prefix: &[u32],
+    ) -> Result<MatchedCorpusInducedDocumentSpinPrediction, CorpusInducedDocumentSpinError> {
+        self.validate_binding(table, base_overlay)?;
+        self.predict_matched_bound(table, base_overlay, prefix)
+    }
+
+    fn predict_matched_bound(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        prefix: &[u32],
+    ) -> Result<MatchedCorpusInducedDocumentSpinPrediction, CorpusInducedDocumentSpinError> {
+        if prefix.first().copied() != Some(BOS_TOKEN)
+            || prefix.iter().any(|&token| token > self.max_token_id)
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "document-spin prediction requires a BOS-led in-range prefix".to_owned(),
+            ));
+        }
+        let frame = CausalPrefixCursor::from_prefix(prefix, &self.leaves, &self.h4_table)?.frame();
+        let local = table.predict_multiscale_count_radius(prefix, base_overlay)?;
+        self.predict_from_frame(local, frame)
+    }
+
+    /// Continue each arm on its own causal history after the shared first
+    /// decision. EOS and period-one/two sentinels are not appended.
+    pub fn continue_matched(
+        &self,
+        table: &SourceFreeTable,
+        base_overlay: &MultiscaleCountRadiusR4V1,
+        prefix: &[u32],
+        max_units: usize,
+    ) -> Result<MatchedCorpusInducedDocumentSpinContinuation, CorpusInducedDocumentSpinError> {
+        if max_units == 0 || max_units > MAX_CONTINUATION_UNITS {
+            return Err(CorpusInducedDocumentSpinError::Invalid(format!(
+                "document-spin continuation bound must be 1..={MAX_CONTINUATION_UNITS}"
+            )));
+        }
+        self.validate_binding(table, base_overlay)?;
+        let first_decision = self.predict_matched_bound(table, base_overlay, prefix)?;
+        Ok(MatchedCorpusInducedDocumentSpinContinuation {
+            first_decision,
+            real: continue_arm(
+                self,
+                table,
+                base_overlay,
+                prefix,
+                max_units,
+                CorpusInducedDocumentSpinArm::Real,
+            )?,
+            scope_disabled: continue_arm(
+                self,
+                table,
+                base_overlay,
+                prefix,
+                max_units,
+                CorpusInducedDocumentSpinArm::ScopeDisabled,
+            )?,
+            order_shuffled: continue_arm(
+                self,
+                table,
+                base_overlay,
+                prefix,
+                max_units,
+                CorpusInducedDocumentSpinArm::OrderShuffled,
+            )?,
+            operator_permuted: continue_arm(
+                self,
+                table,
+                base_overlay,
+                prefix,
+                max_units,
+                CorpusInducedDocumentSpinArm::OperatorPermuted,
+            )?,
+        })
+    }
+
+    fn predict_from_frame(
+        &self,
+        local: MatchedGeometricPrediction,
+        frame: CausalScoreFrame,
+    ) -> Result<MatchedCorpusInducedDocumentSpinPrediction, CorpusInducedDocumentSpinError> {
+        if local
+            .max_count_tie_tokens
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+        {
+            return Err(CorpusInducedDocumentSpinError::Invalid(
+                "#953 maximum-count support is not canonical".to_owned(),
+            ));
+        }
+        let score_firewall_certificate = issue_score_firewall_certificate(
+            &self.operator_cid,
+            frame,
+            &self.h4_table,
+            local.max_count_tie_tokens.len(),
+        )?;
+        let forbidden_reads =
+            forbidden_reads_from_mask(score_firewall_certificate.forbidden_dependency_mask);
+        let real_execution = execute_arm(
+            self,
+            CorpusInducedDocumentSpinArm::Real,
+            &local,
+            frame.real,
+            false,
+        )?;
+        let mut scope_execution = execute_arm(
+            self,
+            CorpusInducedDocumentSpinArm::ScopeDisabled,
+            &local,
+            frame.scope_disabled,
+            false,
+        )?;
+        scope_execution.decision.token = local.geometric_token;
+        let order_execution = execute_arm(
+            self,
+            CorpusInducedDocumentSpinArm::OrderShuffled,
+            &local,
+            frame.order_shuffled,
+            false,
+        )?;
+        let permuted_execution = execute_arm(
+            self,
+            CorpusInducedDocumentSpinArm::OperatorPermuted,
+            &local,
+            frame.operator_permuted,
+            true,
+        )?;
+        let decisions = [
+            &real_execution.decision,
+            &scope_execution.decision,
+            &order_execution.decision,
+            &permuted_execution.decision,
+        ];
+        let support_matched = decisions
+            .windows(2)
+            .all(|pair| pair[0].support_tokens == pair[1].support_tokens);
+        let work_matched = decisions
+            .windows(2)
+            .all(|pair| pair[0].work == pair[1].work);
+        let prototype_complete = active_maximum_tie(&local)
+            && decisions.iter().all(|decision| {
+                decision.abstention != Some(CorpusInducedDocumentSpinAbstention::MissingPrototype)
+            });
+        let mut evidence = Vec::new();
+        if active_maximum_tie(&local) && prototype_complete {
+            for ((real, order), permuted) in real_execution
+                .candidates
+                .iter()
+                .zip(&order_execution.candidates)
+                .zip(&permuted_execution.candidates)
+            {
+                if real.support_token != order.support_token
+                    || real.support_token != permuted.support_token
+                {
+                    return Err(CorpusInducedDocumentSpinError::Invalid(
+                        "independently executed arm supports are misaligned".to_owned(),
+                    ));
+                }
+                let prototype = self.prototypes.get(&real.prototype_token).ok_or_else(|| {
+                    CorpusInducedDocumentSpinError::Invalid(
+                        "executed real prototype disappeared".to_owned(),
+                    )
+                })?;
+                evidence.push(CorpusInducedDocumentSpinCandidateEvidence {
+                    token: real.support_token,
+                    prototype_state: real.prototype_state.trace(&self.h4_table)?,
+                    prototype_document_support: prototype.construction_document_support,
+                    prototype_distinct_state_support: prototype.distinct_state_support,
+                    real_relative_state: real.relative_state.trace(&self.h4_table)?,
+                    real_cost: real.cost,
+                    order_shuffled_relative_state: order.relative_state.trace(&self.h4_table)?,
+                    order_shuffled_cost: order.cost,
+                    permuted_from_token: permuted.prototype_token,
+                    permuted_prototype_state: permuted.prototype_state.trace(&self.h4_table)?,
+                    operator_permuted_relative_state: permuted
+                        .relative_state
+                        .trace(&self.h4_table)?,
+                    operator_permuted_cost: permuted.cost,
+                });
+            }
+        }
+        let permutation_cost_vector_changed = real_execution
+            .candidates
+            .iter()
+            .map(|candidate| candidate.cost)
+            .ne(permuted_execution
+                .candidates
+                .iter()
+                .map(|candidate| candidate.cost));
+        Ok(MatchedCorpusInducedDocumentSpinPrediction {
+            local,
+            operator_cid: self.operator_cid.clone(),
+            natural_state: frame.real.state.trace(&self.h4_table)?,
+            reverse_state: frame.order_shuffled.state.trace(&self.h4_table)?,
+            candidate_evidence: evidence,
+            real: real_execution.decision,
+            scope_disabled: scope_execution.decision,
+            order_shuffled: order_execution.decision,
+            operator_permuted: permuted_execution.decision,
+            prototype_complete,
+            natural_reverse_distinct: frame.real.state != frame.order_shuffled.state,
+            permutation_cost_vector_changed,
+            support_matched,
+            work_matched,
+            score_firewall_certificate,
+            forbidden_reads,
+        })
+    }
+}

--- a/crates/uor-r4-core/src/lib.rs
+++ b/crates/uor-r4-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod canonical_lexical_ingestion;
 pub mod cayley_dickson;
 pub mod construction_causal_return_attention;
 pub mod conversation_entity_spin_path_attention;
+pub mod corpus_induced_spin_placement;
 pub mod higher_scope_geometric_attention;
 pub mod local_geometric_generation;
 pub mod paragraph_entity_spin_path_attention;

--- a/crates/uor-r4-core/src/source_free_table.rs
+++ b/crates/uor-r4-core/src/source_free_table.rs
@@ -243,6 +243,8 @@ pub struct MultiscaleCountRadiusR4V1 {
     table_artifact_hash: [u8; 32],
     bigram_rows: BTreeMap<u32, MultiscaleCountRadiusRow>,
     trigram_rows: BTreeMap<(u32, u32), MultiscaleCountRadiusRow>,
+    /// Derived cache only; it is deliberately absent from `SFTR4O01` bytes.
+    artifact_hash: [u8; 32],
 }
 
 impl MultiscaleCountRadiusR4V1 {
@@ -280,11 +282,14 @@ impl MultiscaleCountRadiusR4V1 {
                 );
             }
         }
-        Ok(Self {
+        let mut overlay = Self {
             table_artifact_hash: table.artifact_hash,
             bigram_rows,
             trigram_rows,
-        })
+            artifact_hash: [0; 32],
+        };
+        overlay.artifact_hash = *blake3::hash(&overlay.to_bytes()).as_bytes();
+        Ok(overlay)
     }
 
     pub fn table_artifact_cid(&self) -> String {
@@ -292,7 +297,7 @@ impl MultiscaleCountRadiusR4V1 {
     }
 
     pub fn artifact_cid(&self) -> String {
-        format!("blake3:{}", blake3::hash(&self.to_bytes()).to_hex())
+        format!("blake3:{}", hex::encode(self.artifact_hash))
     }
 
     pub fn stats(&self) -> MultiscaleCountRadiusStats {
@@ -402,6 +407,7 @@ impl MultiscaleCountRadiusR4V1 {
             table_artifact_hash,
             bigram_rows,
             trigram_rows,
+            artifact_hash: *blake3::hash(bytes).as_bytes(),
         };
         let expected = Self::compile(table)?;
         if overlay != expected || overlay.to_bytes() != bytes {
@@ -519,12 +525,12 @@ impl SourceFreeTable {
         self.construction_document_ids.len()
     }
 
-    /// Verify that an additive construction-bound operator was compiled from
-    /// the exact document-id and text-CID sets that produced this table.
-    pub(crate) fn is_bound_to_construction_documents(
-        &self,
-        construction: &[SourceDocument],
-    ) -> bool {
+    /// Verify that a construction-bound artifact or cache uses the exact
+    /// document-id and text-CID sets that produced this table.
+    ///
+    /// This is a read-only provenance check. It deliberately exposes neither
+    /// the stored identifiers nor the table's fitted distributions.
+    pub fn is_bound_to_construction_documents(&self, construction: &[SourceDocument]) -> bool {
         let ids = construction
             .iter()
             .map(|document| document.id.clone())
@@ -539,8 +545,58 @@ impl SourceFreeTable {
             && text_cids == self.construction_text_cids
     }
 
+    /// Check a target-blind D3 held-out population for strict provenance
+    /// separation from this table's construction set.
+    ///
+    /// This examines only document IDs and complete text CIDs. It does not
+    /// encode document text, inspect a next-route target, or score a row.
+    pub fn is_disjoint_d3_held_out_documents(&self, held_out: &[SourceDocument]) -> bool {
+        if held_out.is_empty() {
+            return false;
+        }
+        let mut seen_ids = BTreeSet::new();
+        let mut seen_text_cids = BTreeSet::new();
+        held_out.iter().all(|document| {
+            let text_cid = document.text_cid();
+            validate_document_id(&document.id).is_ok()
+                && d3_is_held_out(&document.id)
+                && !self.construction_document_ids.contains(&document.id)
+                && !self.construction_text_cids.contains(&text_cid)
+                && seen_ids.insert(document.id.clone())
+                && seen_text_cids.insert(text_cid)
+        })
+    }
+
+    /// Encode one source document as the exact stream used to compile and
+    /// evaluate this table: `BOS`, canonical lexical-or-byte units, then
+    /// `EOS`.
+    ///
+    /// The returned vector is an immutable observation of the table's codec;
+    /// it does not admit the document into construction or alter any counts.
+    pub fn encode_document_stream(
+        &self,
+        document: &SourceDocument,
+    ) -> Result<Vec<u32>, SourceFreeTableError> {
+        let encoded = self.encode_text(&document.text)?;
+        let mut stream = Vec::with_capacity(encoded.len().saturating_add(2));
+        stream.push(BOS_TOKEN);
+        stream.extend(encoded);
+        stream.push(EOS_TOKEN);
+        Ok(stream)
+    }
+
     pub fn lexical_piece_count(&self) -> usize {
         self.lexical_pieces.len()
+    }
+
+    /// Highest valid token identifier in this table's complete lexical token
+    /// namespace. `BOS`, `EOS`, and byte-fallback tokens occupy lower IDs.
+    pub fn maximum_token_id(&self) -> u32 {
+        self.piece_tokens
+            .values()
+            .next_back()
+            .copied()
+            .unwrap_or(LEXICAL_TOKEN_BASE - 1)
     }
 
     pub fn artifact_cid(&self) -> String {
@@ -1213,7 +1269,12 @@ impl SourceFreeTable {
         Ok(())
     }
 
-    pub(crate) fn is_fitted_lexical_token(&self, token: u32) -> bool {
+    /// Whether `token` names one construction-fitted lexical payload.
+    ///
+    /// Byte fallbacks, `BOS`, `EOS`, and out-of-range identifiers return
+    /// `false`. This is a read-only identity check and exposes no fitted
+    /// counts or mutable table state.
+    pub fn is_fitted_lexical_token(&self, token: u32) -> bool {
         token.checked_sub(LEXICAL_TOKEN_BASE).is_some_and(|offset| {
             usize::try_from(offset)
                 .ok()

--- a/crates/uor-r4-core/tests/corpus_induced_document_spin_placement_973.rs
+++ b/crates/uor-r4-core/tests/corpus_induced_document_spin_placement_973.rs
@@ -1,0 +1,1357 @@
+//! Executable research contract for #973 corpus-induced document spin placement.
+//!
+//! The ordinary test is a small natural-language fixture that exercises the
+//! immutable placement artifact, construction-only anti-recall index, target-
+//! free census, four matched arms, and post-join report shape. The ignored D3
+//! runner is the decision-bearing experiment. It validates the frozen corpus
+//! identities and persists the target-free report before it is allowed to
+//! attach a held-out next-route target.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use uor_r4_core::corpus_induced_spin_placement::{
+    CorpusInducedDocumentSpinAntiRecallIndex, CorpusInducedDocumentSpinArm,
+    CorpusInducedDocumentSpinArtifactStats, CorpusInducedDocumentSpinComparatorEvaluation,
+    CorpusInducedDocumentSpinEvaluation, CorpusInducedDocumentSpinForbiddenReads,
+    CorpusInducedDocumentSpinPlacementR4V1, CorpusInducedDocumentSpinTargetFreeCensus,
+    MIN_OPERATIVE_ANTI_RECALL_POSITIONS, NEGATIVE_TERMINAL, POSITIVE_TERMINAL,
+    UNAVAILABLE_TERMINAL,
+};
+use uor_r4_core::source_free_table::{
+    d3_is_held_out, MultiscaleCountRadiusR4V1, SourceDocument, SourceFreeTable, BOS_TOKEN,
+    EOS_TOKEN,
+};
+
+const CORPUS_PATH_ENV: &str = "UOR_R4_973_D3_CORPUS";
+const OUTPUT_DIR_ENV: &str = "UOR_R4_973_OUTPUT_DIR";
+const DEFAULT_CORPUS_PATH: &str =
+    "/Users/casey.allard/uor-r4/.uor-models/corpora/simple-wiki-20231101/articles.jsonl";
+const DEFAULT_OUTPUT_DIR: &str =
+    "/Users/casey.allard/uor-r4/.uor-models/research/issue-973-corpus-spin-v1";
+
+const FROZEN_CORPUS_CID: &str =
+    "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf";
+const FROZEN_MANIFEST_CID: &str =
+    "blake3:bb5f446ce92df60f7824ed5a1f04ede385386e7a47b9c198ae83a5d0f907bab3";
+const FROZEN_TABLE_CID: &str =
+    "blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297";
+const FROZEN_OVERLAY_CID: &str =
+    "blake3:914126a311c3984d1482258a8f0a7fa2e34896540d502d19f1d9076fbd4a9b76";
+const FROZEN_CONSTRUCTION_SET_KAPPA: &str =
+    "blake3:af2a2d7d49db55279e7ea40947a3259ac0a100aa56e8d920951e7c27eaf6df5c";
+const FROZEN_HELD_OUT_SET_KAPPA: &str =
+    "blake3:7a7558e96aa86aa2d8965972b69ddce02222c6eccc8ca560df2141fc0ac4170e";
+const FROZEN_DOCUMENTS: usize = 3_000;
+const FROZEN_CONSTRUCTION_DOCUMENTS: usize = 2_404;
+const FROZEN_HELD_OUT_DOCUMENTS: usize = 596;
+const FROZEN_TARGET_FREE_ADMISSIONS: u64 = 81_177;
+const FROZEN_KNOWN_TARGET_ADMISSIONS: u64 = 76_641;
+
+const TABLE_ARTIFACT_FILE: &str = "source_free_table.sftbl001";
+const OVERLAY_ARTIFACT_FILE: &str = "multiscale_count_radius.sftr4o01";
+const OPERATOR_ARTIFACT_FILE: &str = "corpus_induced_document_spin.cidsp001";
+const TARGET_FREE_REPORT_FILE: &str = "target_free_preflight.json";
+const EVALUATION_REPORT_FILE: &str = "evaluation_report.json";
+const CANONICAL_RUN_FILE: &str = "canonical_run.json";
+
+type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+
+static TEMPORARY_REPORT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Deserialize)]
+struct D3Manifest {
+    schema: u32,
+    article_count: usize,
+    corpus_cid: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct D3Article {
+    id: String,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DecodedDecision {
+    token: u32,
+    decoded_utf8: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DecodedWitness {
+    document_id: String,
+    target_index: u32,
+    real: DecodedDecision,
+    scope_disabled: DecodedDecision,
+    order_shuffled: DecodedDecision,
+    operator_permuted: DecodedDecision,
+}
+
+#[derive(Serialize, Clone, Copy)]
+struct ReportIdentity<'a> {
+    manifest_cid: &'a str,
+    corpus_cid: &'a str,
+    table_cid: &'a str,
+    overlay_cid: &'a str,
+}
+
+const FROZEN_REPORT_IDENTITY: ReportIdentity<'static> = ReportIdentity {
+    manifest_cid: FROZEN_MANIFEST_CID,
+    corpus_cid: FROZEN_CORPUS_CID,
+    table_cid: FROZEN_TABLE_CID,
+    overlay_cid: FROZEN_OVERLAY_CID,
+};
+
+struct TemporaryReportDirectory {
+    path: PathBuf,
+}
+
+impl TemporaryReportDirectory {
+    fn create() -> io::Result<Self> {
+        loop {
+            let sequence = TEMPORARY_REPORT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "uor-r4-973-unavailable-report-{}-{sequence}",
+                std::process::id()
+            ));
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TemporaryReportDirectory {
+    fn drop(&mut self) {
+        for file in [
+            TARGET_FREE_REPORT_FILE,
+            EVALUATION_REPORT_FILE,
+            CANONICAL_RUN_FILE,
+        ] {
+            let _ = fs::remove_file(self.path.join(file));
+        }
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+#[derive(Serialize)]
+struct TargetFreePreflightReport<'a> {
+    schema: u32,
+    domain: &'static str,
+    manifest_cid: &'a str,
+    corpus_cid: &'a str,
+    table_cid: &'a str,
+    overlay_cid: &'a str,
+    operator_cid: String,
+    operator_stats: CorpusInducedDocumentSpinArtifactStats,
+    anti_recall_index_kappa: &'a str,
+    anti_recall_full_prefixes: usize,
+    anti_recall_natural_states: usize,
+    anti_recall_operative_signatures: usize,
+    census_cid: String,
+    decoded_witness: Option<&'a DecodedWitness>,
+    census: &'a CorpusInducedDocumentSpinTargetFreeCensus,
+}
+
+#[derive(Serialize)]
+struct CanonicalD3RunReport<'a> {
+    schema: u32,
+    domain: &'static str,
+    manifest_cid: &'a str,
+    corpus_cid: &'a str,
+    table_cid: &'a str,
+    overlay_cid: &'a str,
+    operator_cid: String,
+    census_cid: String,
+    evaluation_report_cid: String,
+    decoded_witness: Option<&'a DecodedWitness>,
+    evaluation: &'a CorpusInducedDocumentSpinEvaluation,
+}
+
+fn natural_construction_fixture() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new("14", b"The red fox rests.".to_vec()),
+        SourceDocument::new("657", b"At noon the red fox rests.".to_vec()),
+        SourceDocument::new("4579", b"The red fox runs.".to_vec()),
+        SourceDocument::new("5121", b"At dusk the red fox runs.".to_vec()),
+    ]
+}
+
+fn natural_held_out_fixture() -> Vec<SourceDocument> {
+    vec![
+        SourceDocument::new("12", b"Tonight the red fox rests.".to_vec()),
+        SourceDocument::new("13", b"Tomorrow the red fox runs.".to_vec()),
+    ]
+}
+
+fn cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn require(condition: bool, message: impl Into<String>) -> io::Result<()> {
+    if condition {
+        Ok(())
+    } else {
+        Err(invalid_data(message))
+    }
+}
+
+fn report_stage(stage: &str, started: Instant) {
+    eprintln!(
+        "#973 stage={stage} elapsed={:.3}s",
+        started.elapsed().as_secs_f64()
+    );
+}
+
+fn decision_bytes(table: &SourceFreeTable, token: u32) -> TestResult<String> {
+    Ok(String::from_utf8(table.decode_tokens(&[token])?)?)
+}
+
+fn decode_witness(
+    table: &SourceFreeTable,
+    census: &CorpusInducedDocumentSpinTargetFreeCensus,
+) -> TestResult<DecodedWitness> {
+    let witness = census
+        .frozen_decoded_witness
+        .as_ref()
+        .ok_or_else(|| invalid_data("target-free census has no frozen decoded witness"))?;
+    Ok(DecodedWitness {
+        document_id: witness.document_id.clone(),
+        target_index: witness.target_index,
+        real: DecodedDecision {
+            token: witness.real_token,
+            decoded_utf8: decision_bytes(table, witness.real_token)?,
+        },
+        scope_disabled: DecodedDecision {
+            token: witness.scope_disabled_token,
+            decoded_utf8: decision_bytes(table, witness.scope_disabled_token)?,
+        },
+        order_shuffled: DecodedDecision {
+            token: witness.order_shuffled_token,
+            decoded_utf8: decision_bytes(table, witness.order_shuffled_token)?,
+        },
+        operator_permuted: DecodedDecision {
+            token: witness.operator_permuted_token,
+            decoded_utf8: decision_bytes(table, witness.operator_permuted_token)?,
+        },
+    })
+}
+
+fn assert_comparator_report(
+    comparator: &CorpusInducedDocumentSpinComparatorEvaluation,
+    expected_pairs: Option<u64>,
+) {
+    assert_eq!(
+        comparator.wins + comparator.losses,
+        comparator.discordant,
+        "discordant count must be the paired win/loss denominator"
+    );
+    if let Some(expected_pairs) = expected_pairs {
+        assert_eq!(
+            comparator.wins + comparator.losses + comparator.ties,
+            expected_pairs,
+            "every declared pair must enter the exact comparator report"
+        );
+    }
+    assert!(
+        comparator
+            .one_sided_exact_sign_test
+            .starts_with("20*sum_{k=0}^{"),
+        "exact sign-test expression must be explicit: {comparator:?}"
+    );
+    let exact_threshold_passes = comparator.one_sided_exact_sign_test.ends_with(": true");
+    assert!(
+        exact_threshold_passes || comparator.one_sided_exact_sign_test.ends_with(": false"),
+        "exact integer sign-test decision is missing: {comparator:?}"
+    );
+    assert_eq!(
+        comparator.passes,
+        comparator.wins > comparator.losses && exact_threshold_passes
+    );
+    assert_eq!(
+        comparator.terminal,
+        if comparator.passes {
+            "PASS_DIRECTIONAL_EXACT_SIGN_TEST"
+        } else {
+            "FAIL_DIRECTIONAL_EXACT_SIGN_TEST"
+        }
+    );
+}
+
+fn assert_evaluation_report(evaluation: &CorpusInducedDocumentSpinEvaluation) {
+    for comparator in [
+        &evaluation.versus_scope_disabled,
+        &evaluation.versus_order_shuffled,
+        &evaluation.versus_operator_permuted,
+    ] {
+        assert_comparator_report(
+            comparator,
+            Some(evaluation.operative_known_target_positions),
+        );
+    }
+    let document_blocked = [
+        &evaluation.document_blocked_versus_scope_disabled,
+        &evaluation.document_blocked_versus_order_shuffled,
+        &evaluation.document_blocked_versus_operator_permuted,
+    ];
+    let document_pairs =
+        document_blocked[0].wins + document_blocked[0].losses + document_blocked[0].ties;
+    assert!(document_pairs <= evaluation.held_out_documents);
+    for comparator in document_blocked {
+        assert_comparator_report(comparator, Some(document_pairs));
+    }
+    assert_eq!(
+        evaluation.witness_continuation.is_some(),
+        evaluation.witness_continuation_cid.is_some()
+    );
+    if let (Some(continuation), Some(continuation_cid)) = (
+        &evaluation.witness_continuation,
+        &evaluation.witness_continuation_cid,
+    ) {
+        assert_eq!(
+            continuation_cid,
+            &cid(&serde_json::to_vec(continuation).unwrap())
+        );
+    }
+    let all_six_comparators_pass = [
+        &evaluation.versus_scope_disabled,
+        &evaluation.versus_order_shuffled,
+        &evaluation.versus_operator_permuted,
+        &evaluation.document_blocked_versus_scope_disabled,
+        &evaluation.document_blocked_versus_order_shuffled,
+        &evaluation.document_blocked_versus_operator_permuted,
+    ]
+    .into_iter()
+    .all(|comparator| comparator.passes);
+    assert_eq!(
+        evaluation.decision == POSITIVE_TERMINAL,
+        all_six_comparators_pass && evaluation.witness_continuation_contrast
+    );
+    assert_eq!(evaluation.forbidden_reads.total(), 0);
+}
+
+fn validate_unavailable_evaluation(
+    evaluation: &CorpusInducedDocumentSpinEvaluation,
+    census: &CorpusInducedDocumentSpinTargetFreeCensus,
+) -> TestResult {
+    require(
+        !census.meets_frozen_preflight,
+        "UNAVAILABLE evaluation requires a valid failed target-free preflight",
+    )?;
+    require(
+        census.support_mismatches == 0
+            && census.work_mismatches == 0
+            && census.invalid_score_firewall_certificates == 0
+            && census.forbidden_reads.total() == 0,
+        "contract-invalid target-free evidence cannot terminate as scientific UNAVAILABLE",
+    )?;
+    require(
+        evaluation.decision == UNAVAILABLE_TERMINAL,
+        format!(
+            "failed preflight produced an invalid terminal: {}",
+            evaluation.decision
+        ),
+    )?;
+    require(
+        evaluation.census_cid == census.artifact_cid()?,
+        "UNAVAILABLE evaluation is not bound to the persisted target-free census",
+    )?;
+    require(
+        evaluation.held_out_set_kappa == census.held_out_set_kappa,
+        "UNAVAILABLE evaluation held-out binding drifted",
+    )?;
+    require(
+        evaluation.held_out_documents == census.held_out_documents,
+        "UNAVAILABLE evaluation held-out document count drifted",
+    )?;
+    require(
+        evaluation.operative_positions == census.operative_positions.len() as u64,
+        "UNAVAILABLE evaluation operative count drifted",
+    )?;
+    require(
+        evaluation.post_join_admission_opportunities == 0
+            && evaluation.post_join_known_target_admission_opportunities == 0
+            && evaluation.operative_known_target_positions == 0
+            && evaluation.real_correct == 0
+            && evaluation.scope_disabled_correct == 0
+            && evaluation.order_shuffled_correct == 0
+            && evaluation.operator_permuted_correct == 0,
+        "UNAVAILABLE evaluation attached label-bearing held-out results",
+    )?;
+    require(
+        !evaluation.witness_continuation_contrast
+            && evaluation.witness_continuation.is_none()
+            && evaluation.witness_continuation_cid.is_none(),
+        "UNAVAILABLE evaluation emitted a post-join continuation witness",
+    )?;
+    require(
+        evaluation.target_reads == 0,
+        "failed preflight attempted to read a held-out target",
+    )?;
+    require(
+        evaluation.forbidden_reads.total() == 0,
+        "UNAVAILABLE evaluation recorded a forbidden read",
+    )?;
+    assert_evaluation_report(evaluation);
+    Ok(())
+}
+
+fn source_slice<'a>(source: &'a str, start: &str, end: &str) -> Result<&'a str, String> {
+    let start_index = source
+        .find(start)
+        .ok_or_else(|| format!("score-firewall start marker is absent: {start}"))?;
+    let end_index = source[start_index..]
+        .find(end)
+        .map(|offset| start_index + offset)
+        .ok_or_else(|| format!("score-firewall end marker is absent: {end}"))?;
+    Ok(&source[start_index..end_index])
+}
+
+fn invocation_slices<'a>(source: &'a str, name: &str) -> Result<Vec<&'a str>, String> {
+    let mut invocations = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative_start) = source[cursor..].find(name) {
+        let start = cursor + relative_start;
+        let open = source[start..]
+            .find('(')
+            .map(|offset| start + offset)
+            .ok_or_else(|| {
+                format!("score-firewall invocation has no opening parenthesis: {name}")
+            })?;
+        let mut depth = 0_u32;
+        let mut close = None;
+        for (offset, byte) in source.as_bytes()[open..].iter().enumerate() {
+            match byte {
+                b'(' => depth += 1,
+                b')' => {
+                    depth = depth
+                        .checked_sub(1)
+                        .ok_or_else(|| "score-firewall parenthesis underflow".to_owned())?;
+                    if depth == 0 {
+                        close = Some(open + offset + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close = close.ok_or_else(|| {
+            format!("score-firewall invocation has no closing parenthesis: {name}")
+        })?;
+        invocations.push(&source[start..close]);
+        cursor = close;
+    }
+    Ok(invocations)
+}
+
+fn source_without_comments_or_strings(source: &str) -> String {
+    source
+        .lines()
+        .filter_map(|line| {
+            let code = line.split_once("//").map_or(line, |(code, _)| code);
+            let mut outside = true;
+            let mut escaped = false;
+            let mut scrubbed = String::new();
+            for character in code.chars() {
+                if outside {
+                    if character == '"' {
+                        outside = false;
+                    } else {
+                        scrubbed.push(character);
+                    }
+                } else if escaped {
+                    escaped = false;
+                } else if character == '\\' {
+                    escaped = true;
+                } else if character == '"' {
+                    outside = true;
+                }
+            }
+            (!scrubbed.trim().is_empty()).then_some(scrubbed)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn enforce_exact_score_firewall(
+    placement_source: &str,
+    exact_kernel_source: &str,
+    forbidden_reads: CorpusInducedDocumentSpinForbiddenReads,
+) -> Result<(), String> {
+    if forbidden_reads.total() != 0 {
+        return Err(format!(
+            "score-firewall rejected {} injected forbidden reads",
+            forbidden_reads.total()
+        ));
+    }
+
+    let executed_score_kernel = source_slice(
+        placement_source,
+        "fn execute_arm(",
+        "fn issue_score_firewall_certificate(",
+    )?;
+    let relative_calls = invocation_slices(executed_score_kernel, "candidate_relative_exact_cost")?;
+    if relative_calls.len() != 1 {
+        return Err(format!(
+            "score-firewall expected one shared executed-arm relative-cost seam, found {}",
+            relative_calls.len()
+        ));
+    }
+    let decision_kernel =
+        source_slice(placement_source, "fn select_decision(", "fn blake3_label(")?;
+    let selection_calls = invocation_slices(decision_kernel, "select_unique_minimum_exact_costs")?;
+    if selection_calls.len() != 1 {
+        return Err(format!(
+            "score-firewall expected one exact unique-minimum call, found {}",
+            selection_calls.len()
+        ));
+    }
+    let exact_cost_kernel = source_slice(
+        exact_kernel_source,
+        "pub(crate) fn candidate_relative_exact_cost(",
+        "#[derive(Debug, Clone, Copy)]",
+    )?;
+    let exact_selection_kernel = source_slice(
+        exact_kernel_source,
+        "pub(crate) fn select_unique_minimum_exact_costs(",
+        "fn select_exact_costs(",
+    )?;
+    let prediction_kernel = placement_source
+        .split_once("    fn predict_from_frame(")
+        .map(|(_, suffix)| suffix)
+        .ok_or_else(|| "predict_from_frame production certificate seam is absent".to_owned())?;
+    if invocation_slices(prediction_kernel, "issue_score_firewall_certificate")?.len() != 1
+        || invocation_slices(prediction_kernel, "forbidden_reads_from_mask")?.len() != 1
+    {
+        return Err(
+            "score-firewall production certificate must issue and consume exactly once".to_owned(),
+        );
+    }
+    for required_production_certificate_seam in [
+        "score_firewall_certificate: CorpusInducedDocumentSpinScoreFirewallCertificate",
+        "ScoreFrameOrigin::CausalPrefix => 0",
+        "ScoreFrameOrigin::InjectedHeldOutTarget => 1",
+    ] {
+        if !placement_source.contains(required_production_certificate_seam) {
+            return Err(format!(
+                "score-firewall lost production certificate seam `{required_production_certificate_seam}`"
+            ));
+        }
+    }
+
+    let mut guarded_source = String::new();
+    for invocation in relative_calls.iter().chain(selection_calls.iter()) {
+        guarded_source.push_str(invocation);
+        guarded_source.push('\n');
+    }
+    guarded_source.push_str(exact_cost_kernel);
+    guarded_source.push_str(exact_selection_kernel);
+    let guarded_source = source_without_comments_or_strings(&guarded_source);
+    for forbidden in [
+        "target",
+        "future",
+        "teacher",
+        "provider",
+        "source_weight",
+        "payload",
+        "prime",
+        "rank",
+        "digest",
+        "support",
+        "provenance",
+    ] {
+        if guarded_source.contains(forbidden) {
+            return Err(format!(
+                "score-firewall rejected forbidden numeric input `{forbidden}`"
+            ));
+        }
+    }
+    for required_type_seam in [
+        "class_state: ExactSpinState",
+        "global_state: ExactSpinState",
+        "relative: ExactSpinState",
+        "costs: &[BoundedGlobalExactSpinCost]",
+        "select_unique_minimum_exact_costs(costs)",
+    ] {
+        if !guarded_source.contains(required_type_seam) {
+            return Err(format!(
+                "score-firewall lost required exact type seam `{required_type_seam}`"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn exact_score_source_and_counter_firewall_rejects_injected_leaks() {
+    const PLACEMENT_SOURCE: &str = include_str!("../src/corpus_induced_spin_placement.rs");
+    const EXACT_KERNEL_SOURCE: &str = include_str!("../src/bounded_global_exact_spin_attention.rs");
+
+    enforce_exact_score_firewall(
+        PLACEMENT_SOURCE,
+        EXACT_KERNEL_SOURCE,
+        CorpusInducedDocumentSpinForbiddenReads::default(),
+    )
+    .expect("the live exact score seam must accept only exact geometry and exact costs");
+
+    let executed_score_kernel = source_slice(
+        PLACEMENT_SOURCE,
+        "fn execute_arm(",
+        "fn issue_score_firewall_certificate(",
+    )
+    .expect("live executed-arm score kernel must be source-addressable");
+    let relative_invocation =
+        invocation_slices(executed_score_kernel, "candidate_relative_exact_cost")
+            .expect("live relative-cost call must parse")
+            .into_iter()
+            .next()
+            .expect("live relative-cost call must exist");
+    let injected_invocation =
+        relative_invocation.replacen("query.state", "held_out_target_derived_state", 1);
+    let injected_source = PLACEMENT_SOURCE.replacen(relative_invocation, &injected_invocation, 1);
+    assert_ne!(
+        injected_source, PLACEMENT_SOURCE,
+        "target-derived-state injection must reach the live executed-arm score seam"
+    );
+    let injected_source_error = enforce_exact_score_firewall(
+        &injected_source,
+        EXACT_KERNEL_SOURCE,
+        CorpusInducedDocumentSpinForbiddenReads::default(),
+    )
+    .expect_err("an injected target score input must fail the source firewall");
+    assert!(injected_source_error.contains("target"));
+
+    let mut injected_counter = CorpusInducedDocumentSpinForbiddenReads::default();
+    injected_counter.teacher_calls = 1;
+    let injected_counter_error =
+        enforce_exact_score_firewall(PLACEMENT_SOURCE, EXACT_KERNEL_SOURCE, injected_counter)
+            .expect_err("an injected forbidden-read counter must fail the typed firewall");
+    assert!(injected_counter_error.contains("injected forbidden reads"));
+}
+
+#[test]
+fn natural_fixture_replays_artifact_and_exercises_four_target_join_arms() -> TestResult {
+    let construction = natural_construction_fixture();
+    let held_out = natural_held_out_fixture();
+    assert!(
+        construction
+            .iter()
+            .all(|document| !d3_is_held_out(&document.id)),
+        "fixture construction IDs must remain in the D3 construction partition"
+    );
+    assert!(
+        held_out.iter().all(|document| d3_is_held_out(&document.id)),
+        "fixture held-out IDs must remain in the D3 held-out partition"
+    );
+
+    let table = SourceFreeTable::compile(&construction)?;
+    assert!(table.is_bound_to_construction_documents(&construction));
+    assert!(table.is_disjoint_d3_held_out_documents(&held_out));
+    let held_stream = table.encode_document_stream(&held_out[0])?;
+    assert_eq!(held_stream.first(), Some(&BOS_TOKEN));
+    assert_eq!(held_stream.last(), Some(&EOS_TOKEN));
+    assert!(!table.is_fitted_lexical_token(BOS_TOKEN));
+    assert!(!table.is_fitted_lexical_token(EOS_TOKEN));
+    assert!(!table.is_fitted_lexical_token(table.maximum_token_id() + 1));
+
+    let overlay = MultiscaleCountRadiusR4V1::compile(&table)?;
+    let compiled =
+        CorpusInducedDocumentSpinPlacementR4V1::compile(&table, &overlay, &construction)?;
+    let artifact_bytes = compiled.to_bytes()?;
+    assert_eq!(
+        CorpusInducedDocumentSpinPlacementR4V1::compile(&table, &overlay, &construction)?
+            .to_bytes()?,
+        artifact_bytes,
+        "construction-only compilation must be byte reproducible"
+    );
+    let expected_operator_cid = compiled.artifact_cid()?;
+    let operator = CorpusInducedDocumentSpinPlacementR4V1::from_bytes(
+        &table,
+        &overlay,
+        &expected_operator_cid,
+        &artifact_bytes,
+    )?;
+    assert_eq!(operator.to_bytes()?, artifact_bytes);
+    assert_eq!(operator.artifact_cid()?, cid(&artifact_bytes));
+    assert!(operator.stats().usable_prototypes >= 2);
+
+    let mut prefix = vec![BOS_TOKEN];
+    prefix.extend(table.encode_text(b"Tonight the red fox")?);
+    let prediction = operator.predict_matched(&table, &overlay, &prefix)?;
+    assert!(
+        prediction.score_firewall_certificate.validate(),
+        "production score-firewall certificate must self-validate"
+    );
+    assert_eq!(
+        prediction.score_firewall_certificate.operator_cid,
+        operator.artifact_cid()?
+    );
+    assert_eq!(
+        prediction.score_firewall_certificate.causal_prefix_units,
+        prefix.len() as u64
+    );
+    assert_eq!(
+        prediction.score_firewall_certificate.candidate_count,
+        prediction.local.max_count_tie_tokens.len() as u64
+    );
+    assert_eq!(
+        prediction
+            .score_firewall_certificate
+            .forbidden_dependency_mask,
+        0
+    );
+    assert!(prediction.prototype_complete, "{prediction:#?}");
+    assert!(prediction.natural_reverse_distinct, "{prediction:#?}");
+    assert!(
+        prediction.permutation_cost_vector_changed,
+        "{prediction:#?}"
+    );
+    assert!(prediction.support_matched, "{prediction:#?}");
+    assert!(prediction.work_matched, "{prediction:#?}");
+    assert_eq!(prediction.forbidden_reads.total(), 0);
+    assert_eq!(prediction.real.arm, CorpusInducedDocumentSpinArm::Real);
+    assert_eq!(
+        prediction.scope_disabled.arm,
+        CorpusInducedDocumentSpinArm::ScopeDisabled
+    );
+    assert_eq!(
+        prediction.order_shuffled.arm,
+        CorpusInducedDocumentSpinArm::OrderShuffled
+    );
+    assert_eq!(
+        prediction.operator_permuted.arm,
+        CorpusInducedDocumentSpinArm::OperatorPermuted
+    );
+    for control in [
+        &prediction.scope_disabled,
+        &prediction.order_shuffled,
+        &prediction.operator_permuted,
+    ] {
+        assert_eq!(control.support_tokens, prediction.real.support_tokens);
+        assert_eq!(control.work, prediction.real.work);
+    }
+    let mut support = prediction
+        .real
+        .support_tokens
+        .iter()
+        .map(|&token| table.decode_tokens(&[token]))
+        .collect::<Result<Vec<_>, _>>()?;
+    support.sort();
+    assert_eq!(support, vec![b" rests".to_vec(), b" runs".to_vec()]);
+
+    let anti_recall = CorpusInducedDocumentSpinAntiRecallIndex::compile(
+        &operator,
+        &table,
+        &overlay,
+        &construction,
+    )?;
+    let census = operator.target_free_census(&table, &overlay, &anti_recall, &held_out)?;
+    let census_bytes = census.canonical_bytes()?;
+    assert_eq!(census.canonical_bytes()?, census_bytes);
+    assert_eq!(census.forbidden_reads.total(), 0);
+    assert_eq!(census.support_mismatches, 0);
+    assert_eq!(census.work_mismatches, 0);
+    assert_eq!(census.invalid_score_firewall_certificates, 0);
+    assert_eq!(
+        census.score_firewall_policy_kappa,
+        prediction.score_firewall_certificate.policy_kappa
+    );
+    assert!(!census.meets_frozen_preflight);
+
+    let fixture_manifest_cid = cid(b"uor-r4.issue-973-natural-fixture-manifest/1");
+    let fixture_corpus_cid = cid(b"uor-r4.issue-973-natural-fixture-corpus/1");
+    let fixture_table_cid = table.artifact_cid();
+    let fixture_overlay_cid = overlay.artifact_cid();
+    let fixture_identity = ReportIdentity {
+        manifest_cid: &fixture_manifest_cid,
+        corpus_cid: &fixture_corpus_cid,
+        table_cid: &fixture_table_cid,
+        overlay_cid: &fixture_overlay_cid,
+    };
+    let decoded_witness = census
+        .frozen_decoded_witness
+        .as_ref()
+        .map(|_| decode_witness(&table, &census))
+        .transpose()?;
+    let census_cid = census.artifact_cid()?;
+    let target_free_report = TargetFreePreflightReport {
+        schema: 1,
+        domain: "uor-r4.issue-973-target-free-preflight/1",
+        manifest_cid: fixture_identity.manifest_cid,
+        corpus_cid: fixture_identity.corpus_cid,
+        table_cid: fixture_identity.table_cid,
+        overlay_cid: fixture_identity.overlay_cid,
+        operator_cid: operator.artifact_cid()?,
+        operator_stats: operator.stats(),
+        anti_recall_index_kappa: anti_recall.index_kappa(),
+        anti_recall_full_prefixes: anti_recall.full_prefix_count(),
+        anti_recall_natural_states: anti_recall.natural_state_count(),
+        anti_recall_operative_signatures: anti_recall.operative_signature_count(),
+        census_cid: census_cid.clone(),
+        decoded_witness: decoded_witness.as_ref(),
+        census: &census,
+    };
+    let target_free_bytes = serde_json::to_vec(&target_free_report)?;
+    let temporary_output = TemporaryReportDirectory::create()?;
+    persist_and_replay(
+        &temporary_output.path().join(TARGET_FREE_REPORT_FILE),
+        &target_free_bytes,
+        "fixture target-free report",
+    )?;
+
+    // This non-frozen fixture deliberately exercises the unavailable report
+    // shape. The decision-bearing full-D3 runner below may not join targets
+    // unless its frozen preflight passes.
+    let evaluation =
+        operator.evaluate_held_out(&table, &overlay, &anti_recall, &census, &held_out)?;
+    validate_unavailable_evaluation(&evaluation, &census)?;
+    let report_bytes = evaluation.canonical_bytes()?;
+    assert_eq!(evaluation.canonical_bytes()?, report_bytes);
+    assert_eq!(evaluation.report_cid()?, cid(&report_bytes));
+    let canonical_run_bytes = persist_terminal_bundle(
+        temporary_output.path(),
+        fixture_identity,
+        &operator.artifact_cid()?,
+        &census_cid,
+        &target_free_bytes,
+        decoded_witness.as_ref(),
+        &evaluation,
+    )?;
+    let persisted_evaluation: serde_json::Value = serde_json::from_slice(&fs::read(
+        temporary_output.path().join(EVALUATION_REPORT_FILE),
+    )?)?;
+    assert_eq!(persisted_evaluation["decision"], UNAVAILABLE_TERMINAL);
+    assert_eq!(persisted_evaluation["target_reads"], 0);
+    let persisted_run: serde_json::Value = serde_json::from_slice(&canonical_run_bytes)?;
+    assert_eq!(
+        persisted_run["evaluation"]["decision"],
+        UNAVAILABLE_TERMINAL
+    );
+    assert_eq!(persisted_run["evaluation"]["target_reads"], 0);
+    Ok(())
+}
+
+fn load_frozen_d3_corpus(
+    corpus_path: &Path,
+) -> TestResult<(Vec<SourceDocument>, Vec<SourceDocument>)> {
+    let corpus_bytes = fs::read(corpus_path)?;
+    require(
+        cid(&corpus_bytes) == FROZEN_CORPUS_CID,
+        format!(
+            "D3 corpus CID mismatch at {}: got {}",
+            corpus_path.display(),
+            cid(&corpus_bytes)
+        ),
+    )?;
+
+    let manifest_path = corpus_path.with_file_name("manifest.json");
+    let manifest_bytes = fs::read(&manifest_path)?;
+    require(
+        cid(&manifest_bytes) == FROZEN_MANIFEST_CID,
+        format!(
+            "D3 manifest CID mismatch at {}: got {}",
+            manifest_path.display(),
+            cid(&manifest_bytes)
+        ),
+    )?;
+    let manifest: D3Manifest = serde_json::from_slice(&manifest_bytes)?;
+    require(manifest.schema == 1, "D3 manifest schema must be 1")?;
+    require(
+        manifest.article_count == FROZEN_DOCUMENTS,
+        "D3 manifest article count drifted",
+    )?;
+    require(
+        manifest.corpus_cid == FROZEN_CORPUS_CID,
+        "D3 manifest no longer declares the frozen corpus CID",
+    )?;
+
+    let corpus_text = std::str::from_utf8(&corpus_bytes)?;
+    let mut seen_ids = BTreeSet::new();
+    let mut documents = Vec::with_capacity(FROZEN_DOCUMENTS);
+    for (line_index, line) in corpus_text.lines().enumerate() {
+        require(
+            !line.trim().is_empty(),
+            format!("D3 corpus contains an empty line at {}", line_index + 1),
+        )?;
+        let article: D3Article = serde_json::from_str(line).map_err(|error| {
+            invalid_data(format!(
+                "invalid D3 article JSON at line {}: {error}",
+                line_index + 1
+            ))
+        })?;
+        require(
+            seen_ids.insert(article.id.clone()),
+            format!("duplicate D3 article ID {}", article.id),
+        )?;
+        documents.push(SourceDocument::new(article.id, article.text.into_bytes()));
+    }
+    require(
+        documents.len() == FROZEN_DOCUMENTS,
+        format!(
+            "D3 corpus has {} articles, expected {FROZEN_DOCUMENTS}",
+            documents.len()
+        ),
+    )?;
+    documents.sort_by(|left, right| left.id.cmp(&right.id));
+    let (held_out, construction): (Vec<_>, Vec<_>) = documents
+        .into_iter()
+        .partition(|document| d3_is_held_out(&document.id));
+    require(
+        construction.len() == FROZEN_CONSTRUCTION_DOCUMENTS,
+        format!(
+            "D3 construction partition has {} documents, expected {FROZEN_CONSTRUCTION_DOCUMENTS}",
+            construction.len()
+        ),
+    )?;
+    require(
+        held_out.len() == FROZEN_HELD_OUT_DOCUMENTS,
+        format!(
+            "D3 held-out partition has {} documents, expected {FROZEN_HELD_OUT_DOCUMENTS}",
+            held_out.len()
+        ),
+    )?;
+    Ok((construction, held_out))
+}
+
+fn write_atomically(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_data(format!("output path has no parent: {}", path.display())))?;
+    fs::create_dir_all(parent)?;
+    if path.exists() && fs::read(path)? == bytes {
+        return Ok(());
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid_data(format!("output filename is invalid: {}", path.display())))?;
+    let temporary = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temporary)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    drop(file);
+    fs::rename(temporary, path)?;
+    #[cfg(unix)]
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn persist_and_replay(path: &Path, bytes: &[u8], label: &str) -> TestResult {
+    write_atomically(path, bytes)?;
+    require(
+        fs::read(path)? == bytes,
+        format!("{label} did not replay byte-identically from disk"),
+    )?;
+    Ok(())
+}
+
+fn persist_terminal_bundle(
+    output_dir: &Path,
+    identity: ReportIdentity<'_>,
+    operator_cid: &str,
+    census_cid: &str,
+    target_free_bytes: &[u8],
+    decoded_witness: Option<&DecodedWitness>,
+    evaluation: &CorpusInducedDocumentSpinEvaluation,
+) -> TestResult<Vec<u8>> {
+    persist_and_replay(
+        &output_dir.join(TARGET_FREE_REPORT_FILE),
+        target_free_bytes,
+        "target-free report",
+    )?;
+
+    let evaluation_bytes = evaluation.canonical_bytes()?;
+    require(
+        evaluation.canonical_bytes()? == evaluation_bytes,
+        "evaluation report bytes are not reproducible",
+    )?;
+    require(
+        evaluation.report_cid()? == cid(&evaluation_bytes),
+        "evaluation report CID does not bind its canonical bytes",
+    )?;
+    persist_and_replay(
+        &output_dir.join(EVALUATION_REPORT_FILE),
+        &evaluation_bytes,
+        "evaluation report",
+    )?;
+
+    let canonical_run = CanonicalD3RunReport {
+        schema: 1,
+        domain: "uor-r4.issue-973-corpus-induced-document-spin-run/1",
+        manifest_cid: identity.manifest_cid,
+        corpus_cid: identity.corpus_cid,
+        table_cid: identity.table_cid,
+        overlay_cid: identity.overlay_cid,
+        operator_cid: operator_cid.to_owned(),
+        census_cid: census_cid.to_owned(),
+        evaluation_report_cid: evaluation.report_cid()?,
+        decoded_witness,
+        evaluation,
+    };
+    let canonical_run_bytes = serde_json::to_vec(&canonical_run)?;
+    require(
+        serde_json::to_vec(&canonical_run)? == canonical_run_bytes,
+        "canonical run bytes are not reproducible",
+    )?;
+    persist_and_replay(
+        &output_dir.join(CANONICAL_RUN_FILE),
+        &canonical_run_bytes,
+        "canonical run report",
+    )?;
+    Ok(canonical_run_bytes)
+}
+
+fn load_or_compile_table(
+    path: &Path,
+    construction: &[SourceDocument],
+) -> TestResult<SourceFreeTable> {
+    let bytes = if path.exists() {
+        fs::read(path)?
+    } else {
+        let table = SourceFreeTable::compile(construction)?;
+        let bytes = table.to_bytes();
+        require(
+            table.artifact_cid() == FROZEN_TABLE_CID,
+            format!("fresh SFTBL001 CID drifted: {}", table.artifact_cid()),
+        )?;
+        write_atomically(path, &bytes)?;
+        bytes
+    };
+    let table = SourceFreeTable::from_bytes(&bytes)?;
+    require(
+        table.to_bytes() == bytes,
+        "cached SFTBL001 artifact is not canonical",
+    )?;
+    require(
+        table.artifact_cid() == FROZEN_TABLE_CID,
+        format!("cached SFTBL001 CID drifted: {}", table.artifact_cid()),
+    )?;
+    require(
+        table.is_bound_to_construction_documents(construction),
+        "cached SFTBL001 artifact is not bound to the frozen construction set",
+    )?;
+    Ok(table)
+}
+
+fn load_or_compile_overlay(
+    path: &Path,
+    table: &SourceFreeTable,
+) -> TestResult<MultiscaleCountRadiusR4V1> {
+    let bytes = if path.exists() {
+        fs::read(path)?
+    } else {
+        let overlay = MultiscaleCountRadiusR4V1::compile(table)?;
+        let bytes = overlay.to_bytes();
+        require(
+            overlay.artifact_cid() == FROZEN_OVERLAY_CID,
+            format!("fresh #953 overlay CID drifted: {}", overlay.artifact_cid()),
+        )?;
+        write_atomically(path, &bytes)?;
+        bytes
+    };
+    let overlay = MultiscaleCountRadiusR4V1::from_bytes(table, &bytes)?;
+    require(
+        overlay.to_bytes() == bytes,
+        "cached #953 overlay artifact is not canonical",
+    )?;
+    require(
+        overlay.table_artifact_cid() == FROZEN_TABLE_CID,
+        "cached #953 overlay is not bound to the frozen table",
+    )?;
+    require(
+        overlay.artifact_cid() == FROZEN_OVERLAY_CID,
+        format!(
+            "cached #953 overlay CID drifted: {}",
+            overlay.artifact_cid()
+        ),
+    )?;
+    Ok(overlay)
+}
+
+fn compile_and_replay_operator(
+    path: &Path,
+    table: &SourceFreeTable,
+    overlay: &MultiscaleCountRadiusR4V1,
+    construction: &[SourceDocument],
+) -> TestResult<CorpusInducedDocumentSpinPlacementR4V1> {
+    // Recompile from the exact construction set on every decision-bearing run
+    // so the expected CID is trusted independently of the cached bytes. The
+    // frozen table and #953 overlay remain the expensive reusable inputs.
+    let compiled = CorpusInducedDocumentSpinPlacementR4V1::compile(table, overlay, construction)?;
+    let expected_operator_cid = compiled.artifact_cid()?;
+    let compiled_bytes = compiled.to_bytes()?;
+    require(
+        expected_operator_cid == cid(&compiled_bytes),
+        "fresh #973 operator CID does not bind its canonical bytes",
+    )?;
+    let bytes = if path.exists() {
+        let cached = fs::read(path)?;
+        require(
+            cached == compiled_bytes,
+            "cached #973 operator differs from the fresh construction-only compile",
+        )?;
+        cached
+    } else {
+        write_atomically(path, &compiled_bytes)?;
+        compiled_bytes
+    };
+    let operator = CorpusInducedDocumentSpinPlacementR4V1::from_bytes(
+        table,
+        overlay,
+        &expected_operator_cid,
+        &bytes,
+    )?;
+    require(
+        operator.to_bytes()? == bytes,
+        "cached #973 operator does not replay byte identically",
+    )?;
+    require(
+        operator.artifact_cid()? == cid(&bytes),
+        "cached #973 operator CID does not bind its canonical bytes",
+    )?;
+    require(
+        operator.table_artifact_cid() == FROZEN_TABLE_CID,
+        "cached #973 operator table binding drifted",
+    )?;
+    require(
+        operator.base_overlay_artifact_cid() == FROZEN_OVERLAY_CID,
+        "cached #973 operator overlay binding drifted",
+    )?;
+    Ok(operator)
+}
+
+/// Decision-bearing D3 run. It caches the frozen #989 table, accepted #953
+/// overlay, and aggregate #973 operator in an explicit output directory. The
+/// target-free report is durably written before any evaluation call.
+#[test]
+#[ignore = "full frozen D3 corpus-induction experiment; approximately 20-30 minutes on M1"]
+fn full_d3_corpus_induced_document_spin_placement_973() -> TestResult {
+    let run_started = Instant::now();
+    eprintln!(
+        "#973 stage=start native_workers={}",
+        std::thread::available_parallelism()
+            .map_or(1, usize::from)
+            .min(8)
+    );
+    let report_identity = FROZEN_REPORT_IDENTITY;
+    let corpus_path =
+        PathBuf::from(env::var_os(CORPUS_PATH_ENV).unwrap_or_else(|| DEFAULT_CORPUS_PATH.into()));
+    let output_dir =
+        PathBuf::from(env::var_os(OUTPUT_DIR_ENV).unwrap_or_else(|| DEFAULT_OUTPUT_DIR.into()));
+    let (construction, held_out) = load_frozen_d3_corpus(&corpus_path)?;
+    report_stage("corpus_loaded", run_started);
+
+    let table = load_or_compile_table(&output_dir.join(TABLE_ARTIFACT_FILE), &construction)?;
+    report_stage("table_replayed", run_started);
+    require(
+        table.is_disjoint_d3_held_out_documents(&held_out),
+        "frozen held-out population is not strictly disjoint from construction",
+    )?;
+    let overlay = load_or_compile_overlay(&output_dir.join(OVERLAY_ARTIFACT_FILE), &table)?;
+    report_stage("overlay_replayed", run_started);
+    let operator = compile_and_replay_operator(
+        &output_dir.join(OPERATOR_ARTIFACT_FILE),
+        &table,
+        &overlay,
+        &construction,
+    )?;
+    report_stage("operator_recompiled_and_replayed", run_started);
+    require(
+        operator.construction_set_kappa() == FROZEN_CONSTRUCTION_SET_KAPPA,
+        format!(
+            "#973 construction-set kappa drifted: {}",
+            operator.construction_set_kappa()
+        ),
+    )?;
+    let anti_recall = CorpusInducedDocumentSpinAntiRecallIndex::compile(
+        &operator,
+        &table,
+        &overlay,
+        &construction,
+    )?;
+    report_stage("anti_recall_compiled", run_started);
+
+    let census = operator.target_free_census(&table, &overlay, &anti_recall, &held_out)?;
+    report_stage("target_free_census_complete", run_started);
+    require(
+        census.held_out_documents == FROZEN_HELD_OUT_DOCUMENTS as u64,
+        "target-free census held-out population drifted",
+    )?;
+    require(
+        census.admission_opportunities == FROZEN_TARGET_FREE_ADMISSIONS,
+        format!(
+            "target-free census produced {} admissions, expected {FROZEN_TARGET_FREE_ADMISSIONS}",
+            census.admission_opportunities
+        ),
+    )?;
+    require(
+        census.held_out_set_kappa == FROZEN_HELD_OUT_SET_KAPPA,
+        format!(
+            "target-free held-out-set kappa drifted: {}",
+            census.held_out_set_kappa
+        ),
+    )?;
+    require(
+        census.support_mismatches == 0 && census.work_mismatches == 0,
+        "target-free census violated the matched support/work contract",
+    )?;
+    require(
+        census.invalid_score_firewall_certificates == 0,
+        "target-free census contains an invalid production score-firewall certificate",
+    )?;
+    require(
+        !census.score_firewall_policy_kappa.is_empty(),
+        "target-free census omitted the production score-firewall policy binding",
+    )?;
+    require(
+        census.forbidden_reads.total() == 0,
+        "target-free census recorded a forbidden read",
+    )?;
+    let decoded_witness = census
+        .frozen_decoded_witness
+        .as_ref()
+        .map(|_| decode_witness(&table, &census))
+        .transpose()?;
+    let census_cid = census.artifact_cid()?;
+    let target_free_report = TargetFreePreflightReport {
+        schema: 1,
+        domain: "uor-r4.issue-973-target-free-preflight/1",
+        manifest_cid: report_identity.manifest_cid,
+        corpus_cid: report_identity.corpus_cid,
+        table_cid: report_identity.table_cid,
+        overlay_cid: report_identity.overlay_cid,
+        operator_cid: operator.artifact_cid()?,
+        operator_stats: operator.stats(),
+        anti_recall_index_kappa: anti_recall.index_kappa(),
+        anti_recall_full_prefixes: anti_recall.full_prefix_count(),
+        anti_recall_natural_states: anti_recall.natural_state_count(),
+        anti_recall_operative_signatures: anti_recall.operative_signature_count(),
+        census_cid: census_cid.clone(),
+        decoded_witness: decoded_witness.as_ref(),
+        census: &census,
+    };
+    let target_free_bytes = serde_json::to_vec(&target_free_report)?;
+    require(
+        serde_json::to_vec(&target_free_report)? == target_free_bytes,
+        "target-free report bytes are not reproducible",
+    )?;
+    persist_and_replay(
+        &output_dir.join(TARGET_FREE_REPORT_FILE),
+        &target_free_bytes,
+        "target-free report",
+    )?;
+    report_stage("target_free_report_durable", run_started);
+
+    if !census.meets_frozen_preflight {
+        // A scientifically unavailable preflight is still a valid terminal.
+        // Ask the evaluator to reproduce the census and emit its zero-target-
+        // read report, then stop without entering the target-join branch.
+        let evaluation =
+            operator.evaluate_held_out(&table, &overlay, &anti_recall, &census, &held_out)?;
+        validate_unavailable_evaluation(&evaluation, &census)?;
+        let canonical_run_bytes = persist_terminal_bundle(
+            &output_dir,
+            report_identity,
+            &operator.artifact_cid()?,
+            &census_cid,
+            &target_free_bytes,
+            decoded_witness.as_ref(),
+            &evaluation,
+        )?;
+        report_stage("unavailable_terminal_durable", run_started);
+        println!("{}", std::str::from_utf8(&canonical_run_bytes)?);
+        return Ok(());
+    }
+
+    require(
+        census.operative_positions.len() as u64 >= MIN_OPERATIVE_ANTI_RECALL_POSITIONS,
+        "passing preflight has too few operative anti-recall positions",
+    )?;
+    let decoded_witness = decoded_witness
+        .as_ref()
+        .ok_or_else(|| invalid_data("passing preflight has no all-control decoded witness"))?;
+    require(
+        decoded_witness.real.token != EOS_TOKEN,
+        "frozen witness real arm may not select EOS",
+    )?;
+    for control in [
+        &decoded_witness.scope_disabled,
+        &decoded_witness.order_shuffled,
+        &decoded_witness.operator_permuted,
+    ] {
+        require(
+            decoded_witness.real.token != control.token,
+            "frozen witness real arm must differ from every control",
+        )?;
+    }
+
+    // The only authorized target join is below this point, after the frozen
+    // target-free report is complete, validated, and durably persisted.
+    let evaluation =
+        operator.evaluate_held_out(&table, &overlay, &anti_recall, &census, &held_out)?;
+    report_stage("authorized_target_join_complete", run_started);
+    require(
+        evaluation.post_join_admission_opportunities == FROZEN_TARGET_FREE_ADMISSIONS,
+        "post-join structural population drifted",
+    )?;
+    require(
+        evaluation.post_join_known_target_admission_opportunities == FROZEN_KNOWN_TARGET_ADMISSIONS,
+        format!(
+            "post-join known-target population produced {}, expected {FROZEN_KNOWN_TARGET_ADMISSIONS}",
+            evaluation.post_join_known_target_admission_opportunities
+        ),
+    )?;
+    require(
+        evaluation.operative_positions == census.operative_positions.len() as u64,
+        "post-join operative population drifted from the target-free census",
+    )?;
+    require(
+        evaluation.target_reads > 0,
+        "post-join evaluation did not record its held-out target reads",
+    )?;
+    require(
+        matches!(
+            evaluation.decision.as_str(),
+            POSITIVE_TERMINAL | NEGATIVE_TERMINAL
+        ),
+        format!(
+            "a passing preflight produced an invalid terminal: {}",
+            evaluation.decision
+        ),
+    )?;
+    assert_evaluation_report(&evaluation);
+    let canonical_run_bytes = persist_terminal_bundle(
+        &output_dir,
+        report_identity,
+        &operator.artifact_cid()?,
+        &census_cid,
+        &target_free_bytes,
+        Some(decoded_witness),
+        &evaluation,
+    )?;
+    report_stage("decision_terminal_durable", run_started);
+    println!("{}", std::str::from_utf8(&canonical_run_bytes)?);
+    Ok(())
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,34 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
+> **Negative #973 document-scope corpus-induction result, 2026-08-28.** The
+> independently frozen `CorpusInducedDocumentSpinPlacementR4V1` target-free
+> gate passed with 36,533 operative anti-recall positions, zero support/work
+> mismatches or forbidden reads, and a frozen all-control decoded divergence.
+> After the one authorized held-out target-join traversal, 35,028 positions had
+> construction-fitted targets. Exact componentwise Frechet placement was
+> correct on 2,931 (8.367592%), versus 4,281 (12.221651%) for the unchanged
+> #953 fallback, 2,934 (8.376156%) for the order-shuffled state, and 2,966
+> (8.467512%) for permuted prototypes. Real lost to scope-disabled by 1,350
+> correct routes (-3.854060 pp); every required position-level and
+> document-blocked directional exact sign test failed. The operator therefore
+> terminated
+> `RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`. Its exact
+> geometry was causally active—the witness chose `I` where all controls chose
+> `The`, and their bounded continuations differed—but it was not useful
+> attention on the frozen held-out population. The operator, target-free
+> census, evaluation, and witness identities are
+> `blake3:6aa7edc027e6d26c2d6f924edbe55b835720bf0fa3e0a110a367a79b73b3d344`,
+> `blake3:e511415747c7d8ddec2723ee97ea8b32cd38dad6fd90511184ae80e2d0d79d10`,
+> `blake3:aebd4edb5ca2d5469c62615cb7f712c71953fa0d09d207686a247bcac460ec51`,
+> and `blake3:93cc3273990739639fa1fa699777868e396d3401342b20e175f528d48ac6de54`.
+> Retain bounded-global V2, keep #973 open and #954 blocked, and replace the
+> componentwise marginal-center objective with a separately frozen
+> candidate-relative discriminative exact-R4 placement objective before any
+> further scale or final requalification. Conversation and task scope for this
+> corpus operator are `NOT_RUN`. See the
+> [corpus-induced document placement record](corpus_induced_document_spin_placement_973.md).
+
 > **Positive #973 bounded-global V2 result, 2026-08-28.** The independently
 > frozen `BoundedGlobalNoncommutingExactSpinR4V2` contract reached
 > `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
@@ -33,9 +61,10 @@ assumptions, or objectives rather than measured results.
 > `blake3:c3fb3568028f924fb12971c888193cc5780111a7af14503e240f39fbeb58dd4a`,
 > and `blake3:41207999bb088e3b5f186cce983951cc27c2962d34ef8046a0beae4754b44218`.
 > This establishes one bounded synthetic causal global geometric-attention
-> witness only. Corpus induction, general semantics, correctness, reasoning,
-> and product readiness remain unestablished. #973 next freezes an independent
-> corpus-induction gate; #954 remains blocked. See the
+> witness only. The subsequent first document-scope corpus-induced placement
+> rule failed its frozen held-out gate and is recorded above. General semantics,
+> correctness, reasoning, and product readiness remain unestablished; #973
+> remains open and #954 remains blocked. See the
 > [bounded-global record](bounded_global_exact_spin_attention_973.md).
 
 > **Earlier target-free #973 bounded-global V1 negative, 2026-08-28.** The frozen
@@ -54,7 +83,8 @@ assumptions, or objectives rather than measured results.
 > and `blake3:6c0a9f89a29584a09d917ae427a494b53c06b76e56482f665870ae86c1cd130a`.
 > The retained paragraph/conversation results remain valid. This V1 negative
 > is append-only history; the independently frozen V2 repair above subsequently
-> qualified one bounded-global mechanism while leaving corpus induction open.
+> qualified one bounded-global mechanism. The first subsequent document-scope
+> corpus placement failed its held-out promotion gate as recorded above.
 > See the [bounded-global record](bounded_global_exact_spin_attention_973.md).
 
 > **Retained #973 conversation mechanism, 2026-08-28.** The independently
@@ -78,7 +108,8 @@ assumptions, or objectives rather than measured results.
 > and `blake3:6930de3c07d30df4420bb68e60ea74531c8076516bcfef1c016240eddf1b9ca2`.
 > The subsequent V1 bounded-global contrast failed its target-free relation
 > gate; the independently frozen V2 repair later passed its bounded decoded
-> contract. #973 now proceeds to corpus induction; #954 remains blocked. See the
+> contract. The subsequent first document-scope corpus-induced placement failed
+> its held-out gate; #973 remains open and #954 remains blocked. See the
 > [#973 conversation record](conversation_entity_spin_path_attention_973.md).
 
 > **Retained #973 paragraph mechanism, 2026-08-28.** The frozen two-case
@@ -104,8 +135,9 @@ assumptions, or objectives rather than measured results.
 > The subsequent independently frozen conversation-scope contrast has now
 > retained its bounded mechanism. The subsequent bounded-global V1 relation
 > failed target-free; its independently frozen V2 repair later passed the
-> bounded decoded contract. Corpus induction remains inside #973; #954 remains
-> blocked.
+> bounded decoded contract. The subsequent first document-scope corpus-induced
+> placement failed its held-out gate. Its replacement and final requalification
+> remain inside #973; #954 remains blocked.
 > See the [#973 paragraph record](paragraph_entity_spin_path_attention_973.md).
 
 > **Retained #973 Gate 0 mechanism, 2026-08-28.**
@@ -201,8 +233,10 @@ assumptions, or objectives rather than measured results.
 > entity-binding path selectors at paragraph and conversation scope. The first
 > independently frozen bounded-global V1 relation then failed target-free
 > because its swapped exact states commute. The independently frozen V2 repair
-> passed its bounded noncommuting decoded contract. Corpus induction is now the
-> next #973 gate; #954 remains blocked behind #973.
+> passed its bounded noncommuting decoded contract. The first independently
+> frozen document-scope corpus-induced placement then passed target-free but
+> failed its held-out accuracy/control gate. #973 now requires a new placement
+> objective; #954 remains blocked behind #973.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -762,8 +796,11 @@ paragraph and conversation slices retained construction-bound exact-descriptor/
 entity-binding path selectors at their respective scopes. The first
 independently frozen bounded-global V1 relation failed target-free because its
 swapped exact states commute; the independently frozen V2 repair then retained
-one bounded synthetic noncommuting exact-spin mechanism. Corpus induction and
-final requalification remain. Dependable broad coherent
+one bounded synthetic noncommuting exact-spin mechanism. The first
+document-scope corpus-induced componentwise Frechet placement then passed its
+target-free gate but failed every held-out promotion comparison, including a
+1,350-correct-route deficit to the unchanged #953 fallback. A replacement
+placement objective and final requalification remain. Dependable broad coherent
 text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
@@ -1335,8 +1372,10 @@ closed at `PROCEED_TO_A1Q_H_WITH_BOUNDED_SOURCE_FREE_GEOMETRIC_GENERATION`.
 plus bounded construction-bound exact-descriptor/entity-binding path selectors
 at paragraph and conversation scope. The first bounded-global V1 relation
 remains target-free negative history; its V2 noncommuting repair passed the
-bounded decoded contract. Corpus induction and final requalification remain
-active in that order and continue to block #954.
+bounded decoded contract. Its first document-scope corpus-induced placement
+passed target-free but failed the held-out promotion gate. A replacement
+placement objective and final requalification remain active in that order and
+continue to block #954.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/corpus_induced_document_spin_placement_973.md
+++ b/docs/corpus_induced_document_spin_placement_973.md
@@ -1,0 +1,387 @@
+# #973 corpus-induced document spin-placement contract
+
+- **Issue:** #973
+- **Mechanism:** `CorpusInducedDocumentSpinPlacementR4V1`
+- **Status:** frozen before implementation and before held-out target attachment
+- **Scope:** document only
+- **Conversation scope:** `NOT_RUN`
+- **Task scope:** `NOT_RUN`
+- **Frozen corpus:** `blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf`
+- **D3 partition:** 2,404 construction documents / 596 held-out documents
+- **Base table:** `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`
+- **Accepted #953 overlay:** `blake3:914126a311c3984d1482258a8f0a7fa2e34896540d502d19f1d9076fbd4a9b76`
+
+This record freezes the next #973 decision before the mechanism is implemented
+and before any held-out next-route value is attached to its structural census.
+The accepted #953 admission policy, candidate support, and fallback remain
+unchanged. This rung tests whether construction-induced placement in an exact
+ordered spin state can choose among that fixed support on natural held-out
+document prefixes. It does not test conversation or task scope and does not
+claim semantics, correctness, reasoning, broad coherence, performance or
+energy advantage, or product readiness.
+
+## Frozen representation and identity boundary
+
+**Definition.** The exact product state is
+
+```text
+S = 2I x Z_M x Z_M, M = 3,373,259,426
+(h,f,t) o (h',f',t') =
+    (h h', wrap_M(f + f'), wrap_M(t + t'))
+```
+
+where `2I` is the canonical 120-root H4 binary-icosahedral table already used
+by the bounded-global V2 mechanism and `wrap_M` returns the canonical interval
+`[-1,686,629,713, 1,686,629,713)`.
+
+**Definition.** `SFTBL001` token ID `r` receives immutable identity leaf
+`L_r`. `BOS` is the identity/reset. For every other fitted lexical, byte
+fallback, special, or EOS token, let `p_r` be the zero-based `r`th prime and
+set:
+
+```text
+h_r = the V2 exact root row selected by r mod 4
+f_r = wrap_M(p_r * 1,000,003 + r * 17,071)
+t_r = wrap_M(-p_r * 97,409 + r * 7,919)
+L_r = (h_r, f_r, t_r)
+```
+
+The four-row H4 map, prime enumeration, constants, modulus, table kappas, and
+source-free table CID are artifact-bound. These leaves are route identity
+coordinates only. Their prime/rank provenance is recorded explicitly and is
+not interpreted as learned meaning.
+
+**Definition.** The learned object is a separate versioned placement overlay.
+It never mutates a token ID, payload, base-table row, #953 radius row, or the
+immutable leaf. Every stored prototype row contains the source-free token,
+exact decoded-payload CID, exact product state, distinct construction-document
+support, distinct state support, and binding kappas. Token-to-payload decoding
+is its inverse/provenance witness. Support and provenance cannot enter the
+score.
+
+## Construction-only induction rule
+
+**Definition.** In each D3 construction document, at a position where the
+unchanged #953 path exposes a trigram/bigram maximum-count tie `A` and the
+observed construction next route is `c in A`, form the natural document-prefix
+state
+
+```text
+G(d,i) = L(x_0) o L(x_1) o ... o L(x_(i-1)).
+```
+
+Construction prefix-to-observed-next-route pairs are the only label-bearing
+input permitted during compilation. Validation/held-out continuations,
+teachers, providers, source weights, and runtime future routes are forbidden.
+
+**Definition.** Retain one exemplar per `(candidate token, construction
+document)`: the earliest eligible stream position in that document. This
+natural cap is at most 2,404 exemplars per candidate and prevents repeated
+mentions within one article from dominating. A prototype is usable only with
+at least two distinct construction documents and two distinct exact prefix
+states.
+
+**Definition.** For each usable candidate `c`, compile exact componentwise
+product-space Frechet prototype `C_c = (h_c,f_c,t_c)`:
+
+```text
+h_c = argmin over all 120 H4 roots h of
+      sum_g shell_rank(h^-1 g_h)
+f_c = argmin over observed exemplar phases z of
+      sum_g circular_abs_q29(z - g_f)
+t_c = argmin over observed exemplar phases z of
+      sum_g circular_abs_q29(z - g_t)
+```
+
+Ties use canonical H4 table order and then ascending signed Q29. Only integer
+table operations and integer phase arithmetic define the artifact. The
+compiler may parallelize independent documents and candidates, but reduction
+and serialization are in canonical document/token order.
+
+**Guarantee sought.** Compile/serialize/reload must be byte-identical, and the
+runtime artifact contains only aggregate prototypes and provenance. Runtime
+prediction performs no corpus scan and loads no prefix row or source tensor.
+
+## Frozen query rule and controls
+
+**Definition.** #953 first admits its unchanged canonical maximum-count tie
+`A`. For observed document-prefix state `G` and every `c in A` with a usable
+prototype:
+
+```text
+Delta_c = C_c^-1 o G
+K_c = (H4S3AngularShell(Delta_c.h),
+       circular_abs_q29(Delta_c.f),
+       circular_abs_q29(Delta_c.t)).
+```
+
+The unique lexicographic minimum wins. A missing prototype or equal minimum
+abstains to the exact #953 choice. Candidate token, payload, prime, rank,
+digest, support count, and provenance are lookup keys or audit fields, never
+numeric score inputs.
+
+**Definition.** Four arms share the same #953 row, support, prototype reads,
+exact inverses/products, cost reads, comparisons, decode, and declared-work
+ledger:
+
+1. `real`: natural left-ordered prefix fold and induced prototypes;
+2. `scope_disabled`: compute the complete real decision, then mask it to #953;
+3. `order_shuffled`: use the reverse-prefix product maintained as
+   `R_i = L(x_i) o R_(i-1)`;
+4. `operator_permuted`: cyclically rotate prototype assignments across
+   canonical `A`, with no fixed point when `|A| > 1`.
+
+The controls may change only the named factor. Admission, support, payloads,
+base evidence, ceilings, and work remain matched.
+
+## Operative anti-recall slice
+
+**Definition.** After fitting prototypes, construction is replayed once to
+build an audit-only set of exact document-prefix state and operative decision
+signatures
+
+```text
+Omega = (backoff order, A, G, [(c, Delta_c, K_c) for c in A]).
+```
+
+Construction prefix/state/signature indexes are qualification evidence and
+are not stored in the runtime artifact.
+
+**Definition.** Before any held-out target is read, a held-out position enters
+the operative census only when:
+
+- its active #953 structural row occurs in at least two held-out documents;
+- every candidate has a usable construction prototype;
+- its exact full-prefix CID, exact natural state `G`, and exact `Omega` are all
+  absent from construction;
+- natural and reverse states differ;
+- prototype permutation changes the operative cost vector; and
+- all four arms complete with zero support/work mismatch.
+
+Full-prefix disjointness is reported but is not sufficient by itself. The
+first canonical non-EOS operative prefix for which real differs from
+scope-disabled, order-shuffled, and operator-permuted is frozen for the decoded
+witness before its next route is attached.
+
+## Cheap preflight and run contract
+
+**Empirical Criterion.** The target-free preflight must reproduce all frozen
+corpus/base identities and the unchanged 76,641 #953 held-out admission
+opportunities. It must then report:
+
+- byte-identical operator compile/reload;
+- at least 1,024 prototype-complete operative anti-recall positions;
+- at least one frozen non-EOS all-control contrast;
+- nondegenerate natural/reverse state and real/permuted cost vectors;
+- zero support/work mismatches; and
+- zero held-out-target, compiler-future, teacher, provider, source-weight, or
+  runtime-corpus reads.
+
+An empty/undersized operative population or absent decoded witness stops the
+run before target attachment with
+`UNAVAILABLE_OPERATIVE_ANTI_RECALL_OR_REACHABILITY`. Any binding, replay,
+leakage, support, or work failure stops with
+`INVALID_CORPUS_INDUCED_SPIN_PLACEMENT_CONTRACT`.
+
+```text
+metric to move:       correct next routes on the frozen operative anti-recall
+                      slice; fixed comparator is accepted #953 at
+                      103,604/446,342 overall known-target positions
+reachability ceiling: 76,641/446,342 = 17.170914 percentage points can be
+                      touched because admission is frozen
+instrument + verdict: target-free corpus census above; >=1,024 operative
+                      positions and one frozen decoded contrast are required
+exit rule:            after one target join, real must beat each of #953,
+                      order-shuffled, and operator-permuted with directional
+                      paired wins greater than losses and a predeclared
+                      one-sided exact sign-test p <= 0.05 for each comparator
+if positive:          retain document-scope corpus-induced spin attention and
+                      run #973's final bounded requalification
+if negative:          retain the bounded-global V2 result, reject this
+                      placement rule, keep #954 blocked, and redesign placement
+cost estimate:        about 20-30 minutes on this M1 after compilation; document
+                      scans and prototype fits run in parallel with ordered
+                      deterministic reduction
+```
+
+**Empirical Criterion.** A positive result additionally requires zero contract
+failures, byte-reproducible artifact/report bytes, and the frozen prefix to
+produce a distinct exact decoded continuation under the real geometry. The
+positive terminal is
+`RETAIN_CORPUS_INDUCED_DOCUMENT_SPIN_ATTENTION_CONTINUE_FINAL_973_REQUALIFICATION`.
+A valid run without the declared uplift/control separation terminates
+`RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`.
+
+No threshold, basis row, phase constant, scope rule, prototype rule, candidate
+population, control, witness-selection rule, or decision threshold may change
+after this freeze. A placement epoch or structural operator revision receives
+new kappas and reruns its owning bounded gate before downstream evidence is
+read.
+
+## Pre-implementation target-blind accounting correction
+
+Append-only correction, posted before any held-out target attachment: the
+`76,641` count above is the accepted #953 count after the next route has been
+classified as a construction-fitted known target. Requiring that count in the
+target-free preflight would require reading `stream[target_index]` and would
+violate the same preflight's zero-target-read rule.
+
+The target-free preflight therefore reproduces **81,177 reachable held-out
+prefixes without reading their next routes**. After the one authorized target
+join, evaluation must reproduce **76,641 reachable known-target positions**.
+The overall known-target reachability ceiling remains
+`76,641/446,342 = 17.170914` percentage points. The 1,024-position operative
+threshold, mechanism, population, witness rule, controls, positive criterion,
+and terminals are unchanged. No held-out next-route identity was inspected to
+make this correction.
+
+The same target-blind binding pass freezes the exact D3 sets before target
+attachment:
+
+```text
+construction-set kappa:
+  blake3:af2a2d7d49db55279e7ea40947a3259ac0a100aa56e8d920951e7c27eaf6df5c
+held-out-set kappa:
+  blake3:7a7558e96aa86aa2d8965972b69ddce02222c6eccc8ca560df2141fc0ac4170e
+```
+
+Each kappa hashes canonical document IDs plus complete text CIDs under its
+declared construction/held-out domain. This closes alternate-D3-subset
+substitution while revealing no next-route value.
+
+## Pre-target document-blocked statistical correction
+
+Append-only correction, posted while held-out next routes remain unattached:
+operative token positions within one article are correlated and may repeat the
+same structural row. A position-level sign-test p-value alone would therefore
+overstate independent natural-document evidence.
+
+For each comparator, the original position counts and direction remain
+required and reported. In addition, each of the 596 held-out documents receives
+at most one paired vote: document win when the real arm has more correct
+operative known-target positions than the comparator in that document,
+document loss when it has fewer, and tie otherwise. A positive terminal now
+also requires document wins greater than document losses and the one-sided
+exact paired sign test over those document votes to satisfy `p <= 0.05` for
+scope-disabled, order-shuffled, and operator-permuted separately.
+
+This strengthens rather than relaxes the frozen positive rule. The mechanism,
+placement, operative population, target-free threshold, witness, controls, and
+failure terminals are unchanged. No held-out next-route identity was inspected
+to make this correction.
+
+## Observed document-scope result — 2026-08-28
+
+**Empirical result.** The frozen run completed at
+`RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`. The target-free
+preflight passed, the exact spin operator was causally active, and its frozen
+decoded witness diverged across every control. The held-out target join then
+falsified the promotion criterion: componentwise construction Frechet
+placement was less accurate than the unchanged #953 fallback and did not beat
+either geometry control.
+
+The compiled operator retained these construction-only statistics:
+
+| Quantity | Count |
+| --- | ---: |
+| construction documents | 2,404 |
+| eligible construction positions | 300,483 |
+| one-per-document exemplars | 197,717 |
+| observed candidate tokens | 43,047 |
+| usable prototypes | 15,320 |
+| rejected for single-document support | 27,726 |
+| rejected for single-state support | 1 |
+
+The target-free qualification traversed 596 held-out documents without reading
+their next routes. It indexed 1,934,246 construction full prefixes, 1,934,246
+construction natural states, and 287,517 construction operative signatures.
+Against those indexes it observed 81,177 admitted held-out prefixes, of which
+62,603 had complete prototype support. Overlapping disqualification predicates
+counted 83 exact construction-prefix hits, 83 construction-state hits, 29
+construction-signature hits, 10,223 natural/reverse equal states, and 18,574
+permutation-inert positions. Their conjunction left 36,533 operative positions,
+exceeding the frozen 1,024 minimum. Rows contributing to the census occurred in
+multiple held-out documents on 53,772 positions. Support mismatches, work
+mismatches, invalid score-firewall certificates, and every forbidden-read
+counter were zero.
+
+The one authorized target-join traversal reproduced all 81,177 structural
+admissions and 76,641 construction-fitted known-target admissions. It observed
+617,710 next-route values: this counter is one read for each evaluated document
+stream position in that single post-gate traversal, not 617,710 separate joins.
+None of those values entered candidate scoring, prototype construction, the
+target-free census, or witness selection. Of the 36,533 operative positions,
+35,028 had a construction-fitted target:
+
+| Arm | Correct | Accuracy on 35,028 | Difference from real |
+| --- | ---: | ---: | ---: |
+| real componentwise Frechet placement | 2,931 | 8.367592% | — |
+| scope-disabled / unchanged #953 | 4,281 | 12.221651% | real -3.854060 pp |
+| order-shuffled query state | 2,934 | 8.376156% | real -0.008565 pp |
+| operator-permuted prototypes | 2,966 | 8.467512% | real -0.099920 pp |
+
+The predeclared exact paired tests all failed in the required direction:
+
+| Comparator | Position wins/losses/ties | Document wins/losses/ties | Pass |
+| --- | ---: | ---: | :---: |
+| scope-disabled | 1,118 / 2,468 / 31,442 | 71 / 364 / 161 | no |
+| order-shuffled | 1,734 / 1,737 / 31,557 | 199 / 212 / 185 | no |
+| operator-permuted | 2,931 / 2,966 / 29,131 | 221 / 228 / 147 | no |
+
+Every table entry is an exact integer count. Each one-sided exact sign-test
+predicate `20 * sum <= 2^n` evaluated false; no floating-point p-value or
+post-run threshold decided the terminal.
+
+The target-free witness was document `4546`, target index `9560`. The real arm
+selected token `106399` (`I`), while scope-disabled, order-shuffled, and
+operator-permuted each selected token `109525` (`The`). Their complete bounded
+64-unit continuations were pairwise distinct from the real continuation, so
+the frozen continuation-contrast predicate passed. This is evidence that the
+exact geometric operator can causally change decoded behavior. It is not
+evidence that the change is useful attention: the held-out accuracy and every
+matched paired comparison reject that claim for this placement.
+
+Canonical evidence identities are:
+
+```text
+operator:                  blake3:6aa7edc027e6d26c2d6f924edbe55b835720bf0fa3e0a110a367a79b73b3d344
+anti-recall index:         blake3:4d662e9c2e8f63228cd6d95bf04a25e0cd357350534e2efb339e68f4cddf258c
+target-free census:        blake3:e511415747c7d8ddec2723ee97ea8b32cd38dad6fd90511184ae80e2d0d79d10
+evaluation report:         blake3:aebd4edb5ca2d5469c62615cb7f712c71953fa0d09d207686a247bcac460ec51
+witness continuation:      blake3:93cc3273990739639fa1fa699777868e396d3401342b20e175f528d48ac6de54
+target-free report sha256: cfa6c82cf0ad8918f27530a32c974259f10bd230d555a915cf1b737398ef6375
+evaluation report sha256:  e070550fb55b8c2ad727c365b8637aa3277a28fa4f521b375ec01452b4a40879
+canonical run sha256:      b681935a1dcabc863ab4b2b4857a6b6ce944e203eb06127121dbdcfcc4823844
+```
+
+The first profile-only attempt was stopped before a target-free report was
+written and before any held-out target was attached after it exposed serial
+document scans. Frozen table/operator inputs were retained. Construction,
+anti-recall, and target-free document work were then partitioned over at most
+eight native workers with canonical ordered reduction; WASM remains serial.
+Forced one-worker and eight-worker tests reproduced byte-identical anti-recall
+indexes, census reports, and CIDs. The completed decision run took 281.741
+seconds from bound input load through durable terminal. The target-free census
+milestone was reached at 56.653 seconds, its report was durable at 56.756
+seconds, and the serial label-bearing traversal plus final serialization
+occupied the remaining 224.985 seconds.
+
+**Decision and next action.** Retain the bounded-global V2 result, reject
+`CorpusInducedDocumentSpinPlacementR4V1` as the corpus placement rule, keep
+#973 open, and keep #954 blocked. More documents, table density, or execution
+time are not authorized as the next action: the real arm already acts on a
+large operative population, yet did not establish superiority over the
+order/permutation controls and was materially worse than scope-disabled
+fallback.
+The next #973 construction must therefore freeze a new candidate-relative,
+construction-only discriminative placement objective in exact R4 state—one
+that is trained to separate competing admitted candidates rather than estimate
+each candidate's componentwise marginal center. It must preserve immutable
+route/payload identity, the #953 admission/support boundary, exact least-cost
+routing, target-free anti-recall admission, matched controls, and a single
+held-out join. No final #973 requalification or #954 work is authorized until
+such a replacement independently passes its own frozen gate.
+
+Conversation scope and task scope remain `NOT_RUN` for this corpus-induced
+operator. General semantic attention, coherence, correctness, reasoning,
+performance or energy advantage, and product readiness remain unestablished.

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -1158,7 +1158,10 @@ is now accepted at the positive terminal after external replay adjudication.
 #973 has since retained the bounded Gate 0, paragraph, conversation, and V2
 noncommuting global mechanisms recorded below. Its first bounded-global V1
 relation remains negative history; V2 qualified one bounded-global selection
-mechanism while leaving corpus induction open.
+mechanism. The first independently frozen document-scope corpus-induced
+placement subsequently passed target-free qualification but failed its held-out
+promotion comparisons, leaving replacement placement and final
+requalification open.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
 identity-scoped hive-memory lifecycle remain #962 scope.
 
@@ -1463,8 +1466,9 @@ The binding terminal is
 `RETAIN_BOUNDED_GLOBAL_NONCOMMUTING_EXACT_SPIN_ATTENTION_CONTINUE_CORPUS_INDUCTION`.
 This establishes one bounded synthetic causal global geometric-attention
 witness, not corpus induction, general semantics, correctness, reasoning, or
-product readiness. #973 next independently freezes its corpus-induction gate;
-#954 remains blocked. See the
+product readiness. The subsequent first document-scope corpus-induced
+placement passed target-free but failed its held-out promotion gate; #973
+remains open and #954 remains blocked. See the
 [#973 bounded-global exact-spin record](bounded_global_exact_spin_attention_973.md).
 
 ##### Historical V1 repair direction, superseded by V2
@@ -1520,10 +1524,29 @@ explicit native revision must change #973's scope and dependencies.
 #### #973 higher-scope/corpus-scale induction qualification and handoff to #954
 
 The accepted bounded local selector, #953, and the required bounded #973
-higher-scope interventions now qualify at their declared narrow scopes. The
-next authorized action is to freeze the corpus-induction gate independently;
-only after that immutable contract exists may the programme execute controlled
-higher-scope/corpus-scale offline induction.
+higher-scope interventions qualify at their declared narrow scopes. The first
+independently frozen document-scope corpus-induction gate has now run and
+terminated
+`RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`. Its target-free
+gate found 36,533 operative anti-recall positions, zero support/work mismatch
+or forbidden reads, and one all-control decoded divergence. On 35,028
+operative construction-fitted targets, real componentwise Frechet placement
+scored 2,931 (8.367592%), below unchanged #953 at 4,281 (12.221651%),
+order-shuffled state at 2,934 (8.376156%), and operator-permuted prototypes at
+2,966 (8.467512%). All required position-level and document-blocked exact
+directional tests failed.
+
+This separates causal action from useful attention. The exact `2I x Z_M x
+Z_M` relation and `C^-1*G` least-cost route changed both selected tokens and a
+bounded decoded continuation, but its componentwise marginal-center placement
+did not transfer useful candidate preference. More scale is not the next
+action. #973 must independently freeze a new construction-only,
+candidate-relative discriminative placement objective in exact R4 state while
+preserving immutable route/payload identity, #953 admission and support,
+target-free anti-recall qualification, matched controls, and a single held-out
+join. See the
+[#973 corpus-induced document placement record](corpus_induced_document_spin_placement_973.md).
+
 This ladder and its final requalification are part of #973's definition of done
 and terminal; #973 cannot close and #954 cannot start without them. The one
 separation permitted inside #953 was a tiny construction-only, same-frame,
@@ -1689,7 +1712,9 @@ hours remains a hard kill ceiling, never an estimate.
   exposed #973. #973 has retained bounded paragraph and conversation
   mechanisms; its first bounded-global V1 relation failed target-free, and its
   independently frozen V2 repair retained one bounded noncommuting global
-  mechanism. It alone owns corpus induction and final requalification.
+  mechanism. Its first document-scope corpus-induced placement passed
+  target-free qualification but failed the held-out promotion gate. It alone
+  owns replacement placement and final requalification.
 - S3/R4 compute, Hopf S2/R3 observation, and an E8 action plane are distinct
   objects.
 - Exact recall, grammatical text, correct inference, and reasoning are separate


### PR DESCRIPTION
## Outcome

Qualifies the independently frozen `CorpusInducedDocumentSpinPlacementR4V1` document-scope rung and records its binding negative terminal:

`RETAIN_BOUNDED_GLOBAL_ONLY_REDESIGN_CORPUS_SPIN_PLACEMENT`

The target-free gate passed with 36,533 operative anti-recall positions, zero support/work mismatch or forbidden reads, and a frozen all-control decoded continuation contrast. After the one authorized target-join traversal, real placement scored 2,931/35,028 (8.367592%), versus unchanged #953 at 4,281/35,028 (12.221651%), order-shuffled at 2,934/35,028, and operator-permuted at 2,966/35,028. Every frozen position-level and document-blocked directional exact sign test failed.

This retains bounded-global V2, rejects this componentwise Frechet placement, keeps #973 open, and keeps #954 blocked. The recorded next action is a separately frozen candidate-relative, construction-only discriminative exact-R4 placement objective—not more corpus scale.

## Implementation

- Adds exact `2I x Z_M x Z_M` construction-induced document placement over immutable source-free token identity.
- Compiles one-per-document candidate exemplars into exact componentwise prototypes.
- Ranks only unchanged #953 admitted support by exact candidate-relative `C^-1*G` least cost.
- Freezes scope-disabled, order-shuffled, and operator-permuted matched controls.
- Enforces full-prefix/state/signature anti-recall, target-free witness selection, score-source firewall certificates, trusted artifact CIDs, and one post-gate label traversal.
- Runs independent document work on at most eight native workers with canonical ordered reduction; WASM remains serial.
- Proves forced 1-vs-8 byte/CID identity and rejects target-derived scoring, tamper, work mismatch, and score-source leakage.

## Bound evidence

- operator: `blake3:6aa7edc027e6d26c2d6f924edbe55b835720bf0fa3e0a110a367a79b73b3d344`
- target-free census: `blake3:e511415747c7d8ddec2723ee97ea8b32cd38dad6fd90511184ae80e2d0d79d10`
- evaluation: `blake3:aebd4edb5ca2d5469c62615cb7f712c71953fa0d09d207686a247bcac460ec51`
- witness continuation: `blake3:93cc3273990739639fa1fa699777868e396d3401342b20e175f528d48ac6de54`
- canonical-run SHA-256: `b681935a1dcabc863ab4b2b4857a6b6ce944e203eb06127121dbdcfcc4823844`

The completed release decision run took 281.741 seconds. Its target-free report was durable before held-out target attachment.

## Verification

Passed:

- full frozen D3 decision run: 1/1
- new module tests: 7/7
- #973 integration tests: 2/2; full evidence test ignored in routine runs
- #989 source-free table regressions: 3/3
- #953 geometric intervention regressions: 3/3
- bounded-global V2 regression: 1/1
- `cargo check --workspace --all-targets --offline`
- WASM target check
- both graph-format no-std ladders
- formatting, diff, and claim-wording gates

The no-fail-fast full workspace run completed and exposed three pre-existing `origin/main` failures outside this diff: the #958 source-marker scanner already contains `rebuild_witnesses`, the exact-executor source manifest already omits eight existing modules (and now reports this new module too), and the browser-option BDD expects stale HTML. Strict clippy is likewise blocked by unchanged main-branch warnings. Current PR and merge-group CI intentionally run the repository's dormant-QA transport acknowledgements.

Conversation and task scope remain `NOT_RUN`. This PR does not close #973.

References #973
