### PR TITLE
#973: freeze HELM-D learned-manifold R4 construction qualifier

### DIFF
--- a/crates/uor-r4-core/src/helm_d_r4_attention.rs
+++ b/crates/uor-r4-core/src/helm_d_r4_attention.rs
@@ -23,7 +23,8 @@ use crate::canonical_lexical_ingestion::{
 };
 use crate::corpus_induced_spin_placement::{compile_identity_leaves, leaf_for_token};
 use uor_r4_model_source::attention::{
-    CausalAttentionHeadContext, CausalAttentionSourceContext, CausalAttentionTransport,
+    CausalAttentionHeadContext, CausalAttentionProjectionContext, CausalAttentionSourceContext,
+    CausalAttentionTransport,
 };
 
 const R4_WIDTH: usize = 4;
@@ -1749,6 +1750,1246 @@ impl CausalAttentionTransport for IntrinsicR4CausalAttentionTransport {
     }
 }
 
+/// The construction qualifier copied from HELM-D's dense Lorentz attention.
+///
+/// Both arms own the same learned R4-block affine adapters. `Lorentz` changes
+/// only the compatibility relation and value centroid; `Euclidean` is the
+/// equal-capacity curvature-destroying control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HelmDLearnedManifoldMetric {
+    Lorentz,
+    Euclidean,
+}
+
+/// Equal-shape interventions used to test whether coherent R4 transport and
+/// value binding are causally responsible for an observed construction gain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HelmDLearnedManifoldIntervention {
+    Coherent,
+    SourceFramePermuted,
+    ValuePermuted,
+    OrderKeyShuffled,
+}
+
+/// One compact learned affine map over a canonical four-lane R4 block.
+///
+/// HELM-D upstream uses unrestricted dense Q/K/V maps. This block-diagonal
+/// adapter is UOR's explicitly bounded construction parameterization over the
+/// donor-projected Q/K/V; it is not a checkpoint-parity claim.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct R4AffineAdapter {
+    pub matrix: Matrix4,
+    pub bias: Vector4,
+}
+
+impl R4AffineAdapter {
+    pub const fn identity() -> Self {
+        Self {
+            matrix: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            bias: [0.0; R4_WIDTH],
+        }
+    }
+
+    pub fn apply(self, input: Vector4) -> Result<Vector4, HelmDR4AttentionError> {
+        let mut output = checked_matrix_vector(self.matrix, input, "learned R4 affine adapter")?;
+        for (coordinate, bias) in output.iter_mut().zip(self.bias) {
+            *coordinate += bias;
+        }
+        if output.iter().any(|coordinate| !coordinate.is_finite()) {
+            return Err(HelmDR4AttentionError::Arithmetic(
+                "learned R4 affine adapter produced a non-finite coordinate".to_owned(),
+            ));
+        }
+        Ok(output)
+    }
+
+    fn validate(self) -> Result<(), HelmDR4AttentionError> {
+        if self
+            .matrix
+            .iter()
+            .flatten()
+            .chain(&self.bias)
+            .any(|value| !value.is_finite())
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned R4 affine adapter parameters must be finite".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Matched learned parameters for the construction-only HELM-D qualifier.
+///
+/// Query adapters follow query heads; key and value adapters follow the
+/// checkpoint's grouped-query K/V heads. Each layer also owns the one positive
+/// scale and uniform bias appearing in the pinned upstream attention logit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HelmDLearnedManifoldParameters {
+    layers: usize,
+    query_heads: usize,
+    key_value_heads: usize,
+    blocks_per_head: usize,
+    query_adapters: Vec<R4AffineAdapter>,
+    key_adapters: Vec<R4AffineAdapter>,
+    value_adapters: Vec<R4AffineAdapter>,
+    learned_scales: Vec<f64>,
+    learned_biases: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LearnedProjectionRole {
+    Query,
+    Key,
+    Value,
+}
+
+impl HelmDLearnedManifoldParameters {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        layers: usize,
+        query_heads: usize,
+        key_value_heads: usize,
+        blocks_per_head: usize,
+        query_adapters: Vec<R4AffineAdapter>,
+        key_adapters: Vec<R4AffineAdapter>,
+        value_adapters: Vec<R4AffineAdapter>,
+        learned_scales: Vec<f64>,
+        learned_biases: Vec<f64>,
+    ) -> Result<Self, HelmDR4AttentionError> {
+        let parameters = Self {
+            layers,
+            query_heads,
+            key_value_heads,
+            blocks_per_head,
+            query_adapters,
+            key_adapters,
+            value_adapters,
+            learned_scales,
+            learned_biases,
+        };
+        parameters.validate()?;
+        Ok(parameters)
+    }
+
+    pub fn identity(
+        layers: usize,
+        query_heads: usize,
+        key_value_heads: usize,
+        blocks_per_head: usize,
+        initial_scale: f64,
+    ) -> Result<Self, HelmDR4AttentionError> {
+        let query_count = Self::adapter_count(layers, query_heads, blocks_per_head)?;
+        let key_value_count = Self::adapter_count(layers, key_value_heads, blocks_per_head)?;
+        Self::new(
+            layers,
+            query_heads,
+            key_value_heads,
+            blocks_per_head,
+            vec![R4AffineAdapter::identity(); query_count],
+            vec![R4AffineAdapter::identity(); key_value_count],
+            vec![R4AffineAdapter::identity(); key_value_count],
+            vec![initial_scale; layers],
+            vec![0.0; layers],
+        )
+    }
+
+    pub const fn layers(&self) -> usize {
+        self.layers
+    }
+
+    pub const fn query_heads(&self) -> usize {
+        self.query_heads
+    }
+
+    pub const fn key_value_heads(&self) -> usize {
+        self.key_value_heads
+    }
+
+    pub const fn blocks_per_head(&self) -> usize {
+        self.blocks_per_head
+    }
+
+    pub const fn head_width(&self) -> usize {
+        self.blocks_per_head * R4_WIDTH
+    }
+
+    /// Total scalar capacity, including each 4x4 matrix, four-vector bias,
+    /// and the scale/bias pair per layer.
+    pub fn scalar_parameter_count(&self) -> Result<usize, HelmDR4AttentionError> {
+        let adapters = self
+            .query_adapters
+            .len()
+            .checked_add(self.key_adapters.len())
+            .and_then(|count| count.checked_add(self.value_adapters.len()))
+            .ok_or_else(|| {
+                HelmDR4AttentionError::Invalid(
+                    "learned-manifold adapter count overflows usize".to_owned(),
+                )
+            })?;
+        adapters
+            .checked_mul(R4_WIDTH * R4_WIDTH + R4_WIDTH)
+            .and_then(|count| count.checked_add(self.layers.checked_mul(2)?))
+            .ok_or_else(|| {
+                HelmDR4AttentionError::Invalid(
+                    "learned-manifold scalar parameter count overflows usize".to_owned(),
+                )
+            })
+    }
+
+    /// Versioned, architecture-independent identity of the ordered learned
+    /// parameter stream used by both checkpoints and live operator evidence.
+    pub fn parameter_identity(&self) -> Result<String, HelmDR4AttentionError> {
+        self.validate()?;
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"uor-r4.helm-d-learned-manifold-parameters/2\0");
+        for dimension in [
+            self.layers,
+            self.query_heads,
+            self.key_value_heads,
+            self.blocks_per_head,
+        ] {
+            let dimension = u64::try_from(dimension).map_err(|_| {
+                HelmDR4AttentionError::Invalid(
+                    "learned-manifold parameter dimension exceeds u64".to_owned(),
+                )
+            })?;
+            hasher.update(&dimension.to_le_bytes());
+        }
+        for (role, adapters) in [
+            (b"query".as_slice(), self.query_adapters.as_slice()),
+            (b"key".as_slice(), self.key_adapters.as_slice()),
+            (b"value".as_slice(), self.value_adapters.as_slice()),
+        ] {
+            hasher.update(role);
+            let count = u64::try_from(adapters.len()).map_err(|_| {
+                HelmDR4AttentionError::Invalid(
+                    "learned-manifold adapter count exceeds u64".to_owned(),
+                )
+            })?;
+            hasher.update(&count.to_le_bytes());
+            for adapter in adapters {
+                for value in adapter.matrix.iter().flatten().chain(&adapter.bias) {
+                    hasher.update(&value.to_bits().to_le_bytes());
+                }
+            }
+        }
+        hasher.update(b"scale");
+        for value in &self.learned_scales {
+            hasher.update(&value.to_bits().to_le_bytes());
+        }
+        hasher.update(b"bias");
+        for value in &self.learned_biases {
+            hasher.update(&value.to_bits().to_le_bytes());
+        }
+        Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+    }
+
+    pub fn query_adapters(&self) -> &[R4AffineAdapter] {
+        &self.query_adapters
+    }
+
+    pub fn query_adapters_mut(&mut self) -> &mut [R4AffineAdapter] {
+        &mut self.query_adapters
+    }
+
+    pub fn key_adapters(&self) -> &[R4AffineAdapter] {
+        &self.key_adapters
+    }
+
+    pub fn key_adapters_mut(&mut self) -> &mut [R4AffineAdapter] {
+        &mut self.key_adapters
+    }
+
+    pub fn value_adapters(&self) -> &[R4AffineAdapter] {
+        &self.value_adapters
+    }
+
+    pub fn value_adapters_mut(&mut self) -> &mut [R4AffineAdapter] {
+        &mut self.value_adapters
+    }
+
+    pub fn learned_scales(&self) -> &[f64] {
+        &self.learned_scales
+    }
+
+    pub fn learned_scales_mut(&mut self) -> &mut [f64] {
+        &mut self.learned_scales
+    }
+
+    pub fn learned_biases(&self) -> &[f64] {
+        &self.learned_biases
+    }
+
+    pub fn learned_biases_mut(&mut self) -> &mut [f64] {
+        &mut self.learned_biases
+    }
+
+    pub fn learned_scale(&self, layer: usize) -> Result<f64, HelmDR4AttentionError> {
+        self.learned_scales.get(layer).copied().ok_or_else(|| {
+            HelmDR4AttentionError::Invalid(format!(
+                "learned-manifold scale layer {layer} exceeds {} layers",
+                self.layers
+            ))
+        })
+    }
+
+    pub fn learned_bias(&self, layer: usize) -> Result<f64, HelmDR4AttentionError> {
+        self.learned_biases.get(layer).copied().ok_or_else(|| {
+            HelmDR4AttentionError::Invalid(format!(
+                "learned-manifold bias layer {layer} exceeds {} layers",
+                self.layers
+            ))
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), HelmDR4AttentionError> {
+        if self.layers == 0
+            || self.query_heads == 0
+            || self.key_value_heads == 0
+            || self.blocks_per_head == 0
+            || !self.query_heads.is_multiple_of(self.key_value_heads)
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold dimensions must be positive with query heads divisible by KV heads"
+                    .to_owned(),
+            ));
+        }
+        let expected_query =
+            Self::adapter_count(self.layers, self.query_heads, self.blocks_per_head)?;
+        let expected_key_value =
+            Self::adapter_count(self.layers, self.key_value_heads, self.blocks_per_head)?;
+        if self.query_adapters.len() != expected_query
+            || self.key_adapters.len() != expected_key_value
+            || self.value_adapters.len() != expected_key_value
+            || self.learned_scales.len() != self.layers
+            || self.learned_biases.len() != self.layers
+        {
+            return Err(HelmDR4AttentionError::Invalid(format!(
+                "learned-manifold parameter shape mismatch: q={} (expected {expected_query}), k={}, v={} (expected {expected_key_value}), scales={}, biases={}, layers={}",
+                self.query_adapters.len(),
+                self.key_adapters.len(),
+                self.value_adapters.len(),
+                self.learned_scales.len(),
+                self.learned_biases.len(),
+                self.layers
+            )));
+        }
+        for adapter in self
+            .query_adapters
+            .iter()
+            .chain(&self.key_adapters)
+            .chain(&self.value_adapters)
+        {
+            adapter.validate()?;
+        }
+        if self
+            .learned_scales
+            .iter()
+            .any(|scale| !scale.is_finite() || *scale <= 0.0)
+            || self.learned_biases.iter().any(|bias| !bias.is_finite())
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold scales must be finite and positive and biases finite".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn adapter_count(
+        layers: usize,
+        heads: usize,
+        blocks_per_head: usize,
+    ) -> Result<usize, HelmDR4AttentionError> {
+        if layers == 0 || heads == 0 || blocks_per_head == 0 {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold adapter dimensions must be positive".to_owned(),
+            ));
+        }
+        layers
+            .checked_mul(heads)
+            .and_then(|count| count.checked_mul(blocks_per_head))
+            .ok_or_else(|| {
+                HelmDR4AttentionError::Invalid(
+                    "learned-manifold adapter dimensions overflow usize".to_owned(),
+                )
+            })
+    }
+
+    fn adapter(
+        &self,
+        role: LearnedProjectionRole,
+        layer: usize,
+        head: usize,
+        block: usize,
+    ) -> Result<R4AffineAdapter, HelmDR4AttentionError> {
+        let (heads, adapters, label) = match role {
+            LearnedProjectionRole::Query => (self.query_heads, &self.query_adapters, "query"),
+            LearnedProjectionRole::Key => (self.key_value_heads, &self.key_adapters, "key"),
+            LearnedProjectionRole::Value => (self.key_value_heads, &self.value_adapters, "value"),
+        };
+        if layer >= self.layers || head >= heads || block >= self.blocks_per_head {
+            return Err(HelmDR4AttentionError::Invalid(format!(
+                "learned-manifold {label} adapter index ({layer},{head},{block}) exceeds ({},{heads},{})",
+                self.layers, self.blocks_per_head
+            )));
+        }
+        let index = (layer * heads + head) * self.blocks_per_head + block;
+        adapters.get(index).copied().ok_or_else(|| {
+            HelmDR4AttentionError::Invalid(format!(
+                "learned-manifold {label} adapter index is unavailable"
+            ))
+        })
+    }
+}
+
+pub const HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY: &str = concat!(
+    "schema=helm-d-learned-manifold-r4-construction/2\n",
+    "upstream=Graph-and-Geometric-Learning/helm@7501deca8f413848bfef804be64ce874b72a3cd7\n",
+    "projection=learned-block-diagonal-r4-affine-adapter-over-donor-qkv-before-rope\n",
+    "position=unchanged-donor-rope-on-query-and-key\n",
+    "manifold=one-unit-lorentz-h64-point-per-64-spatial-lane-head\n",
+    "score=(2+2*lorentz-inner)/learned-layer-scale+uniform-bias\n",
+    "selector=stable-complete-prefix-causal-softmax\n",
+    "aggregate=full-head-normalized-lorentz-centroid\n",
+    "storage=sixteen-r4-blocks-per-head\n",
+    "transport=coherent-exact-cumulative-spin-h4-query-frame\n",
+    "output=unchanged-frozen-donor-wo\n",
+    "numerical-adaptation=compensated-f64-sums-and-fail-closed-future-timelike-normalization\n",
+    "not-claimed=full-dense-qkv,checkpoint-parity,paper-result-inheritance,softmax-free,source-free,transformerless-serving"
+);
+
+pub const HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY: &str = concat!(
+    "schema=helm-d-learned-manifold-r4-euclidean-control/2\n",
+    "projection=identical-learned-block-diagonal-r4-affine-capacity\n",
+    "position=unchanged-donor-rope-on-query-and-key\n",
+    "score=negative-full-head-squared-euclidean-distance/learned-layer-scale+uniform-bias\n",
+    "selector=identical-stable-complete-prefix-causal-softmax\n",
+    "aggregate=full-head-arithmetic-centroid\n",
+    "storage-and-transport=identical-r4-block-layout-and-coherent-spin-h4-query-frame\n",
+    "output=unchanged-frozen-donor-wo\n",
+    "claim=equal-capacity-curvature-destroying-control"
+);
+
+/// Pure full-head logit used by both the fitter and the live decoder seam.
+pub fn helm_d_learned_manifold_logit(
+    metric: HelmDLearnedManifoldMetric,
+    query: &[f64],
+    key: &[f64],
+    learned_scale: f64,
+    bias: f64,
+) -> Result<f64, HelmDR4AttentionError> {
+    if query.is_empty()
+        || query.len() != key.len()
+        || query.iter().chain(key).any(|value| !value.is_finite())
+        || !learned_scale.is_finite()
+        || learned_scale <= 0.0
+        || !bias.is_finite()
+    {
+        return Err(HelmDR4AttentionError::Invalid(
+            "learned-manifold logit inputs are empty, misaligned, non-finite, or have invalid scale"
+                .to_owned(),
+        ));
+    }
+    let numerator = match metric {
+        HelmDLearnedManifoldMetric::Lorentz => {
+            let query_norm_squared = compensated_square_sum(query)?;
+            let key_norm_squared = compensated_square_sum(key)?;
+            let query_time = libm::sqrt(1.0 + query_norm_squared);
+            let key_time = libm::sqrt(1.0 + key_norm_squared);
+            let dot = compensated_dot(query, key)?;
+            2.0 + 2.0 * (-query_time * key_time + dot)
+        }
+        HelmDLearnedManifoldMetric::Euclidean => {
+            let differences = query
+                .iter()
+                .zip(key)
+                .map(|(left, right)| *left - *right)
+                .collect::<Vec<_>>();
+            -compensated_square_sum(&differences)?
+        }
+    };
+    let logit = numerator / learned_scale + bias;
+    if !logit.is_finite() {
+        return Err(HelmDR4AttentionError::Arithmetic(
+            "learned-manifold logit is non-finite".to_owned(),
+        ));
+    }
+    Ok(logit)
+}
+
+/// Pure whole-head aggregate. Lorentz values are lifted as one H^D point,
+/// never as an independent product of H4 blocks.
+pub fn helm_d_learned_manifold_centroid(
+    metric: HelmDLearnedManifoldMetric,
+    values: &[Vec<f64>],
+    weights: &[f64],
+) -> Result<Vec<f64>, HelmDR4AttentionError> {
+    if values.is_empty()
+        || values.len() != weights.len()
+        || values[0].is_empty()
+        || values.iter().any(|value| {
+            value.len() != values[0].len() || value.iter().any(|coordinate| !coordinate.is_finite())
+        })
+        || weights
+            .iter()
+            .any(|weight| !weight.is_finite() || *weight < 0.0)
+    {
+        return Err(HelmDR4AttentionError::Invalid(
+            "learned-manifold centroid values/weights are empty, misaligned, or non-finite"
+                .to_owned(),
+        ));
+    }
+    let weight_sum = compensated_sum(weights)?;
+    if weight_sum <= EPSILON {
+        return Err(HelmDR4AttentionError::Arithmetic(
+            "learned-manifold centroid weight sum is not positive".to_owned(),
+        ));
+    }
+    let width = values[0].len();
+    let mut spatial_sum = vec![0.0; width];
+    let mut spatial_correction = vec![0.0; width];
+    let mut time_sum = 0.0;
+    let mut time_correction = 0.0;
+    for (value, weight) in values.iter().zip(weights) {
+        let normalized_weight = *weight / weight_sum;
+        for ((sum, correction), coordinate) in spatial_sum
+            .iter_mut()
+            .zip(&mut spatial_correction)
+            .zip(value)
+        {
+            compensated_add(sum, correction, normalized_weight * *coordinate);
+        }
+        if metric == HelmDLearnedManifoldMetric::Lorentz {
+            let time = libm::sqrt(1.0 + compensated_square_sum(value)?);
+            compensated_add(
+                &mut time_sum,
+                &mut time_correction,
+                normalized_weight * time,
+            );
+        }
+    }
+    for (sum, correction) in spatial_sum.iter_mut().zip(spatial_correction) {
+        *sum += correction;
+    }
+    time_sum += time_correction;
+    if spatial_sum.iter().any(|coordinate| !coordinate.is_finite()) {
+        return Err(HelmDR4AttentionError::Arithmetic(
+            "learned-manifold centroid spatial sum is non-finite".to_owned(),
+        ));
+    }
+    if metric == HelmDLearnedManifoldMetric::Euclidean {
+        return Ok(spatial_sum);
+    }
+
+    let spatial_norm = libm::sqrt(compensated_square_sum(&spatial_sum)?);
+    let lower = time_sum - spatial_norm;
+    let upper = time_sum + spatial_norm;
+    let timelike_norm_squared = lower * upper;
+    if !time_sum.is_finite()
+        || !spatial_norm.is_finite()
+        || lower <= 0.0
+        || !timelike_norm_squared.is_finite()
+        || timelike_norm_squared <= EPSILON
+    {
+        return Err(HelmDR4AttentionError::Arithmetic(
+            "learned-manifold Lorentz centroid is not future timelike".to_owned(),
+        ));
+    }
+    let normalization = libm::sqrt(timelike_norm_squared).recip();
+    for coordinate in &mut spatial_sum {
+        *coordinate *= normalization;
+    }
+    let normalized_time = time_sum * normalization;
+    let residual =
+        (-normalized_time * normalized_time + compensated_square_sum(&spatial_sum)? + 1.0).abs();
+    let residual_scale =
+        1.0 + normalized_time * normalized_time + compensated_square_sum(&spatial_sum)?;
+    if spatial_sum.iter().any(|coordinate| !coordinate.is_finite())
+        || !normalized_time.is_finite()
+        || normalized_time <= 0.0
+        || !residual.is_finite()
+        || residual > 1.0e-9 * residual_scale
+    {
+        return Err(HelmDR4AttentionError::Arithmetic(format!(
+            "learned-manifold Lorentz centroid residual {residual} exceeds tolerance"
+        )));
+    }
+    Ok(spatial_sum)
+}
+
+fn compensated_add(sum: &mut f64, correction: &mut f64, value: f64) {
+    let next = *sum + value;
+    if sum.abs() >= value.abs() {
+        *correction += (*sum - next) + value;
+    } else {
+        *correction += (value - next) + *sum;
+    }
+    *sum = next;
+}
+
+fn compensated_sum(values: &[f64]) -> Result<f64, HelmDR4AttentionError> {
+    let mut sum = 0.0;
+    let mut correction = 0.0;
+    for value in values {
+        compensated_add(&mut sum, &mut correction, *value);
+    }
+    let total = sum + correction;
+    if !total.is_finite() {
+        return Err(HelmDR4AttentionError::Arithmetic(
+            "compensated sum is non-finite".to_owned(),
+        ));
+    }
+    Ok(total)
+}
+
+fn compensated_square_sum(values: &[f64]) -> Result<f64, HelmDR4AttentionError> {
+    let squares = values.iter().map(|value| value * value).collect::<Vec<_>>();
+    compensated_sum(&squares)
+}
+
+fn compensated_dot(left: &[f64], right: &[f64]) -> Result<f64, HelmDR4AttentionError> {
+    let products = left
+        .iter()
+        .zip(right)
+        .map(|(left, right)| left * right)
+        .collect::<Vec<_>>();
+    compensated_sum(&products)
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelmDLearnedManifoldAudit {
+    pub projection_tuples: u64,
+    pub projected_query_lanes: u64,
+    pub projected_key_lanes: u64,
+    pub projected_value_lanes: u64,
+    pub score_rows: u64,
+    pub compatibility_pairs: u64,
+    pub centroid_rows: u64,
+    pub centroid_source_pairs: u64,
+    pub source_frame_permutations: u64,
+    pub value_permutations: u64,
+    pub order_key_permutations: u64,
+    pub arithmetic_failures: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelmDLearnedManifoldEvidence {
+    pub schema: String,
+    pub policy_identity: String,
+    pub parameter_identity: String,
+    pub scalar_parameter_count: usize,
+    pub metric: HelmDLearnedManifoldMetric,
+    pub intervention: HelmDLearnedManifoldIntervention,
+    pub frame_table_offsets: Vec<u16>,
+    pub transport_audit: R4SpinTransportAudit,
+    pub learned_manifold_audit: HelmDLearnedManifoldAudit,
+}
+
+/// Live compiler-side construction operator retaining the donor decoder,
+/// ordinary complete-prefix causal softmax, RoPE, and Wo around a copied
+/// HELM-D Lorentz score/centroid core.
+#[derive(Debug, Clone)]
+pub struct HelmDLearnedManifoldR4Transport {
+    atlas: R4SpinFrameAtlas,
+    parameters: HelmDLearnedManifoldParameters,
+    metric: HelmDLearnedManifoldMetric,
+    intervention: HelmDLearnedManifoldIntervention,
+    audit: HelmDLearnedManifoldAudit,
+    logit_scratch: Vec<f64>,
+    fault: Option<String>,
+}
+
+impl HelmDLearnedManifoldR4Transport {
+    pub fn new(
+        maximum_token_id: u32,
+        sequence_capacity: usize,
+        parameters: HelmDLearnedManifoldParameters,
+        metric: HelmDLearnedManifoldMetric,
+        intervention: HelmDLearnedManifoldIntervention,
+    ) -> Result<Self, HelmDR4AttentionError> {
+        parameters.validate()?;
+        Ok(Self {
+            atlas: R4SpinFrameAtlas::new(maximum_token_id, sequence_capacity)?,
+            parameters,
+            metric,
+            intervention,
+            audit: HelmDLearnedManifoldAudit::default(),
+            logit_scratch: vec![0.0; sequence_capacity],
+            fault: None,
+        })
+    }
+
+    pub fn parameters(&self) -> &HelmDLearnedManifoldParameters {
+        &self.parameters
+    }
+
+    pub const fn metric(&self) -> HelmDLearnedManifoldMetric {
+        self.metric
+    }
+
+    pub const fn intervention(&self) -> HelmDLearnedManifoldIntervention {
+        self.intervention
+    }
+
+    pub const fn audit(&self) -> HelmDLearnedManifoldAudit {
+        self.audit
+    }
+
+    pub const fn transport_audit(&self) -> R4SpinTransportAudit {
+        self.atlas.audit()
+    }
+
+    pub fn fault(&self) -> Option<&str> {
+        self.fault.as_deref()
+    }
+
+    pub fn policy_identity(&self) -> &'static str {
+        match self.metric {
+            HelmDLearnedManifoldMetric::Lorentz => HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY,
+            HelmDLearnedManifoldMetric::Euclidean => HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY,
+        }
+    }
+
+    pub fn parameter_identity(&self) -> Result<String, HelmDR4AttentionError> {
+        self.parameters.parameter_identity()
+    }
+
+    pub fn evidence_snapshot(&self) -> Result<HelmDLearnedManifoldEvidence, HelmDR4AttentionError> {
+        let frame_table_offsets = (0..self.atlas.next_position())
+            .map(|position| self.atlas.frame_table_offset(position))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(HelmDLearnedManifoldEvidence {
+            schema: "uor-r4.helm-d-learned-manifold-r4-evidence/2".to_owned(),
+            policy_identity: self.policy_identity().to_owned(),
+            parameter_identity: self.parameter_identity()?,
+            scalar_parameter_count: self.parameters.scalar_parameter_count()?,
+            metric: self.metric,
+            intervention: self.intervention,
+            frame_table_offsets,
+            transport_audit: self.atlas.audit(),
+            learned_manifold_audit: self.audit,
+        })
+    }
+
+    fn transport_intervention(&self) -> R4SpinTransportIntervention {
+        match self.intervention {
+            HelmDLearnedManifoldIntervention::SourceFramePermuted => {
+                R4SpinTransportIntervention::SourceFramePermuted
+            }
+            HelmDLearnedManifoldIntervention::Coherent
+            | HelmDLearnedManifoldIntervention::ValuePermuted
+            | HelmDLearnedManifoldIntervention::OrderKeyShuffled => {
+                R4SpinTransportIntervention::Coherent
+            }
+        }
+    }
+
+    fn record_fault(&mut self, reason: impl Into<String>) {
+        if self.fault.is_none() {
+            self.audit.arithmetic_failures = self.audit.arithmetic_failures.saturating_add(1);
+            self.fault = Some(reason.into());
+        }
+    }
+
+    fn fail_and_copy(&mut self, reason: impl Into<String>, input: &[f32], output: &mut [f32]) {
+        self.record_fault(reason);
+        output.fill(0.0);
+        for (target, source) in output.iter_mut().zip(input) {
+            *target = *source;
+        }
+    }
+
+    fn read_block(input: &[f32], offset: usize) -> Vector4 {
+        [
+            f64::from(input[offset]),
+            f64::from(input[offset + 1]),
+            f64::from(input[offset + 2]),
+            f64::from(input[offset + 3]),
+        ]
+    }
+
+    fn write_block(output: &mut [f32], offset: usize, block: Vector4) -> bool {
+        for (target, source) in output[offset..offset + R4_WIDTH].iter_mut().zip(block) {
+            *target = source as f32;
+            if !target.is_finite() {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn valid_head_slices(&mut self, input: &[f32], output: &mut [f32]) -> bool {
+        if input.len() == self.parameters.head_width() && output.len() == input.len() {
+            true
+        } else {
+            self.fail_and_copy(
+                format!(
+                    "learned-manifold transport requires one {}-lane head; input={}, output={}",
+                    self.parameters.head_width(),
+                    input.len(),
+                    output.len()
+                ),
+                input,
+                output,
+            );
+            false
+        }
+    }
+
+    fn apply_projection_role(
+        &self,
+        role: LearnedProjectionRole,
+        context: CausalAttentionProjectionContext,
+        vectors: &mut [f32],
+    ) -> Result<(), HelmDR4AttentionError> {
+        let heads = match role {
+            LearnedProjectionRole::Query => context.query_heads,
+            LearnedProjectionRole::Key | LearnedProjectionRole::Value => context.key_value_heads,
+        };
+        if context.layer >= self.parameters.layers()
+            || context.query_heads != self.parameters.query_heads()
+            || context.key_value_heads != self.parameters.key_value_heads()
+            || context.head_size != self.parameters.head_width()
+            || heads
+                .checked_mul(context.head_size)
+                .filter(|expected| *expected == vectors.len())
+                .is_none()
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold pre-RoPE projection shape differs from frozen parameters"
+                    .to_owned(),
+            ));
+        }
+        for head in 0..heads {
+            let head_offset = head * context.head_size;
+            for block in 0..self.parameters.blocks_per_head() {
+                let offset = head_offset + block * R4_WIDTH;
+                let adapter = self.parameters.adapter(role, context.layer, head, block)?;
+                let output = adapter.apply(Self::read_block(vectors, offset))?;
+                if !Self::write_block(vectors, offset, output) {
+                    return Err(HelmDR4AttentionError::Arithmetic(
+                        "learned-manifold pre-RoPE projection overflowed f32".to_owned(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn score_row(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        query: &[f32],
+        packed_keys: &[f32],
+        output_weights: &mut [f32],
+    ) -> Result<(), HelmDR4AttentionError> {
+        let width = self.parameters.head_width();
+        if query.len() != width
+            || context.head >= self.parameters.query_heads()
+            || output_weights.is_empty()
+            || output_weights.len() > self.logit_scratch.len()
+            || output_weights.len().checked_mul(width) != Some(packed_keys.len())
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold score row has inconsistent shapes".to_owned(),
+            ));
+        }
+        let query = query
+            .iter()
+            .map(|value| f64::from(*value))
+            .collect::<Vec<_>>();
+        let scale = self.parameters.learned_scale(context.layer)?;
+        let bias = self.parameters.learned_bias(context.layer)?;
+        for source in 0..output_weights.len() {
+            let key_source = match self.intervention {
+                HelmDLearnedManifoldIntervention::OrderKeyShuffled if output_weights.len() > 1 => {
+                    self.audit.order_key_permutations =
+                        self.audit.order_key_permutations.saturating_add(1);
+                    (source + 1) % output_weights.len()
+                }
+                _ => source,
+            };
+            let key = &packed_keys[key_source * width..(key_source + 1) * width];
+            let key = key
+                .iter()
+                .map(|value| f64::from(*value))
+                .collect::<Vec<_>>();
+            self.logit_scratch[source] =
+                helm_d_learned_manifold_logit(self.metric, &query, &key, scale, bias)?;
+            self.audit.compatibility_pairs = self.audit.compatibility_pairs.saturating_add(1);
+        }
+        intrinsic_stable_softmax_into(
+            &mut self.logit_scratch[..output_weights.len()],
+            output_weights,
+        )?;
+        self.audit.score_rows = self.audit.score_rows.saturating_add(1);
+        Ok(())
+    }
+
+    fn centroid_row(
+        &mut self,
+        weights: &[f32],
+        packed_values: &[f32],
+        output: &mut [f32],
+    ) -> Result<(), HelmDR4AttentionError> {
+        let width = self.parameters.head_width();
+        if output.len() != width
+            || weights.is_empty()
+            || weights.len().checked_mul(width) != Some(packed_values.len())
+        {
+            return Err(HelmDR4AttentionError::Invalid(
+                "learned-manifold centroid row has inconsistent shapes".to_owned(),
+            ));
+        }
+        let mut values = Vec::with_capacity(weights.len());
+        for source in 0..weights.len() {
+            let value_source = match self.intervention {
+                HelmDLearnedManifoldIntervention::ValuePermuted if weights.len() > 1 => {
+                    self.audit.value_permutations = self.audit.value_permutations.saturating_add(1);
+                    (source + 1) % weights.len()
+                }
+                _ => source,
+            };
+            values.push(
+                packed_values[value_source * width..(value_source + 1) * width]
+                    .iter()
+                    .map(|value| f64::from(*value))
+                    .collect::<Vec<_>>(),
+            );
+        }
+        let weights = weights
+            .iter()
+            .map(|weight| f64::from(*weight))
+            .collect::<Vec<_>>();
+        let centroid = helm_d_learned_manifold_centroid(self.metric, &values, &weights)?;
+        for (target, source) in output.iter_mut().zip(centroid) {
+            *target = source as f32;
+            if !target.is_finite() {
+                return Err(HelmDR4AttentionError::Arithmetic(
+                    "learned-manifold centroid overflowed f32".to_owned(),
+                ));
+            }
+        }
+        self.audit.centroid_source_pairs = self
+            .audit
+            .centroid_source_pairs
+            .saturating_add(u64::try_from(weights.len()).unwrap_or(u64::MAX));
+        self.audit.centroid_rows = self.audit.centroid_rows.saturating_add(1);
+        Ok(())
+    }
+}
+
+impl CausalAttentionTransport for HelmDLearnedManifoldR4Transport {
+    fn reset(&mut self) {
+        self.atlas.reset();
+        self.audit = HelmDLearnedManifoldAudit::default();
+        self.fault = None;
+    }
+
+    fn policy_identity(&self) -> &str {
+        HelmDLearnedManifoldR4Transport::policy_identity(self)
+    }
+
+    fn implementation_evidence(&self) -> Result<Option<String>, String> {
+        self.evidence_snapshot()
+            .and_then(|evidence| {
+                serde_json::to_string(&evidence)
+                    .map_err(|error| HelmDR4AttentionError::Invalid(error.to_string()))
+            })
+            .map(Some)
+            .map_err(|error| error.to_string())
+    }
+
+    fn status(&self) -> Result<(), String> {
+        match &self.fault {
+            Some(reason) => Err(reason.clone()),
+            None => Ok(()),
+        }
+    }
+
+    fn begin_position(&mut self, token: usize, position: usize) {
+        let result = u32::try_from(token)
+            .map_err(|_| {
+                HelmDR4AttentionError::Invalid(
+                    "decoder token does not fit the UOR u32 namespace".to_owned(),
+                )
+            })
+            .and_then(|token| self.atlas.begin_position(token, position));
+        if let Err(error) = result {
+            self.record_fault(error.to_string());
+        }
+    }
+
+    fn transform_projected_qkv_before_rope(
+        &mut self,
+        context: CausalAttentionProjectionContext,
+        query: &mut [f32],
+        key: &mut [f32],
+        value: &mut [f32],
+    ) {
+        if self.fault.is_some() {
+            return;
+        }
+        let result = self
+            .apply_projection_role(LearnedProjectionRole::Query, context, query)
+            .and_then(|()| self.apply_projection_role(LearnedProjectionRole::Key, context, key))
+            .and_then(|()| {
+                self.apply_projection_role(LearnedProjectionRole::Value, context, value)
+            });
+        match result {
+            Ok(()) => {
+                self.audit.projection_tuples = self.audit.projection_tuples.saturating_add(1);
+                self.audit.projected_query_lanes = self
+                    .audit
+                    .projected_query_lanes
+                    .saturating_add(u64::try_from(query.len()).unwrap_or(u64::MAX));
+                self.audit.projected_key_lanes = self
+                    .audit
+                    .projected_key_lanes
+                    .saturating_add(u64::try_from(key.len()).unwrap_or(u64::MAX));
+                self.audit.projected_value_lanes = self
+                    .audit
+                    .projected_value_lanes
+                    .saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+            }
+            Err(error) => self.record_fault(error.to_string()),
+        }
+    }
+
+    fn transform_query(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if self.fault.is_some() || !self.valid_head_slices(input, output) {
+            if self.fault.is_some() {
+                self.fail_and_copy(
+                    "learned-manifold transport is already faulted",
+                    input,
+                    output,
+                );
+            }
+            return;
+        }
+        for offset in (0..input.len()).step_by(R4_WIDTH) {
+            let encoded = self
+                .atlas
+                .encode_model_block(context.query_position, Self::read_block(input, offset));
+            match encoded {
+                Ok(block) if Self::write_block(output, offset, block) => {}
+                Ok(_) => {
+                    self.fail_and_copy(
+                        "learned-manifold query encoding overflowed f32",
+                        input,
+                        output,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    self.fail_and_copy(error.to_string(), input, output);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn transport_key(
+        &mut self,
+        context: CausalAttentionSourceContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if self.fault.is_some() || !self.valid_head_slices(input, output) {
+            if self.fault.is_some() {
+                self.fail_and_copy(
+                    "learned-manifold transport is already faulted",
+                    input,
+                    output,
+                );
+            }
+            return;
+        }
+        let intervention = self.transport_intervention();
+        for offset in (0..input.len()).step_by(R4_WIDTH) {
+            let result = self
+                .atlas
+                .encode_model_block(context.source_position, Self::read_block(input, offset))
+                .and_then(|local| {
+                    self.atlas.transport_local_block(
+                        context.source_position,
+                        context.query_position,
+                        local,
+                        intervention,
+                        false,
+                    )
+                });
+            match result {
+                Ok(block) if Self::write_block(output, offset, block) => {}
+                Ok(_) => {
+                    self.fail_and_copy(
+                        "learned-manifold key transport overflowed f32",
+                        input,
+                        output,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    self.fail_and_copy(error.to_string(), input, output);
+                    return;
+                }
+            }
+        }
+        if intervention == R4SpinTransportIntervention::SourceFramePermuted
+            && context.query_position != 0
+        {
+            self.audit.source_frame_permutations = self
+                .audit
+                .source_frame_permutations
+                .saturating_add(u64::try_from(input.len() / R4_WIDTH).unwrap_or(u64::MAX));
+        }
+    }
+
+    fn transport_value(
+        &mut self,
+        context: CausalAttentionSourceContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if self.fault.is_some() || !self.valid_head_slices(input, output) {
+            if self.fault.is_some() {
+                self.fail_and_copy(
+                    "learned-manifold transport is already faulted",
+                    input,
+                    output,
+                );
+            }
+            return;
+        }
+        let intervention = self.transport_intervention();
+        for offset in (0..input.len()).step_by(R4_WIDTH) {
+            let result = self
+                .atlas
+                .encode_model_block(context.source_position, Self::read_block(input, offset))
+                .and_then(|local| {
+                    self.atlas.transport_local_block(
+                        context.source_position,
+                        context.query_position,
+                        local,
+                        intervention,
+                        true,
+                    )
+                });
+            match result {
+                Ok(block) if Self::write_block(output, offset, block) => {}
+                Ok(_) => {
+                    self.fail_and_copy(
+                        "learned-manifold value transport overflowed f32",
+                        input,
+                        output,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    self.fail_and_copy(error.to_string(), input, output);
+                    return;
+                }
+            }
+        }
+        if intervention == R4SpinTransportIntervention::SourceFramePermuted
+            && context.query_position != 0
+        {
+            self.audit.source_frame_permutations = self
+                .audit
+                .source_frame_permutations
+                .saturating_add(u64::try_from(input.len() / R4_WIDTH).unwrap_or(u64::MAX));
+        }
+    }
+
+    fn output_to_model_frame(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if self.fault.is_some() || !self.valid_head_slices(input, output) {
+            if self.fault.is_some() {
+                self.fail_and_copy(
+                    "learned-manifold transport is already faulted",
+                    input,
+                    output,
+                );
+            }
+            return;
+        }
+        for offset in (0..input.len()).step_by(R4_WIDTH) {
+            let decoded = self
+                .atlas
+                .decode_query_block(context.query_position, Self::read_block(input, offset));
+            match decoded {
+                Ok(block) if Self::write_block(output, offset, block) => {}
+                Ok(_) => {
+                    self.fail_and_copy(
+                        "learned-manifold output decoding overflowed f32",
+                        input,
+                        output,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    self.fail_and_copy(error.to_string(), input, output);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn score_and_normalize(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        query: &[f32],
+        packed_keys: &[f32],
+        output_weights: &mut [f32],
+        _canonical_math: bool,
+    ) {
+        if self.fault.is_some() {
+            output_weights.fill(0.0);
+            return;
+        }
+        if let Err(error) = self.score_row(context, query, packed_keys, output_weights) {
+            output_weights.fill(0.0);
+            self.record_fault(error.to_string());
+        }
+    }
+
+    fn weighted_value_centroid(
+        &mut self,
+        _context: CausalAttentionHeadContext,
+        weights: &[f32],
+        packed_values: &[f32],
+        output: &mut [f32],
+    ) {
+        if self.fault.is_some() {
+            output.fill(0.0);
+            return;
+        }
+        if let Err(error) = self.centroid_row(weights, packed_values, output) {
+            output.fill(0.0);
+            self.record_fault(error.to_string());
+        }
+    }
+}
+
 fn lorentz_project(spatial: &[f64], curvature: f64) -> Result<Vec<f64>, HelmDR4AttentionError> {
     let spatial_norm_squared = spatial.iter().map(|value| value * value).sum::<f64>();
     let time = (spatial_norm_squared + curvature).sqrt();
@@ -2288,5 +3529,355 @@ mod tests {
         operator.score_and_normalize(context, &[0.1, 0.2, 0.3, 0.4], &[], &mut no_weights, true);
         assert!(CausalAttentionTransport::status(&operator).is_err());
         assert_eq!(operator.intrinsic_audit().arithmetic_failures, 1);
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_has_the_frozen_matched_capacity() {
+        let parameters =
+            HelmDLearnedManifoldParameters::identity(30, 9, 3, 16, 24.0).expect("parameters");
+        assert_eq!(parameters.head_width(), 64);
+        assert_eq!(parameters.scalar_parameter_count().expect("count"), 144_060);
+        assert_eq!(parameters.query_adapters().len(), 30 * 9 * 16);
+        assert_eq!(parameters.key_adapters().len(), 30 * 3 * 16);
+        assert_eq!(parameters.value_adapters().len(), 30 * 3 * 16);
+
+        let lorentz = HelmDLearnedManifoldR4Transport::new(
+            32,
+            2,
+            parameters.clone(),
+            HelmDLearnedManifoldMetric::Lorentz,
+            HelmDLearnedManifoldIntervention::Coherent,
+        )
+        .expect("Lorentz arm");
+        let euclidean = HelmDLearnedManifoldR4Transport::new(
+            32,
+            2,
+            parameters,
+            HelmDLearnedManifoldMetric::Euclidean,
+            HelmDLearnedManifoldIntervention::Coherent,
+        )
+        .expect("Euclidean arm");
+        assert_eq!(
+            lorentz
+                .parameters()
+                .scalar_parameter_count()
+                .expect("Lorentz count"),
+            euclidean
+                .parameters()
+                .scalar_parameter_count()
+                .expect("Euclidean count")
+        );
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_identity_projection_is_exact() {
+        let parameters =
+            HelmDLearnedManifoldParameters::identity(1, 9, 3, 16, 24.0).expect("parameters");
+        let mut operator = HelmDLearnedManifoldR4Transport::new(
+            64,
+            2,
+            parameters,
+            HelmDLearnedManifoldMetric::Lorentz,
+            HelmDLearnedManifoldIntervention::Coherent,
+        )
+        .expect("operator");
+        let mut query = (0..576)
+            .map(|index| (index as f32 - 288.0) / 1024.0)
+            .collect::<Vec<_>>();
+        let mut key = (0..192)
+            .map(|index| (index as f32 - 96.0) / 512.0)
+            .collect::<Vec<_>>();
+        let mut value = (0..192)
+            .map(|index| (96.0 - index as f32) / 768.0)
+            .collect::<Vec<_>>();
+        let expected = (query.clone(), key.clone(), value.clone());
+        CausalAttentionTransport::transform_projected_qkv_before_rope(
+            &mut operator,
+            CausalAttentionProjectionContext {
+                layer: 0,
+                query_position: 0,
+                query_heads: 9,
+                key_value_heads: 3,
+                head_size: 64,
+            },
+            &mut query,
+            &mut key,
+            &mut value,
+        );
+        assert_eq!((query, key, value), expected);
+        assert_eq!(operator.audit().projection_tuples, 1);
+        assert_eq!(operator.audit().projected_query_lanes, 576);
+        assert_eq!(operator.audit().projected_key_lanes, 192);
+        assert_eq!(operator.audit().projected_value_lanes, 192);
+        assert!(CausalAttentionTransport::status(&operator).is_ok());
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_matches_the_upstream_h64_row() {
+        let query = (0..64)
+            .map(|index| ((index as f64 + 1.0) * 0.03125).sin() * 0.4)
+            .collect::<Vec<_>>();
+        let keys = (0..3)
+            .map(|source| {
+                (0..64)
+                    .map(|index| ((index + source * 7) as f64 * 0.023).cos() * 0.35)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let values = (0..3)
+            .map(|source| {
+                (0..64)
+                    .map(|index| ((index * 3 + source * 11) as f64 * 0.017).sin() * 0.25)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let scale = 7.25;
+        let bias = -0.375;
+        let reference = helm_d_lorentz_causal_row(
+            &query,
+            &keys,
+            &values,
+            HelmDLorentzReferenceConfig {
+                curvature: 1.0,
+                learned_scale: scale,
+                bias,
+            },
+        )
+        .expect("upstream row");
+        for (source, key) in keys.iter().enumerate() {
+            let actual = helm_d_learned_manifold_logit(
+                HelmDLearnedManifoldMetric::Lorentz,
+                &query,
+                key,
+                scale,
+                bias,
+            )
+            .expect("full-head logit");
+            assert!((actual - reference.logits[source]).abs() <= 1.0e-12);
+        }
+        let centroid = helm_d_learned_manifold_centroid(
+            HelmDLearnedManifoldMetric::Lorentz,
+            &values,
+            &reference.weights,
+        )
+        .expect("full-head centroid");
+        for (actual, expected) in centroid.iter().zip(&reference.centroid[1..]) {
+            assert!((*actual - *expected).abs() <= 1.0e-12);
+        }
+        let time = libm::sqrt(1.0 + compensated_square_sum(&centroid).expect("norm"));
+        let residual =
+            (-time * time + compensated_square_sum(&centroid).expect("normalized norm") + 1.0)
+                .abs();
+        assert!(residual <= 1.0e-12);
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_is_covariant_and_mismatch_is_live() {
+        fn model_vector(seed: usize) -> Vec<f64> {
+            (0..64)
+                .map(|lane| ((seed * 17 + lane * 5) as f64 * 0.019).sin() * 0.3)
+                .collect()
+        }
+        fn encode(atlas: &mut R4SpinFrameAtlas, position: usize, vector: &[f64]) -> Vec<f64> {
+            let mut output = Vec::with_capacity(vector.len());
+            for block in vector.chunks_exact(R4_WIDTH) {
+                output.extend_from_slice(
+                    &atlas
+                        .encode_model_block(position, [block[0], block[1], block[2], block[3]])
+                        .expect("encode"),
+                );
+            }
+            output
+        }
+        fn transport(
+            atlas: &mut R4SpinFrameAtlas,
+            source: usize,
+            query: usize,
+            vector: &[f64],
+            intervention: R4SpinTransportIntervention,
+            value: bool,
+        ) -> Vec<f64> {
+            let mut output = Vec::with_capacity(vector.len());
+            for block in vector.chunks_exact(R4_WIDTH) {
+                let local = atlas
+                    .encode_model_block(source, [block[0], block[1], block[2], block[3]])
+                    .expect("source encode");
+                output.extend_from_slice(
+                    &atlas
+                        .transport_local_block(source, query, local, intervention, value)
+                        .expect("transport"),
+                );
+            }
+            output
+        }
+        fn decode(atlas: &mut R4SpinFrameAtlas, position: usize, vector: &[f64]) -> Vec<f64> {
+            let mut output = Vec::with_capacity(vector.len());
+            for block in vector.chunks_exact(R4_WIDTH) {
+                output.extend_from_slice(
+                    &atlas
+                        .decode_query_block(position, [block[0], block[1], block[2], block[3]])
+                        .expect("decode"),
+                );
+            }
+            output
+        }
+
+        let mut atlas = R4SpinFrameAtlas::new(64, 3).expect("atlas");
+        for (position, token) in [5, 11, 23].into_iter().enumerate() {
+            atlas.begin_position(token, position).expect("position");
+        }
+        let query = model_vector(3);
+        let keys = [model_vector(7), model_vector(13), model_vector(19)];
+        let values = [model_vector(29), model_vector(31), model_vector(37)];
+        let query_gauge = encode(&mut atlas, 2, &query);
+        let keys_gauge = keys
+            .iter()
+            .enumerate()
+            .map(|(source, key)| {
+                transport(
+                    &mut atlas,
+                    source,
+                    2,
+                    key,
+                    R4SpinTransportIntervention::Coherent,
+                    false,
+                )
+            })
+            .collect::<Vec<_>>();
+        let values_gauge = values
+            .iter()
+            .enumerate()
+            .map(|(source, value)| {
+                transport(
+                    &mut atlas,
+                    source,
+                    2,
+                    value,
+                    R4SpinTransportIntervention::Coherent,
+                    true,
+                )
+            })
+            .collect::<Vec<_>>();
+        let model_logits = keys
+            .iter()
+            .map(|key| {
+                helm_d_learned_manifold_logit(
+                    HelmDLearnedManifoldMetric::Lorentz,
+                    &query,
+                    key,
+                    24.0,
+                    0.0,
+                )
+                .expect("model logit")
+            })
+            .collect::<Vec<_>>();
+        let gauge_logits = keys_gauge
+            .iter()
+            .map(|key| {
+                helm_d_learned_manifold_logit(
+                    HelmDLearnedManifoldMetric::Lorentz,
+                    &query_gauge,
+                    key,
+                    24.0,
+                    0.0,
+                )
+                .expect("gauge logit")
+            })
+            .collect::<Vec<_>>();
+        for (model, gauge) in model_logits.iter().zip(&gauge_logits) {
+            assert!((*model - *gauge).abs() <= 1.0e-12);
+        }
+        let weights = stable_softmax(&model_logits).expect("weights");
+        let model_centroid = helm_d_learned_manifold_centroid(
+            HelmDLearnedManifoldMetric::Lorentz,
+            &values,
+            &weights,
+        )
+        .expect("model centroid");
+        let gauge_centroid = helm_d_learned_manifold_centroid(
+            HelmDLearnedManifoldMetric::Lorentz,
+            &values_gauge,
+            &weights,
+        )
+        .expect("gauge centroid");
+        let decoded = decode(&mut atlas, 2, &gauge_centroid);
+        let maximum_error = decoded
+            .iter()
+            .zip(&model_centroid)
+            .map(|(left, right)| (*left - *right).abs())
+            .fold(0.0, f64::max);
+        assert!(maximum_error <= 1.0e-8, "covariance error {maximum_error}");
+
+        let mismatched = transport(
+            &mut atlas,
+            0,
+            2,
+            &keys[0],
+            R4SpinTransportIntervention::SourceFramePermuted,
+            false,
+        );
+        let mismatch_logit = helm_d_learned_manifold_logit(
+            HelmDLearnedManifoldMetric::Lorentz,
+            &query_gauge,
+            &mismatched,
+            24.0,
+            0.0,
+        )
+        .expect("mismatch logit");
+        assert!((mismatch_logit - model_logits[0]).abs() > 1.0e-6);
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_rejects_invalid_parameters() {
+        let mut parameters =
+            HelmDLearnedManifoldParameters::identity(1, 9, 3, 16, 24.0).expect("parameters");
+        parameters.learned_scales_mut()[0] = 0.0;
+        assert!(parameters.validate().is_err());
+
+        let mut parameters =
+            HelmDLearnedManifoldParameters::identity(1, 9, 3, 16, 24.0).expect("parameters");
+        parameters.query_adapters_mut()[0].matrix[0][0] = f64::NAN;
+        assert!(parameters.validate().is_err());
+        assert!(HelmDLearnedManifoldParameters::identity(1, 8, 3, 16, 24.0).is_err());
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_order_key_control_is_live() {
+        let parameters =
+            HelmDLearnedManifoldParameters::identity(1, 1, 1, 16, 24.0).expect("parameters");
+        let mut coherent = HelmDLearnedManifoldR4Transport::new(
+            32,
+            3,
+            parameters.clone(),
+            HelmDLearnedManifoldMetric::Lorentz,
+            HelmDLearnedManifoldIntervention::Coherent,
+        )
+        .expect("coherent");
+        let mut shuffled = HelmDLearnedManifoldR4Transport::new(
+            32,
+            3,
+            parameters,
+            HelmDLearnedManifoldMetric::Lorentz,
+            HelmDLearnedManifoldIntervention::OrderKeyShuffled,
+        )
+        .expect("shuffled");
+        let query = (0..64)
+            .map(|lane| (lane as f32 * 0.013).sin())
+            .collect::<Vec<_>>();
+        let packed_keys = (0..3)
+            .flat_map(|source| (0..64).map(move |lane| ((source * 19 + lane) as f32 * 0.021).cos()))
+            .collect::<Vec<_>>();
+        let context = CausalAttentionHeadContext {
+            layer: 0,
+            head: 0,
+            query_position: 2,
+        };
+        let mut coherent_weights = [0.0_f32; 3];
+        let mut shuffled_weights = [0.0_f32; 3];
+        coherent.score_and_normalize(context, &query, &packed_keys, &mut coherent_weights, true);
+        shuffled.score_and_normalize(context, &query, &packed_keys, &mut shuffled_weights, true);
+        assert_ne!(coherent_weights, shuffled_weights);
+        assert_eq!(shuffled.audit().order_key_permutations, 3);
+        assert!(CausalAttentionTransport::status(&shuffled).is_ok());
     }
 }

--- a/crates/uor-r4-core/tests/helm_d_learned_manifold_r4_construction_973.rs
+++ b/crates/uor-r4-core/tests/helm_d_learned_manifold_r4_construction_973.rs
@@ -1,0 +1,4056 @@
+//! Construction-only HELM-D learned-manifold R4 decision harness for #973.
+//!
+//! The ignored freeze test commits a fresh 16-fit/8-validation population
+//! without serializing any next-token target. The ignored decision test opens
+//! fit inputs first, fits and independently replays two equal-capacity arms,
+//! publishes an exclusive checkpoint, and only then materializes validation.
+
+use std::collections::{BTreeMap, HashSet};
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use uor_r4_core::helm_d_r4_attention::{
+    helm_d_learned_manifold_centroid, helm_d_learned_manifold_logit, helm_d_lorentz_causal_row,
+    HelmDLearnedManifoldEvidence, HelmDLearnedManifoldIntervention, HelmDLearnedManifoldMetric,
+    HelmDLearnedManifoldParameters, HelmDLearnedManifoldR4Transport, HelmDLorentzReferenceConfig,
+    R4AffineAdapter, R4SpinCausalAttentionTransport, R4SpinFrameAtlas, R4SpinTransportEvidence,
+    R4SpinTransportIntervention, HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY,
+    HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY, HELM_D_R4_GAUGE_SOFTMAX_POLICY,
+    HELM_D_UPSTREAM_COMMIT,
+};
+use uor_r4_core::transformerless::scenarios::Tokenizer;
+use uor_r4_model_source::attention::{
+    head_attention_value_aggregate, standard_head_attention_weights, CausalAttentionHeadContext,
+    CausalAttentionLayerSelection, CausalAttentionProjectionAudit,
+    CausalAttentionProjectionContext, CausalAttentionSourceContext, CausalAttentionTransport,
+    CausalAttentionTransportAudit,
+};
+use uor_r4_model_source::{
+    HuggingFaceLlamaOracle, TeacherExecutionConfig, TeacherExecutionPreparation,
+    TeacherExecutionSnapshot,
+};
+
+const MODEL_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_MODEL";
+const TOKENIZER_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_TOKENIZER";
+const CORPUS_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_CORPUS";
+const PARTITION_OUTPUT_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_PARTITION_OUTPUT";
+const PARTITION_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_PARTITION";
+const CHECKPOINT_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_CHECKPOINT";
+const RESULT_OUTPUT_ENV: &str = "UOR_R4_973_HELM_D_MANIFOLD_OUTPUT";
+const CANONICAL_DETERMINISTIC_ENV: &str = "TLESS_CANONICAL_DETERMINISTIC";
+
+const DEFAULT_MODEL: &str = "/Users/casey.allard/uor-r4/.uor-models/sources/smollm2-135m-instruct";
+const DEFAULT_TOKENIZER: &str =
+    "/Users/casey.allard/uor-r4/.uor-models/compiled/smollm2-135m-instruct/tokenizer.bin";
+const DEFAULT_CORPUS: &str =
+    "/Users/casey.allard/uor-r4/.uor-models/corpora/simple-wiki-20231101/articles.jsonl";
+
+const CORPUS_CID: &str = "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf";
+const DONOR_CID: &str = "blake3:12d2cd8a877ef2cdcf785b3d4d1f373e0419074cc884aeaff06fc059686a5ba5";
+const PREDECESSOR_PARTITION_CID: &str =
+    "blake3:cad3dfd17159fdacc5c40e38753109c11764117e3c960f42b9b198d5731272a1";
+const CORPUS_DOCUMENTS: usize = 3_000;
+const PARITY_DOCUMENT_ID: &str = "12";
+const FIT_DOCUMENTS: usize = 16;
+const VALIDATION_DOCUMENTS: usize = 8;
+const REQUIRED_TOKENS: usize = 17;
+const INPUT_POSITIONS: usize = 16;
+const SCORE_START: usize = 8;
+const SCORE_POSITIONS: usize = 8;
+const SHARDS: usize = 8;
+const ADAM_STEPS: usize = 128;
+const LEARNING_RATE: f64 = 1.0e-3;
+const ADAM_BETA1: f64 = 0.9;
+const ADAM_BETA2: f64 = 0.999;
+const ADAM_EPSILON: f64 = 1.0e-8;
+const RIDGE: f64 = 1.0e-6;
+const SCALE_FLOOR: f64 = 1.0e-6;
+const INITIAL_SCALE: f64 = 24.0;
+const MAX_CANARY_SECONDS: f64 = 2.0 * 60.0 * 60.0;
+const EXPECTED_LAYERS: usize = 30;
+const EXPECTED_QUERY_HEADS: usize = 9;
+const EXPECTED_KV_HEADS: usize = 3;
+const HEAD_WIDTH: usize = 64;
+const R4_WIDTH: usize = 4;
+const BLOCKS_PER_HEAD: usize = HEAD_WIDTH / R4_WIDTH;
+const PARAMETER_SCALARS: usize = 144_060;
+const PARTITION_SCHEMA: &str = "uor-r4.helm-d-learned-manifold-r4-construction-partition/2";
+const CHECKPOINT_SCHEMA: &str = "uor-r4.helm-d-learned-manifold-r4-construction-checkpoint/2";
+const RESULT_SCHEMA: &str = "uor-r4.helm-d-learned-manifold-r4-construction-result/2";
+
+const PASS_TERMINAL: &str = "PASS_HELM_D_LEARNED_MANIFOLD_R4_CONSTRUCTION_AUTHORIZE_HELDOUT_FREEZE";
+const RETAIN_TERMINAL: &str = "RETAIN_HELM_D_MANIFOLD_FUNCTIONAL_PARITY_NO_CURVATURE_ADVANTAGE";
+const FAIL_TERMINAL: &str =
+    "FAIL_HELM_D_MANIFOLD_CONSTRUCTION_REVISE_PROJECTION_SCORE_CENTROID_OR_TRAINING";
+const UNAVAILABLE_TERMINAL: &str = "UNAVAILABLE_HELM_D_MANIFOLD_CONSTRUCTION_EVIDENCE";
+
+const COMPILED_CONTRACT: &[u8] =
+    include_bytes!("../../../docs/helm_d_learned_manifold_r4_construction_973.md");
+const COMPILED_PREDECESSOR_PARTITION: &[u8] =
+    include_bytes!("../../../docs/intrinsic_lorentz_r4_attention_partition_973.json");
+const COMPILED_CORE_SOURCE: &[u8] = include_bytes!("../src/helm_d_r4_attention.rs");
+const COMPILED_HARNESS_SOURCE: &[u8] =
+    include_bytes!("helm_d_learned_manifold_r4_construction_973.rs");
+const COMPILED_MODEL_ATTENTION_SOURCE: &[u8] =
+    include_bytes!("../../uor-r4-model-source/src/attention.rs");
+const COMPILED_MODEL_SOURCE: &[u8] = include_bytes!("../../uor-r4-model-source/src/lib.rs");
+
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Debug, Deserialize)]
+struct Article {
+    id: String,
+    title: String,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusManifest {
+    article_count: usize,
+    corpus_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrozenDocumentCommitment {
+    id: String,
+    selection_digest: String,
+    title_cid: String,
+    input_cid: String,
+    predecessor_domain_input_cid: String,
+    corpus_byte_offset: u64,
+    corpus_byte_length: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrozenExclusionSet {
+    predecessor_partition_cid: String,
+    document_ids: Vec<String>,
+    input_cids: Vec<String>,
+    exclusion_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrozenPartition {
+    schema: String,
+    issue: u32,
+    selection_policy: String,
+    selection_policy_cid: String,
+    corpus_cid: String,
+    corpus_documents: usize,
+    donor_cid: String,
+    tokenizer_cid: String,
+    upstream_source_commit: String,
+    required_tokens_per_document: usize,
+    input_positions: usize,
+    scored_positions: Vec<usize>,
+    exclusions: FrozenExclusionSet,
+    construction_fit: Vec<FrozenDocumentCommitment>,
+    construction_validation: Vec<FrozenDocumentCommitment>,
+    partition_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrozenPartitionEnvelope {
+    manifest_cid: String,
+    manifest: FrozenPartition,
+}
+
+#[derive(Debug)]
+struct Candidate {
+    selection_digest: [u8; 32],
+    commitment: FrozenDocumentCommitment,
+}
+
+#[derive(Clone, Debug)]
+struct FrozenDocument {
+    id: String,
+    tokens: Vec<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PredecessorEnvelope {
+    manifest: PredecessorManifest,
+}
+
+#[derive(Debug, Deserialize)]
+struct PredecessorManifest {
+    partition_cid: String,
+    construction_fit: Vec<PredecessorDocument>,
+    construction_validation: Vec<PredecessorDocument>,
+    #[serde(rename = "d3_heldout")]
+    predecessor_heldout: Vec<PredecessorDocument>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PredecessorDocument {
+    id: String,
+    input_cid: String,
+}
+
+fn path_from_env(name: &str, default: &str) -> PathBuf {
+    env::var_os(name).map_or_else(|| PathBuf::from(default), PathBuf::from)
+}
+
+fn required_path_from_env(name: &str) -> TestResult<PathBuf> {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("required path environment variable {name} is unset").into())
+}
+
+fn cid_bytes(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn file_cid(path: &Path) -> TestResult<String> {
+    let mut input = fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = input.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+fn token_cid(domain: &[u8], tokens: &[u32]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(domain);
+    hasher.update(
+        &u64::try_from(tokens.len())
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    for token in tokens {
+        hasher.update(&token.to_le_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn string_cid(domain: &[u8], value: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(domain);
+    hasher.update(&u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(value.as_bytes());
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn selection_digest(id: &str) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.helm-d-learned-manifold-r4-construction/2\0");
+    hasher.update(id.as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+fn reserved_partition_id(id: &str) -> bool {
+    blake3::hash(id.as_bytes()).as_bytes()[0].is_multiple_of(5)
+}
+
+fn canonical_json_bytes(value: &impl Serialize) -> TestResult<Vec<u8>> {
+    let mut value = serde_json::to_value(value)?;
+    sort_json_keys(&mut value);
+    Ok(serde_json::to_vec(&value)?)
+}
+
+fn sort_json_keys(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => values.iter_mut().for_each(sort_json_keys),
+        serde_json::Value::Object(object) => {
+            let mut entries = std::mem::take(object).into_iter().collect::<Vec<_>>();
+            entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+            for (key, mut value) in entries {
+                sort_json_keys(&mut value);
+                object.insert(key, value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn canonical_json_cid(value: &impl Serialize) -> TestResult<String> {
+    Ok(cid_bytes(&canonical_json_bytes(value)?))
+}
+
+fn write_pretty_json(path: &Path, value: &impl Serialize) -> TestResult {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn write_pretty_json_exclusive(path: &Path, value: &impl Serialize) -> TestResult {
+    let parent = path.parent().ok_or("exclusive path has no parent")?;
+    fs::create_dir_all(parent)?;
+    let mut output = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    output.write_all(&bytes)?;
+    output.sync_all()?;
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn verify_corpus_manifest(path: &Path) -> TestResult {
+    let manifest_path = path.with_file_name("manifest.json");
+    let manifest: CorpusManifest = serde_json::from_slice(&fs::read(manifest_path)?)?;
+    if manifest.article_count != CORPUS_DOCUMENTS || manifest.corpus_cid != CORPUS_CID {
+        return Err("SimpleWiki manifest identity mismatch".into());
+    }
+    Ok(())
+}
+
+fn verify_complete_corpus(path: &Path) -> TestResult {
+    verify_corpus_manifest(path)?;
+    if file_cid(path)? != CORPUS_CID {
+        return Err("SimpleWiki byte identity mismatch".into());
+    }
+    Ok(())
+}
+
+fn predecessor_exclusions() -> TestResult<FrozenExclusionSet> {
+    let predecessor: PredecessorEnvelope = serde_json::from_slice(COMPILED_PREDECESSOR_PARTITION)?;
+    if predecessor.manifest.partition_cid != PREDECESSOR_PARTITION_CID {
+        return Err("predecessor partition CID does not match the frozen exclusion source".into());
+    }
+    let documents = predecessor
+        .manifest
+        .construction_fit
+        .iter()
+        .chain(&predecessor.manifest.construction_validation)
+        .chain(&predecessor.manifest.predecessor_heldout)
+        .collect::<Vec<_>>();
+    let mut document_ids = documents
+        .iter()
+        .map(|document| document.id.clone())
+        .collect::<Vec<_>>();
+    let mut input_cids = documents
+        .iter()
+        .map(|document| document.input_cid.clone())
+        .collect::<Vec<_>>();
+    document_ids.sort_unstable_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    input_cids.sort_unstable();
+    if document_ids.len() != 28
+        || input_cids.len() != 28
+        || document_ids.windows(2).any(|pair| pair[0] == pair[1])
+        || input_cids.windows(2).any(|pair| pair[0] == pair[1])
+    {
+        return Err("predecessor exclusion set is incomplete or duplicated".into());
+    }
+    let mut exclusion = FrozenExclusionSet {
+        predecessor_partition_cid: PREDECESSOR_PARTITION_CID.to_owned(),
+        document_ids,
+        input_cids,
+        exclusion_cid: String::new(),
+    };
+    exclusion.exclusion_cid = canonical_json_cid(&exclusion)?;
+    Ok(exclusion)
+}
+
+fn partition_cid(partition: &FrozenPartition) -> TestResult<String> {
+    let mut commitment = partition.clone();
+    commitment.partition_cid.clear();
+    canonical_json_cid(&commitment)
+}
+
+fn validate_partition(partition: &FrozenPartition) -> TestResult {
+    if partition.schema != PARTITION_SCHEMA
+        || partition.issue != 973
+        || partition.corpus_cid != CORPUS_CID
+        || partition.corpus_documents != CORPUS_DOCUMENTS
+        || partition.donor_cid != DONOR_CID
+        || partition.upstream_source_commit != HELM_D_UPSTREAM_COMMIT
+        || partition.required_tokens_per_document != REQUIRED_TOKENS
+        || partition.input_positions != INPUT_POSITIONS
+        || partition.scored_positions != (SCORE_START..INPUT_POSITIONS).collect::<Vec<_>>()
+        || partition.construction_fit.len() != FIT_DOCUMENTS
+        || partition.construction_validation.len() != VALIDATION_DOCUMENTS
+        || partition.exclusions != predecessor_exclusions()?
+        || partition.selection_policy_cid
+            != string_cid(b"uor-r4.selection-policy/1", &partition.selection_policy)
+        || partition.partition_cid != partition_cid(partition)?
+    {
+        return Err("frozen construction partition header or identity is invalid".into());
+    }
+    let excluded_ids = partition
+        .exclusions
+        .document_ids
+        .iter()
+        .collect::<HashSet<_>>();
+    let excluded_inputs = partition
+        .exclusions
+        .input_cids
+        .iter()
+        .collect::<HashSet<_>>();
+    let mut selected_ids = HashSet::new();
+    let mut selected_inputs = HashSet::new();
+    let mut ordered = partition
+        .construction_fit
+        .iter()
+        .chain(&partition.construction_validation);
+    let mut prior: Option<([u8; 32], Vec<u8>)> = None;
+    for document in ordered.by_ref() {
+        let digest = selection_digest(&document.id);
+        let key = (digest, document.id.as_bytes().to_vec());
+        if document.id == PARITY_DOCUMENT_ID
+            || reserved_partition_id(&document.id)
+            || excluded_ids.contains(&document.id)
+            || excluded_inputs.contains(&document.predecessor_domain_input_cid)
+            || document.selection_digest != format!("blake3:{}", hex::encode(digest))
+            || !document.title_cid.starts_with("blake3:")
+            || !document.input_cid.starts_with("blake3:")
+            || !document.predecessor_domain_input_cid.starts_with("blake3:")
+            || document.corpus_byte_length == 0
+            || document
+                .corpus_byte_offset
+                .checked_add(document.corpus_byte_length)
+                .is_none()
+            || !selected_ids.insert(document.id.clone())
+            || !selected_inputs.insert(document.input_cid.clone())
+            || prior.as_ref().is_some_and(|prior| prior >= &key)
+        {
+            return Err(format!(
+                "selected document {} violates the frozen policy",
+                document.id
+            )
+            .into());
+        }
+        prior = Some(key);
+    }
+    Ok(())
+}
+
+fn parse_partition(bytes: &[u8]) -> TestResult<FrozenPartitionEnvelope> {
+    let envelope: FrozenPartitionEnvelope = serde_json::from_slice(bytes)?;
+    validate_partition(&envelope.manifest)?;
+    if envelope.manifest_cid != canonical_json_cid(&envelope.manifest)? {
+        return Err("partition envelope CID mismatch".into());
+    }
+    Ok(envelope)
+}
+
+#[test]
+#[ignore = "freezes a fresh 16-fit/8-validation construction-only population"]
+fn freeze_helm_d_learned_manifold_r4_construction_partition() -> TestResult {
+    let tokenizer_path = path_from_env(TOKENIZER_ENV, DEFAULT_TOKENIZER);
+    let corpus_path = path_from_env(CORPUS_ENV, DEFAULT_CORPUS);
+    verify_complete_corpus(&corpus_path)?;
+    let tokenizer = Tokenizer::try_load(&tokenizer_path)?;
+    let exclusions = predecessor_exclusions()?;
+    let excluded_ids = exclusions.document_ids.iter().collect::<HashSet<_>>();
+    let excluded_inputs = exclusions.input_cids.iter().collect::<HashSet<_>>();
+    let mut observed_ids = HashSet::new();
+    let mut observed_documents = 0_usize;
+    let mut candidates = Vec::new();
+    let mut corpus = BufReader::new(fs::File::open(&corpus_path)?);
+    let mut line = Vec::new();
+    let mut offset = 0_u64;
+    loop {
+        line.clear();
+        let count = corpus.read_until(b'\n', &mut line)?;
+        if count == 0 {
+            break;
+        }
+        let line_offset = offset;
+        let line_length = u64::try_from(count)?;
+        offset = offset
+            .checked_add(line_length)
+            .ok_or("corpus offset overflow")?;
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        observed_documents += 1;
+        let article: Article = serde_json::from_slice(&line)?;
+        if !observed_ids.insert(article.id.clone()) {
+            return Err(format!("duplicate corpus document {}", article.id).into());
+        }
+        if article.id == PARITY_DOCUMENT_ID
+            || reserved_partition_id(&article.id)
+            || excluded_ids.contains(&article.id)
+        {
+            continue;
+        }
+        let tokens = tokenizer.encode(&format!("{}\n\n{}", article.title, article.text));
+        if tokens.len() < REQUIRED_TOKENS {
+            continue;
+        }
+        let input_cid = token_cid(
+            b"uor-r4.helm-d-learned-manifold.inputs/2",
+            &tokens[..INPUT_POSITIONS],
+        );
+        let predecessor_domain_input_cid =
+            token_cid(b"uor-r4.intrinsic.inputs/1", &tokens[..INPUT_POSITIONS]);
+        if excluded_inputs.contains(&predecessor_domain_input_cid) {
+            continue;
+        }
+        let digest = selection_digest(&article.id);
+        candidates.push(Candidate {
+            selection_digest: digest,
+            commitment: FrozenDocumentCommitment {
+                id: article.id,
+                selection_digest: format!("blake3:{}", hex::encode(digest)),
+                title_cid: string_cid(b"uor-r4.helm-d-learned-manifold.title/2", &article.title),
+                input_cid,
+                predecessor_domain_input_cid,
+                corpus_byte_offset: line_offset,
+                corpus_byte_length: line_length,
+            },
+        });
+    }
+    if observed_documents != CORPUS_DOCUMENTS {
+        return Err(format!(
+            "corpus count mismatch: expected {CORPUS_DOCUMENTS}, observed {observed_documents}"
+        )
+        .into());
+    }
+    candidates.sort_by(|left, right| {
+        left.selection_digest
+            .cmp(&right.selection_digest)
+            .then_with(|| {
+                left.commitment
+                    .id
+                    .as_bytes()
+                    .cmp(right.commitment.id.as_bytes())
+            })
+    });
+    if candidates.len() < FIT_DOCUMENTS + VALIDATION_DOCUMENTS {
+        return Err("insufficient fresh eligible construction documents".into());
+    }
+    let selected = candidates
+        .into_iter()
+        .take(FIT_DOCUMENTS + VALIDATION_DOCUMENTS)
+        .map(|candidate| candidate.commitment)
+        .collect::<Vec<_>>();
+    let selection_policy = concat!(
+        "BLAKE3(domain-nul-UTF8(id)); exclude reserved digest class, id 12, and every ",
+        "predecessor id/input CID; eligible encoded length >=17; sort complete digest then UTF8 id; ",
+        "first 16 fit, next 8 validation; commit id/title CID/input CID/byte span only"
+    )
+    .to_owned();
+    let mut partition = FrozenPartition {
+        schema: PARTITION_SCHEMA.to_owned(),
+        issue: 973,
+        selection_policy_cid: string_cid(b"uor-r4.selection-policy/1", &selection_policy),
+        selection_policy,
+        corpus_cid: CORPUS_CID.to_owned(),
+        corpus_documents: CORPUS_DOCUMENTS,
+        donor_cid: DONOR_CID.to_owned(),
+        tokenizer_cid: file_cid(&tokenizer_path)?,
+        upstream_source_commit: HELM_D_UPSTREAM_COMMIT.to_owned(),
+        required_tokens_per_document: REQUIRED_TOKENS,
+        input_positions: INPUT_POSITIONS,
+        scored_positions: (SCORE_START..INPUT_POSITIONS).collect(),
+        exclusions,
+        construction_fit: selected[..FIT_DOCUMENTS].to_vec(),
+        construction_validation: selected[FIT_DOCUMENTS..].to_vec(),
+        partition_cid: String::new(),
+    };
+    partition.partition_cid = partition_cid(&partition)?;
+    validate_partition(&partition)?;
+    let envelope = FrozenPartitionEnvelope {
+        manifest_cid: canonical_json_cid(&partition)?,
+        manifest: partition,
+    };
+    let output = required_path_from_env(PARTITION_OUTPUT_ENV)?;
+    write_pretty_json(&output, &envelope)?;
+    eprintln!(
+        "frozen HELM-D learned-manifold construction partition: {}",
+        envelope.manifest_cid
+    );
+    Ok(())
+}
+
+fn materialize_documents(
+    corpus_path: &Path,
+    tokenizer: &Tokenizer,
+    commitments: &[FrozenDocumentCommitment],
+    include_next_token: bool,
+) -> TestResult<Vec<FrozenDocument>> {
+    let mut corpus = fs::File::open(corpus_path)?;
+    let corpus_len = corpus.metadata()?.len();
+    let mut documents = Vec::with_capacity(commitments.len());
+    for commitment in commitments {
+        if reserved_partition_id(&commitment.id) || commitment.id == PARITY_DOCUMENT_ID {
+            return Err(format!(
+                "materialization rejected reserved document {}",
+                commitment.id
+            )
+            .into());
+        }
+        let end = commitment
+            .corpus_byte_offset
+            .checked_add(commitment.corpus_byte_length)
+            .filter(|end| commitment.corpus_byte_length > 0 && *end <= corpus_len)
+            .ok_or("committed corpus span is invalid")?;
+        let mut bytes = vec![0_u8; usize::try_from(commitment.corpus_byte_length)?];
+        corpus.seek(SeekFrom::Start(commitment.corpus_byte_offset))?;
+        corpus.read_exact(&mut bytes)?;
+        if corpus.stream_position()? != end {
+            return Err("committed corpus span ended at the wrong offset".into());
+        }
+        let article: Article = serde_json::from_slice(&bytes)?;
+        if article.id != commitment.id
+            || string_cid(b"uor-r4.helm-d-learned-manifold.title/2", &article.title)
+                != commitment.title_cid
+        {
+            return Err(format!("committed document {} identity mismatch", commitment.id).into());
+        }
+        let mut tokens = tokenizer.encode(&format!("{}\n\n{}", article.title, article.text));
+        if tokens.len() < REQUIRED_TOKENS {
+            return Err(
+                format!("committed document {} is no longer eligible", commitment.id).into(),
+            );
+        }
+        if token_cid(
+            b"uor-r4.helm-d-learned-manifold.inputs/2",
+            &tokens[..INPUT_POSITIONS],
+        ) != commitment.input_cid
+            || token_cid(b"uor-r4.intrinsic.inputs/1", &tokens[..INPUT_POSITIONS])
+                != commitment.predecessor_domain_input_cid
+        {
+            return Err(format!("committed document {} input CID mismatch", commitment.id).into());
+        }
+        tokens.truncate(if include_next_token {
+            REQUIRED_TOKENS
+        } else {
+            INPUT_POSITIONS
+        });
+        documents.push(FrozenDocument {
+            id: article.id,
+            tokens,
+        });
+    }
+    Ok(documents)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ProjectionTrace {
+    query: Vec<f32>,
+    key: Vec<f32>,
+    value: Vec<f32>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct HeadTrace {
+    post_rope_query: Vec<f32>,
+    post_rope_current_key: Vec<f32>,
+    current_value: Vec<f32>,
+    donor_weights: Vec<f32>,
+    donor_aggregate: Vec<f32>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct DonorTraceState {
+    projections: BTreeMap<(usize, usize), ProjectionTrace>,
+    heads: BTreeMap<(usize, usize, usize), HeadTrace>,
+}
+
+#[derive(Clone, Debug)]
+struct CapturedDocument {
+    document: FrozenDocument,
+    projections: Vec<Vec<ProjectionTrace>>,
+    heads: Vec<Vec<Vec<HeadTrace>>>,
+    decoder_audit: CausalAttentionTransportAudit,
+    projection_audit: CausalAttentionProjectionAudit,
+    trace_cid: String,
+}
+
+struct DonorTracingTransport {
+    state: Arc<Mutex<DonorTraceState>>,
+}
+
+impl DonorTracingTransport {
+    fn with_head(&self, context: CausalAttentionHeadContext, update: impl FnOnce(&mut HeadTrace)) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        update(
+            state
+                .heads
+                .entry((context.query_position, context.layer, context.head))
+                .or_default(),
+        );
+    }
+}
+
+impl CausalAttentionTransport for DonorTracingTransport {
+    fn policy_identity(&self) -> &str {
+        "uor-r4.donor-pre-rope-qkv-attention-trace/2"
+    }
+
+    fn begin_position(&mut self, _token: usize, _position: usize) {}
+
+    fn transform_projected_qkv_before_rope(
+        &mut self,
+        context: CausalAttentionProjectionContext,
+        query: &mut [f32],
+        key: &mut [f32],
+        value: &mut [f32],
+    ) {
+        let replaced = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .projections
+            .insert(
+                (context.query_position, context.layer),
+                ProjectionTrace {
+                    query: query.to_vec(),
+                    key: key.to_vec(),
+                    value: value.to_vec(),
+                },
+            );
+        assert!(replaced.is_none(), "projection hook invoked more than once");
+    }
+
+    fn transform_query(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        self.with_head(context, |head| head.post_rope_query = input.to_vec());
+        output.copy_from_slice(input);
+    }
+
+    fn transport_key(
+        &mut self,
+        context: CausalAttentionSourceContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if context.source_position == context.query_position {
+            self.with_head(
+                CausalAttentionHeadContext {
+                    layer: context.layer,
+                    head: context.head,
+                    query_position: context.query_position,
+                },
+                |head| head.post_rope_current_key = input.to_vec(),
+            );
+        }
+        output.copy_from_slice(input);
+    }
+
+    fn transport_value(
+        &mut self,
+        context: CausalAttentionSourceContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        if context.source_position == context.query_position {
+            self.with_head(
+                CausalAttentionHeadContext {
+                    layer: context.layer,
+                    head: context.head,
+                    query_position: context.query_position,
+                },
+                |head| head.current_value = input.to_vec(),
+            );
+        }
+        output.copy_from_slice(input);
+    }
+
+    fn score_and_normalize(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        query: &[f32],
+        packed_keys: &[f32],
+        output_weights: &mut [f32],
+        canonical_math: bool,
+    ) {
+        standard_head_attention_weights(
+            output_weights,
+            query,
+            packed_keys,
+            0,
+            query.len(),
+            canonical_math,
+        );
+        self.with_head(context, |head| head.donor_weights = output_weights.to_vec());
+    }
+
+    fn weighted_value_centroid(
+        &mut self,
+        context: CausalAttentionHeadContext,
+        weights: &[f32],
+        packed_values: &[f32],
+        output: &mut [f32],
+    ) {
+        let width = output.len();
+        head_attention_value_aggregate(output, weights, packed_values, 0, width);
+        self.with_head(context, |head| head.donor_aggregate = output.to_vec());
+    }
+
+    fn output_to_model_frame(
+        &mut self,
+        _context: CausalAttentionHeadContext,
+        input: &[f32],
+        output: &mut [f32],
+    ) {
+        output.copy_from_slice(input);
+    }
+}
+
+fn capture_document(
+    oracle: &HuggingFaceLlamaOracle,
+    document: &FrozenDocument,
+) -> TestResult<CapturedDocument> {
+    if document.tokens.len() != INPUT_POSITIONS {
+        return Err("fit trace must not contain a next-token target".into());
+    }
+    let config = oracle.cfg();
+    let shared = Arc::new(Mutex::new(DonorTraceState::default()));
+    let mut traced = oracle.new_causal_attention_transport_session(
+        Box::new(DonorTracingTransport {
+            state: shared.clone(),
+        }),
+        CausalAttentionLayerSelection::All,
+        INPUT_POSITIONS,
+    )?;
+    let mut donor = oracle.new_state_bounded(INPUT_POSITIONS)?;
+    let mut traced_logits = vec![0.0_f32; config.vocab];
+    let mut donor_logits = vec![0.0_f32; config.vocab];
+    let mut logits = Vec::with_capacity(INPUT_POSITIONS);
+    for (position, token) in document.tokens.iter().copied().enumerate() {
+        oracle.step_state(&mut donor, token as usize, position, &mut donor_logits)?;
+        oracle.step_causal_attention_transport(
+            &mut traced,
+            token as usize,
+            position,
+            &mut traced_logits,
+        )?;
+        if donor_logits
+            .iter()
+            .zip(&traced_logits)
+            .any(|(left, right)| left.to_bits() != right.to_bits())
+        {
+            return Err(format!("identity trace changed donor logits for {}", document.id).into());
+        }
+        logits.push(traced_logits.clone());
+    }
+    if donor.persistent_state_cid() != traced.persistent_state_cid() {
+        return Err("identity tracing path changed persistent decoder state".into());
+    }
+    let raw = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let mut projections = Vec::with_capacity(INPUT_POSITIONS);
+    let mut heads = Vec::with_capacity(INPUT_POSITIONS);
+    for position in 0..INPUT_POSITIONS {
+        let mut position_projections = Vec::with_capacity(config.n_layers);
+        let mut position_heads = Vec::with_capacity(config.n_layers);
+        for layer in 0..config.n_layers {
+            position_projections.push(
+                raw.projections
+                    .get(&(position, layer))
+                    .cloned()
+                    .ok_or("missing pre-RoPE projection trace")?,
+            );
+            let mut layer_heads = Vec::with_capacity(config.n_heads);
+            for head in 0..config.n_heads {
+                let trace = raw
+                    .heads
+                    .get(&(position, layer, head))
+                    .cloned()
+                    .ok_or("missing donor attention row trace")?;
+                if trace.post_rope_query.len() != HEAD_WIDTH
+                    || trace.post_rope_current_key.len() != HEAD_WIDTH
+                    || trace.current_value.len() != HEAD_WIDTH
+                    || trace.donor_weights.len() != position + 1
+                    || trace.donor_aggregate.len() != HEAD_WIDTH
+                {
+                    return Err("donor attention row trace shape mismatch".into());
+                }
+                layer_heads.push(trace);
+            }
+            position_heads.push(layer_heads);
+        }
+        projections.push(position_projections);
+        heads.push(position_heads);
+    }
+    let decoder_audit = traced.audit();
+    let projection_audit = traced.pre_rope_projection_audit();
+    let trace_cid = donor_trace_cid(&projections, &heads, &logits);
+    Ok(CapturedDocument {
+        document: document.clone(),
+        projections,
+        heads,
+        decoder_audit,
+        projection_audit,
+        trace_cid,
+    })
+}
+
+fn donor_trace_cid(
+    projections: &[Vec<ProjectionTrace>],
+    heads: &[Vec<Vec<HeadTrace>>],
+    logits: &[Vec<f32>],
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.helm-d-learned-manifold.donor-trace/2\0");
+    for projection in projections.iter().flatten() {
+        for values in [&projection.query, &projection.key, &projection.value] {
+            for value in values {
+                hasher.update(&value.to_bits().to_le_bytes());
+            }
+        }
+    }
+    for head in heads.iter().flatten().flatten() {
+        for values in [
+            &head.post_rope_query,
+            &head.post_rope_current_key,
+            &head.current_value,
+            &head.donor_weights,
+            &head.donor_aggregate,
+        ] {
+            for value in values {
+                hasher.update(&value.to_bits().to_le_bytes());
+            }
+        }
+    }
+    for value in logits.iter().flatten() {
+        hasher.update(&value.to_bits().to_le_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn capture_fit_documents(
+    oracle: &HuggingFaceLlamaOracle,
+    documents: &[FrozenDocument],
+) -> TestResult<Vec<CapturedDocument>> {
+    documents
+        .iter()
+        .map(|document| capture_document(oracle, document))
+        .collect()
+}
+
+#[derive(Clone, Debug, Default)]
+struct AffineGradient {
+    matrix: [[f64; R4_WIDTH]; R4_WIDTH],
+    bias: [f64; R4_WIDTH],
+}
+
+#[derive(Clone, Debug)]
+struct ParameterGradient {
+    query: Vec<AffineGradient>,
+    key: Vec<AffineGradient>,
+    value: Vec<AffineGradient>,
+    scale: Vec<f64>,
+    bias: Vec<f64>,
+}
+
+impl ParameterGradient {
+    fn zero(parameters: &HelmDLearnedManifoldParameters) -> Self {
+        Self {
+            query: vec![AffineGradient::default(); parameters.query_adapters().len()],
+            key: vec![AffineGradient::default(); parameters.key_adapters().len()],
+            value: vec![AffineGradient::default(); parameters.value_adapters().len()],
+            scale: vec![0.0; parameters.layers()],
+            bias: vec![0.0; parameters.layers()],
+        }
+    }
+
+    fn add_assign(&mut self, other: &Self) {
+        for (target, source) in self.query.iter_mut().zip(&other.query) {
+            add_affine_gradient(target, source);
+        }
+        for (target, source) in self.key.iter_mut().zip(&other.key) {
+            add_affine_gradient(target, source);
+        }
+        for (target, source) in self.value.iter_mut().zip(&other.value) {
+            add_affine_gradient(target, source);
+        }
+        for (target, source) in self.scale.iter_mut().zip(&other.scale) {
+            *target += source;
+        }
+        for (target, source) in self.bias.iter_mut().zip(&other.bias) {
+            *target += source;
+        }
+    }
+
+    fn scale_by(&mut self, factor: f64) {
+        for gradient in self
+            .query
+            .iter_mut()
+            .chain(&mut self.key)
+            .chain(&mut self.value)
+        {
+            for value in gradient
+                .matrix
+                .iter_mut()
+                .flatten()
+                .chain(&mut gradient.bias)
+            {
+                *value *= factor;
+            }
+        }
+        for value in self.scale.iter_mut().chain(&mut self.bias) {
+            *value *= factor;
+        }
+    }
+
+    fn all_finite(&self) -> bool {
+        self.query
+            .iter()
+            .chain(&self.key)
+            .chain(&self.value)
+            .flat_map(|gradient| gradient.matrix.iter().flatten().chain(&gradient.bias))
+            .chain(&self.scale)
+            .chain(&self.bias)
+            .all(|value| value.is_finite())
+    }
+
+    fn bind_identity_and_maximum(&self, hasher: &mut blake3::Hasher, maximum_absolute: &mut f64) {
+        for gradient in self.query.iter().chain(&self.key).chain(&self.value) {
+            for value in gradient.matrix.iter().flatten().chain(&gradient.bias) {
+                hasher.update(&value.to_bits().to_le_bytes());
+                *maximum_absolute = maximum_absolute.max(value.abs());
+            }
+        }
+        for value in self.scale.iter().chain(&self.bias) {
+            hasher.update(&value.to_bits().to_le_bytes());
+            *maximum_absolute = maximum_absolute.max(value.abs());
+        }
+    }
+}
+
+fn add_affine_gradient(target: &mut AffineGradient, source: &AffineGradient) {
+    for (target, source) in target
+        .matrix
+        .iter_mut()
+        .flatten()
+        .zip(source.matrix.iter().flatten())
+    {
+        *target += source;
+    }
+    for (target, source) in target.bias.iter_mut().zip(source.bias) {
+        *target += source;
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct WorkLedger {
+    workers: usize,
+    full_batch_steps: usize,
+    full_batch_evaluations: usize,
+    rows_per_shard_per_evaluation: Vec<u64>,
+    source_pairs_per_shard_per_evaluation: Vec<u64>,
+    total_row_evaluations: u64,
+    total_source_pair_evaluations: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct GradientAudit {
+    schema: String,
+    gradient_evaluations: usize,
+    optimizer_gradient_evaluations: usize,
+    diagnostic_gradient_evaluations: usize,
+    maximum_absolute_gradient: f64,
+    ordered_evaluation_cids: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ShardEvaluation {
+    loss: f64,
+    rows: u64,
+    source_pairs: u64,
+    gradient: ParameterGradient,
+}
+
+#[derive(Clone, Debug)]
+struct DatasetEvaluation {
+    objective: f64,
+    gradient: ParameterGradient,
+    rows_per_shard: Vec<u64>,
+    source_pairs_per_shard: Vec<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct FitReport {
+    metric: HelmDLearnedManifoldMetric,
+    optimizer: String,
+    steps: usize,
+    workers: usize,
+    fit_documents: usize,
+    fit_rows: u64,
+    initial_objective: f64,
+    final_objective: f64,
+    parameter_scalars: usize,
+    parameter_cid: String,
+    donor_trace_cid: String,
+    gradient_audit: GradientAudit,
+    gradient_audit_cid: String,
+    work: WorkLedger,
+    report_cid: String,
+}
+
+fn fit_report_cid(report: &FitReport) -> TestResult<String> {
+    let mut commitment = report.clone();
+    commitment.report_cid.clear();
+    canonical_json_cid(&commitment)
+}
+
+#[derive(Clone, Debug)]
+struct FittedArm {
+    parameters: HelmDLearnedManifoldParameters,
+    parameter_bytes: Vec<u8>,
+    report: FitReport,
+}
+
+fn adapter_index(layer: usize, head: usize, block: usize, heads: usize) -> usize {
+    (layer * heads + head) * BLOCKS_PER_HEAD + block
+}
+
+fn apply_adapters(
+    adapters: &[R4AffineAdapter],
+    layer: usize,
+    head: usize,
+    heads: usize,
+    input: &[f32],
+) -> TestResult<Vec<f64>> {
+    if input.len() != HEAD_WIDTH {
+        return Err("adapter input is not one complete head".into());
+    }
+    let mut output = vec![0.0; HEAD_WIDTH];
+    for block in 0..BLOCKS_PER_HEAD {
+        let adapter = adapters
+            .get(adapter_index(layer, head, block, heads))
+            .ok_or("adapter index is unavailable")?;
+        for row in 0..R4_WIDTH {
+            let mut value = adapter.bias[row];
+            for column in 0..R4_WIDTH {
+                value += adapter.matrix[row][column] * f64::from(input[block * R4_WIDTH + column]);
+            }
+            if !value.is_finite() {
+                return Err("adapter produced a non-finite value".into());
+            }
+            output[block * R4_WIDTH + row] = value;
+        }
+    }
+    Ok(output)
+}
+
+fn rope_coefficients(position: usize, frequency_index: usize, rope_theta: f32) -> (f64, f64) {
+    let frequency =
+        1.0_f32 / libm::powf(rope_theta, (2 * frequency_index) as f32 / HEAD_WIDTH as f32);
+    let angle = position as f32 * frequency;
+    (f64::from(libm::cosf(angle)), f64::from(libm::sinf(angle)))
+}
+
+fn apply_rope_f64(values: &mut [f64], position: usize, rope_theta: f32, interleaved: bool) {
+    if interleaved {
+        for pair in 0..HEAD_WIDTH / 2 {
+            let (cos, sin) = rope_coefficients(position, pair, rope_theta);
+            let first = values[2 * pair];
+            let second = values[2 * pair + 1];
+            values[2 * pair] = first * cos - second * sin;
+            values[2 * pair + 1] = second * cos + first * sin;
+        }
+    } else {
+        let half = HEAD_WIDTH / 2;
+        for lane in 0..half {
+            let (cos, sin) = rope_coefficients(position, lane, rope_theta);
+            let first = values[lane];
+            let second = values[lane + half];
+            values[lane] = first * cos - second * sin;
+            values[lane + half] = second * cos + first * sin;
+        }
+    }
+}
+
+fn apply_rope_f32(values: &mut [f32], position: usize, rope_theta: f32, interleaved: bool) {
+    if interleaved {
+        for pair in 0..HEAD_WIDTH / 2 {
+            let (cos, sin) = rope_coefficients(position, pair, rope_theta);
+            let cos = cos as f32;
+            let sin = sin as f32;
+            let first = values[2 * pair];
+            let second = values[2 * pair + 1];
+            values[2 * pair] = first * cos - second * sin;
+            values[2 * pair + 1] = second * cos + first * sin;
+        }
+    } else {
+        let half = HEAD_WIDTH / 2;
+        for lane in 0..half {
+            let (cos, sin) = rope_coefficients(position, lane, rope_theta);
+            let cos = cos as f32;
+            let sin = sin as f32;
+            let first = values[lane];
+            let second = values[lane + half];
+            values[lane] = first * cos - second * sin;
+            values[lane + half] = second * cos + first * sin;
+        }
+    }
+}
+
+fn rope_gradient_to_input(
+    gradient: &[f64],
+    position: usize,
+    rope_theta: f32,
+    interleaved: bool,
+) -> Vec<f64> {
+    let mut output = vec![0.0; HEAD_WIDTH];
+    if interleaved {
+        for pair in 0..HEAD_WIDTH / 2 {
+            let (cos, sin) = rope_coefficients(position, pair, rope_theta);
+            let first = gradient[2 * pair];
+            let second = gradient[2 * pair + 1];
+            output[2 * pair] = first * cos + second * sin;
+            output[2 * pair + 1] = -first * sin + second * cos;
+        }
+    } else {
+        let half = HEAD_WIDTH / 2;
+        for lane in 0..half {
+            let (cos, sin) = rope_coefficients(position, lane, rope_theta);
+            let first = gradient[lane];
+            let second = gradient[lane + half];
+            output[lane] = first * cos + second * sin;
+            output[lane + half] = -first * sin + second * cos;
+        }
+    }
+    output
+}
+
+fn stable_softmax_f64(logits: &[f64]) -> TestResult<Vec<f64>> {
+    if logits.is_empty() || logits.iter().any(|value| !value.is_finite()) {
+        return Err("softmax received empty or non-finite logits".into());
+    }
+    let maximum = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let mut weights = logits
+        .iter()
+        .map(|logit| libm::exp(*logit - maximum))
+        .collect::<Vec<_>>();
+    let sum = weights.iter().sum::<f64>();
+    if !sum.is_finite() || sum <= 0.0 {
+        return Err("softmax denominator is invalid".into());
+    }
+    for weight in &mut weights {
+        *weight /= sum;
+    }
+    Ok(weights)
+}
+
+fn score_numerator_and_gradients(
+    metric: HelmDLearnedManifoldMetric,
+    query: &[f64],
+    key: &[f64],
+) -> TestResult<(f64, Vec<f64>, Vec<f64>)> {
+    match metric {
+        HelmDLearnedManifoldMetric::Euclidean => {
+            let mut numerator = 0.0;
+            let mut query_gradient = vec![0.0; query.len()];
+            let mut key_gradient = vec![0.0; key.len()];
+            for lane in 0..query.len() {
+                let difference = query[lane] - key[lane];
+                numerator -= difference * difference;
+                query_gradient[lane] = -2.0 * difference;
+                key_gradient[lane] = 2.0 * difference;
+            }
+            Ok((numerator, query_gradient, key_gradient))
+        }
+        HelmDLearnedManifoldMetric::Lorentz => {
+            let query_norm = query.iter().map(|value| value * value).sum::<f64>();
+            let key_norm = key.iter().map(|value| value * value).sum::<f64>();
+            let query_time = libm::sqrt(1.0 + query_norm);
+            let key_time = libm::sqrt(1.0 + key_norm);
+            let dot = query
+                .iter()
+                .zip(key)
+                .map(|(left, right)| left * right)
+                .sum::<f64>();
+            let numerator = 2.0 + 2.0 * (-query_time * key_time + dot);
+            let query_gradient = query
+                .iter()
+                .zip(key)
+                .map(|(query, key)| 2.0 * (*key - key_time * *query / query_time))
+                .collect();
+            let key_gradient = query
+                .iter()
+                .zip(key)
+                .map(|(query, key)| 2.0 * (*query - query_time * *key / key_time))
+                .collect();
+            Ok((numerator, query_gradient, key_gradient))
+        }
+    }
+}
+
+type CentroidBackward = (Vec<f64>, Vec<f64>, Vec<Vec<f64>>);
+
+fn centroid_forward_backward(
+    metric: HelmDLearnedManifoldMetric,
+    values: &[Vec<f64>],
+    weights: &[f64],
+    output_gradient: &[f64],
+) -> TestResult<CentroidBackward> {
+    let width = output_gradient.len();
+    if values.is_empty()
+        || values.len() != weights.len()
+        || values.iter().any(|value| value.len() != width)
+    {
+        return Err("centroid differentiation shape mismatch".into());
+    }
+    if metric == HelmDLearnedManifoldMetric::Euclidean {
+        let mut output = vec![0.0; width];
+        for (weight, value) in weights.iter().zip(values) {
+            for lane in 0..width {
+                output[lane] += *weight * value[lane];
+            }
+        }
+        let weight_gradients = values
+            .iter()
+            .map(|value| value.iter().zip(output_gradient).map(|(v, g)| v * g).sum())
+            .collect();
+        let value_gradients = weights
+            .iter()
+            .map(|weight| {
+                output_gradient
+                    .iter()
+                    .map(|gradient| *weight * *gradient)
+                    .collect()
+            })
+            .collect();
+        return Ok((output, weight_gradients, value_gradients));
+    }
+
+    let times = values
+        .iter()
+        .map(|value| libm::sqrt(1.0 + value.iter().map(|lane| lane * lane).sum::<f64>()))
+        .collect::<Vec<_>>();
+    let time_sum = weights.iter().zip(&times).map(|(w, t)| w * t).sum::<f64>();
+    let mut spatial_sum = vec![0.0; width];
+    for (weight, value) in weights.iter().zip(values) {
+        for lane in 0..width {
+            spatial_sum[lane] += *weight * value[lane];
+        }
+    }
+    let spatial_norm = libm::sqrt(spatial_sum.iter().map(|value| value * value).sum());
+    let denominator = libm::sqrt((time_sum - spatial_norm) * (time_sum + spatial_norm));
+    if !denominator.is_finite() || denominator <= 0.0 {
+        return Err("Lorentz centroid derivative is not future timelike".into());
+    }
+    let output = spatial_sum
+        .iter()
+        .map(|coordinate| *coordinate / denominator)
+        .collect::<Vec<_>>();
+    let contraction = output_gradient
+        .iter()
+        .zip(&spatial_sum)
+        .map(|(left, right)| left * right)
+        .sum::<f64>();
+    let denominator_cubed = denominator * denominator * denominator;
+    let spatial_gradient = output_gradient
+        .iter()
+        .zip(&spatial_sum)
+        .map(|(gradient, spatial)| {
+            gradient / denominator + contraction * spatial / denominator_cubed
+        })
+        .collect::<Vec<_>>();
+    let time_gradient = -contraction * time_sum / denominator_cubed;
+    let weight_gradients = values
+        .iter()
+        .zip(&times)
+        .map(|(value, time)| {
+            value
+                .iter()
+                .zip(&spatial_gradient)
+                .map(|(value, gradient)| value * gradient)
+                .sum::<f64>()
+                + time_gradient * time
+        })
+        .collect::<Vec<_>>();
+    let value_gradients = values
+        .iter()
+        .zip(weights)
+        .zip(&times)
+        .map(|((value, weight), time)| {
+            value
+                .iter()
+                .zip(&spatial_gradient)
+                .map(|(value, spatial)| *weight * (*spatial + time_gradient * *value / *time))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    Ok((output, weight_gradients, value_gradients))
+}
+
+fn accumulate_adapter_gradient(
+    target: &mut AffineGradient,
+    input: &[f32],
+    output_gradient: &[f64],
+    block: usize,
+) {
+    for row in 0..R4_WIDTH {
+        let gradient = output_gradient[block * R4_WIDTH + row];
+        target.bias[row] += gradient;
+        for column in 0..R4_WIDTH {
+            target.matrix[row][column] += gradient * f64::from(input[block * R4_WIDTH + column]);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn evaluate_row(
+    parameters: &HelmDLearnedManifoldParameters,
+    metric: HelmDLearnedManifoldMetric,
+    document: &CapturedDocument,
+    layer: usize,
+    head: usize,
+    position: usize,
+    rope_theta: f32,
+    rope_interleaved: bool,
+    gradient: &mut ParameterGradient,
+) -> TestResult<(f64, u64)> {
+    let projection = &document.projections[position][layer];
+    let query_input = &projection.query[head * HEAD_WIDTH..(head + 1) * HEAD_WIDTH];
+    let mut query = apply_adapters(
+        parameters.query_adapters(),
+        layer,
+        head,
+        EXPECTED_QUERY_HEADS,
+        query_input,
+    )?;
+    apply_rope_f64(&mut query, position, rope_theta, rope_interleaved);
+
+    let kv_head = head / (EXPECTED_QUERY_HEADS / EXPECTED_KV_HEADS);
+    let mut keys = Vec::with_capacity(position + 1);
+    let mut values = Vec::with_capacity(position + 1);
+    let mut key_inputs = Vec::with_capacity(position + 1);
+    let mut value_inputs = Vec::with_capacity(position + 1);
+    for source in 0..=position {
+        let source_projection = &document.projections[source][layer];
+        let key_input =
+            source_projection.key[kv_head * HEAD_WIDTH..(kv_head + 1) * HEAD_WIDTH].to_vec();
+        let value_input =
+            source_projection.value[kv_head * HEAD_WIDTH..(kv_head + 1) * HEAD_WIDTH].to_vec();
+        let mut key = apply_adapters(
+            parameters.key_adapters(),
+            layer,
+            kv_head,
+            EXPECTED_KV_HEADS,
+            &key_input,
+        )?;
+        apply_rope_f64(&mut key, source, rope_theta, rope_interleaved);
+        let value = apply_adapters(
+            parameters.value_adapters(),
+            layer,
+            kv_head,
+            EXPECTED_KV_HEADS,
+            &value_input,
+        )?;
+        key_inputs.push(key_input);
+        value_inputs.push(value_input);
+        keys.push(key);
+        values.push(value);
+    }
+
+    let scale = parameters.learned_scale(layer)?;
+    let bias = parameters.learned_bias(layer)?;
+    let mut numerators = Vec::with_capacity(position + 1);
+    let mut query_numerator_gradients = Vec::with_capacity(position + 1);
+    let mut key_numerator_gradients = Vec::with_capacity(position + 1);
+    let mut logits = Vec::with_capacity(position + 1);
+    for key in &keys {
+        let (numerator, query_gradient, key_gradient) =
+            score_numerator_and_gradients(metric, &query, key)?;
+        let public_logit = helm_d_learned_manifold_logit(metric, &query, key, scale, bias)?;
+        let logit = numerator / scale + bias;
+        if (public_logit - logit).abs() > 1.0e-12 {
+            return Err("analytic score drifted from the public construction operator".into());
+        }
+        numerators.push(numerator);
+        query_numerator_gradients.push(query_gradient);
+        key_numerator_gradients.push(key_gradient);
+        logits.push(logit);
+    }
+    let weights = stable_softmax_f64(&logits)?;
+    let donor_weights = document.heads[position][layer][head]
+        .donor_weights
+        .iter()
+        .map(|weight| f64::from(*weight))
+        .collect::<Vec<_>>();
+    let donor_weight_sum = donor_weights.iter().sum::<f64>();
+    let cross_entropy = donor_weights
+        .iter()
+        .zip(&weights)
+        .map(|(donor, learned)| -*donor * libm::log(*learned))
+        .sum::<f64>();
+
+    let learned_aggregate = helm_d_learned_manifold_centroid(metric, &values, &weights)?;
+    let donor_aggregate = &document.heads[position][layer][head].donor_aggregate;
+    let donor_norm = libm::sqrt(
+        donor_aggregate
+            .iter()
+            .map(|value| f64::from(*value) * f64::from(*value))
+            .sum::<f64>(),
+    );
+    let normalization = donor_norm.max(1.0);
+    let mut aggregate_gradient = vec![0.0; HEAD_WIDTH];
+    let mut aggregate_loss = 0.0;
+    for lane in 0..HEAD_WIDTH {
+        let difference = learned_aggregate[lane] - f64::from(donor_aggregate[lane]);
+        aggregate_loss += difference * difference / (normalization * normalization);
+        aggregate_gradient[lane] =
+            2.0 * difference / (HEAD_WIDTH as f64 * normalization * normalization);
+    }
+    aggregate_loss /= HEAD_WIDTH as f64;
+    let (differentiated_aggregate, weight_gradient, value_gradients) =
+        centroid_forward_backward(metric, &values, &weights, &aggregate_gradient)?;
+    if learned_aggregate
+        .iter()
+        .zip(&differentiated_aggregate)
+        .any(|(left, right)| (*left - *right).abs() > 2.0e-12 * (1.0 + left.abs()))
+    {
+        return Err("analytic centroid drifted from the public construction operator".into());
+    }
+
+    let weighted_weight_gradient = weights
+        .iter()
+        .zip(&weight_gradient)
+        .map(|(weight, gradient)| weight * gradient)
+        .sum::<f64>();
+    let mut logit_gradients = Vec::with_capacity(weights.len());
+    for source in 0..weights.len() {
+        let cross_entropy_gradient = weights[source] * donor_weight_sum - donor_weights[source];
+        let aggregate_weight_gradient =
+            weights[source] * (weight_gradient[source] - weighted_weight_gradient);
+        logit_gradients.push(cross_entropy_gradient + aggregate_weight_gradient);
+    }
+
+    let mut query_post_gradient = vec![0.0; HEAD_WIDTH];
+    for source in 0..=position {
+        let logit_gradient = logit_gradients[source];
+        for lane in 0..HEAD_WIDTH {
+            query_post_gradient[lane] +=
+                logit_gradient * query_numerator_gradients[source][lane] / scale;
+        }
+        let key_post_gradient = key_numerator_gradients[source]
+            .iter()
+            .map(|gradient| logit_gradient * gradient / scale)
+            .collect::<Vec<_>>();
+        let key_adapter_gradient =
+            rope_gradient_to_input(&key_post_gradient, source, rope_theta, rope_interleaved);
+        let key_base = adapter_index(layer, kv_head, 0, EXPECTED_KV_HEADS);
+        let value_base = adapter_index(layer, kv_head, 0, EXPECTED_KV_HEADS);
+        for block in 0..BLOCKS_PER_HEAD {
+            accumulate_adapter_gradient(
+                &mut gradient.key[key_base + block],
+                &key_inputs[source],
+                &key_adapter_gradient,
+                block,
+            );
+            accumulate_adapter_gradient(
+                &mut gradient.value[value_base + block],
+                &value_inputs[source],
+                &value_gradients[source],
+                block,
+            );
+        }
+        gradient.scale[layer] += logit_gradient * -numerators[source] / (scale * scale);
+        gradient.bias[layer] += logit_gradient;
+    }
+    let query_adapter_gradient =
+        rope_gradient_to_input(&query_post_gradient, position, rope_theta, rope_interleaved);
+    let query_base = adapter_index(layer, head, 0, EXPECTED_QUERY_HEADS);
+    for block in 0..BLOCKS_PER_HEAD {
+        accumulate_adapter_gradient(
+            &mut gradient.query[query_base + block],
+            query_input,
+            &query_adapter_gradient,
+            block,
+        );
+    }
+    let loss = cross_entropy + aggregate_loss;
+    if !loss.is_finite() || !gradient.all_finite() {
+        return Err("construction objective or gradient is non-finite".into());
+    }
+    Ok((loss, u64::try_from(position + 1)?))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn evaluate_shard(
+    parameters: &HelmDLearnedManifoldParameters,
+    metric: HelmDLearnedManifoldMetric,
+    documents: &[CapturedDocument],
+    document_limit: usize,
+    shard: usize,
+    rope_theta: f32,
+    rope_interleaved: bool,
+) -> TestResult<ShardEvaluation> {
+    let mut evaluation = ShardEvaluation {
+        loss: 0.0,
+        rows: 0,
+        source_pairs: 0,
+        gradient: ParameterGradient::zero(parameters),
+    };
+    // Frozen order inside a shard: layer, head, query position, document,
+    // source position, block, lane. Shards are reduced separately in 0..8.
+    for layer in 0..EXPECTED_LAYERS {
+        for head in 0..EXPECTED_QUERY_HEADS {
+            for position in SCORE_START..INPUT_POSITIONS {
+                for (document_index, document) in documents[..document_limit].iter().enumerate() {
+                    let ordinal = (((document_index * EXPECTED_LAYERS + layer)
+                        * EXPECTED_QUERY_HEADS
+                        + head)
+                        * SCORE_POSITIONS)
+                        + (position - SCORE_START);
+                    if ordinal % SHARDS != shard {
+                        continue;
+                    }
+                    let (loss, source_pairs) = evaluate_row(
+                        parameters,
+                        metric,
+                        document,
+                        layer,
+                        head,
+                        position,
+                        rope_theta,
+                        rope_interleaved,
+                        &mut evaluation.gradient,
+                    )?;
+                    evaluation.loss += loss;
+                    evaluation.rows += 1;
+                    evaluation.source_pairs += source_pairs;
+                }
+            }
+        }
+    }
+    Ok(evaluation)
+}
+
+fn ridge_objective_and_gradient(
+    parameters: &HelmDLearnedManifoldParameters,
+    gradient: &mut ParameterGradient,
+) -> f64 {
+    let mut objective = 0.0;
+    for (adapters, gradients) in [
+        (parameters.query_adapters(), &mut gradient.query),
+        (parameters.key_adapters(), &mut gradient.key),
+        (parameters.value_adapters(), &mut gradient.value),
+    ] {
+        for (adapter, target) in adapters.iter().zip(gradients.iter_mut()) {
+            for row in 0..R4_WIDTH {
+                for column in 0..R4_WIDTH {
+                    let expected = if row == column { 1.0 } else { 0.0 };
+                    let difference = adapter.matrix[row][column] - expected;
+                    objective += RIDGE * difference * difference;
+                    target.matrix[row][column] += 2.0 * RIDGE * difference;
+                }
+                objective += RIDGE * adapter.bias[row] * adapter.bias[row];
+                target.bias[row] += 2.0 * RIDGE * adapter.bias[row];
+            }
+        }
+    }
+    objective
+}
+
+fn evaluate_dataset(
+    parameters: &HelmDLearnedManifoldParameters,
+    metric: HelmDLearnedManifoldMetric,
+    documents: &[CapturedDocument],
+    document_limit: usize,
+    rope_theta: f32,
+    rope_interleaved: bool,
+) -> TestResult<DatasetEvaluation> {
+    if document_limit == 0 || document_limit > documents.len() {
+        return Err("dataset evaluation document limit is invalid".into());
+    }
+    let shards = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(SHARDS);
+        for shard in 0..SHARDS {
+            handles.push(scope.spawn(move || {
+                evaluate_shard(
+                    parameters,
+                    metric,
+                    documents,
+                    document_limit,
+                    shard,
+                    rope_theta,
+                    rope_interleaved,
+                )
+            }));
+        }
+        handles
+            .into_iter()
+            .map(|handle| handle.join().map_err(|_| "construction shard panicked")?)
+            .collect::<TestResult<Vec<_>>>()
+    })?;
+    let mut loss = 0.0;
+    let mut rows = 0_u64;
+    let mut gradient = ParameterGradient::zero(parameters);
+    let mut rows_per_shard = Vec::with_capacity(SHARDS);
+    let mut source_pairs_per_shard = Vec::with_capacity(SHARDS);
+    for shard in &shards {
+        loss += shard.loss;
+        rows += shard.rows;
+        gradient.add_assign(&shard.gradient);
+        rows_per_shard.push(shard.rows);
+        source_pairs_per_shard.push(shard.source_pairs);
+    }
+    let expected_rows =
+        u64::try_from(document_limit * SCORE_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS)?;
+    if rows != expected_rows || rows_per_shard.contains(&0) {
+        return Err("eight-shard work ledger is incomplete".into());
+    }
+    let reciprocal_rows = 1.0 / rows as f64;
+    loss *= reciprocal_rows;
+    gradient.scale_by(reciprocal_rows);
+    loss += ridge_objective_and_gradient(parameters, &mut gradient);
+    if !loss.is_finite() || !gradient.all_finite() {
+        return Err("reduced construction objective or gradient is non-finite".into());
+    }
+    Ok(DatasetEvaluation {
+        objective: loss,
+        gradient,
+        rows_per_shard,
+        source_pairs_per_shard,
+    })
+}
+
+fn update_scalar(
+    parameter: &mut f64,
+    gradient: f64,
+    first_moment: &mut f64,
+    second_moment: &mut f64,
+    step: usize,
+) {
+    *first_moment = ADAM_BETA1 * *first_moment + (1.0 - ADAM_BETA1) * gradient;
+    *second_moment = ADAM_BETA2 * *second_moment + (1.0 - ADAM_BETA2) * gradient * gradient;
+    let first_hat = *first_moment / (1.0 - libm::pow(ADAM_BETA1, step as f64));
+    let second_hat = *second_moment / (1.0 - libm::pow(ADAM_BETA2, step as f64));
+    *parameter -= LEARNING_RATE * first_hat / (libm::sqrt(second_hat) + ADAM_EPSILON);
+}
+
+fn adam_step(
+    parameters: &mut HelmDLearnedManifoldParameters,
+    gradient: &ParameterGradient,
+    first: &mut ParameterGradient,
+    second: &mut ParameterGradient,
+    step: usize,
+) -> TestResult {
+    fn update_adapters(
+        adapters: &mut [R4AffineAdapter],
+        gradients: &[AffineGradient],
+        first: &mut [AffineGradient],
+        second: &mut [AffineGradient],
+        step: usize,
+    ) {
+        for (((adapter, gradient), first), second) in
+            adapters.iter_mut().zip(gradients).zip(first).zip(second)
+        {
+            for row in 0..R4_WIDTH {
+                for column in 0..R4_WIDTH {
+                    update_scalar(
+                        &mut adapter.matrix[row][column],
+                        gradient.matrix[row][column],
+                        &mut first.matrix[row][column],
+                        &mut second.matrix[row][column],
+                        step,
+                    );
+                }
+                update_scalar(
+                    &mut adapter.bias[row],
+                    gradient.bias[row],
+                    &mut first.bias[row],
+                    &mut second.bias[row],
+                    step,
+                );
+            }
+        }
+    }
+    update_adapters(
+        parameters.query_adapters_mut(),
+        &gradient.query,
+        &mut first.query,
+        &mut second.query,
+        step,
+    );
+    update_adapters(
+        parameters.key_adapters_mut(),
+        &gradient.key,
+        &mut first.key,
+        &mut second.key,
+        step,
+    );
+    update_adapters(
+        parameters.value_adapters_mut(),
+        &gradient.value,
+        &mut first.value,
+        &mut second.value,
+        step,
+    );
+    for layer in 0..parameters.layers() {
+        update_scalar(
+            &mut parameters.learned_scales_mut()[layer],
+            gradient.scale[layer],
+            &mut first.scale[layer],
+            &mut second.scale[layer],
+            step,
+        );
+        parameters.learned_scales_mut()[layer] =
+            parameters.learned_scales()[layer].max(SCALE_FLOOR);
+        update_scalar(
+            &mut parameters.learned_biases_mut()[layer],
+            gradient.bias[layer],
+            &mut first.bias[layer],
+            &mut second.bias[layer],
+            step,
+        );
+    }
+    parameters.validate()?;
+    Ok(())
+}
+
+fn aggregate_trace_cid(documents: &[CapturedDocument]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.helm-d-learned-manifold.fit-traces/2\0");
+    for document in documents {
+        hasher.update(document.document.id.as_bytes());
+        hasher.update(document.trace_cid.as_bytes());
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn evaluation_gradient_identity(
+    evaluation: &DatasetEvaluation,
+    phase: &str,
+    ordinal: usize,
+) -> (String, f64) {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.helm-d-learned-manifold.gradient-evaluation/2\0");
+    hasher.update(&u64::try_from(phase.len()).unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(phase.as_bytes());
+    hasher.update(&u64::try_from(ordinal).unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(&evaluation.objective.to_bits().to_le_bytes());
+    for rows in &evaluation.rows_per_shard {
+        hasher.update(&rows.to_le_bytes());
+    }
+    for pairs in &evaluation.source_pairs_per_shard {
+        hasher.update(&pairs.to_le_bytes());
+    }
+    let mut maximum_absolute = 0.0_f64;
+    evaluation
+        .gradient
+        .bind_identity_and_maximum(&mut hasher, &mut maximum_absolute);
+    (
+        format!("blake3:{}", hasher.finalize().to_hex()),
+        maximum_absolute,
+    )
+}
+
+fn public_parameter_identity(parameters: &HelmDLearnedManifoldParameters) -> TestResult<String> {
+    Ok(parameters.parameter_identity()?)
+}
+
+fn fit_arm(
+    metric: HelmDLearnedManifoldMetric,
+    documents: &[CapturedDocument],
+    document_limit: usize,
+    rope_theta: f32,
+    rope_interleaved: bool,
+    steps: usize,
+) -> TestResult<FittedArm> {
+    let mut parameters = HelmDLearnedManifoldParameters::identity(
+        EXPECTED_LAYERS,
+        EXPECTED_QUERY_HEADS,
+        EXPECTED_KV_HEADS,
+        BLOCKS_PER_HEAD,
+        INITIAL_SCALE,
+    )?;
+    if parameters.scalar_parameter_count()? != PARAMETER_SCALARS {
+        return Err("learned parameter capacity differs from 144,060 scalars".into());
+    }
+    let initial = evaluate_dataset(
+        &parameters,
+        metric,
+        documents,
+        document_limit,
+        rope_theta,
+        rope_interleaved,
+    )?;
+    let mut first = ParameterGradient::zero(&parameters);
+    let mut second = ParameterGradient::zero(&parameters);
+    let rows_per_shard = initial.rows_per_shard.clone();
+    let source_pairs_per_shard = initial.source_pairs_per_shard.clone();
+    let (initial_gradient_cid, mut maximum_absolute_gradient) =
+        evaluation_gradient_identity(&initial, "initial-diagnostic", 0);
+    let mut ordered_evaluation_cids = vec![initial_gradient_cid];
+    for step in 1..=steps {
+        let evaluation = evaluate_dataset(
+            &parameters,
+            metric,
+            documents,
+            document_limit,
+            rope_theta,
+            rope_interleaved,
+        )?;
+        if evaluation.rows_per_shard != rows_per_shard
+            || evaluation.source_pairs_per_shard != source_pairs_per_shard
+        {
+            return Err("deterministic shard schedule changed during fitting".into());
+        }
+        let (gradient_cid, maximum) =
+            evaluation_gradient_identity(&evaluation, "optimizer-step", step);
+        ordered_evaluation_cids.push(gradient_cid);
+        maximum_absolute_gradient = maximum_absolute_gradient.max(maximum);
+        adam_step(
+            &mut parameters,
+            &evaluation.gradient,
+            &mut first,
+            &mut second,
+            step,
+        )?;
+    }
+    let final_evaluation = evaluate_dataset(
+        &parameters,
+        metric,
+        documents,
+        document_limit,
+        rope_theta,
+        rope_interleaved,
+    )?;
+    if final_evaluation.rows_per_shard != rows_per_shard
+        || final_evaluation.source_pairs_per_shard != source_pairs_per_shard
+    {
+        return Err("deterministic shard schedule changed during final evaluation".into());
+    }
+    let (final_gradient_cid, final_maximum) =
+        evaluation_gradient_identity(&final_evaluation, "final-diagnostic", steps + 1);
+    ordered_evaluation_cids.push(final_gradient_cid);
+    maximum_absolute_gradient = maximum_absolute_gradient.max(final_maximum);
+    let parameter_bytes = canonical_json_bytes(&parameters)?;
+    let parameter_cid = public_parameter_identity(&parameters)?;
+    let rows_per_step = rows_per_shard.iter().sum::<u64>();
+    let source_pairs_per_step = source_pairs_per_shard.iter().sum::<u64>();
+    let full_batch_evaluations = steps.checked_add(2).ok_or("evaluation count overflow")?;
+    let gradient_audit = GradientAudit {
+        schema: "uor-r4.helm-d-learned-manifold-gradient-audit/2".to_owned(),
+        gradient_evaluations: full_batch_evaluations,
+        optimizer_gradient_evaluations: steps,
+        diagnostic_gradient_evaluations: 2,
+        maximum_absolute_gradient,
+        ordered_evaluation_cids,
+    };
+    if !gradient_audit.maximum_absolute_gradient.is_finite()
+        || gradient_audit.ordered_evaluation_cids.len() != full_batch_evaluations
+    {
+        return Err("gradient audit is incomplete or non-finite".into());
+    }
+    let gradient_audit_cid = canonical_json_cid(&gradient_audit)?;
+    let mut report = FitReport {
+        metric,
+        optimizer: format!(
+            "full-batch-f64-adam(lr={LEARNING_RATE},beta1={ADAM_BETA1},beta2={ADAM_BETA2},epsilon={ADAM_EPSILON},ridge={RIDGE},scale_floor={SCALE_FLOOR})"
+        ),
+        steps,
+        workers: SHARDS,
+        fit_documents: document_limit,
+        fit_rows: rows_per_step,
+        initial_objective: initial.objective,
+        final_objective: final_evaluation.objective,
+        parameter_scalars: parameters.scalar_parameter_count()?,
+        parameter_cid,
+        donor_trace_cid: aggregate_trace_cid(&documents[..document_limit]),
+        gradient_audit,
+        gradient_audit_cid,
+        work: WorkLedger {
+            workers: SHARDS,
+            full_batch_steps: steps,
+            full_batch_evaluations,
+            rows_per_shard_per_evaluation: rows_per_shard,
+            source_pairs_per_shard_per_evaluation: source_pairs_per_shard,
+            total_row_evaluations: rows_per_step.saturating_mul(full_batch_evaluations as u64),
+            total_source_pair_evaluations: source_pairs_per_step
+                .saturating_mul(full_batch_evaluations as u64),
+        },
+        report_cid: String::new(),
+    };
+    report.report_cid = fit_report_cid(&report)?;
+    Ok(FittedArm {
+        parameters,
+        parameter_bytes,
+        report,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct SyntheticGradient {
+    query: Vec<f64>,
+    keys: Vec<Vec<f64>>,
+    values: Vec<Vec<f64>>,
+    scale: f64,
+}
+
+fn synthetic_objective_and_gradient(
+    metric: HelmDLearnedManifoldMetric,
+    query: &[f64],
+    keys: &[Vec<f64>],
+    values: &[Vec<f64>],
+    scale: f64,
+) -> TestResult<(f64, SyntheticGradient)> {
+    let donor_weights = [0.61_f64, 0.39];
+    let donor_aggregate = [0.13_f64, -0.07, 0.23, 0.31];
+    let mut numerators = Vec::new();
+    let mut query_partials = Vec::new();
+    let mut key_partials = Vec::new();
+    let mut logits = Vec::new();
+    for key in keys {
+        let (numerator, query_partial, key_partial) =
+            score_numerator_and_gradients(metric, query, key)?;
+        numerators.push(numerator);
+        query_partials.push(query_partial);
+        key_partials.push(key_partial);
+        logits.push(numerator / scale);
+    }
+    let weights = stable_softmax_f64(&logits)?;
+    let cross_entropy = donor_weights
+        .iter()
+        .zip(&weights)
+        .map(|(donor, learned)| -*donor * libm::log(*learned))
+        .sum::<f64>();
+    let aggregate = helm_d_learned_manifold_centroid(metric, values, &weights)?;
+    let mut aggregate_gradient = vec![0.0; query.len()];
+    let mut aggregate_loss = 0.0;
+    for lane in 0..query.len() {
+        let difference = aggregate[lane] - donor_aggregate[lane];
+        aggregate_loss += difference * difference / query.len() as f64;
+        aggregate_gradient[lane] = 2.0 * difference / query.len() as f64;
+    }
+    let (_, weight_gradient, value_gradient) =
+        centroid_forward_backward(metric, values, &weights, &aggregate_gradient)?;
+    let mean_weight_gradient = weights
+        .iter()
+        .zip(&weight_gradient)
+        .map(|(weight, gradient)| weight * gradient)
+        .sum::<f64>();
+    let mut logit_gradient = Vec::new();
+    for source in 0..weights.len() {
+        logit_gradient.push(
+            weights[source] - donor_weights[source]
+                + weights[source] * (weight_gradient[source] - mean_weight_gradient),
+        );
+    }
+    let mut query_gradient = vec![0.0; query.len()];
+    let mut key_gradient = vec![vec![0.0; query.len()]; keys.len()];
+    let mut scale_gradient = 0.0;
+    for source in 0..keys.len() {
+        for lane in 0..query.len() {
+            query_gradient[lane] += logit_gradient[source] * query_partials[source][lane] / scale;
+            key_gradient[source][lane] =
+                logit_gradient[source] * key_partials[source][lane] / scale;
+        }
+        scale_gradient += logit_gradient[source] * -numerators[source] / (scale * scale);
+    }
+    Ok((
+        cross_entropy + aggregate_loss,
+        SyntheticGradient {
+            query: query_gradient,
+            keys: key_gradient,
+            values: value_gradient,
+            scale: scale_gradient,
+        },
+    ))
+}
+
+fn finite_difference_gradient_preflight() -> TestResult<f64> {
+    const STEP: f64 = 1.0e-6;
+    const TOLERANCE: f64 = 3.0e-5;
+    let query = vec![0.17, -0.31, 0.23, 0.41];
+    let keys = vec![vec![0.11, -0.19, 0.29, 0.37], vec![-0.43, 0.07, 0.13, 0.31]];
+    let values = vec![vec![0.27, 0.17, -0.09, 0.33], vec![-0.21, 0.41, 0.05, 0.19]];
+    let scale = 2.7;
+    let mut maximum_error = 0.0_f64;
+    for metric in [
+        HelmDLearnedManifoldMetric::Lorentz,
+        HelmDLearnedManifoldMetric::Euclidean,
+    ] {
+        let (_, analytic) =
+            synthetic_objective_and_gradient(metric, &query, &keys, &values, scale)?;
+        for lane in 0..query.len() {
+            let mut plus = query.clone();
+            let mut minus = query.clone();
+            plus[lane] += STEP;
+            minus[lane] -= STEP;
+            let plus = synthetic_objective_and_gradient(metric, &plus, &keys, &values, scale)?.0;
+            let minus = synthetic_objective_and_gradient(metric, &minus, &keys, &values, scale)?.0;
+            maximum_error =
+                maximum_error.max(((plus - minus) / (2.0 * STEP) - analytic.query[lane]).abs());
+        }
+        for source in 0..keys.len() {
+            for lane in 0..query.len() {
+                let mut plus = keys.clone();
+                let mut minus = keys.clone();
+                plus[source][lane] += STEP;
+                minus[source][lane] -= STEP;
+                let plus =
+                    synthetic_objective_and_gradient(metric, &query, &plus, &values, scale)?.0;
+                let minus =
+                    synthetic_objective_and_gradient(metric, &query, &minus, &values, scale)?.0;
+                maximum_error = maximum_error
+                    .max(((plus - minus) / (2.0 * STEP) - analytic.keys[source][lane]).abs());
+            }
+        }
+        for source in 0..values.len() {
+            for lane in 0..query.len() {
+                let mut plus = values.clone();
+                let mut minus = values.clone();
+                plus[source][lane] += STEP;
+                minus[source][lane] -= STEP;
+                let plus = synthetic_objective_and_gradient(metric, &query, &keys, &plus, scale)?.0;
+                let minus =
+                    synthetic_objective_and_gradient(metric, &query, &keys, &minus, scale)?.0;
+                maximum_error = maximum_error
+                    .max(((plus - minus) / (2.0 * STEP) - analytic.values[source][lane]).abs());
+            }
+        }
+        let plus =
+            synthetic_objective_and_gradient(metric, &query, &keys, &values, scale + STEP)?.0;
+        let minus =
+            synthetic_objective_and_gradient(metric, &query, &keys, &values, scale - STEP)?.0;
+        maximum_error = maximum_error.max(((plus - minus) / (2.0 * STEP) - analytic.scale).abs());
+    }
+    if maximum_error > TOLERANCE {
+        return Err(format!(
+            "central finite-difference gradient error {maximum_error} exceeds {TOLERANCE}"
+        )
+        .into());
+    }
+    Ok(maximum_error)
+}
+
+fn identity_projection_ordering_preflight(
+    captures: &[CapturedDocument],
+    rope_theta: f32,
+    rope_interleaved: bool,
+) -> TestResult<u64> {
+    let mut compared_lanes = 0_u64;
+    let expected_projection_calls = u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS)?;
+    for document in captures {
+        if document.projection_audit.hook_calls != expected_projection_calls
+            || document.projection_audit.query_vectors
+                != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS)?
+            || document.projection_audit.key_vectors
+                != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS)?
+            || document.projection_audit.value_vectors
+                != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS)?
+            || document.decoder_audit.future_reads != 0
+        {
+            return Err("identity projection trace audit is incomplete or noncausal".into());
+        }
+        for position in 0..INPUT_POSITIONS {
+            for layer in 0..EXPECTED_LAYERS {
+                let projection = &document.projections[position][layer];
+                for head in 0..EXPECTED_QUERY_HEADS {
+                    let mut query =
+                        projection.query[head * HEAD_WIDTH..(head + 1) * HEAD_WIDTH].to_vec();
+                    apply_rope_f32(&mut query, position, rope_theta, rope_interleaved);
+                    let kv_head = head / (EXPECTED_QUERY_HEADS / EXPECTED_KV_HEADS);
+                    let mut key =
+                        projection.key[kv_head * HEAD_WIDTH..(kv_head + 1) * HEAD_WIDTH].to_vec();
+                    apply_rope_f32(&mut key, position, rope_theta, rope_interleaved);
+                    let value = &projection.value[kv_head * HEAD_WIDTH..(kv_head + 1) * HEAD_WIDTH];
+                    let observed = &document.heads[position][layer][head];
+                    if query
+                        .iter()
+                        .zip(&observed.post_rope_query)
+                        .chain(key.iter().zip(&observed.post_rope_current_key))
+                        .chain(value.iter().zip(&observed.current_value))
+                        .any(|(expected, actual)| expected.to_bits() != actual.to_bits())
+                    {
+                        return Err(
+                            "identity adapter trace does not prove pre-RoPE ordering".into()
+                        );
+                    }
+                    compared_lanes += u64::try_from(3 * HEAD_WIDTH)?;
+                }
+            }
+        }
+    }
+    Ok(compared_lanes)
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct GeometryPreflight {
+    golden_maximum_error: f64,
+    finite_difference_maximum_error: f64,
+    identity_ordering_compared_lanes: u64,
+    registered_frames: usize,
+    maximum_score_covariance_error: f64,
+    maximum_weight_covariance_error: f64,
+    maximum_hyperboloid_residual: f64,
+    maximum_centroid_covariance_error: f64,
+    source_frame_permutation_live: bool,
+}
+
+fn pinned_golden_preflight() -> TestResult<f64> {
+    let trace = helm_d_lorentz_causal_row(
+        &[0.25, -0.5, 0.75],
+        &[vec![0.1, -0.2, 0.3], vec![-0.4, 0.2, 0.6]],
+        &[vec![0.7, 0.1, -0.2], vec![-0.3, 0.8, 0.4]],
+        HelmDLorentzReferenceConfig {
+            curvature: 1.0,
+            learned_scale: 2.5,
+            bias: -0.125,
+        },
+    )?;
+    let expected_logits = [-0.214_615_321_377_075_56, -0.493_210_510_118_965_55];
+    let expected_weights = [0.569_201_782_148_292_1, 0.430_798_217_851_707_9];
+    let expected_centroid = [
+        1.078_716_185_780_169_5,
+        0.223_617_725_820_237_98,
+        0.333_562_632_088_915_3,
+        0.048_576_667_619_514_846,
+    ];
+    let maximum = trace
+        .logits
+        .iter()
+        .zip(expected_logits)
+        .map(|(actual, expected)| (*actual - expected).abs())
+        .chain(
+            trace
+                .weights
+                .iter()
+                .zip(expected_weights)
+                .map(|(actual, expected)| (*actual - expected).abs()),
+        )
+        .chain(
+            trace
+                .centroid
+                .iter()
+                .zip(expected_centroid)
+                .map(|(actual, expected)| (*actual - expected).abs()),
+        )
+        .fold(0.0_f64, f64::max);
+    if maximum > 1.0e-15 {
+        return Err("pinned HELM-D golden vector drifted".into());
+    }
+    Ok(maximum)
+}
+
+fn hyperboloid_residual(spatial: &[f64]) -> f64 {
+    let time = libm::sqrt(1.0 + spatial.iter().map(|value| value * value).sum::<f64>());
+    (-time * time + spatial.iter().map(|value| value * value).sum::<f64>() + 1.0).abs()
+}
+
+fn registered_frame_covariance_preflight(
+    maximum_token_id: u32,
+) -> TestResult<(usize, f64, f64, f64, f64, bool)> {
+    let capacity = usize::try_from(maximum_token_id)? + 1;
+    let mut atlas = R4SpinFrameAtlas::new(maximum_token_id, capacity)?;
+    let mut frames = BTreeMap::new();
+    for token in 0..=maximum_token_id {
+        let position = usize::try_from(token)?;
+        atlas.begin_position(token, position)?;
+        frames
+            .entry(atlas.frame_table_offset(position)?)
+            .or_insert(position);
+        if frames.len() == 120 {
+            break;
+        }
+    }
+    if frames.len() != 120 {
+        return Err(format!(
+            "only {} of 120 registered H4 frames were reachable",
+            frames.len()
+        )
+        .into());
+    }
+    let query = (0..HEAD_WIDTH)
+        .map(|lane| (lane as f64 - 31.5) / 37.0)
+        .collect::<Vec<_>>();
+    let keys = [
+        (0..HEAD_WIDTH)
+            .map(|lane| (lane as f64 - 17.0) / 41.0)
+            .collect::<Vec<_>>(),
+        (0..HEAD_WIDTH)
+            .map(|lane| (23.0 - lane as f64) / 43.0)
+            .collect::<Vec<_>>(),
+    ];
+    let values = [
+        (0..HEAD_WIDTH)
+            .map(|lane| (lane as f64 - 7.0) / 47.0)
+            .collect::<Vec<_>>(),
+        (0..HEAD_WIDTH)
+            .map(|lane| (11.0 - lane as f64) / 53.0)
+            .collect::<Vec<_>>(),
+    ];
+    let baseline_logits = keys
+        .iter()
+        .map(|key| {
+            helm_d_learned_manifold_logit(
+                HelmDLearnedManifoldMetric::Lorentz,
+                &query,
+                key,
+                2.5,
+                -0.125,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let baseline_weights = stable_softmax_f64(&baseline_logits)?;
+    let baseline_centroid = helm_d_learned_manifold_centroid(
+        HelmDLearnedManifoldMetric::Lorentz,
+        &values,
+        &baseline_weights,
+    )?;
+    let mut maximum_score = 0.0_f64;
+    let mut maximum_weight = 0.0_f64;
+    let mut maximum_centroid = 0.0_f64;
+    let mut maximum_output = 0.0_f64;
+    for position in frames.values().copied() {
+        let mut encode = |vector: &[f64]| -> TestResult<Vec<f64>> {
+            let mut encoded = Vec::with_capacity(HEAD_WIDTH);
+            for block in vector.chunks_exact(R4_WIDTH) {
+                let block = [block[0], block[1], block[2], block[3]];
+                encoded.extend_from_slice(&atlas.encode_model_block(position, block)?);
+            }
+            Ok(encoded)
+        };
+        let encoded_query = encode(&query)?;
+        let encoded_keys = keys
+            .iter()
+            .map(|key| encode(key))
+            .collect::<TestResult<Vec<_>>>()?;
+        let encoded_values = values
+            .iter()
+            .map(|value| encode(value))
+            .collect::<TestResult<Vec<_>>>()?;
+        let encoded_logits = encoded_keys
+            .iter()
+            .map(|key| {
+                helm_d_learned_manifold_logit(
+                    HelmDLearnedManifoldMetric::Lorentz,
+                    &encoded_query,
+                    key,
+                    2.5,
+                    -0.125,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let encoded_weights = stable_softmax_f64(&encoded_logits)?;
+        let encoded_centroid = helm_d_learned_manifold_centroid(
+            HelmDLearnedManifoldMetric::Lorentz,
+            &encoded_values,
+            &encoded_weights,
+        )?;
+        let mut decoded = Vec::with_capacity(HEAD_WIDTH);
+        for block in encoded_centroid.chunks_exact(R4_WIDTH) {
+            decoded.extend_from_slice(
+                &atlas.decode_query_block(position, [block[0], block[1], block[2], block[3]])?,
+            );
+        }
+        maximum_score = maximum_score.max(
+            baseline_logits
+                .iter()
+                .zip(&encoded_logits)
+                .map(|(left, right)| (*left - *right).abs())
+                .fold(0.0, f64::max),
+        );
+        maximum_weight = maximum_weight.max(
+            baseline_weights
+                .iter()
+                .zip(&encoded_weights)
+                .map(|(left, right)| (*left - *right).abs())
+                .fold(0.0, f64::max),
+        );
+        maximum_centroid = maximum_centroid.max(
+            hyperboloid_residual(&encoded_centroid).max(hyperboloid_residual(&baseline_centroid)),
+        );
+        maximum_output = maximum_output.max(
+            baseline_centroid
+                .iter()
+                .zip(&decoded)
+                .map(|(left, right)| (*left - *right).abs())
+                .fold(0.0, f64::max),
+        );
+    }
+    if maximum_score > 1.0e-8
+        || maximum_weight > 1.0e-8
+        || maximum_centroid > 1.0e-8
+        || maximum_output > 1.0e-8
+    {
+        return Err("registered-frame Lorentz covariance exceeds the frozen bound".into());
+    }
+    let mut reached_frames = frames
+        .iter()
+        .map(|(offset, position)| (*position, *offset))
+        .collect::<Vec<_>>();
+    reached_frames.sort_unstable();
+    let (source_position, source_offset) = reached_frames[0];
+    let (query_position, query_offset) = reached_frames
+        .iter()
+        .copied()
+        .find(|(position, offset)| *position > source_position && *offset != source_offset)
+        .ok_or("two causally ordered distinct frames are unavailable")?;
+    if source_position >= query_position || source_offset == query_offset {
+        return Err("frame-permutation liveness pair is not causally ordered and distinct".into());
+    }
+    let block = [0.25, -0.5, 0.75, 0.125];
+    let local = atlas.encode_model_block(source_position, block)?;
+    let coherent = atlas.transport_local_block(
+        source_position,
+        query_position,
+        local,
+        R4SpinTransportIntervention::Coherent,
+        false,
+    )?;
+    let permuted = atlas.transport_local_block(
+        source_position,
+        query_position,
+        local,
+        R4SpinTransportIntervention::SourceFramePermuted,
+        false,
+    )?;
+    let permutation_live = coherent
+        .iter()
+        .zip(permuted)
+        .any(|(left, right)| (*left - right).abs() > 1.0e-8);
+    if !permutation_live {
+        return Err("source-frame permutation is not live".into());
+    }
+    Ok((
+        frames.len(),
+        maximum_score,
+        maximum_weight,
+        maximum_centroid,
+        maximum_output,
+        true,
+    ))
+}
+
+fn construction_preflight(
+    captures: &[CapturedDocument],
+    maximum_token_id: u32,
+    rope_theta: f32,
+    rope_interleaved: bool,
+) -> TestResult<GeometryPreflight> {
+    let golden_maximum_error = pinned_golden_preflight()?;
+    let finite_difference_maximum_error = finite_difference_gradient_preflight()?;
+    let identity_ordering_compared_lanes =
+        identity_projection_ordering_preflight(captures, rope_theta, rope_interleaved)?;
+    let (registered_frames, score, weight, centroid, output, source_frame_permutation_live) =
+        registered_frame_covariance_preflight(maximum_token_id)?;
+    Ok(GeometryPreflight {
+        golden_maximum_error,
+        finite_difference_maximum_error,
+        identity_ordering_compared_lanes,
+        registered_frames,
+        maximum_score_covariance_error: score,
+        maximum_weight_covariance_error: weight,
+        maximum_hyperboloid_residual: centroid,
+        maximum_centroid_covariance_error: output,
+        source_frame_permutation_live,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct CanaryReport {
+    lorentz_initial_objective: f64,
+    lorentz_after_one_step: f64,
+    euclidean_initial_objective: f64,
+    euclidean_after_one_step: f64,
+    rows_per_shard: Vec<u64>,
+    extrapolated_complete_seconds: f64,
+    passed: bool,
+}
+
+fn objective_canary(
+    captures: &[CapturedDocument],
+    rope_theta: f32,
+    rope_interleaved: bool,
+) -> TestResult<CanaryReport> {
+    let started = Instant::now();
+    let lorentz = fit_arm(
+        HelmDLearnedManifoldMetric::Lorentz,
+        captures,
+        2,
+        rope_theta,
+        rope_interleaved,
+        1,
+    )?;
+    let euclidean = fit_arm(
+        HelmDLearnedManifoldMetric::Euclidean,
+        captures,
+        2,
+        rope_theta,
+        rope_interleaved,
+        1,
+    )?;
+    let elapsed = started.elapsed().as_secs_f64();
+    // Each one-step canary evaluates its dataset three times (initial, update,
+    // final). The complete fit evaluates each arm 130 times, has eight times
+    // as many documents, and repeats both independent arms for replay. Ten
+    // percent is then reserved for admitted validation and result I/O.
+    let extrapolated_complete_seconds = elapsed * (130.0 / 3.0) * 8.0 * 2.0 * 1.1;
+    let passed = lorentz.report.final_objective < lorentz.report.initial_objective
+        && euclidean.report.final_objective < euclidean.report.initial_objective
+        && lorentz.report.work.rows_per_shard_per_evaluation.len() == SHARDS
+        && lorentz
+            .report
+            .work
+            .rows_per_shard_per_evaluation
+            .iter()
+            .all(|rows| *rows > 0)
+        && lorentz.report.work.rows_per_shard_per_evaluation
+            == euclidean.report.work.rows_per_shard_per_evaluation
+        && extrapolated_complete_seconds <= MAX_CANARY_SECONDS;
+    let report = CanaryReport {
+        lorentz_initial_objective: lorentz.report.initial_objective,
+        lorentz_after_one_step: lorentz.report.final_objective,
+        euclidean_initial_objective: euclidean.report.initial_objective,
+        euclidean_after_one_step: euclidean.report.final_objective,
+        rows_per_shard: lorentz.report.work.rows_per_shard_per_evaluation,
+        extrapolated_complete_seconds,
+        passed,
+    };
+    if !report.passed {
+        return Err(format!("two-document objective/runtime canary failed: {report:?}").into());
+    }
+    Ok(report)
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ImplementationIdentity {
+    contract_cid: String,
+    predecessor_partition_bytes_cid: String,
+    implementation_source_cid: String,
+    executable_cid: String,
+    git_revision: String,
+    git_tracked_tree_clean: bool,
+}
+
+fn repository_root() -> TestResult<PathBuf> {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    Ok(manifest
+        .parent()
+        .and_then(Path::parent)
+        .ok_or("core crate is not inside the expected workspace")?
+        .to_path_buf())
+}
+
+fn verified_git_revision() -> TestResult<String> {
+    let root = repository_root()?;
+    let revision = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&root)
+        .output()?;
+    if !revision.status.success() {
+        return Err("could not resolve the implementation Git revision".into());
+    }
+    let revision = String::from_utf8(revision.stdout)?.trim().to_owned();
+    if revision.len() != 40 || !revision.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err("implementation Git revision is not a complete commit identity".into());
+    }
+    let status = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .current_dir(root)
+        .output()?;
+    if !status.status.success() || !status.stdout.is_empty() {
+        return Err("decision execution requires a clean tracked Git tree".into());
+    }
+    Ok(revision)
+}
+
+fn implementation_identity() -> TestResult<ImplementationIdentity> {
+    let mut source = blake3::Hasher::new();
+    source.update(b"uor-r4.helm-d-learned-manifold.implementation/2\0");
+    for bytes in [
+        COMPILED_CORE_SOURCE,
+        COMPILED_HARNESS_SOURCE,
+        COMPILED_MODEL_ATTENTION_SOURCE,
+        COMPILED_MODEL_SOURCE,
+    ] {
+        source.update(&u64::try_from(bytes.len())?.to_le_bytes());
+        source.update(bytes);
+    }
+    let executable = env::current_exe()?;
+    let git_revision = verified_git_revision()?;
+    Ok(ImplementationIdentity {
+        contract_cid: cid_bytes(COMPILED_CONTRACT),
+        predecessor_partition_bytes_cid: cid_bytes(COMPILED_PREDECESSOR_PARTITION),
+        implementation_source_cid: format!("blake3:{}", source.finalize().to_hex()),
+        executable_cid: file_cid(&executable)?,
+        git_revision,
+        git_tracked_tree_clean: true,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct FitReplayReport {
+    lorentz_parameter_bytes_identical: bool,
+    euclidean_parameter_bytes_identical: bool,
+    lorentz_report_identical: bool,
+    euclidean_report_identical: bool,
+    replay_cid: String,
+}
+
+fn fit_replay_cid(report: &FitReplayReport) -> TestResult<String> {
+    let mut commitment = report.clone();
+    commitment.replay_cid.clear();
+    canonical_json_cid(&commitment)
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct FitCheckpoint {
+    schema: String,
+    issue: u32,
+    contract_cid: String,
+    population_cid: String,
+    partition_cid: String,
+    manifest_cid: String,
+    donor_cid: String,
+    tokenizer_cid: String,
+    upstream_source_commit: String,
+    lorentz_policy: String,
+    euclidean_policy: String,
+    optimizer_specification: String,
+    implementation: ImplementationIdentity,
+    exact_workers: usize,
+    execution_preparation: TeacherExecutionPreparation,
+    fit_trace_cid: String,
+    preflight: GeometryPreflight,
+    canary: CanaryReport,
+    lorentz_parameters: HelmDLearnedManifoldParameters,
+    lorentz_parameter_cid: String,
+    lorentz_fit_report: FitReport,
+    euclidean_parameters: HelmDLearnedManifoldParameters,
+    euclidean_parameter_cid: String,
+    euclidean_fit_report: FitReport,
+    replay: FitReplayReport,
+    validation_materialized: bool,
+    future_position_reads: u64,
+    target_as_input_reads: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct FitCheckpointEnvelope {
+    checkpoint_cid: String,
+    checkpoint: FitCheckpoint,
+}
+
+#[derive(Debug)]
+struct ValidationAdmission {
+    checkpoint_cid: String,
+    partition_cid: String,
+    manifest_cid: String,
+}
+
+fn validate_fit_report(
+    report: &FitReport,
+    parameters: &HelmDLearnedManifoldParameters,
+    metric: HelmDLearnedManifoldMetric,
+) -> TestResult {
+    let rows_per_evaluation =
+        u64::try_from(FIT_DOCUMENTS * SCORE_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS)?;
+    let source_pairs_per_evaluation = u64::try_from(
+        FIT_DOCUMENTS
+            * EXPECTED_LAYERS
+            * EXPECTED_QUERY_HEADS
+            * ((SCORE_START + 1)..=INPUT_POSITIONS).sum::<usize>(),
+    )?;
+    let evaluations = ADAM_STEPS + 2;
+    let rows_per_shard = &report.work.rows_per_shard_per_evaluation;
+    let source_pairs_per_shard = &report.work.source_pairs_per_shard_per_evaluation;
+    if report.metric != metric
+        || report.steps != ADAM_STEPS
+        || report.workers != SHARDS
+        || report.fit_documents != FIT_DOCUMENTS
+        || report.fit_rows != rows_per_evaluation
+        || !report.initial_objective.is_finite()
+        || !report.final_objective.is_finite()
+        || report.parameter_scalars != PARAMETER_SCALARS
+        || report.parameter_cid != public_parameter_identity(parameters)?
+        || report.gradient_audit.schema != "uor-r4.helm-d-learned-manifold-gradient-audit/2"
+        || report.gradient_audit.gradient_evaluations != evaluations
+        || report.gradient_audit.optimizer_gradient_evaluations != ADAM_STEPS
+        || report.gradient_audit.diagnostic_gradient_evaluations != 2
+        || !report.gradient_audit.maximum_absolute_gradient.is_finite()
+        || report.gradient_audit.maximum_absolute_gradient <= 0.0
+        || report.gradient_audit.ordered_evaluation_cids.len() != evaluations
+        || report
+            .gradient_audit
+            .ordered_evaluation_cids
+            .iter()
+            .any(|cid| !cid.starts_with("blake3:"))
+        || report.gradient_audit_cid != canonical_json_cid(&report.gradient_audit)?
+        || report.work.workers != SHARDS
+        || report.work.full_batch_steps != ADAM_STEPS
+        || report.work.full_batch_evaluations != evaluations
+        || rows_per_shard.len() != SHARDS
+        || source_pairs_per_shard.len() != SHARDS
+        || rows_per_shard.contains(&0)
+        || source_pairs_per_shard.contains(&0)
+        || rows_per_shard.iter().sum::<u64>() != rows_per_evaluation
+        || source_pairs_per_shard.iter().sum::<u64>() != source_pairs_per_evaluation
+        || report.work.total_row_evaluations
+            != rows_per_evaluation.saturating_mul(evaluations as u64)
+        || report.work.total_source_pair_evaluations
+            != source_pairs_per_evaluation.saturating_mul(evaluations as u64)
+        || report.report_cid != fit_report_cid(report)?
+    {
+        return Err("fit report gradient/work/parameter evidence is invalid".into());
+    }
+    Ok(())
+}
+
+fn write_and_read_checkpoint(
+    path: &Path,
+    checkpoint: FitCheckpoint,
+) -> TestResult<(FitCheckpointEnvelope, ValidationAdmission)> {
+    let preflight_scalars = [
+        checkpoint.preflight.golden_maximum_error,
+        checkpoint.preflight.finite_difference_maximum_error,
+        checkpoint.preflight.maximum_score_covariance_error,
+        checkpoint.preflight.maximum_weight_covariance_error,
+        checkpoint.preflight.maximum_hyperboloid_residual,
+        checkpoint.preflight.maximum_centroid_covariance_error,
+        checkpoint.canary.extrapolated_complete_seconds,
+    ];
+    if checkpoint.validation_materialized
+        || checkpoint.schema != CHECKPOINT_SCHEMA
+        || checkpoint.issue != 973
+        || checkpoint.contract_cid != checkpoint.implementation.contract_cid
+        || checkpoint.population_cid != CORPUS_CID
+        || checkpoint.donor_cid != DONOR_CID
+        || checkpoint.upstream_source_commit != HELM_D_UPSTREAM_COMMIT
+        || checkpoint.lorentz_policy != HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY
+        || checkpoint.euclidean_policy != HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY
+        || checkpoint.exact_workers != SHARDS
+        || checkpoint.fit_trace_cid != checkpoint.lorentz_fit_report.donor_trace_cid
+        || checkpoint.fit_trace_cid != checkpoint.euclidean_fit_report.donor_trace_cid
+        || checkpoint.implementation.git_revision.len() != 40
+        || !checkpoint.implementation.git_tracked_tree_clean
+        || checkpoint.preflight.registered_frames != 120
+        || checkpoint.preflight.golden_maximum_error > 1.0e-15
+        || checkpoint.preflight.finite_difference_maximum_error > 3.0e-5
+        || checkpoint.preflight.maximum_score_covariance_error > 1.0e-8
+        || checkpoint.preflight.maximum_weight_covariance_error > 1.0e-8
+        || checkpoint.preflight.maximum_hyperboloid_residual > 1.0e-8
+        || checkpoint.preflight.maximum_centroid_covariance_error > 1.0e-8
+        || preflight_scalars.iter().any(|value| !value.is_finite())
+        || !checkpoint.preflight.source_frame_permutation_live
+        || !checkpoint.canary.passed
+        || checkpoint.future_position_reads != 0
+        || checkpoint.target_as_input_reads != 0
+        || !checkpoint.replay.lorentz_parameter_bytes_identical
+        || !checkpoint.replay.euclidean_parameter_bytes_identical
+        || !checkpoint.replay.lorentz_report_identical
+        || !checkpoint.replay.euclidean_report_identical
+        || checkpoint.replay.replay_cid != fit_replay_cid(&checkpoint.replay)?
+        || checkpoint.lorentz_parameter_cid != checkpoint.lorentz_fit_report.parameter_cid
+        || checkpoint.euclidean_parameter_cid != checkpoint.euclidean_fit_report.parameter_cid
+        || checkpoint
+            .lorentz_fit_report
+            .work
+            .rows_per_shard_per_evaluation
+            != checkpoint
+                .euclidean_fit_report
+                .work
+                .rows_per_shard_per_evaluation
+        || checkpoint
+            .lorentz_fit_report
+            .work
+            .source_pairs_per_shard_per_evaluation
+            != checkpoint
+                .euclidean_fit_report
+                .work
+                .source_pairs_per_shard_per_evaluation
+    {
+        return Err("fit checkpoint does not seal construction-only replay evidence".into());
+    }
+    validate_fit_report(
+        &checkpoint.lorentz_fit_report,
+        &checkpoint.lorentz_parameters,
+        HelmDLearnedManifoldMetric::Lorentz,
+    )?;
+    validate_fit_report(
+        &checkpoint.euclidean_fit_report,
+        &checkpoint.euclidean_parameters,
+        HelmDLearnedManifoldMetric::Euclidean,
+    )?;
+    let envelope = FitCheckpointEnvelope {
+        checkpoint_cid: canonical_json_cid(&checkpoint)?,
+        checkpoint,
+    };
+    write_pretty_json_exclusive(path, &envelope)?;
+    let readback: FitCheckpointEnvelope = serde_json::from_slice(&fs::read(path)?)?;
+    if readback != envelope
+        || readback.checkpoint_cid != canonical_json_cid(&readback.checkpoint)?
+        || canonical_json_bytes(&readback)? != canonical_json_bytes(&envelope)?
+    {
+        return Err("exclusive fit checkpoint readback is not byte-identical".into());
+    }
+    let admission = ValidationAdmission {
+        checkpoint_cid: readback.checkpoint_cid.clone(),
+        partition_cid: readback.checkpoint.partition_cid.clone(),
+        manifest_cid: readback.checkpoint.manifest_cid.clone(),
+    };
+    Ok((readback, admission))
+}
+
+fn materialize_validation_documents(
+    admission: &ValidationAdmission,
+    partition: &FrozenPartitionEnvelope,
+    corpus_path: &Path,
+    tokenizer: &Tokenizer,
+) -> TestResult<Vec<FrozenDocument>> {
+    if admission.checkpoint_cid.is_empty()
+        || admission.partition_cid != partition.manifest.partition_cid
+        || admission.manifest_cid != partition.manifest_cid
+    {
+        return Err("typed validation admission is not bound to this partition".into());
+    }
+    // The whole-file identity scan is deliberately admission-gated because it
+    // streams bytes belonging to the sealed validation ranges.
+    verify_complete_corpus(corpus_path)?;
+    materialize_documents(
+        corpus_path,
+        tokenizer,
+        &partition.manifest.construction_validation,
+        true,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum ArmSpec<'a> {
+    Donor,
+    Gauge,
+    Learned {
+        parameters: &'a HelmDLearnedManifoldParameters,
+        metric: HelmDLearnedManifoldMetric,
+        intervention: HelmDLearnedManifoldIntervention,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ArmReport {
+    name: String,
+    policy_identity: String,
+    positions: usize,
+    mean_next_token_nll: f64,
+    top1_correct: usize,
+    top1_token_ids: Vec<u32>,
+    decoded_snippets: Vec<String>,
+    logits_cid: String,
+    replay_identical: bool,
+    target_as_input_reads: u64,
+    decoder_audits: Vec<CausalAuditRecord>,
+    projection_audits: Vec<ProjectionAuditRecord>,
+    implementation_evidence: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct CausalAuditRecord {
+    positions: u64,
+    layers: u64,
+    heads: u64,
+    query_transforms: u64,
+    key_transports: u64,
+    value_transports: u64,
+    output_transforms: u64,
+    future_reads: u64,
+    maximum_query_position: Option<usize>,
+    maximum_source_position: Option<usize>,
+}
+
+impl From<CausalAttentionTransportAudit> for CausalAuditRecord {
+    fn from(audit: CausalAttentionTransportAudit) -> Self {
+        Self {
+            positions: audit.positions,
+            layers: audit.layers,
+            heads: audit.heads,
+            query_transforms: audit.query_transforms,
+            key_transports: audit.key_transports,
+            value_transports: audit.value_transports,
+            output_transforms: audit.output_transforms,
+            future_reads: audit.future_reads,
+            maximum_query_position: audit.maximum_query_position,
+            maximum_source_position: audit.maximum_source_position,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ProjectionAuditRecord {
+    hook_calls: u64,
+    query_vectors: u64,
+    key_vectors: u64,
+    value_vectors: u64,
+    query_lanes: u64,
+    key_lanes: u64,
+    value_lanes: u64,
+}
+
+impl From<CausalAttentionProjectionAudit> for ProjectionAuditRecord {
+    fn from(audit: CausalAttentionProjectionAudit) -> Self {
+        Self {
+            hook_calls: audit.hook_calls,
+            query_vectors: audit.query_vectors,
+            key_vectors: audit.key_vectors,
+            value_vectors: audit.value_vectors,
+            query_lanes: audit.query_lanes,
+            key_lanes: audit.key_lanes,
+            value_lanes: audit.value_lanes,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ArmExecution {
+    report: ArmReport,
+    scored_logits: Vec<Vec<f32>>,
+    top1_tokens: Vec<usize>,
+}
+
+fn expected_transport_source_pairs() -> u64 {
+    u64::try_from(EXPECTED_LAYERS * EXPECTED_QUERY_HEADS * (1..=INPUT_POSITIONS).sum::<usize>())
+        .unwrap_or(u64::MAX)
+}
+
+fn expected_nonidentity_source_frame_blocks() -> u64 {
+    u64::try_from(
+        EXPECTED_LAYERS
+            * EXPECTED_QUERY_HEADS
+            * (1..INPUT_POSITIONS)
+                .map(|position| position + 1)
+                .sum::<usize>()
+            * BLOCKS_PER_HEAD
+            * 2,
+    )
+    .unwrap_or(u64::MAX)
+}
+
+fn expected_nonidentity_row_permutations() -> u64 {
+    u64::try_from(
+        EXPECTED_LAYERS
+            * EXPECTED_QUERY_HEADS
+            * (1..INPUT_POSITIONS)
+                .map(|position| position + 1)
+                .sum::<usize>(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+fn validate_transport_audit(
+    audit: &uor_r4_core::helm_d_r4_attention::R4SpinTransportAudit,
+    expected_source_frame_permutations: u64,
+) -> bool {
+    let head_rows =
+        u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS).unwrap_or(u64::MAX);
+    let source_pairs = expected_transport_source_pairs();
+    let blocks = u64::try_from(BLOCKS_PER_HEAD).unwrap_or(u64::MAX);
+    audit.positions_prepared == INPUT_POSITIONS as u64
+        && audit.r4_blocks_encoded
+            == head_rows
+                .saturating_mul(blocks)
+                .saturating_add(source_pairs.saturating_mul(blocks).saturating_mul(2))
+        && audit.key_blocks_transported == source_pairs.saturating_mul(blocks)
+        && audit.value_blocks_transported == source_pairs.saturating_mul(blocks)
+        && audit.output_blocks_decoded == head_rows.saturating_mul(blocks)
+        && audit.future_position_reads == 0
+        && audit.source_frame_permutations == expected_source_frame_permutations
+}
+
+fn validate_gauge_evidence(evidence: &R4SpinTransportEvidence, actual_policy: &str) -> TestResult {
+    if evidence.schema != "uor-r4.r4-spin-transport-evidence/1"
+        || evidence.policy_identity != actual_policy
+        || actual_policy != HELM_D_R4_GAUGE_SOFTMAX_POLICY
+        || evidence.intervention != R4SpinTransportIntervention::Coherent
+        || evidence.frame_table_offsets.len() != INPUT_POSITIONS
+        || evidence
+            .frame_table_offsets
+            .iter()
+            .any(|offset| *offset >= 120)
+        || !validate_transport_audit(&evidence.audit, 0)
+    {
+        return Err("gauge implementation evidence does not match exact frozen work".into());
+    }
+    Ok(())
+}
+
+fn validate_learned_evidence(
+    evidence: &HelmDLearnedManifoldEvidence,
+    actual_policy: &str,
+    expected_parameter_identity: &str,
+    metric: HelmDLearnedManifoldMetric,
+    intervention: HelmDLearnedManifoldIntervention,
+) -> TestResult {
+    let expected_policy = match metric {
+        HelmDLearnedManifoldMetric::Lorentz => HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY,
+        HelmDLearnedManifoldMetric::Euclidean => HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY,
+    };
+    let head_rows = u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS)?;
+    let source_pairs = expected_transport_source_pairs();
+    let expected_source_frame_permutations =
+        if intervention == HelmDLearnedManifoldIntervention::SourceFramePermuted {
+            expected_nonidentity_source_frame_blocks()
+        } else {
+            0
+        };
+    let expected_value_permutations =
+        if intervention == HelmDLearnedManifoldIntervention::ValuePermuted {
+            expected_nonidentity_row_permutations()
+        } else {
+            0
+        };
+    let expected_order_key_permutations =
+        if intervention == HelmDLearnedManifoldIntervention::OrderKeyShuffled {
+            expected_nonidentity_row_permutations()
+        } else {
+            0
+        };
+    let audit = evidence.learned_manifold_audit;
+    if evidence.schema != "uor-r4.helm-d-learned-manifold-r4-evidence/2"
+        || evidence.policy_identity != actual_policy
+        || actual_policy != expected_policy
+        || evidence.parameter_identity != expected_parameter_identity
+        || evidence.scalar_parameter_count != PARAMETER_SCALARS
+        || evidence.metric != metric
+        || evidence.intervention != intervention
+        || evidence.frame_table_offsets.len() != INPUT_POSITIONS
+        || evidence
+            .frame_table_offsets
+            .iter()
+            .any(|offset| *offset >= 120)
+        || !validate_transport_audit(
+            &evidence.transport_audit,
+            expected_source_frame_permutations,
+        )
+        || audit.projection_tuples != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS)?
+        || audit.projected_query_lanes
+            != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS * HEAD_WIDTH)?
+        || audit.projected_key_lanes
+            != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS * HEAD_WIDTH)?
+        || audit.projected_value_lanes
+            != u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS * HEAD_WIDTH)?
+        || audit.score_rows != head_rows
+        || audit.compatibility_pairs != source_pairs
+        || audit.centroid_rows != head_rows
+        || audit.centroid_source_pairs != source_pairs
+        || audit.source_frame_permutations != expected_source_frame_permutations
+        || audit.value_permutations != expected_value_permutations
+        || audit.order_key_permutations != expected_order_key_permutations
+        || audit.arithmetic_failures != 0
+    {
+        return Err("learned implementation evidence does not match exact frozen work".into());
+    }
+    Ok(())
+}
+
+fn bind_actual_policy(observed: &mut Option<String>, actual: &str) -> TestResult {
+    if observed
+        .as_ref()
+        .is_some_and(|established| established != actual)
+    {
+        return Err("arm transport policy changed between validation documents".into());
+    }
+    if observed.is_none() {
+        *observed = Some(actual.to_owned());
+    }
+    Ok(())
+}
+
+fn argmax(values: &[f32]) -> TestResult<usize> {
+    values
+        .iter()
+        .enumerate()
+        .max_by(|(left_index, left), (right_index, right)| {
+            left.total_cmp(right)
+                .then_with(|| right_index.cmp(left_index))
+        })
+        .map(|(index, _)| index)
+        .ok_or_else(|| "argmax received an empty row".into())
+}
+
+fn next_token_nll(logits: &[f32], target: usize) -> TestResult<f64> {
+    if target >= logits.len() || logits.is_empty() || logits.iter().any(|value| !value.is_finite())
+    {
+        return Err("next-token NLL received invalid logits or target".into());
+    }
+    let maximum = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let denominator = logits
+        .iter()
+        .map(|logit| libm::exp(f64::from(*logit - maximum)))
+        .sum::<f64>();
+    Ok(libm::log(denominator) + f64::from(maximum - logits[target]))
+}
+
+fn scored_logits_cid(logits: &[Vec<f32>]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uor-r4.helm-d-learned-manifold.validation-logits/2\0");
+    for row in logits {
+        hasher.update(&u64::try_from(row.len()).unwrap_or(u64::MAX).to_le_bytes());
+        for value in row {
+            hasher.update(&value.to_bits().to_le_bytes());
+        }
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+fn run_arm_once(
+    oracle: &HuggingFaceLlamaOracle,
+    tokenizer: &Tokenizer,
+    documents: &[FrozenDocument],
+    spec: ArmSpec<'_>,
+    name: &str,
+) -> TestResult<ArmExecution> {
+    let maximum_token_id = u32::try_from(oracle.cfg().vocab.checked_sub(1).ok_or("empty vocab")?)?;
+    let mut scored_logits = Vec::with_capacity(documents.len() * SCORE_POSITIONS);
+    let mut top1_tokens = Vec::with_capacity(documents.len() * SCORE_POSITIONS);
+    let mut nll_sum = 0.0;
+    let mut top1_correct = 0_usize;
+    let mut target_reads = 0_u64;
+    let mut decoder_audits = Vec::new();
+    let mut projection_audits = Vec::new();
+    let mut evidence = Vec::new();
+    let mut observed_policy = match spec {
+        ArmSpec::Donor => Some("smollm2-135m-ordinary-causal-softmax".to_owned()),
+        ArmSpec::Gauge | ArmSpec::Learned { .. } => None,
+    };
+    let expected_parameter_identity = match spec {
+        ArmSpec::Learned { parameters, .. } => Some(public_parameter_identity(parameters)?),
+        ArmSpec::Donor | ArmSpec::Gauge => None,
+    };
+    for document in documents {
+        if document.tokens.len() != REQUIRED_TOKENS {
+            return Err("validation arm requires exactly 16 inputs plus one target token".into());
+        }
+        let mut logits = vec![0.0_f32; oracle.cfg().vocab];
+        match spec {
+            ArmSpec::Donor => {
+                let mut state = oracle.new_state_bounded(INPUT_POSITIONS)?;
+                for position in 0..INPUT_POSITIONS {
+                    oracle.step_state(
+                        &mut state,
+                        document.tokens[position] as usize,
+                        position,
+                        &mut logits,
+                    )?;
+                    if position >= SCORE_START {
+                        let target = document.tokens[position + 1] as usize;
+                        target_reads += 1;
+                        nll_sum += next_token_nll(&logits, target)?;
+                        let top1 = argmax(&logits)?;
+                        top1_correct += usize::from(top1 == target);
+                        top1_tokens.push(top1);
+                        scored_logits.push(logits.clone());
+                    }
+                }
+            }
+            ArmSpec::Gauge => {
+                let transport = R4SpinCausalAttentionTransport::new(
+                    maximum_token_id,
+                    INPUT_POSITIONS,
+                    R4SpinTransportIntervention::Coherent,
+                )?;
+                let mut session = oracle.new_causal_attention_transport_session(
+                    Box::new(transport),
+                    CausalAttentionLayerSelection::All,
+                    INPUT_POSITIONS,
+                )?;
+                let actual_policy = session.policy_identity().to_owned();
+                bind_actual_policy(&mut observed_policy, &actual_policy)?;
+                for position in 0..INPUT_POSITIONS {
+                    oracle.step_causal_attention_transport(
+                        &mut session,
+                        document.tokens[position] as usize,
+                        position,
+                        &mut logits,
+                    )?;
+                    if position >= SCORE_START {
+                        let target = document.tokens[position + 1] as usize;
+                        target_reads += 1;
+                        nll_sum += next_token_nll(&logits, target)?;
+                        let top1 = argmax(&logits)?;
+                        top1_correct += usize::from(top1 == target);
+                        top1_tokens.push(top1);
+                        scored_logits.push(logits.clone());
+                    }
+                }
+                session.transport_status()?;
+                decoder_audits.push(session.audit().into());
+                projection_audits.push(session.pre_rope_projection_audit().into());
+                let value = session
+                    .transport_implementation_evidence()?
+                    .ok_or("gauge arm omitted implementation evidence")?;
+                let parsed: R4SpinTransportEvidence = serde_json::from_str(&value)?;
+                validate_gauge_evidence(&parsed, &actual_policy)?;
+                evidence.push(serde_json::to_value(parsed)?);
+            }
+            ArmSpec::Learned {
+                parameters,
+                metric,
+                intervention,
+            } => {
+                let transport = HelmDLearnedManifoldR4Transport::new(
+                    maximum_token_id,
+                    INPUT_POSITIONS,
+                    parameters.clone(),
+                    metric,
+                    intervention,
+                )?;
+                let mut session = oracle.new_causal_attention_transport_session(
+                    Box::new(transport),
+                    CausalAttentionLayerSelection::All,
+                    INPUT_POSITIONS,
+                )?;
+                let actual_policy = session.policy_identity().to_owned();
+                bind_actual_policy(&mut observed_policy, &actual_policy)?;
+                for position in 0..INPUT_POSITIONS {
+                    oracle.step_causal_attention_transport(
+                        &mut session,
+                        document.tokens[position] as usize,
+                        position,
+                        &mut logits,
+                    )?;
+                    if position >= SCORE_START {
+                        let target = document.tokens[position + 1] as usize;
+                        target_reads += 1;
+                        nll_sum += next_token_nll(&logits, target)?;
+                        let top1 = argmax(&logits)?;
+                        top1_correct += usize::from(top1 == target);
+                        top1_tokens.push(top1);
+                        scored_logits.push(logits.clone());
+                    }
+                }
+                session.transport_status()?;
+                decoder_audits.push(session.audit().into());
+                projection_audits.push(session.pre_rope_projection_audit().into());
+                let value = session
+                    .transport_implementation_evidence()?
+                    .ok_or("learned arm omitted implementation evidence")?;
+                let parsed: HelmDLearnedManifoldEvidence = serde_json::from_str(&value)?;
+                validate_learned_evidence(
+                    &parsed,
+                    &actual_policy,
+                    expected_parameter_identity
+                        .as_deref()
+                        .ok_or("learned arm parameter identity is unavailable")?,
+                    metric,
+                    intervention,
+                )?;
+                evidence.push(serde_json::to_value(parsed)?);
+            }
+        }
+    }
+    let positions = documents.len() * SCORE_POSITIONS;
+    if scored_logits.len() != positions || target_reads != u64::try_from(positions)? {
+        return Err("arm scored work does not match the frozen 64-position ledger".into());
+    }
+    let top1_token_ids = top1_tokens
+        .iter()
+        .copied()
+        .map(u32::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+    let decoded_snippets = top1_token_ids
+        .chunks_exact(SCORE_POSITIONS)
+        .map(|tokens| tokenizer.decode(tokens))
+        .collect::<Vec<_>>();
+    if top1_token_ids.len() != positions || decoded_snippets.len() != documents.len() {
+        return Err("bounded top-1 diagnostics are incomplete".into());
+    }
+    Ok(ArmExecution {
+        report: ArmReport {
+            name: name.to_owned(),
+            policy_identity: observed_policy.ok_or("arm did not bind an actual policy identity")?,
+            positions,
+            mean_next_token_nll: nll_sum / positions as f64,
+            top1_correct,
+            top1_token_ids,
+            decoded_snippets,
+            logits_cid: scored_logits_cid(&scored_logits),
+            replay_identical: false,
+            target_as_input_reads: 0,
+            decoder_audits,
+            projection_audits,
+            implementation_evidence: evidence,
+        },
+        scored_logits,
+        top1_tokens,
+    })
+}
+
+fn run_arm(
+    oracle: &HuggingFaceLlamaOracle,
+    tokenizer: &Tokenizer,
+    documents: &[FrozenDocument],
+    spec: ArmSpec<'_>,
+    name: &str,
+) -> TestResult<ArmExecution> {
+    let mut first = run_arm_once(oracle, tokenizer, documents, spec, name)?;
+    let second = run_arm_once(oracle, tokenizer, documents, spec, name)?;
+    let identical = first.report == second.report
+        && first.report.logits_cid == second.report.logits_cid
+        && first
+            .scored_logits
+            .iter()
+            .flatten()
+            .zip(second.scored_logits.iter().flatten())
+            .all(|(left, right)| left.to_bits() == right.to_bits())
+        && first.top1_tokens == second.top1_tokens
+        && first.report.top1_token_ids == second.report.top1_token_ids
+        && first.report.decoded_snippets == second.report.decoded_snippets
+        && first.report.decoder_audits == second.report.decoder_audits
+        && first.report.projection_audits == second.report.projection_audits
+        && first.report.implementation_evidence == second.report.implementation_evidence;
+    first.report.replay_identical = identical;
+    Ok(first)
+}
+
+fn audit_is_exact(report: &ArmReport) -> bool {
+    if report.name == "donor" {
+        return report.decoder_audits.is_empty()
+            && report.projection_audits.is_empty()
+            && report.implementation_evidence.is_empty()
+            && report.target_as_input_reads == 0;
+    }
+    let expected_layers = u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS).unwrap_or(u64::MAX);
+    let expected_heads =
+        u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_QUERY_HEADS).unwrap_or(u64::MAX);
+    let expected_source_pairs = u64::try_from(
+        EXPECTED_LAYERS * EXPECTED_QUERY_HEADS * (1..=INPUT_POSITIONS).sum::<usize>(),
+    )
+    .unwrap_or(u64::MAX);
+    report.decoder_audits.len() == VALIDATION_DOCUMENTS
+        && report.projection_audits.len() == VALIDATION_DOCUMENTS
+        && report.decoder_audits.iter().all(|audit| {
+            audit.positions == INPUT_POSITIONS as u64
+                && audit.layers == expected_layers
+                && audit.heads == expected_heads
+                && audit.query_transforms == expected_heads
+                && audit.key_transports == expected_source_pairs
+                && audit.value_transports == expected_source_pairs
+                && audit.output_transforms == expected_heads
+                && audit.future_reads == 0
+                && audit.maximum_query_position == Some(INPUT_POSITIONS - 1)
+                && audit.maximum_source_position == Some(INPUT_POSITIONS - 1)
+        })
+        && report.projection_audits.iter().all(|audit| {
+            audit.hook_calls == expected_layers
+                && audit.query_vectors == expected_heads
+                && audit.key_vectors
+                    == u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS)
+                        .unwrap_or(u64::MAX)
+                && audit.value_vectors
+                    == u64::try_from(INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS)
+                        .unwrap_or(u64::MAX)
+                && audit.query_lanes == expected_heads * HEAD_WIDTH as u64
+                && audit.key_lanes
+                    == u64::try_from(
+                        INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS * HEAD_WIDTH,
+                    )
+                    .unwrap_or(u64::MAX)
+                && audit.value_lanes
+                    == u64::try_from(
+                        INPUT_POSITIONS * EXPECTED_LAYERS * EXPECTED_KV_HEADS * HEAD_WIDTH,
+                    )
+                    .unwrap_or(u64::MAX)
+        })
+        && report.implementation_evidence.len() == VALIDATION_DOCUMENTS
+        && report.target_as_input_reads == 0
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct DecisionComparisons {
+    donor_gauge_top1_matches: usize,
+    gauge_minus_donor_nll: f64,
+    donor_gauge_mean_absolute_logit_delta: f64,
+    donor_gauge_maximum_relative_bound_excess: f64,
+    functional_retention: bool,
+    matched_learned_parity: bool,
+    lorentz_euclidean_advantage: bool,
+    source_frame_control_separates: bool,
+    value_control_separates: bool,
+    order_key_control_separates: bool,
+    all_arm_replay: bool,
+    causal_work_valid: bool,
+}
+
+fn compare_decision_arms(
+    donor: &ArmExecution,
+    gauge: &ArmExecution,
+    lorentz: &ArmExecution,
+    euclidean: &ArmExecution,
+    source_frame: &ArmExecution,
+    value: &ArmExecution,
+    order_key: &ArmExecution,
+) -> TestResult<DecisionComparisons> {
+    let positions = VALIDATION_DOCUMENTS * SCORE_POSITIONS;
+    let donor_gauge_top1_matches = donor
+        .top1_tokens
+        .iter()
+        .zip(&gauge.top1_tokens)
+        .filter(|(left, right)| left == right)
+        .count();
+    let mut absolute_sum = 0.0;
+    let mut lanes = 0_u64;
+    let mut maximum_excess = 0.0_f64;
+    for (donor_row, gauge_row) in donor.scored_logits.iter().zip(&gauge.scored_logits) {
+        if donor_row.len() != gauge_row.len() {
+            return Err("donor/gauge logit shapes differ".into());
+        }
+        for (donor, gauge) in donor_row.iter().zip(gauge_row) {
+            let delta = f64::from((*gauge - *donor).abs());
+            absolute_sum += delta;
+            lanes += 1;
+            let bound = 0.02 + 0.001 * f64::from(donor.abs().max(gauge.abs()));
+            maximum_excess = maximum_excess.max(delta - bound);
+        }
+    }
+    let all_arm_replay = [
+        donor,
+        gauge,
+        lorentz,
+        euclidean,
+        source_frame,
+        value,
+        order_key,
+    ]
+    .iter()
+    .all(|arm| arm.report.replay_identical);
+    let causal_work_valid = audit_is_exact(&donor.report)
+        && audit_is_exact(&gauge.report)
+        && audit_is_exact(&lorentz.report)
+        && audit_is_exact(&euclidean.report)
+        && audit_is_exact(&source_frame.report)
+        && audit_is_exact(&value.report)
+        && audit_is_exact(&order_key.report);
+    Ok(DecisionComparisons {
+        donor_gauge_top1_matches,
+        gauge_minus_donor_nll: gauge.report.mean_next_token_nll - donor.report.mean_next_token_nll,
+        donor_gauge_mean_absolute_logit_delta: absolute_sum / lanes as f64,
+        donor_gauge_maximum_relative_bound_excess: maximum_excess,
+        functional_retention: lorentz.report.mean_next_token_nll
+            <= donor.report.mean_next_token_nll + 0.05,
+        matched_learned_parity: lorentz.report.mean_next_token_nll
+            <= euclidean.report.mean_next_token_nll + 0.05,
+        lorentz_euclidean_advantage: lorentz.report.mean_next_token_nll
+            <= euclidean.report.mean_next_token_nll - 0.01,
+        source_frame_control_separates: source_frame.report.mean_next_token_nll
+            >= lorentz.report.mean_next_token_nll + 0.02,
+        value_control_separates: value.report.mean_next_token_nll
+            >= lorentz.report.mean_next_token_nll + 0.02,
+        order_key_control_separates: order_key.report.mean_next_token_nll
+            >= lorentz.report.mean_next_token_nll + 0.02,
+        all_arm_replay,
+        causal_work_valid: causal_work_valid && donor_gauge_top1_matches <= positions && lanes > 0,
+    })
+}
+
+fn terminal_for(comparisons: &DecisionComparisons) -> &'static str {
+    let donor_gauge = comparisons.donor_gauge_top1_matches
+        == VALIDATION_DOCUMENTS * SCORE_POSITIONS
+        && comparisons.gauge_minus_donor_nll <= 0.002
+        && comparisons.donor_gauge_mean_absolute_logit_delta <= 0.002
+        && comparisons.donor_gauge_maximum_relative_bound_excess <= 0.0;
+    let destructive = comparisons.source_frame_control_separates
+        && comparisons.value_control_separates
+        && comparisons.order_key_control_separates;
+    let shared = donor_gauge
+        && comparisons.functional_retention
+        && comparisons.matched_learned_parity
+        && destructive
+        && comparisons.all_arm_replay
+        && comparisons.causal_work_valid;
+    if shared && comparisons.lorentz_euclidean_advantage {
+        PASS_TERMINAL
+    } else if shared {
+        RETAIN_TERMINAL
+    } else {
+        FAIL_TERMINAL
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct TimingReport {
+    fit_trace_seconds: f64,
+    preflight_and_canary_seconds: f64,
+    fit_and_replay_seconds: f64,
+    validation_seconds: f64,
+    total_seconds: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct ResultPayload {
+    schema: String,
+    issue: u32,
+    terminal: String,
+    partition_cid: String,
+    checkpoint_cid: String,
+    implementation: ImplementationIdentity,
+    preflight: GeometryPreflight,
+    canary: CanaryReport,
+    comparisons: DecisionComparisons,
+    donor: ArmReport,
+    gauge: ArmReport,
+    learned_lorentz: ArmReport,
+    learned_euclidean: ArmReport,
+    source_frame_permuted: ArmReport,
+    value_permuted: ArmReport,
+    order_key_shuffled: ArmReport,
+    execution_snapshot: TeacherExecutionSnapshot,
+    timing: TimingReport,
+    validation_materialized_after_checkpoint: bool,
+    d3_status: String,
+    result_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct UnavailablePayload {
+    schema: String,
+    issue: u32,
+    terminal: String,
+    reason: String,
+    validation_materialized: bool,
+    checkpoint_exists: bool,
+    d3_status: String,
+    result_cid: String,
+}
+
+trait SelfCommittedResult: Clone + DeserializeOwned + PartialEq + Serialize {
+    fn result_cid(&self) -> &str;
+    fn result_cid_mut(&mut self) -> &mut String;
+}
+
+impl SelfCommittedResult for ResultPayload {
+    fn result_cid(&self) -> &str {
+        &self.result_cid
+    }
+
+    fn result_cid_mut(&mut self) -> &mut String {
+        &mut self.result_cid
+    }
+}
+
+impl SelfCommittedResult for UnavailablePayload {
+    fn result_cid(&self) -> &str {
+        &self.result_cid
+    }
+
+    fn result_cid_mut(&mut self) -> &mut String {
+        &mut self.result_cid
+    }
+}
+
+fn result_payload_cid<T: SelfCommittedResult>(payload: &T) -> TestResult<String> {
+    let mut commitment = payload.clone();
+    commitment.result_cid_mut().clear();
+    canonical_json_cid(&commitment)
+}
+
+fn write_result<T: SelfCommittedResult>(path: &Path, payload: &T) -> TestResult<String> {
+    let cid = result_payload_cid(payload)?;
+    if payload.result_cid() != cid {
+        return Err("result self-CID does not commit the empty result_cid convention".into());
+    }
+    write_pretty_json_exclusive(path, payload)?;
+    let readback: T = serde_json::from_slice(&fs::read(path)?)?;
+    if readback != *payload
+        || readback.result_cid() != cid
+        || result_payload_cid(&readback)? != cid
+        || canonical_json_bytes(&readback)? != canonical_json_bytes(payload)?
+    {
+        return Err("exclusive result readback failed its self-CID convention".into());
+    }
+    Ok(cid)
+}
+
+fn write_unavailable(
+    path: &Path,
+    reason: &str,
+    validation_materialized: bool,
+    checkpoint_exists: bool,
+) -> TestResult<String> {
+    let mut payload = UnavailablePayload {
+        schema: RESULT_SCHEMA.to_owned(),
+        issue: 973,
+        terminal: UNAVAILABLE_TERMINAL.to_owned(),
+        reason: reason.to_owned(),
+        validation_materialized,
+        checkpoint_exists,
+        d3_status: "NOT_RUN".to_owned(),
+        result_cid: String::new(),
+    };
+    payload.result_cid = result_payload_cid(&payload)?;
+    write_result(path, &payload)
+}
+
+#[test]
+fn helm_d_learned_manifold_r4_construction_partition_policy_and_exclusions_are_sealed() -> TestResult
+{
+    let exclusions = predecessor_exclusions()?;
+    if exclusions.document_ids.len() != 28 || exclusions.input_cids.len() != 28 {
+        return Err("focused exclusion census is not the frozen 28-document predecessor".into());
+    }
+    let mut exclusion_commitment = exclusions.clone();
+    exclusion_commitment.exclusion_cid.clear();
+    if exclusions.exclusion_cid != canonical_json_cid(&exclusion_commitment)? {
+        return Err("exclusion self-commitment drifted".into());
+    }
+    let predecessor: PredecessorEnvelope = serde_json::from_slice(COMPILED_PREDECESSOR_PARTITION)?;
+    for document in predecessor
+        .manifest
+        .construction_fit
+        .iter()
+        .chain(&predecessor.manifest.construction_validation)
+        .chain(&predecessor.manifest.predecessor_heldout)
+    {
+        if !exclusions.document_ids.contains(&document.id)
+            || !exclusions.input_cids.contains(&document.input_cid)
+        {
+            return Err("a predecessor identity escaped the exclusion seal".into());
+        }
+    }
+    let sample_tokens = (0..INPUT_POSITIONS as u32).collect::<Vec<_>>();
+    let new_domain_input_cid =
+        token_cid(b"uor-r4.helm-d-learned-manifold.inputs/2", &sample_tokens);
+    let predecessor_domain_input_cid = token_cid(b"uor-r4.intrinsic.inputs/1", &sample_tokens);
+    if new_domain_input_cid == predecessor_domain_input_cid {
+        return Err("versioned input CID domains unexpectedly alias".into());
+    }
+    let commitment = FrozenDocumentCommitment {
+        id: "focused-policy-fixture".to_owned(),
+        selection_digest: format!(
+            "blake3:{}",
+            hex::encode(selection_digest("focused-policy-fixture"))
+        ),
+        title_cid: string_cid(b"uor-r4.helm-d-learned-manifold.title/2", "fixture"),
+        input_cid: new_domain_input_cid,
+        predecessor_domain_input_cid,
+        corpus_byte_offset: 7,
+        corpus_byte_length: 11,
+    };
+    let serialized = serde_json::to_value(commitment)?;
+    let object = serialized
+        .as_object()
+        .ok_or("commitment did not serialize as an object")?;
+    if object
+        .keys()
+        .any(|key| key.contains("target") || key.contains("token"))
+        || object.len() != 7
+    {
+        return Err("partition commitment serialized a target/token identity".into());
+    }
+    let reserved_count = (0..100)
+        .filter(|id| reserved_partition_id(&id.to_string()))
+        .count();
+    if reserved_count == 0 || reserved_count == 100 || PARITY_DOCUMENT_ID != "12" {
+        return Err("reserved partition policy is not live".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn helm_d_learned_manifold_r4_construction_analytic_gradients_match_finite_difference() -> TestResult
+{
+    let maximum_error = finite_difference_gradient_preflight()?;
+    if maximum_error > 3.0e-5 {
+        return Err("analytic gradient exceeded the frozen finite-difference bound".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn helm_d_learned_manifold_r4_construction_golden_operator_is_pinned() -> TestResult {
+    if pinned_golden_preflight()? > 1.0e-15 {
+        return Err("HELM-D golden operator exceeded the frozen error bound".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn helm_d_learned_manifold_r4_construction_public_identities_and_work_counts_are_pinned(
+) -> TestResult {
+    let parameters = HelmDLearnedManifoldParameters::identity(
+        EXPECTED_LAYERS,
+        EXPECTED_QUERY_HEADS,
+        EXPECTED_KV_HEADS,
+        BLOCKS_PER_HEAD,
+        INITIAL_SCALE,
+    )?;
+    let parameter_cid = public_parameter_identity(&parameters)?;
+    let transport = HelmDLearnedManifoldR4Transport::new(
+        0,
+        1,
+        parameters.clone(),
+        HelmDLearnedManifoldMetric::Lorentz,
+        HelmDLearnedManifoldIntervention::Coherent,
+    )?;
+    if transport.parameter_identity()? != parameter_cid
+        || !parameter_cid.starts_with("blake3:")
+        || expected_transport_source_pairs() != 36_720
+        || expected_nonidentity_source_frame_blocks() != 1_166_400
+        || expected_nonidentity_row_permutations() != 36_450
+    {
+        return Err("public parameter identity or exact intervention work count drifted".into());
+    }
+    let mut unavailable = UnavailablePayload {
+        schema: RESULT_SCHEMA.to_owned(),
+        issue: 973,
+        terminal: UNAVAILABLE_TERMINAL.to_owned(),
+        reason: "focused self-CID fixture".to_owned(),
+        validation_materialized: false,
+        checkpoint_exists: false,
+        d3_status: "NOT_RUN".to_owned(),
+        result_cid: String::new(),
+    };
+    unavailable.result_cid = result_payload_cid(&unavailable)?;
+    if unavailable.result_cid != result_payload_cid(&unavailable)? {
+        return Err("result empty-field self-CID convention drifted".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn helm_d_learned_manifold_r4_construction_validation_replay_failure_is_a_failed_result() {
+    let comparisons = DecisionComparisons {
+        donor_gauge_top1_matches: VALIDATION_DOCUMENTS * SCORE_POSITIONS,
+        gauge_minus_donor_nll: 0.0,
+        donor_gauge_mean_absolute_logit_delta: 0.0,
+        donor_gauge_maximum_relative_bound_excess: 0.0,
+        functional_retention: true,
+        matched_learned_parity: true,
+        lorentz_euclidean_advantage: true,
+        source_frame_control_separates: true,
+        value_control_separates: true,
+        order_key_control_separates: true,
+        all_arm_replay: false,
+        causal_work_valid: true,
+    };
+    assert_eq!(terminal_for(&comparisons), FAIL_TERMINAL);
+}
+
+#[test]
+#[ignore = "fits and evaluates the sealed 16-fit/8-validation HELM-D construction"]
+fn helm_d_learned_manifold_r4_construction_decision() -> TestResult {
+    let result_path = required_path_from_env(RESULT_OUTPUT_ENV)?;
+    let checkpoint_path = required_path_from_env(CHECKPOINT_ENV)?;
+    let mut validation_materialized = false;
+    match run_helm_d_learned_manifold_r4_construction(
+        &result_path,
+        &checkpoint_path,
+        &mut validation_materialized,
+    ) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = write_unavailable(
+                &result_path,
+                &error.to_string(),
+                validation_materialized,
+                checkpoint_path.is_file(),
+            );
+            Err(error)
+        }
+    }
+}
+
+fn run_helm_d_learned_manifold_r4_construction(
+    result_path: &Path,
+    checkpoint_path: &Path,
+    validation_materialized: &mut bool,
+) -> TestResult {
+    let total_started = Instant::now();
+    if env::var(CANONICAL_DETERMINISTIC_ENV).as_deref() != Ok("1") {
+        return Err(format!("{CANONICAL_DETERMINISTIC_ENV}=1 is required").into());
+    }
+    if result_path.exists() || checkpoint_path.exists() {
+        return Err("exclusive result or checkpoint path already exists".into());
+    }
+    let partition_path = required_path_from_env(PARTITION_ENV)?;
+    let partition_envelope = parse_partition(&fs::read(&partition_path)?)?;
+    let partition = &partition_envelope.manifest;
+    let tokenizer_path = path_from_env(TOKENIZER_ENV, DEFAULT_TOKENIZER);
+    let corpus_path = path_from_env(CORPUS_ENV, DEFAULT_CORPUS);
+    let model_path = path_from_env(MODEL_ENV, DEFAULT_MODEL);
+    // Before the checkpoint, only the adjacent manifest and the individually
+    // committed fit ranges may be read. Whole-corpus hashing is admission-gated.
+    verify_corpus_manifest(&corpus_path)?;
+    if file_cid(&tokenizer_path)? != partition.tokenizer_cid {
+        return Err("tokenizer identity differs from the frozen partition".into());
+    }
+    let tokenizer = Tokenizer::try_load(&tokenizer_path)?;
+    let workers = NonZeroUsize::new(SHARDS).ok_or("eight workers must be nonzero")?;
+    let oracle = HuggingFaceLlamaOracle::load_with_execution(
+        &model_path,
+        TeacherExecutionConfig::fixed_workers(workers),
+    )?;
+    if oracle.source_cid() != DONOR_CID || oracle.source_cid() != partition.donor_cid {
+        return Err("donor identity differs from the frozen partition".into());
+    }
+    let config = oracle.cfg();
+    if config.n_layers != EXPECTED_LAYERS
+        || config.n_heads != EXPECTED_QUERY_HEADS
+        || config.n_kv_heads != EXPECTED_KV_HEADS
+        || config.dim / config.n_heads != HEAD_WIDTH
+        || config.r4_attention
+        || config.seq_len < INPUT_POSITIONS
+    {
+        return Err("donor model geometry differs from the frozen construction operator".into());
+    }
+    let rope_theta = config.rope_theta;
+    let rope_interleaved = config.rope_interleaved;
+    let maximum_token_id = u32::try_from(config.vocab.checked_sub(1).ok_or("empty vocab")?)?;
+    let preparation = oracle.prepare_exact_execution(1)?;
+    if preparation.workers_observed != SHARDS || !preparation.backend_exercised {
+        return Err("exact eight-worker donor preparation was not exercised".into());
+    }
+    let implementation = implementation_identity()?;
+
+    let fit_trace_started = Instant::now();
+    let fit_documents =
+        materialize_documents(&corpus_path, &tokenizer, &partition.construction_fit, false)?;
+    if fit_documents
+        .iter()
+        .any(|document| document.tokens.len() != INPUT_POSITIONS)
+    {
+        return Err("fit materialization retained a future target".into());
+    }
+    let captures = capture_fit_documents(&oracle, &fit_documents)?;
+    let fit_trace_seconds = fit_trace_started.elapsed().as_secs_f64();
+
+    let preflight_started = Instant::now();
+    let preflight =
+        construction_preflight(&captures, maximum_token_id, rope_theta, rope_interleaved)?;
+    let canary = objective_canary(&captures, rope_theta, rope_interleaved)?;
+    let preflight_and_canary_seconds = preflight_started.elapsed().as_secs_f64();
+
+    let fit_started = Instant::now();
+    let lorentz = fit_arm(
+        HelmDLearnedManifoldMetric::Lorentz,
+        &captures,
+        FIT_DOCUMENTS,
+        rope_theta,
+        rope_interleaved,
+        ADAM_STEPS,
+    )?;
+    let euclidean = fit_arm(
+        HelmDLearnedManifoldMetric::Euclidean,
+        &captures,
+        FIT_DOCUMENTS,
+        rope_theta,
+        rope_interleaved,
+        ADAM_STEPS,
+    )?;
+    let lorentz_replay = fit_arm(
+        HelmDLearnedManifoldMetric::Lorentz,
+        &captures,
+        FIT_DOCUMENTS,
+        rope_theta,
+        rope_interleaved,
+        ADAM_STEPS,
+    )?;
+    let euclidean_replay = fit_arm(
+        HelmDLearnedManifoldMetric::Euclidean,
+        &captures,
+        FIT_DOCUMENTS,
+        rope_theta,
+        rope_interleaved,
+        ADAM_STEPS,
+    )?;
+    let mut replay = FitReplayReport {
+        lorentz_parameter_bytes_identical: lorentz.parameter_bytes
+            == lorentz_replay.parameter_bytes,
+        euclidean_parameter_bytes_identical: euclidean.parameter_bytes
+            == euclidean_replay.parameter_bytes,
+        lorentz_report_identical: lorentz.report == lorentz_replay.report,
+        euclidean_report_identical: euclidean.report == euclidean_replay.report,
+        replay_cid: String::new(),
+    };
+    replay.replay_cid = fit_replay_cid(&replay)?;
+    if !replay.lorentz_parameter_bytes_identical
+        || !replay.euclidean_parameter_bytes_identical
+        || !replay.lorentz_report_identical
+        || !replay.euclidean_report_identical
+    {
+        return Err("independent fit replay is not byte-identical".into());
+    }
+    let fit_and_replay_seconds = fit_started.elapsed().as_secs_f64();
+    let fit_trace_cid = aggregate_trace_cid(&captures);
+    let checkpoint = FitCheckpoint {
+        schema: CHECKPOINT_SCHEMA.to_owned(),
+        issue: 973,
+        contract_cid: implementation.contract_cid.clone(),
+        population_cid: CORPUS_CID.to_owned(),
+        partition_cid: partition.partition_cid.clone(),
+        manifest_cid: partition_envelope.manifest_cid.clone(),
+        donor_cid: DONOR_CID.to_owned(),
+        tokenizer_cid: partition.tokenizer_cid.clone(),
+        upstream_source_commit: HELM_D_UPSTREAM_COMMIT.to_owned(),
+        lorentz_policy: HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY.to_owned(),
+        euclidean_policy: HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY.to_owned(),
+        optimizer_specification: format!(
+            "128 full-batch f64 Adam steps; lr={LEARNING_RATE}; beta1={ADAM_BETA1}; beta2={ADAM_BETA2}; epsilon={ADAM_EPSILON}; ridge={RIDGE}; scale-floor={SCALE_FLOOR}; eight ordered shards"
+        ),
+        implementation: implementation.clone(),
+        exact_workers: SHARDS,
+        execution_preparation: preparation,
+        fit_trace_cid,
+        preflight: preflight.clone(),
+        canary: canary.clone(),
+        lorentz_parameters: lorentz.parameters.clone(),
+        lorentz_parameter_cid: lorentz.report.parameter_cid.clone(),
+        lorentz_fit_report: lorentz.report.clone(),
+        euclidean_parameters: euclidean.parameters.clone(),
+        euclidean_parameter_cid: euclidean.report.parameter_cid.clone(),
+        euclidean_fit_report: euclidean.report.clone(),
+        replay,
+        validation_materialized: false,
+        future_position_reads: captures
+            .iter()
+            .map(|capture| capture.decoder_audit.future_reads)
+            .sum(),
+        target_as_input_reads: 0,
+    };
+    let (checkpoint, validation_admission) =
+        write_and_read_checkpoint(checkpoint_path, checkpoint)?;
+
+    // This is the first operation permitted to materialize validation text,
+    // tokens, or targets. The exclusive checkpoint has already been read back.
+    let validation_started = Instant::now();
+    // Mark the seal opened before even the admitted whole-corpus identity scan
+    // so an unavailable result cannot claim validation stayed sealed after any
+    // validation-range bytes may have been streamed.
+    *validation_materialized = true;
+    let validation_documents = materialize_validation_documents(
+        &validation_admission,
+        &partition_envelope,
+        &corpus_path,
+        &tokenizer,
+    )?;
+    let donor = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Donor,
+        "donor",
+    )?;
+    let gauge = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Gauge,
+        "gauge",
+    )?;
+    let learned_lorentz = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Learned {
+            parameters: &checkpoint.checkpoint.lorentz_parameters,
+            metric: HelmDLearnedManifoldMetric::Lorentz,
+            intervention: HelmDLearnedManifoldIntervention::Coherent,
+        },
+        "learned_lorentz",
+    )?;
+    let learned_euclidean = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Learned {
+            parameters: &checkpoint.checkpoint.euclidean_parameters,
+            metric: HelmDLearnedManifoldMetric::Euclidean,
+            intervention: HelmDLearnedManifoldIntervention::Coherent,
+        },
+        "learned_euclidean",
+    )?;
+    let source_frame_permuted = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Learned {
+            parameters: &checkpoint.checkpoint.lorentz_parameters,
+            metric: HelmDLearnedManifoldMetric::Lorentz,
+            intervention: HelmDLearnedManifoldIntervention::SourceFramePermuted,
+        },
+        "source_frame_permuted",
+    )?;
+    let value_permuted = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Learned {
+            parameters: &checkpoint.checkpoint.lorentz_parameters,
+            metric: HelmDLearnedManifoldMetric::Lorentz,
+            intervention: HelmDLearnedManifoldIntervention::ValuePermuted,
+        },
+        "value_permuted",
+    )?;
+    let order_key_shuffled = run_arm(
+        &oracle,
+        &tokenizer,
+        &validation_documents,
+        ArmSpec::Learned {
+            parameters: &checkpoint.checkpoint.lorentz_parameters,
+            metric: HelmDLearnedManifoldMetric::Lorentz,
+            intervention: HelmDLearnedManifoldIntervention::OrderKeyShuffled,
+        },
+        "order_key_shuffled",
+    )?;
+    let comparisons = compare_decision_arms(
+        &donor,
+        &gauge,
+        &learned_lorentz,
+        &learned_euclidean,
+        &source_frame_permuted,
+        &value_permuted,
+        &order_key_shuffled,
+    )?;
+    let terminal = terminal_for(&comparisons).to_owned();
+    let validation_seconds = validation_started.elapsed().as_secs_f64();
+    let mut payload = ResultPayload {
+        schema: RESULT_SCHEMA.to_owned(),
+        issue: 973,
+        terminal,
+        partition_cid: partition.partition_cid.clone(),
+        checkpoint_cid: checkpoint.checkpoint_cid,
+        implementation,
+        preflight,
+        canary,
+        comparisons,
+        donor: donor.report,
+        gauge: gauge.report,
+        learned_lorentz: learned_lorentz.report,
+        learned_euclidean: learned_euclidean.report,
+        source_frame_permuted: source_frame_permuted.report,
+        value_permuted: value_permuted.report,
+        order_key_shuffled: order_key_shuffled.report,
+        execution_snapshot: oracle.execution_snapshot(),
+        timing: TimingReport {
+            fit_trace_seconds,
+            preflight_and_canary_seconds,
+            fit_and_replay_seconds,
+            validation_seconds,
+            total_seconds: total_started.elapsed().as_secs_f64(),
+        },
+        validation_materialized_after_checkpoint: true,
+        d3_status: "NOT_RUN".to_owned(),
+        result_cid: String::new(),
+    };
+    payload.result_cid = result_payload_cid(&payload)?;
+    let result_cid = write_result(result_path, &payload)?;
+    eprintln!(
+        "HELM-D learned-manifold construction terminal={} result_cid={result_cid}",
+        payload.terminal
+    );
+    Ok(())
+}

--- a/crates/uor-r4-model-source/src/attention.rs
+++ b/crates/uor-r4-model-source/src/attention.rs
@@ -143,26 +143,100 @@ pub struct CausalAttentionSourceContext {
     pub source_position: usize,
 }
 
+/// Immutable layer-level coordinates for an optional learned projection after
+/// the checkpoint's dense Q/K/V matmuls and before RoPE rotates Q and K.
+///
+/// The hook receives every query head and the current grouped-query K/V rows in
+/// their canonical model coordinates. Implementations can therefore apply one
+/// declared learned projection before positional or geometric frame actions
+/// without taking ownership of the checkpoint matmuls themselves.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CausalAttentionProjectionContext {
+    /// Zero-based decoder layer.
+    pub layer: usize,
+    /// Current causal position.
+    pub query_position: usize,
+    /// Number of query heads packed in the mutable query slice.
+    pub query_heads: usize,
+    /// Number of grouped-query key/value heads packed in each K/V slice.
+    pub key_value_heads: usize,
+    /// Number of scalar lanes in each query or key/value head.
+    pub head_size: usize,
+}
+
+/// Decoder-owned census for the optional pre-RoPE learned-projection seam.
+///
+/// This is separate from [`CausalAttentionTransportAudit`] so existing
+/// full-prefix transport evidence remains wire-compatible while a construction
+/// experiment can prove that every selected layer received exactly one complete
+/// projected Q/K/V tuple.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CausalAttentionProjectionAudit {
+    /// Layer-level hook invocations.
+    pub hook_calls: u64,
+    /// Query-head vectors presented across all hook invocations.
+    pub query_vectors: u64,
+    /// Key-head vectors presented across all hook invocations.
+    pub key_vectors: u64,
+    /// Value-head vectors presented across all hook invocations.
+    pub value_vectors: u64,
+    /// Scalar query lanes presented across all hook invocations.
+    pub query_lanes: u64,
+    /// Scalar key lanes presented across all hook invocations.
+    pub key_lanes: u64,
+    /// Scalar value lanes presented across all hook invocations.
+    pub value_lanes: u64,
+}
+
+impl CausalAttentionProjectionAudit {
+    pub(crate) fn record(
+        &mut self,
+        context: CausalAttentionProjectionContext,
+        query_lanes: usize,
+        key_lanes: usize,
+        value_lanes: usize,
+    ) {
+        self.hook_calls = self.hook_calls.saturating_add(1);
+        self.query_vectors = self
+            .query_vectors
+            .saturating_add(context.query_heads as u64);
+        self.key_vectors = self
+            .key_vectors
+            .saturating_add(context.key_value_heads as u64);
+        self.value_vectors = self
+            .value_vectors
+            .saturating_add(context.key_value_heads as u64);
+        self.query_lanes = self.query_lanes.saturating_add(query_lanes as u64);
+        self.key_lanes = self.key_lanes.saturating_add(key_lanes as u64);
+        self.value_lanes = self.value_lanes.saturating_add(value_lanes as u64);
+    }
+}
+
 /// Object-safe coordinate-transport and attention-operator seam around dense
 /// causal attention.
 ///
-/// The decoder retains ownership of learned Q/K/V and Wo projections, RoPE,
-/// the complete causal prefix, residuals, FFN, final norm, and the LM head.
+/// The decoder retains ownership of the checkpoint's dense Q/K/V and Wo
+/// projections, RoPE, the complete causal prefix, residuals, FFN, final norm,
+/// and the LM head. An implementation may mutate the freshly projected Q/K/V
+/// tuple exactly once before RoPE through
+/// [`transform_projected_qkv_before_rope`](Self::transform_projected_qkv_before_rope).
 /// The default score/normalization and value-aggregation hooks preserve the
 /// ordinary scaled-dot-product, stable-softmax, linear-value operator exactly.
 /// Implementations may instead declare an intrinsic compatibility function or
 /// geometric weighted centroid while retaining every surrounding decoder
 /// operation:
 ///
-/// 1. [`transform_query`](Self::transform_query) maps the current query;
-/// 2. [`transport_key`](Self::transport_key) and
+/// 1. [`transform_projected_qkv_before_rope`](Self::transform_projected_qkv_before_rope)
+///    may apply one learned layer-level projection before RoPE;
+/// 2. [`transform_query`](Self::transform_query) maps the current post-RoPE query;
+/// 3. [`transport_key`](Self::transport_key) and
 ///    [`transport_value`](Self::transport_value) map every admitted cached
 ///    source from its frame to the query frame;
-/// 3. [`score_and_normalize`](Self::score_and_normalize) assigns normalized
+/// 4. [`score_and_normalize`](Self::score_and_normalize) assigns normalized
 ///    weights over the complete packed causal prefix;
-/// 4. [`weighted_value_centroid`](Self::weighted_value_centroid) aggregates
+/// 5. [`weighted_value_centroid`](Self::weighted_value_centroid) aggregates
 ///    the packed query-frame values; and
-/// 5. [`output_to_model_frame`](Self::output_to_model_frame) maps the dense
+/// 6. [`output_to_model_frame`](Self::output_to_model_frame) maps the dense
 ///    aggregate back before the unchanged Wo projection.
 ///
 /// All input and output slices have the model's complete head width. The
@@ -199,6 +273,24 @@ pub trait CausalAttentionTransport: Send {
 
     /// Admit the current token once, before any selected layer processes it.
     fn begin_position(&mut self, token: usize, position: usize);
+
+    /// Optionally mutate one complete checkpoint-projected Q/K/V tuple before
+    /// positional rotation.
+    ///
+    /// The default is an exact no-op. The query slice packs every query head;
+    /// key and value pack only the current position's grouped-query K/V heads.
+    /// Slice lengths are fixed by `context` and cannot be changed. An
+    /// implementation that detects an invalid parameter or arithmetic state
+    /// records that failure in [`status`](Self::status); the existing public
+    /// step boundary then withholds logits and returns a transport fault.
+    fn transform_projected_qkv_before_rope(
+        &mut self,
+        _context: CausalAttentionProjectionContext,
+        _query: &mut [f32],
+        _key: &mut [f32],
+        _value: &mut [f32],
+    ) {
+    }
 
     /// Express a post-RoPE query in its query-local frame.
     fn transform_query(

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -483,6 +483,7 @@ pub struct CausalAttentionTransportSession {
     selected_layers: Vec<bool>,
     scratch: CausalAttentionTransportScratch,
     audit: attention::CausalAttentionTransportAudit,
+    pre_rope_projection_audit: attention::CausalAttentionProjectionAudit,
     source_cid: String,
     next_position: usize,
 }
@@ -511,9 +512,16 @@ impl CausalAttentionTransportSession {
         self.audit
     }
 
+    /// Decoder-owned proof that the optional learned Q/K/V projection hook was
+    /// invoked once per selected layer and received complete projected vectors.
+    pub fn pre_rope_projection_audit(&self) -> attention::CausalAttentionProjectionAudit {
+        self.pre_rope_projection_audit
+    }
+
     /// Clear counters without changing model, KV-cache, or transport state.
     pub fn clear_audit(&mut self) {
         self.audit = attention::CausalAttentionTransportAudit::default();
+        self.pre_rope_projection_audit = attention::CausalAttentionProjectionAudit::default();
     }
 
     /// Deterministic identity of the retained residual, KV-cache, and logits.
@@ -546,6 +554,7 @@ impl CausalAttentionTransportSession {
         self.transport.reset();
         self.scratch.clear();
         self.audit = attention::CausalAttentionTransportAudit::default();
+        self.pre_rope_projection_audit = attention::CausalAttentionProjectionAudit::default();
         self.next_position = 0;
     }
 }
@@ -585,6 +594,7 @@ struct CausalAttentionLayerOverride<'a> {
     transport: &'a mut dyn attention::CausalAttentionTransport,
     scratch: &'a mut CausalAttentionTransportScratch,
     audit: &'a mut attention::CausalAttentionTransportAudit,
+    pre_rope_projection_audit: &'a mut attention::CausalAttentionProjectionAudit,
 }
 
 fn causal_attention_layer_mask(
@@ -1245,6 +1255,7 @@ impl Llama {
             selected_layers,
             scratch,
             audit,
+            pre_rope_projection_audit,
             ..
         } = session;
         transport.begin_position(token, pos);
@@ -1266,6 +1277,7 @@ impl Llama {
                     transport: transport.as_mut(),
                     scratch,
                     audit,
+                    pre_rope_projection_audit,
                 };
                 self.layer_forward_with_geometry(
                     state,
@@ -1453,7 +1465,7 @@ impl Llama {
         fast_matmul: bool,
         geometry: Option<&mut geometric_decoder::GeometricRuntime>,
         mut source_capture: Option<&mut geometric_training::SourceLayerCapture>,
-        causal_attention: Option<&mut CausalAttentionLayerOverride<'_>>,
+        mut causal_attention: Option<&mut CausalAttentionLayerOverride<'_>>,
     ) {
         let c = &self.cfg;
         let (dim, hid) = (c.dim, c.hidden);
@@ -1516,6 +1528,24 @@ impl Llama {
                         dim,
                         fast_matmul,
                     );
+                }
+
+                if let Some(causal_attention) = causal_attention.as_deref_mut() {
+                    let context = attention::CausalAttentionProjectionContext {
+                        layer: l,
+                        query_position: pos,
+                        query_heads: c.n_heads,
+                        key_value_heads: c.n_kv_heads,
+                        head_size,
+                    };
+                    let key = &mut st.key_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                    let value = &mut st.value_cache[loff + pos * kv_dim..loff + (pos + 1) * kv_dim];
+                    causal_attention
+                        .transport
+                        .transform_projected_qkv_before_rope(context, &mut st.q, key, value);
+                    causal_attention
+                        .pre_rope_projection_audit
+                        .record(context, dim, kv_dim, kv_dim);
                 }
 
                 // RoPE: converted llama2.c checkpoints interleave pairs; native
@@ -3691,6 +3721,7 @@ impl HuggingFaceLlamaOracle {
             selected_layers,
             scratch,
             audit: attention::CausalAttentionTransportAudit::default(),
+            pre_rope_projection_audit: attention::CausalAttentionProjectionAudit::default(),
             source_cid: self.kappa.clone(),
             next_position: 0,
         })
@@ -5276,6 +5307,100 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct PreRopeProjectionObservations {
+        contexts: Vec<attention::CausalAttentionProjectionContext>,
+        query_at_position_one: Option<[u32; 2]>,
+        key_at_position_one: Option<[u32; 2]>,
+        value_at_position_one: Option<[u32; 2]>,
+    }
+
+    struct PreRopeProjectionProbe {
+        observations: std::sync::Arc<std::sync::Mutex<PreRopeProjectionObservations>>,
+    }
+
+    impl attention::CausalAttentionTransport for PreRopeProjectionProbe {
+        fn policy_identity(&self) -> &str {
+            "pre-rope-projection-probe/1"
+        }
+
+        fn begin_position(&mut self, _token: usize, _position: usize) {}
+
+        fn transform_projected_qkv_before_rope(
+            &mut self,
+            context: attention::CausalAttentionProjectionContext,
+            query: &mut [f32],
+            key: &mut [f32],
+            value: &mut [f32],
+        ) {
+            self.observations
+                .lock()
+                .expect("projection observations lock")
+                .contexts
+                .push(context);
+            query.fill(0.0);
+            key.fill(0.0);
+            value.fill(0.0);
+            query[0] = 1.0;
+            key[0] = 1.0;
+            value[0] = 3.0;
+        }
+
+        fn transform_query(
+            &mut self,
+            context: attention::CausalAttentionHeadContext,
+            input: &[f32],
+            output: &mut [f32],
+        ) {
+            if context.query_position == 1 && context.head == 0 {
+                self.observations
+                    .lock()
+                    .expect("query observations lock")
+                    .query_at_position_one = Some([input[0].to_bits(), input[1].to_bits()]);
+            }
+            output.copy_from_slice(input);
+        }
+
+        fn transport_key(
+            &mut self,
+            context: attention::CausalAttentionSourceContext,
+            input: &[f32],
+            output: &mut [f32],
+        ) {
+            if context.query_position == 1 && context.source_position == 1 && context.head == 0 {
+                self.observations
+                    .lock()
+                    .expect("key observations lock")
+                    .key_at_position_one = Some([input[0].to_bits(), input[1].to_bits()]);
+            }
+            output.copy_from_slice(input);
+        }
+
+        fn transport_value(
+            &mut self,
+            context: attention::CausalAttentionSourceContext,
+            input: &[f32],
+            output: &mut [f32],
+        ) {
+            if context.query_position == 1 && context.source_position == 1 && context.head == 0 {
+                self.observations
+                    .lock()
+                    .expect("value observations lock")
+                    .value_at_position_one = Some([input[0].to_bits(), input[1].to_bits()]);
+            }
+            output.copy_from_slice(input);
+        }
+
+        fn output_to_model_frame(
+            &mut self,
+            _context: attention::CausalAttentionHeadContext,
+            input: &[f32],
+            output: &mut [f32],
+        ) {
+            output.copy_from_slice(input);
+        }
+    }
+
     #[derive(Default)]
     struct FaultingCausalAttentionTransport {
         faulted: bool,
@@ -5299,6 +5424,16 @@ mod tests {
         }
 
         fn begin_position(&mut self, _token: usize, _position: usize) {}
+
+        fn transform_projected_qkv_before_rope(
+            &mut self,
+            _context: attention::CausalAttentionProjectionContext,
+            _query: &mut [f32],
+            _key: &mut [f32],
+            _value: &mut [f32],
+        ) {
+            self.faulted = true;
+        }
 
         fn transform_query(
             &mut self,
@@ -5334,7 +5469,6 @@ mod tests {
             output: &mut [f32],
         ) {
             output.copy_from_slice(input);
-            self.faulted = true;
         }
     }
 
@@ -5489,6 +5623,96 @@ mod tests {
         assert_eq!(audit.future_reads, 0);
         assert_eq!(audit.maximum_query_position, Some(2));
         assert_eq!(audit.maximum_source_position, Some(2));
+
+        let projection_audit = transported.pre_rope_projection_audit();
+        assert_eq!(projection_audit.hook_calls, 6);
+        assert_eq!(projection_audit.query_vectors, 12);
+        assert_eq!(projection_audit.key_vectors, 12);
+        assert_eq!(projection_audit.value_vectors, 12);
+        assert_eq!(projection_audit.query_lanes, 48);
+        assert_eq!(projection_audit.key_lanes, 48);
+        assert_eq!(projection_audit.value_lanes, 48);
+    }
+
+    #[test]
+    fn pre_rope_projection_hook_runs_once_per_layer_before_rope() {
+        let oracle = tiny_geometric_oracle();
+        let head_size = oracle.cfg().dim / oracle.cfg().n_heads;
+        let first_angle = head_size / 2;
+        let expected_query_key = [
+            oracle.model.rope_cos[first_angle].to_bits(),
+            oracle.model.rope_sin[first_angle].to_bits(),
+        ];
+        let observations = std::sync::Arc::new(std::sync::Mutex::new(
+            PreRopeProjectionObservations::default(),
+        ));
+        let mut session = oracle
+            .new_causal_attention_transport_session(
+                Box::new(PreRopeProjectionProbe {
+                    observations: observations.clone(),
+                }),
+                attention::CausalAttentionLayerSelection::All,
+                4,
+            )
+            .expect("pre-RoPE projection session");
+        let mut logits = vec![0.0; oracle.cfg().vocab];
+        for (position, token) in [1usize, 3].into_iter().enumerate() {
+            oracle
+                .step_causal_attention_transport(&mut session, token, position, &mut logits)
+                .expect("pre-RoPE projection step");
+        }
+
+        let observations = observations.lock().expect("projection observations lock");
+        assert_eq!(
+            observations.contexts,
+            vec![
+                attention::CausalAttentionProjectionContext {
+                    layer: 0,
+                    query_position: 0,
+                    query_heads: 2,
+                    key_value_heads: 2,
+                    head_size: 4,
+                },
+                attention::CausalAttentionProjectionContext {
+                    layer: 1,
+                    query_position: 0,
+                    query_heads: 2,
+                    key_value_heads: 2,
+                    head_size: 4,
+                },
+                attention::CausalAttentionProjectionContext {
+                    layer: 0,
+                    query_position: 1,
+                    query_heads: 2,
+                    key_value_heads: 2,
+                    head_size: 4,
+                },
+                attention::CausalAttentionProjectionContext {
+                    layer: 1,
+                    query_position: 1,
+                    query_heads: 2,
+                    key_value_heads: 2,
+                    head_size: 4,
+                },
+            ]
+        );
+        assert_eq!(observations.query_at_position_one, Some(expected_query_key));
+        assert_eq!(observations.key_at_position_one, Some(expected_query_key));
+        assert_eq!(
+            observations.value_at_position_one,
+            Some([3.0f32.to_bits(), 0.0f32.to_bits()])
+        );
+        drop(observations);
+
+        let projection_audit = session.pre_rope_projection_audit();
+        assert_eq!(projection_audit.hook_calls, 4);
+        assert_eq!(projection_audit.query_vectors, 8);
+        assert_eq!(projection_audit.key_vectors, 8);
+        assert_eq!(projection_audit.value_vectors, 8);
+        assert_eq!(projection_audit.query_lanes, 32);
+        assert_eq!(projection_audit.key_lanes, 32);
+        assert_eq!(projection_audit.value_lanes, 32);
+        assert_eq!(session.audit().future_reads, 0);
     }
 
     #[test]
@@ -5593,8 +5817,10 @@ mod tests {
             .iter()
             .all(|value| value.to_bits() == 123.0f32.to_bits()));
         assert!(session.transport_status().is_err());
+        assert_eq!(session.pre_rope_projection_audit().hook_calls, 1);
         session.reset();
         assert_eq!(session.transport_status(), Ok(()));
+        assert_eq!(session.pre_rope_projection_audit().hook_calls, 0);
 
         let order_error = oracle.step_causal_attention_transport(&mut session, 1, 1, &mut logits);
         assert!(matches!(

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1530,10 +1530,13 @@ remains target-free negative history; its V2 noncommuting repair passed the
 bounded decoded contract. Its first document-scope corpus-induced placement
 passed target-free but failed the held-out promotion gate. The first bounded
 gated-delta core also trailed plain delta. Ordinary transported Q/K/V/O softmax
-attention is now the bounded qualified reference. Intrinsic V1 is unavailable
-before D3; only its fresh source-faithful learned-manifold construction
-qualifier is active. Multi-resonance replacement, recurrent factorization,
-final requalification, and #954 remain blocked.
+attention is now the bounded qualified reference. Intrinsic V1 is closed
+unavailable before D3. The only active successor is the fresh, non-D3,
+construction-only
+[`HelmDLearnedManifoldR4ConstructionV2`](helm_d_learned_manifold_r4_construction_973.md)
+qualifier; it is not an Intrinsic V1 attempt 03. D3, multi-resonance
+replacement, recurrent factorization, final requalification, and #954 remain
+blocked.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -890,10 +890,11 @@ decision without changing V1. Later corpus-placement, gated-delta, and direct
 V3 results were negative. `ConnectionGaugeCovarianceV4` subsequently passed
 construction covariance but failed held-out functional binding. `HELM-D-R4`
 architecture audit, ordinary-donor reproduction, and full-decoder R4/Spin
-softmax parity then passed. Intrinsic V1 is unavailable before D3; the current
-evaluation action is its fresh source-faithful learned-manifold construction
-qualifier. Resonance and recurrent lowering remain blocked conditional
-successors.
+softmax parity then passed. Intrinsic V1 is closed unavailable before D3. The
+single current evaluation action is the fresh, non-D3, construction-only
+[`HelmDLearnedManifoldR4ConstructionV2`](helm_d_learned_manifold_r4_construction_973.md)
+qualifier; it is not an Intrinsic V1 attempt 03. D3, resonance, and recurrent
+lowering remain blocked conditional successors.
 
 #973 owns paragraph, conversation, and bounded-global influence only after the
 one #989-matched #953 intervention qualifies the decoded loop.

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -157,10 +157,12 @@ target-free because the frozen swapped states commute. The independently
 frozen V2 repair subsequently retained one bounded noncommuting exact-spin
 mechanism. PR #997 then rejected the first natural componentwise placement,
 and the first bounded gated-delta core trailed its plain-delta comparator. The
-ordinary R4/Spin softmax oracle remains qualified. Intrinsic V1 is unavailable
-before D3; only the fresh source-faithful learned-manifold construction
-qualifier is active. Multi-resonance, recurrent factorization, final
-requalification, and #954 remain blocked.
+ordinary R4/Spin softmax oracle remains qualified. Intrinsic V1 is closed
+unavailable before D3. The single active successor is the fresh, non-D3,
+construction-only
+[`HelmDLearnedManifoldR4ConstructionV2`](helm_d_learned_manifold_r4_construction_973.md)
+qualifier; it is not an Intrinsic V1 attempt 03. Multi-resonance, recurrent
+factorization, final requalification, D3, and #954 remain blocked.
 No new H4,
 SpiralCore, harmonic, algebraic, placement, transport, or scale qualifier is
 eligible outside its exposed issue.
@@ -261,8 +263,10 @@ construction-bound exact-descriptor selector at each of paragraph and
   preserved construction covariance but failed held-out functional binding.
   `HELM-D-R4` architecture audit, ordinary donor reproduction, and
   gauge-equivalent full-decoder softmax parity on real causal language now
-  pass. Intrinsic V1 is unavailable before D3; the source-faithful
-  learned-manifold construction qualifier is the active rung. Calling a later
+  pass. Intrinsic V1 is closed unavailable before D3. The only active rung is
+  the fresh, non-D3, construction-only
+  [`HelmDLearnedManifoldR4ConstructionV2`](helm_d_learned_manifold_r4_construction_973.md)
+  qualifier. Calling a later
 #973 operator harmonic additionally requires an
 artifact-bound basis/mode contract. #962
 separately owns product chat integration and persisted, identity-scoped hive

--- a/docs/helm_d_learned_manifold_r4_construction_973.md
+++ b/docs/helm_d_learned_manifold_r4_construction_973.md
@@ -1,0 +1,415 @@
+# HELM-D learned-manifold R4 construction contract (#973)
+
+- **Status:** `NOT_RUN`
+- **Mechanism revision:** `HelmDLearnedManifoldR4ConstructionV2`
+- **Owner:** #973 under programme root #820
+- **Base revision:** to be bound before execution from the protected merge that
+  contains this contract
+- **Positive reference:**
+  [`HELM-D-R4` full-decoder softmax parity](helm_d_r4_softmax_decoder_973.md)
+- **Negative predecessor:**
+  [`IntrinsicLorentzR4AttentionV1` attempt 02](intrinsic_lorentz_r4_attention_973.md)
+- **Upstream architectural source:**
+  `Graph-and-Geometric-Learning/helm@7501deca8f413848bfef804be64ce874b72a3cd7`
+- **Result:** `NOT_RUN`
+
+This is an append-only experiment record. The pre-outcome contract below is
+frozen before construction fitting. Exact population identities, executable
+and parameter identities, execution evidence, and the terminal are added as
+dated sections after they exist; this section is not rewritten in response to
+an outcome.
+
+## Decision and scope
+
+The qualified `HELM-D-R4` reference established that ordinary causal softmax
+attention can run through coherent R4/Spin frames without changing the donor's
+function. `IntrinsicLorentzR4AttentionV1` then changed the score and centroid
+but learned only block coefficients and output scales. Its attempt 02 stopped
+before D3 because its construction covariance missed the frozen bound, and its
+diagnostic construction-validation loss trailed both donor and flat R4.
+
+This successor asks exactly one new question:
+
+> On a fresh, entirely non-D3 construction population, can learned R4-block
+> Q/K/V projections followed by HELM-D's Lorentz inner-product score, ordinary
+> causal softmax, and full-head normalized Lorentz centroid retain donor
+> behavior and outperform an independently fitted, exactly equal-capacity
+> Euclidean score/arithmetic-centroid arm, while geometry-destroying controls
+> lose?
+
+The experiment is construction-only. A positive authorizes only a separately
+frozen held-out contract. It does not reveal or reuse D3, authorize the
+multi-resonance sieve, recurrence, exact lowering, corpus/model scaling, E8
+expansion, close #973, or unblock #954.
+
+## Source-copy boundary
+
+The pinned HELM-D operator supplies these semantics:
+
+- learned affine Q/K/V projection before RoPE;
+- one hyperbolic `H^64` value per 64-spatial-lane head;
+- the Lorentz-inner-product score divided by a learned scale, plus a learned
+  scalar bias;
+- ordinary masked causal softmax; and
+- a normalized full-head Lorentz centroid.
+
+This contract copies those score, softmax, and centroid semantics. It does not
+claim upstream checkpoint parity or inherit any paper or checkpoint result.
+The learned UOR projection is deliberately bounded: it retains the donor's
+full dense Q/K/V maps and learns a block-diagonal `4 x 4` affine adapter over
+each donor-projected R4 block before RoPE. That adapter is a compact UOR
+parameterization within the upstream affine family, not a copy of HELM-D's
+full dense Q/K/V checkpoint maps. HELM-D's learned cross-head output map is
+also not copied in this rung; the donor's `W_o` is frozen unchanged.
+
+The deployed transformerless runtime contract is not exercised. Dense
+all-prefix attention, softmax, floating point, multiplication, allocation, and
+compiler-side fitting are permitted scientific-oracle work and receive no
+runtime-efficiency credit.
+
+## Frozen operator
+
+### Pre-RoPE learned projections
+
+The frozen donor is SmolLM2-135M: 30 layers, 9 query heads, 3 KV heads, head
+width 64, and sixteen ordered R4 blocks per head. After the donor's dense Q/K/V
+projection and before donor RoPE, role `r` applies
+
+```text
+z_(l,r,h,b) = A_(l,r,h,b) x_(l,r,h,b) + a_(l,r,h,b)
+```
+
+where `A` is `4 x 4` and `a` is R4. Query adapters are indexed by the 9 query
+heads. Key and value adapters are indexed by the 3 KV heads before the donor's
+unchanged GQA expansion. Query and key then receive the donor's unchanged
+RoPE; value does not. No adapter may read a future position, observed next
+token, validation metric, candidate label, document ID, or D3 identity.
+
+Each adapter contains 20 fitted scalars. The exact map budget per arm is:
+
+```text
+Q maps: 30 * 9 * 16 * 20 = 86,400
+K maps: 30 * 3 * 16 * 20 = 28,800
+V maps: 30 * 3 * 16 * 20 = 28,800
+map total:                    144,000
+scale + bias: 30 * 2 =            60
+total per learned arm:       144,060
+```
+
+There is exactly one learned positive scale and one learned scalar bias per
+layer. The bias is retained because it is present in the copied operator, but
+it is uniform across each causal softmax row and therefore predictively null;
+it receives no evidentiary credit.
+
+### Coherent R4/Spin transport and one full-head Lorentz point
+
+After RoPE, each query, key, and value head is stored as sixteen ordered R4
+blocks. The existing cumulative Spin/H4 frame supplies one coherent `SO(4)`
+action per block. The block-diagonal action is an `SO(64)` isometry. Keys and
+values are transported from each source frame to the current query frame, and
+the sixteen transported blocks are concatenated before the manifold lift.
+
+For unit curvature, define
+
+```text
+Phi(x)      = (sqrt(1 + ||x||^2), x),              x in R^64
+<X,Y>_L     = -X_0 Y_0 + sum_(a=1..64) X_a Y_a
+score(i,j)  = (2 + 2 <Phi(q_i), Phi(k_(j->i))>_L) / tau_l + beta_l
+alpha(i,*)  = stable_causal_softmax(score(i,0..i))
+S_i         = sum_(j<=i) alpha(i,j) Phi(v_(j->i))
+M_i         = S_i / sqrt(-<S_i,S_i>_L)
+read_i      = spatial(M_i)
+```
+
+`tau_l` is finite and positive. It is initialized to `24.0 = sqrt(9 * 64)`;
+after each optimizer step it is projected to at least `1e-6`. `beta_l` is
+initialized to zero. The centroid denominator uses compensated f64 sums and
+the stable identity
+
+```text
+sqrt(-<S,S>_L) = sqrt((S_0 - ||S_spatial||) * (S_0 + ||S_spatial||)).
+```
+
+Any non-finite lift, score, weight, aggregate, nonpositive scale, or
+non-timelike centroid fails closed. There is no Euclidean fallback. The
+centroid's spatial R4 blocks are mapped from the query frame to model
+coordinates and then passed through the frozen donor `W_o`, residual/FFN
+stack, final norm, and LM head.
+
+### Equal-capacity Euclidean arm
+
+The matched learned control has its own 144,060 parameters with the identical
+Q/K/V adapter shapes, GQA indexing, initialization, construction rows,
+optimizer, step count, precision, causal support, frame transport, frozen
+`W_o`, and full decoder. It changes only the score and value aggregate:
+
+```text
+score(i,j) = -||q_i - k_(j->i)||^2 / tau_l + beta_l
+read_i     = sum_(j<=i) alpha(i,j) v_(j->i)
+```
+
+Its learned parameters are independent of the Lorentz arm. Parameters are
+never shared after their identical initialization.
+
+## Frozen arms and controls
+
+Every arm uses the same selected causal prefixes, donor checkpoint, tokenizer,
+decoder, support, scored positions, and ordered work ledger.
+
+1. **Donor:** unchanged dense Q/K/V, RoPE, causal softmax, linear aggregate,
+   and `W_o`.
+2. **Gauge-equivalent R4 reference:** unchanged donor attention expressed in
+   coherent R4/Spin frames with exact source-to-query K/V transport.
+3. **Learned Lorentz:** the complete operator frozen above.
+4. **Learned Euclidean:** the exactly equal-capacity learned control frozen
+   above.
+5. **Source-frame-permuted:** learned Lorentz parameters with a frozen
+   non-identity permutation applied to source-frame identities only.
+6. **Value-permuted:** learned Lorentz weights with a frozen non-identity
+   permutation of causal values inside each row.
+7. **Order/key-shuffled:** learned Lorentz values remain in causal order while
+   a frozen non-identity permutation reassigns past keys to source positions.
+
+The three destructive controls perform the same number of adapter, transport,
+score, softmax, centroid, and decoder operations as learned Lorentz. A
+permutation must be non-identity on every scored row with at least two causal
+sources, or the control is unavailable.
+
+## Frozen construction population
+
+The raw population remains the 3,000-document SimpleWiki corpus at
+`blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf`.
+The donor remains
+`blake3:12d2cd8a877ef2cdcf785b3d4d1f373e0419074cc884aeaff06fc059686a5ba5`.
+The tokenizer identity is measured from bytes and bound in the partition
+append; it is not inferred from a path.
+
+For document ID bytes `id`, define
+
+```text
+selection_digest(id) =
+  BLAKE3("uor-r4.helm-d-learned-manifold-r4-construction/2\0" || UTF8(id))
+```
+
+Selection is frozen as follows:
+
+1. Stream and verify the raw corpus identity and count. The partition freezer
+   may encode enough source text to establish the target-blind `>=17` token
+   eligibility predicate and therefore transiently observes that token 16
+   exists. It must not persist, hash, compare, or branch on that token's
+   identity; only the boolean length predicate may affect selection.
+2. Exclude every D3 document under
+   `BLAKE3(UTF8(id))[0] mod 5 == 0`.
+3. Exclude parity document ID `12`.
+4. Exclude by both document ID and encoded-input CID every construction-fit,
+   construction-validation, and D3 identity committed by
+   `docs/intrinsic_lorentz_r4_attention_partition_973.json`, whose partition
+   CID is
+   `blake3:cad3dfd17159fdacc5c40e38753109c11764117e3c960f42b9b198d5731272a1`.
+   Opening the predecessor's committed identities is permitted; opening or
+   reusing its target bytes is forbidden.
+5. Encode exactly `title + "\n\n" + text`. A document is eligible only when
+   it contains at least 17 encoded tokens.
+6. Sort eligible documents by complete `selection_digest`, then UTF-8 ID.
+   Assign the first 16 to construction fit and the next 8 to construction
+   validation. No overlap or replacement is allowed.
+7. Bind every selected ID, title CID, first-16-input-token CID, corpus byte
+   range, donor CID, tokenizer CID, selection-policy CID, and exact exclusion
+   set before fitting begins. No target value or target CID is persisted or
+   serialized in this pre-fit partition commitment. The decision runner cannot
+   materialize any construction-validation source text or tokens before the
+   exclusive fit checkpoint has been written and read back successfully.
+
+Each document supplies exactly input positions `0..15`. Only query positions
+`8..15` are fitted or scored, with token `position + 1` used only as the later
+next-token scoring target. Denominators are therefore 128 construction-fit and
+64 construction-validation positions.
+
+This is not D3. No D3 ID, input, target commitment, reveal marker, recovery
+artifact, or result may be created by this experiment.
+
+## Frozen compiler-side fitter
+
+Both learned arms start from identity `4 x 4` adapter matrices, zero adapter
+biases, layer scale `24.0`, and layer bias zero. Frozen donor traces for the 16
+fit documents supply only causal attention rows and donor value aggregates;
+observed next-token targets are not optimizer inputs.
+
+For each scored row, the fit objective is the sum of:
+
+1. mean cross-entropy from the donor causal attention distribution to the
+   learned arm's causal attention distribution;
+2. mean per-lane squared error between the arm aggregate and donor aggregate,
+   after dividing both by `max(1, ||donor aggregate||_2)` for that row; and
+3. ridge `1e-6` from adapter matrices to identity and adapter biases to zero.
+
+The layer scale and uniform bias receive no ridge. The uniform bias is recorded
+but is mathematically null under the row-softmax objective.
+
+Each arm is fitted separately by exactly 128 full-batch Adam steps with
+learning rate `1e-3`, `beta1 = 0.9`, `beta2 = 0.999`, and `epsilon = 1e-8`.
+There is no early stop, convergence-selected step count, learning-rate search,
+validation selection, arm-specific schedule, retry with new initialization, or
+post-validation refit. Compiler arithmetic and optimizer moments use f64.
+Work is partitioned into eight deterministic shards and reduced in shard,
+layer, head, query-position, source-position, block, and lane order. Both arms
+must use the same shard schedule.
+
+Before validation bytes are materialized, an exclusive-create checkpoint must
+bind and immediately read back:
+
+- contract, population, partition, donor, tokenizer, and upstream-source CIDs;
+- exact operator and optimizer specifications;
+- implementation-source and executable CIDs;
+- worker count and ordered-work ledger;
+- both complete parameter byte streams and parameter CIDs;
+- fit objectives, gradients/work audit, fit report, and independent fit replay
+  CIDs; and
+- proof that no validation or future-token read occurred.
+
+If any identity differs, a checkpoint already exists, or fit replay is not
+byte-identical, construction validation remains sealed and the run is
+`UNAVAILABLE_HELM_D_MANIFOLD_CONSTRUCTION_EVIDENCE`.
+
+## Hard preflight and run contract
+
+The run does not open construction validation unless all of these focused
+checks pass:
+
+- pinned HELM-D score/softmax/centroid golden vectors;
+- identity pre-RoPE adapters reproduce donor post-RoPE Q/K/V and demonstrate
+  that the hook is exercised before RoPE;
+- central finite-difference gradients for Q, K, V, layer scale, softmax, and
+  centroid agree with the analytic fitter within the frozen unit tolerance;
+- a synthetic full-head census spanning every registered H4 frame preserves
+  the Lorentz hyperboloid residual, score, weights, and centroid covariance;
+  maximum centroid covariance error is at most `1e-8`;
+- the ordinary donor and coherent gauge reference preserve full-decoder output
+  over the frozen construction population within the empirical bounds below;
+- source-frame permutation is live;
+- the first two construction-fit documents lower the complete objective for
+  both learned arms under the frozen optimizer and exercise all eight shards;
+  and
+- the canary's measured extrapolation is at most two wall-clock hours for the
+  complete fit plus one validation pass on this host.
+
+The only named checks activated by this decision are:
+
+```text
+cargo test -p uor-r4-model-source --offline pre_rope_projection
+cargo test -p uor-r4-core --offline helm_d_learned_manifold_r4_construction
+cargo test -p uor-r4-core --release --offline \
+  --test helm_d_learned_manifold_r4_construction_973 \
+  freeze_helm_d_learned_manifold_r4_construction_partition \
+  -- --exact --ignored --nocapture --test-threads=1
+cargo test -p uor-r4-core --release --offline \
+  --test helm_d_learned_manifold_r4_construction_973 \
+  helm_d_learned_manifold_r4_construction_decision \
+  -- --exact --ignored --nocapture --test-threads=1
+```
+
+The freezer and decision runner are separate single-test launches. They must
+never share one unfiltered `--ignored` invocation.
+
+No workspace-wide QA, D3 runner, generation run, resonance test, recurrent
+test, lowering test, scale test, or #954 test is activated by this contract.
+
+The decision-bearing run contract is:
+
+```text
+metric to move:       64-position non-D3 construction-validation next-token NLL
+reachability ceiling: not inferable from V1 because projections and full-head
+                      manifold aggregation are newly learned; the two-document
+                      objective canary is the binding reachability instrument
+instrument:           all structural checks plus both canary objectives lower
+exit rule:            the empirical criteria and terminals below
+if positive:          freeze a new held-out contract; do not open D3 here
+if parity only:       retain functional parity and stop the curvature claim
+if negative:          revise only projection, score, centroid, or fitter
+if unavailable:       repair evidence/preflight without reading validation
+cost estimate:        at most two hours after release build, eight fixed shards
+```
+
+## Empirical criteria
+
+All NLL comparisons are paired over the same 64 construction-validation
+targets in nats per token.
+
+1. **Donor/gauge replay:** independent donor and gauge-reference executions
+   are byte-identical to their own replays; their top-1 tokens match on all 64
+   positions; gauge minus donor NLL is at most `0.002`; mean absolute logit
+   delta is at most `0.002`; and every logit satisfies
+   `abs(delta) <= 0.02 + 0.001 * max(abs(donor), abs(gauge))`.
+2. **Functional retention:** learned-Lorentz NLL is at most donor NLL plus
+   `0.05`.
+3. **Matched learned parity:** learned-Lorentz NLL is at most
+   learned-Euclidean NLL plus `0.05`.
+4. **Geometry-specific branch:** learned-Lorentz NLL is at most
+   learned-Euclidean NLL minus `0.01`, and each source-frame-permuted,
+   value-permuted, and order/key-shuffled control has NLL at least
+   learned-Lorentz NLL plus `0.02`.
+5. **Causality and replay:** every arm reports zero reads from positions later
+   than its query, zero target-as-input reads, the exact declared work, finite
+   outputs, and byte-identical parameter/report replay.
+
+Top-1 and decoded snippets are reported diagnostics. They cannot override the
+paired NLL rules.
+
+## Frozen terminals
+
+- `PASS_HELM_D_LEARNED_MANIFOLD_R4_CONSTRUCTION_AUTHORIZE_HELDOUT_FREEZE`
+  requires all availability, donor/gauge, functional-retention,
+  matched-parity, geometry-specific, causality, and replay criteria. It
+  authorizes only a new pre-outcome held-out freeze.
+- `RETAIN_HELM_D_MANIFOLD_FUNCTIONAL_PARITY_NO_CURVATURE_ADVANTAGE` requires
+  availability, donor/gauge replay, functional retention, matched learned
+  parity, destructive-control separation, causality, and replay, but the
+  learned Lorentz arm misses the `0.01` Euclidean advantage. The copied
+  mechanism may be retained as functional reference data but earns no
+  curvature claim.
+- `FAIL_HELM_D_MANIFOLD_CONSTRUCTION_REVISE_PROJECTION_SCORE_CENTROID_OR_TRAINING`
+  applies when evidence is available but functional retention, matched parity,
+  destructive-control separation, causality, or deterministic replay fails.
+  The next action is confined to the named learned-manifold seam; more data,
+  routes, dimensions, recurrence, and lowering are not authorized.
+- `UNAVAILABLE_HELM_D_MANIFOLD_CONSTRUCTION_EVIDENCE` applies when source,
+  population, hook ordering, numerical health, gradient/covariance preflight,
+  liveness, checkpoint identity, worker execution, or no-clobber evidence
+  cannot support a valid construction result. Validation remains unopened when
+  the unavailable condition occurs before the checkpoint gate.
+
+Every terminal keeps D3, multi-resonance replacement, recurrent factorization,
+exact/table lowering, corpus/model scaling, E8 expansion, and #954 blocked.
+Even the construction PASS only authorizes writing and merging a separate
+held-out pre-outcome contract.
+
+## Outcome append
+
+`NOT_RUN`. The target-blind construction partition is frozen below. Add the
+protected implementation revision, executable identity, measurements, and
+terminal only after the contract and implementation merge and the applicable
+seal has been opened in the declared order.
+
+### 2026-08-29 construction-partition freeze
+
+The exact, target-blind freezer completed before fitting or decision
+execution. Its tracked envelope is
+[`helm_d_learned_manifold_r4_construction_partition_973.json`](helm_d_learned_manifold_r4_construction_partition_973.json).
+
+- manifest CID:
+  `blake3:359b3270aaa0d3ac157280c9206ad820d18ee93932e0530552ebbb7935ac6410`;
+- partition CID:
+  `blake3:5c5a7dab9d7a0fbc9d176faafd49b42094ef89138cc32699dfc1b4fe937d1bde`;
+- tokenizer CID:
+  `blake3:70af0cb08bbcd3b323d3387ca1d7d33da39873820604d183711e8e99f9903fc1`;
+- selected population: 16 construction-fit plus 8 construction-validation
+  documents, with 24 distinct IDs and 24 distinct input CIDs;
+- predecessor exclusion census: 28 document IDs plus 28 predecessor-domain
+  input CIDs; and
+- serialized validation commitments contain only ID, selection digest, title
+  CID, both versioned input CIDs, and byte range. They contain no target value,
+  target CID, D3 identity, or token sequence.
+
+The learned fit, validation materialization, D3, and decision terminal remain
+`NOT_RUN`. The implementation base revision and executable identity will be
+bound only after protected delivery of this contract and freezer.

--- a/docs/helm_d_learned_manifold_r4_construction_partition_973.json
+++ b/docs/helm_d_learned_manifold_r4_construction_partition_973.json
@@ -1,0 +1,311 @@
+{
+  "manifest_cid": "blake3:359b3270aaa0d3ac157280c9206ad820d18ee93932e0530552ebbb7935ac6410",
+  "manifest": {
+    "schema": "uor-r4.helm-d-learned-manifold-r4-construction-partition/2",
+    "issue": 973,
+    "selection_policy": "BLAKE3(domain-nul-UTF8(id)); exclude reserved digest class, id 12, and every predecessor id/input CID; eligible encoded length >=17; sort complete digest then UTF8 id; first 16 fit, next 8 validation; commit id/title CID/input CID/byte span only",
+    "selection_policy_cid": "blake3:69e96d1969425d6579936a537dae9d8660948ca86226bf6061df1cf807a220cd",
+    "corpus_cid": "blake3:194db0eebf2d49823ece01ee935447a0cc9edeaf018454ceea480ce7590132cf",
+    "corpus_documents": 3000,
+    "donor_cid": "blake3:12d2cd8a877ef2cdcf785b3d4d1f373e0419074cc884aeaff06fc059686a5ba5",
+    "tokenizer_cid": "blake3:70af0cb08bbcd3b323d3387ca1d7d33da39873820604d183711e8e99f9903fc1",
+    "upstream_source_commit": "7501deca8f413848bfef804be64ce874b72a3cd7",
+    "required_tokens_per_document": 17,
+    "input_positions": 16,
+    "scored_positions": [
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "exclusions": {
+      "predecessor_partition_cid": "blake3:cad3dfd17159fdacc5c40e38753109c11764117e3c960f42b9b198d5731272a1",
+      "document_ids": [
+        "195",
+        "309",
+        "310",
+        "3466",
+        "358",
+        "3762",
+        "3890",
+        "431",
+        "4326",
+        "453",
+        "4586",
+        "4700",
+        "4964",
+        "6617",
+        "6828",
+        "7328",
+        "7554",
+        "7593",
+        "7636",
+        "7796",
+        "7905",
+        "8152",
+        "8548",
+        "8561",
+        "8639",
+        "9148",
+        "9252",
+        "9438"
+      ],
+      "input_cids": [
+        "blake3:0468406058f3c059fa70629f607efc7da7b5973ad68329ae209d52fbcae1da7f",
+        "blake3:14cb7125d88e37fe3e99ea6929ee6dd5b507b6ea76acc4468c71d98a86c0fa99",
+        "blake3:2425006c613f16e0213b23bf49ab1814fab3d40574ba73bc93d6ea2c7fb31ba6",
+        "blake3:2e745bd28216424a02475ecc2dbca965496545f6a19afec7a46d69deba8360bd",
+        "blake3:37aaa8420b69eda4a7c7e447e6600d54435d4496dbb669675904c457c86e56ea",
+        "blake3:3d36bedb0ced9f95d0326d43b1b6926bcf781a746a002eefd220d8119cef621d",
+        "blake3:3da062ddf6a7666c11010c4ac043b9457d612572c6096f81b87d79de9d8b7fd2",
+        "blake3:4fa98c7fc3e7213dce69a6dfcaa30e4aec5d9e7e4dad0493e6005f1b557b9522",
+        "blake3:5253d445d0136356b2e0a976442c014227b9a9848c8f0d23328d9ad15d697e06",
+        "blake3:56ef6ab07ff840a111857a497907e0627c5232f0159e21ee38f0aa3b3fd1e601",
+        "blake3:5886d29342c89967d9be3d844fd48941c9a9424106609026aae2ad518369e396",
+        "blake3:627c455a8d2ebcf6fbf306bf4078b3d4d6dae14a873295a2c8e4aa3921df90bd",
+        "blake3:6826ac63e3c18d89d127383cf100899de7712fcb218165af9f79dfb2091b8ad9",
+        "blake3:6b9a7086af394d63da65c522ae7a1cf8c51f5c76310be78dea10d593ba73831f",
+        "blake3:735a58f97d8046446019727feedb66dfffe1d9ae3a3450d2b8c75fd4d380aae5",
+        "blake3:73781877347ddec406621384acc0d6b51678d3ed9fce836993f7834896082408",
+        "blake3:9125197e5bfd3dc9b28a12fb26a86ed64b59491d19f708d22b945e82ca999aea",
+        "blake3:975430a889791da2f568243598c26b048cc97b1190f3e6b8ff62e5e4085c4466",
+        "blake3:a74694e7b0361260d80e27da59f83d72bbb60bc82b440677af0a354d8c0e8e7c",
+        "blake3:afd8e2b7e0024e2c3bbfc349f88be0a133c295245f13710ebb9151d3ed294485",
+        "blake3:c2e660d64e49fa40222afec296b67aa908a8e2f18124c1e923b4936b3b4b698a",
+        "blake3:cdac8ec5c38aa55f9eac5a962e37b860b3fff28d23464b99c519be5080708e78",
+        "blake3:d8c37ef20742ad04d6d2de3b99aa036e55da015649378cd4cd2ef936ccdf5429",
+        "blake3:db19ab0ba2ab5c2167ae66bf7b82e566713f016f448be99c131a076f615da1d3",
+        "blake3:e6b63c9838c3629f8f93a127c0b5f12635b9bbd09311e3728ace4f50165c0251",
+        "blake3:e8dd727070571368f8b6a5d3a97037ddeb60dc3db443264314e0e2b83c4934b6",
+        "blake3:f8bdf744d6e7fa1dc6bf2f4e023892ed0dca4ec5cb3d4c1c9c530ebc466a2282",
+        "blake3:fb5b802f7c49b8835bb64deff3b0d6f1bc9d840ea053a9102e8b41026d82434c"
+      ],
+      "exclusion_cid": "blake3:3f058230e39253b6f66add5a2a4de57c231299bce4a68d09d1c17be54a735bf1"
+    },
+    "construction_fit": [
+      {
+        "id": "8503",
+        "selection_digest": "blake3:0008014e44c6637ec256cf8245aca6a62781cd08725177b17b6d561e5876b11e",
+        "title_cid": "blake3:7991ccb782360ce7537deaa1723aab8317b8a59b9cc4e10fd03f93e296eb0263",
+        "input_cid": "blake3:b4560cd48b6c2c7572d286f5efaaa0571ec4e3ea42c1341a7bd00f3dd9464bd8",
+        "predecessor_domain_input_cid": "blake3:b203322b7f195ab7571f3565a0ddd6a28909c8fafadbadffcf43aa4e3dc03827",
+        "corpus_byte_offset": 10825224,
+        "corpus_byte_length": 1197
+      },
+      {
+        "id": "7754",
+        "selection_digest": "blake3:0046603cd6b277d4f9a984438424eb268980a525401d18b9d971e511810e5f4a",
+        "title_cid": "blake3:95cfcdd9cd7715789fb2ffda641f63ff44a4f04a8a4158f31d7926970c30c0a8",
+        "input_cid": "blake3:7af885edd623f53d2065635afb082a9732f05f2f39431e7c135a54e66b134f9c",
+        "predecessor_domain_input_cid": "blake3:f331aaf0014ceb8a04d2b45f762d80d532f19fd6336fa68d0be21d455527502b",
+        "corpus_byte_offset": 9496008,
+        "corpus_byte_length": 1086
+      },
+      {
+        "id": "3956",
+        "selection_digest": "blake3:00558af0d311c481348f3e9fc78c2d9bbe149633c33f5ffbd9a98811c0e7099a",
+        "title_cid": "blake3:a6722cadd8ec4fd7bd68b59635cdc9518ad7e329c6afbe33d44104461967b2a9",
+        "input_cid": "blake3:f7a6482e9beb83901c3a8092ff9ae0c08c215dda1deceba7733f683a772c0552",
+        "predecessor_domain_input_cid": "blake3:5e68e449303ed2e88918960c35c348aa446232ec4e1a13331470752f06965d66",
+        "corpus_byte_offset": 4183397,
+        "corpus_byte_length": 17409
+      },
+      {
+        "id": "7315",
+        "selection_digest": "blake3:006df1fbd0f2f0bd5b9965b46bac0e73225476eb2e6eefa2816bacfd306ded7a",
+        "title_cid": "blake3:e4a83c31b370c3075509957466604b0255dd58425aa3b85ce57fcfe1537dd26c",
+        "input_cid": "blake3:dc334c67f5b4022b683e84a2d5a8c8347750165c8da260a3666e2d219102597b",
+        "predecessor_domain_input_cid": "blake3:d99026eaa6cfba15317412ad91593b55715f7df3c700ebed0d512b97f3a959ab",
+        "corpus_byte_offset": 8436785,
+        "corpus_byte_length": 1519
+      },
+      {
+        "id": "476",
+        "selection_digest": "blake3:0076bcd0b6e85a4aa5ef876bf6363bd902ea0b8193c1c4ef8c8be15098be8106",
+        "title_cid": "blake3:a2131ed774e29410edd38ab63ba6a2bdafd7323bad036a6c5419173fd996babd",
+        "input_cid": "blake3:62bba3331d5ad505d75a38a820b5da9bf354fc4a0405e408b3fa0eee11ef7ace",
+        "predecessor_domain_input_cid": "blake3:2b8c271b0406ef2330fdcc5d99f8b6fa4ce0334dcb8d8c2236e8a7e8b2aec24b",
+        "corpus_byte_offset": 1085159,
+        "corpus_byte_length": 1352
+      },
+      {
+        "id": "4749",
+        "selection_digest": "blake3:00a4b7db92a4df422fded3b5a1e6dc828f619deebb51676aa7e6392fabd7ecc4",
+        "title_cid": "blake3:da5d706f4da35540c08b4b4a4e3f98c1849c49d88e5fed02e76a6d114bcf7975",
+        "input_cid": "blake3:5b3abcde79a7a8b2edbca2d25a69db7141313e280d42c88510b0ec7e09db73f8",
+        "predecessor_domain_input_cid": "blake3:8485f4615d3ffa505e88f2df07e8e62f89d1ba1d962114f6006acffdf4489982",
+        "corpus_byte_offset": 5580260,
+        "corpus_byte_length": 1612
+      },
+      {
+        "id": "7525",
+        "selection_digest": "blake3:0115315a2fdf4b6e9e2da30b5d300f4a1ce3c910db1d854abf15498ad58ab246",
+        "title_cid": "blake3:1165e45ec950931ed30b82af016cd42330ac0720cc1ef54383b313fa0fa4b11d",
+        "input_cid": "blake3:4ab1b0712f755e36203ae25fd9326e1924b029c5ecf292340b1277e0ac084f6a",
+        "predecessor_domain_input_cid": "blake3:6dacaf7d48ea628e3ee69cf1cd1e7a3603d0dcd90c27583685509eafeaf3a4b3",
+        "corpus_byte_offset": 8897913,
+        "corpus_byte_length": 794
+      },
+      {
+        "id": "8141",
+        "selection_digest": "blake3:0126b24eea399f2300343561243208b3d61373c6031e11ab9eb90ae4acfa990a",
+        "title_cid": "blake3:d42998794eeb2d830bc9ffbeadeff6c11ae3a5070ffff3e486b7fce87a62ce09",
+        "input_cid": "blake3:db6342f7efd03b0d20daca8d73154a498e417f6981dad055288684a2d0fe3456",
+        "predecessor_domain_input_cid": "blake3:4bae000e5f2539d47c547bce0cd96e16a8ee9b7ae3e88ca92fb94e6c3962a4fd",
+        "corpus_byte_offset": 10164833,
+        "corpus_byte_length": 1587
+      },
+      {
+        "id": "6309",
+        "selection_digest": "blake3:0135dd498a61d4b4d4797e18ed4262fcfc47924c152ee9abe971ac543717f259",
+        "title_cid": "blake3:abc23fed761959f5882a3476dad28d3e0de1bdc9c98c0d10b731f8976321b73c",
+        "input_cid": "blake3:721a1531d9ab32c9906c7f9c910453291ecb5130ae3aa27c0b18632d63986189",
+        "predecessor_domain_input_cid": "blake3:a53e72da50e6c6d4a2fed4cdbaa0b2829b45710c8c925dc4263d27240b93a098",
+        "corpus_byte_offset": 7590491,
+        "corpus_byte_length": 4356
+      },
+      {
+        "id": "271",
+        "selection_digest": "blake3:01587ee1807234339b30172e461bab048ccf4cce9175ceeee2febc5067d4f9a6",
+        "title_cid": "blake3:20829979fb32a71d829cb7979c35df19d6c1968d8f7b1d801e2d2507b3bc35d5",
+        "input_cid": "blake3:8426180a40a5479d46c2d469d77a67c337ca029dd11b0aa5fb57bb32ceb660b4",
+        "predecessor_domain_input_cid": "blake3:cc1ba8e47f8aa888204ad3482a23b68510488cdc749b337019d61f8953c3dd78",
+        "corpus_byte_offset": 601058,
+        "corpus_byte_length": 1004
+      },
+      {
+        "id": "6749",
+        "selection_digest": "blake3:0159e1da228da75aa2f8713cad069377ae86568f83fdb83f1a93ed28c33918f4",
+        "title_cid": "blake3:ff8d692c190bc3448163121be243317a4611b90ffe67b3da6960980218bac882",
+        "input_cid": "blake3:03cf55adc3a1974893b5c193b1c15deeb6e1029accbb89cd5baa840d526602dc",
+        "predecessor_domain_input_cid": "blake3:b6d79455da66ef58a17158405c5cc44e389877026d9c85dbf0585cf4194d4103",
+        "corpus_byte_offset": 8068537,
+        "corpus_byte_length": 700
+      },
+      {
+        "id": "7604",
+        "selection_digest": "blake3:017178c1c489a347613831d80e686265d62bf644e70551df9afe0c10418e4d26",
+        "title_cid": "blake3:dacc45d1e86b26b1014b1669fb9af33c5960f36ebdccede42def96d2210d97c1",
+        "input_cid": "blake3:55542030f71a839c4ced97dba7e4dbb86c1839d40c25fcd50fbb4d6d28853c4a",
+        "predecessor_domain_input_cid": "blake3:2c3a93ff1c79cdde88fcbe0756b43c0e1931eeac4d62c00e61ebbf79be59f069",
+        "corpus_byte_offset": 9120278,
+        "corpus_byte_length": 4016
+      },
+      {
+        "id": "8384",
+        "selection_digest": "blake3:018c8c4410ea18b3dacf8b641d444adc4af9a54ea439ee71e16354ed94135abd",
+        "title_cid": "blake3:c994763be41660a29e86919c153d94f3f41c61f8a14a94a8b2c0e976f347f83c",
+        "input_cid": "blake3:ea4853fc4dfb25cfc8a47dc35886f18165cadcbe5ef14660fdf063d459086a21",
+        "predecessor_domain_input_cid": "blake3:d00ac696da20877bab8ca7bda1b39abe6ea47bab2c7dd0d2e4aec95512b75889",
+        "corpus_byte_offset": 10582764,
+        "corpus_byte_length": 9702
+      },
+      {
+        "id": "7183",
+        "selection_digest": "blake3:0195ebeaf7015ab0443e27685f01c4790239014f5ea0db1bdef9ef3e7aa9a03a",
+        "title_cid": "blake3:b32e7c3d9a31c36a8ac9d3d951024aa4e40b5727f3ac646778cf7891e3e3ffc0",
+        "input_cid": "blake3:ebba94afb83ed82ee4480f8f8a77280a1c5aec492b7c906a48992e204e83a9bd",
+        "predecessor_domain_input_cid": "blake3:d986014ea7a49effb1b0957725652f8a21e3b53a2fa81cceb6f46ef2a14a9347",
+        "corpus_byte_offset": 8347073,
+        "corpus_byte_length": 6953
+      },
+      {
+        "id": "3621",
+        "selection_digest": "blake3:01abda7fa27af86c07f8dc330f808564dbeaee166f97ad516c9f730638b138b6",
+        "title_cid": "blake3:29b8d0080106e773dfa4788a4ec80b2a264f6fc551f053f37dc191b569d19443",
+        "input_cid": "blake3:35e6e52c36cd38bb80736b1cd9fc27492ee5d875a9bf76c789d2e13126fe2b27",
+        "predecessor_domain_input_cid": "blake3:5a2dc3b2f435679587f7442591f5d08284f336d8219d5a959bfea624e4e293e8",
+        "corpus_byte_offset": 3648081,
+        "corpus_byte_length": 1413
+      },
+      {
+        "id": "3799",
+        "selection_digest": "blake3:01b11418c62adf984bfd3c2c0c5edc70ecf2b632c6b5d31db077d23c9f826f72",
+        "title_cid": "blake3:c1015cb2e6a439fb2ac179db0230f161946ef493fbb5d5073a25f9bc7323f24a",
+        "input_cid": "blake3:61a8fa836018d7b62bb5123ce5222e846418443c2a00dcffbb07a5962ec1992d",
+        "predecessor_domain_input_cid": "blake3:67dbce2aad00647fb4be353b7f0e438bf4345d4d34c1cecddda80aaeaf2d8040",
+        "corpus_byte_offset": 3958869,
+        "corpus_byte_length": 1201
+      }
+    ],
+    "construction_validation": [
+      {
+        "id": "5950",
+        "selection_digest": "blake3:01b454f5b4e05d4f6f85af0381cd4e08ae4482988a94bbf24a07e40010c4bcbb",
+        "title_cid": "blake3:09a935f334fef2e82e066b37db034ae6dbaaed74c37c64d6a480a2629d669c9a",
+        "input_cid": "blake3:d97f3577626d9f642154a339d93f55bb803af7ea3d94a767a79046fc3615ae84",
+        "predecessor_domain_input_cid": "blake3:8a5c681add053d7e7866262264feb28ae6f4f834d462d7a88a10b01542e35c4a",
+        "corpus_byte_offset": 7237069,
+        "corpus_byte_length": 1529
+      },
+      {
+        "id": "8341",
+        "selection_digest": "blake3:01b6cd36db2d8b1176a94a7dc4e93731476a4ca9198bd555cb4d24a87fffeb89",
+        "title_cid": "blake3:4751f999c3f5782b3e5b3d64b3a17e7750baa7abede4d247acda07685e2e606c",
+        "input_cid": "blake3:5184fe2516c56f7dc95309bd9a28cdfa1669b3e73b07a9954095196a4ee9152d",
+        "predecessor_domain_input_cid": "blake3:40db5ccbd0ee092e447055994c6b7d353f4ea779fd80651371d2ab270b91fbbb",
+        "corpus_byte_offset": 10431476,
+        "corpus_byte_length": 21082
+      },
+      {
+        "id": "3326",
+        "selection_digest": "blake3:01d59506372acd33806c8b9437ca7b554845713d95234f8027aa13599ece5608",
+        "title_cid": "blake3:e2d0aa631007ebb5662b3139fd967e17ce90c5a0e767ae726c3e5509407f1a14",
+        "input_cid": "blake3:926be58d296fd204087d78ec962b0914dfec7665376c80e1788df22f9525ef4d",
+        "predecessor_domain_input_cid": "blake3:9902af92531ba1493b48c3c9bf0b12630e97e53750c7874eee09cba94517517b",
+        "corpus_byte_offset": 3128460,
+        "corpus_byte_length": 1152
+      },
+      {
+        "id": "448",
+        "selection_digest": "blake3:01da8bdd3b46db78c06fbc1ed195d66aad7361757291a19a686f2dfde83a2824",
+        "title_cid": "blake3:21a8a69d8acda632c334e9c71ce887bbea282807452609cae6fa06b6be27c5e9",
+        "input_cid": "blake3:87358c297f8842e714797e266c5db7cd3faaae5c97e0b7267bd5dab21c0e1f19",
+        "predecessor_domain_input_cid": "blake3:75f22c927202553701aade915be6b3768e7db19757e72614a283a640258e67dc",
+        "corpus_byte_offset": 988408,
+        "corpus_byte_length": 1041
+      },
+      {
+        "id": "4470",
+        "selection_digest": "blake3:01eab55fcb4b6dcba1ad6f441a15e857b33b6f167d8325145399fba0f670e2e8",
+        "title_cid": "blake3:1ef2dfbb033861d89aea87c14821f319b149e93dcb479addc4b9c25848e4c761",
+        "input_cid": "blake3:36b2656b2d5078e64fdac9dc1d9e97a93d828475705ffa2e00d2ef204e91ef73",
+        "predecessor_domain_input_cid": "blake3:462eaef242bf123c391a31ca0d3d7b32ae20e8fb887bb54ddbd0e260a568fc62",
+        "corpus_byte_offset": 5107065,
+        "corpus_byte_length": 2086
+      },
+      {
+        "id": "5577",
+        "selection_digest": "blake3:01f0e8fae294bfc1cc39f436b2b3f0344046f1ff70eabeb07b758d0c311bd9c0",
+        "title_cid": "blake3:207b843916c282ef994772c640533ad8870c7642f58e0c953721129fef7260cc",
+        "input_cid": "blake3:3f7bec83584d973148804d698331797953a54dc672c9575576db70b13b9e3416",
+        "predecessor_domain_input_cid": "blake3:f5b126d70ec23292a0a499ed0070180254a1baf4b25c4075d2f932d120820327",
+        "corpus_byte_offset": 6871406,
+        "corpus_byte_length": 1381
+      },
+      {
+        "id": "9407",
+        "selection_digest": "blake3:01f7284b46cd45fb21182f169cbc8807904c27f7597d6232edc45de9852c85dc",
+        "title_cid": "blake3:669d89c6d2d4f63e11085af7b18317c4ea5e92a3db2439c9ee9d758f9e4f494c",
+        "input_cid": "blake3:6a26fd97bab9087ca8639d41438b2aac0d96156a76f014cf2d48bd2965d3e8fa",
+        "predecessor_domain_input_cid": "blake3:4453b197c5903956aa6f2e6510bce033716dbcc04c4bec64ea8437ff6c7611e7",
+        "corpus_byte_offset": 12481644,
+        "corpus_byte_length": 438
+      },
+      {
+        "id": "3596",
+        "selection_digest": "blake3:01fa2a4f460e4cc918adfc367ea3f2e06a800a181bda704970f58c176988eadf",
+        "title_cid": "blake3:bb5f593ac08bae20441eb3f18b47de31c68d37fcaa2ba0f08795cf7b0042798e",
+        "input_cid": "blake3:d8cdbf53891de9b26cc05828ded6cf48f703d363fdebf599e918cb4cb7081e7d",
+        "predecessor_domain_input_cid": "blake3:692dbade5dff72428c33cd6dbaec1a2e355617b6e6f2b91df1e275cd98167320",
+        "corpus_byte_offset": 3585614,
+        "corpus_byte_length": 3568
+      }
+    ],
+    "partition_cid": "blake3:5c5a7dab9d7a0fbc9d176faafd49b42094ef89138cc32699dfc1b4fe937d1bde"
+  }
+}


### PR DESCRIPTION
## Summary

- add the post-projection, pre-RoPE Q/K/V intervention seam and decoder-owned audit
- implement source-faithful full-head HELM-D Lorentz attention over transported R4 blocks
- implement the independently fitted, exactly equal-capacity Euclidean arm and three geometry-destroying controls
- freeze the deterministic eight-shard fitter, causal checkpoint/admission boundary, evidence identities, replay, and terminal logic
- freeze a fresh target-blind 16-fit/8-validation non-D3 partition
- synchronize the living research/programme direction while keeping D3, resonance, recurrence, lowering, E8 expansion, and #954 blocked

## Frozen identities

- partition manifest: `blake3:359b3270aaa0d3ac157280c9206ad820d18ee93932e0530552ebbb7935ac6410`
- partition: `blake3:5c5a7dab9d7a0fbc9d176faafd49b42094ef89138cc32699dfc1b4fe937d1bde`
- tokenizer: `blake3:70af0cb08bbcd3b323d3387ca1d7d33da39873820604d183711e8e99f9903fc1`
- learned capacity: 144,060 scalars per Lorentz/Euclidean arm

Construction validation and D3 remain `NOT_RUN`. The decision run is deliberately deferred until this implementation has a protected merge revision.

## Focused verification

- `cargo test -p uor-r4-model-source --offline pre_rope_projection` — 1 passed
- `cargo test -p uor-r4-core --offline helm_d_learned_manifold_r4_construction` — 6 core plus 5 integration preflight tests passed; only freezer/decision ignored
- focused core, model-source, and integration clippy with `-D warnings` — passed
- `python3 scripts/check_claim_wording.py` — passed
- `cargo fmt --all -- --check` — passed
- wasm library compile — passed
- target-blind partition freezer — passed
- independent P0-P2 contract/implementation review — passed

References #973
