### PR TITLE
fix(#973): repair the canonical H4 frame census

### DIFF
--- a/crates/uor-r4-core/src/helm_d_r4_attention.rs
+++ b/crates/uor-r4-core/src/helm_d_r4_attention.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bounded_global_exact_spin_attention::ExactSpinState;
 use crate::canonical_lexical_ingestion::{
-    validate_h4_binary_icosahedral_closure, H4BinaryIcosahedralClosure,
+    validate_h4_binary_icosahedral_closure, H4BinaryIcosahedralClosure, OpaqueH4TableIndex,
 };
 use crate::corpus_induced_spin_placement::{compile_identity_leaves, leaf_for_token};
 use uor_r4_model_source::attention::{
@@ -448,6 +448,69 @@ pub struct R4SpinTransportEvidence {
     pub intervention: R4SpinTransportIntervention,
     pub frame_table_offsets: Vec<u16>,
     pub audit: R4SpinTransportAudit,
+}
+
+/// One immutable frame from the complete canonical 120-root H4 registry.
+///
+/// This structural census is deliberately independent of the causal token-leaf
+/// map. The latter may occupy a strict subgroup while the covariance preflight
+/// still has to exercise every exact registered H4 frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct R4RegisteredSpinFrame {
+    h4_table_offset: u16,
+    frame_matrix: Matrix4,
+}
+
+impl R4RegisteredSpinFrame {
+    /// Opaque canonical table address for this exact H4 frame.
+    pub const fn h4_table_offset(self) -> u16 {
+        self.h4_table_offset
+    }
+
+    /// Encode one model-space R4 block into this registered local gauge.
+    pub fn encode_model_block(self, model: Vector4) -> Result<Vector4, HelmDR4AttentionError> {
+        checked_matrix_vector(
+            transpose(self.frame_matrix),
+            model,
+            "registered H4 gauge encoding",
+        )
+    }
+
+    /// Decode one local R4 block from this registered gauge into model space.
+    pub fn decode_local_block(self, local: Vector4) -> Result<Vector4, HelmDR4AttentionError> {
+        checked_matrix_vector(self.frame_matrix, local, "registered H4 gauge decoding")
+    }
+}
+
+/// Enumerate every exact H4 frame in the canonical registered table order.
+///
+/// The returned sequence is the structural registry `0..120`, not a claim that
+/// all frames are reachable through the separately frozen token-leaf mapping.
+pub fn canonical_registered_h4_spin_frames(
+) -> Result<Vec<R4RegisteredSpinFrame>, HelmDR4AttentionError> {
+    let table = validate_h4_binary_icosahedral_closure()
+        .map_err(|error| HelmDR4AttentionError::ExactRoute(error.to_string()))?;
+    let mut frames = Vec::with_capacity(table.root_count);
+    for offset in 0..table.root_count {
+        let h4_table_offset = u16::try_from(offset).map_err(|_| {
+            HelmDR4AttentionError::Arithmetic(
+                "registered H4 frame offset does not fit u16".to_owned(),
+            )
+        })?;
+        let index =
+            OpaqueH4TableIndex::from_table_offset(h4_table_offset, &table).ok_or_else(|| {
+                HelmDR4AttentionError::ExactRoute(
+                    "registered H4 frame offset is outside the exact table".to_owned(),
+                )
+            })?;
+        let state = ExactSpinState::from_table_index_and_phases(index, 0, 0, &table)
+            .map_err(|error| HelmDR4AttentionError::ExactRoute(error.to_string()))?;
+        frames.push(R4RegisteredSpinFrame {
+            h4_table_offset,
+            frame_matrix: h4_left_quaternion_matrix(state, &table)?,
+        });
+    }
+    Ok(frames)
 }
 
 /// Exact cumulative Spin/H4 frames for one causal decoder session.
@@ -3248,6 +3311,72 @@ mod tests {
         }
         atlas.reset();
         assert!(atlas.frame_matrix(0).is_err());
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_registered_frame_census_is_exact_and_complete() {
+        let frames = canonical_registered_h4_spin_frames().expect("registered H4 frame census");
+        assert_eq!(frames.len(), 120);
+        assert_eq!(
+            frames
+                .iter()
+                .map(|frame| frame.h4_table_offset())
+                .collect::<Vec<_>>(),
+            (0_u16..120).collect::<Vec<_>>()
+        );
+
+        let model = [0.25, -0.5, 0.75, 0.125];
+        for frame in frames {
+            let local = frame
+                .encode_model_block(model)
+                .expect("registered-frame encoding");
+            let decoded = frame
+                .decode_local_block(local)
+                .expect("registered-frame decoding");
+            for (actual, expected) in decoded.into_iter().zip(model) {
+                assert!((actual - expected).abs() <= 1.0e-10);
+            }
+        }
+    }
+
+    #[test]
+    fn helm_d_learned_manifold_r4_construction_token_leaf_basis_is_strict_24_element_subgroup() {
+        let table = validate_h4_binary_icosahedral_closure().expect("exact H4 closure");
+        let leaves = compile_identity_leaves(480, &table).expect("frozen token leaves");
+        let generator_offsets = (1_usize..=4)
+            .map(|token| leaves[token].table_index().table_offset())
+            .collect::<Vec<_>>();
+        assert_eq!(generator_offsets, [74, 118, 101, 119]);
+
+        let mut subgroup = std::collections::BTreeSet::from([table.identity_index]);
+        loop {
+            let before = subgroup.len();
+            let reached = subgroup.iter().copied().collect::<Vec<_>>();
+            for left in reached {
+                for right in &generator_offsets {
+                    subgroup.insert(
+                        table
+                            .product_index(left, *right)
+                            .expect("exact H4 subgroup product"),
+                    );
+                }
+            }
+            if subgroup.len() == before {
+                break;
+            }
+        }
+        assert_eq!(subgroup.len(), 24);
+        assert!(subgroup.len() < table.root_count);
+
+        let mut cumulative = table.identity_index;
+        let mut monotone_scan = std::collections::BTreeSet::new();
+        for leaf in &leaves {
+            cumulative = table
+                .product_index(cumulative, leaf.table_index().table_offset())
+                .expect("exact cumulative token-frame product");
+            monotone_scan.insert(cumulative);
+        }
+        assert_eq!(monotone_scan.len(), 12);
     }
 
     #[test]

--- a/crates/uor-r4-core/tests/helm_d_learned_manifold_r4_construction_973.rs
+++ b/crates/uor-r4-core/tests/helm_d_learned_manifold_r4_construction_973.rs
@@ -18,10 +18,11 @@ use std::time::Instant;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use uor_r4_core::helm_d_r4_attention::{
-    helm_d_learned_manifold_centroid, helm_d_learned_manifold_logit, helm_d_lorentz_causal_row,
-    HelmDLearnedManifoldEvidence, HelmDLearnedManifoldIntervention, HelmDLearnedManifoldMetric,
-    HelmDLearnedManifoldParameters, HelmDLearnedManifoldR4Transport, HelmDLorentzReferenceConfig,
-    R4AffineAdapter, R4SpinCausalAttentionTransport, R4SpinFrameAtlas, R4SpinTransportEvidence,
+    canonical_registered_h4_spin_frames, helm_d_learned_manifold_centroid,
+    helm_d_learned_manifold_logit, helm_d_lorentz_causal_row, HelmDLearnedManifoldEvidence,
+    HelmDLearnedManifoldIntervention, HelmDLearnedManifoldMetric, HelmDLearnedManifoldParameters,
+    HelmDLearnedManifoldR4Transport, HelmDLorentzReferenceConfig, R4AffineAdapter,
+    R4SpinCausalAttentionTransport, R4SpinFrameAtlas, R4SpinTransportEvidence,
     R4SpinTransportIntervention, HELM_D_LEARNED_EUCLIDEAN_R4_CONTROL_POLICY,
     HELM_D_LEARNED_LORENTZ_R4_CONSTRUCTION_POLICY, HELM_D_R4_GAUGE_SOFTMAX_POLICY,
     HELM_D_UPSTREAM_COMMIT,
@@ -2256,25 +2257,14 @@ fn hyperboloid_residual(spatial: &[f64]) -> f64 {
 fn registered_frame_covariance_preflight(
     maximum_token_id: u32,
 ) -> TestResult<(usize, f64, f64, f64, f64, bool)> {
-    let capacity = usize::try_from(maximum_token_id)? + 1;
-    let mut atlas = R4SpinFrameAtlas::new(maximum_token_id, capacity)?;
-    let mut frames = BTreeMap::new();
-    for token in 0..=maximum_token_id {
-        let position = usize::try_from(token)?;
-        atlas.begin_position(token, position)?;
-        frames
-            .entry(atlas.frame_table_offset(position)?)
-            .or_insert(position);
-        if frames.len() == 120 {
-            break;
-        }
-    }
-    if frames.len() != 120 {
-        return Err(format!(
-            "only {} of 120 registered H4 frames were reachable",
-            frames.len()
-        )
-        .into());
+    let frames = canonical_registered_h4_spin_frames()?;
+    if frames.len() != 120
+        || frames
+            .iter()
+            .enumerate()
+            .any(|(offset, frame)| usize::from(frame.h4_table_offset()) != offset)
+    {
+        return Err("canonical H4 registry did not enumerate all 120 frames in table order".into());
     }
     let query = (0..HEAD_WIDTH)
         .map(|lane| (lane as f64 - 31.5) / 37.0)
@@ -2317,12 +2307,12 @@ fn registered_frame_covariance_preflight(
     let mut maximum_weight = 0.0_f64;
     let mut maximum_centroid = 0.0_f64;
     let mut maximum_output = 0.0_f64;
-    for position in frames.values().copied() {
-        let mut encode = |vector: &[f64]| -> TestResult<Vec<f64>> {
+    for frame in &frames {
+        let encode = |vector: &[f64]| -> TestResult<Vec<f64>> {
             let mut encoded = Vec::with_capacity(HEAD_WIDTH);
             for block in vector.chunks_exact(R4_WIDTH) {
                 let block = [block[0], block[1], block[2], block[3]];
-                encoded.extend_from_slice(&atlas.encode_model_block(position, block)?);
+                encoded.extend_from_slice(&frame.encode_model_block(block)?);
             }
             Ok(encoded)
         };
@@ -2356,7 +2346,7 @@ fn registered_frame_covariance_preflight(
         let mut decoded = Vec::with_capacity(HEAD_WIDTH);
         for block in encoded_centroid.chunks_exact(R4_WIDTH) {
             decoded.extend_from_slice(
-                &atlas.decode_query_block(position, [block[0], block[1], block[2], block[3]])?,
+                &frame.decode_local_block([block[0], block[1], block[2], block[3]])?,
             );
         }
         maximum_score = maximum_score.max(
@@ -2391,20 +2381,16 @@ fn registered_frame_covariance_preflight(
     {
         return Err("registered-frame Lorentz covariance exceeds the frozen bound".into());
     }
-    let mut reached_frames = frames
-        .iter()
-        .map(|(offset, position)| (*position, *offset))
-        .collect::<Vec<_>>();
-    reached_frames.sort_unstable();
-    let (source_position, source_offset) = reached_frames[0];
-    let (query_position, query_offset) = reached_frames
-        .iter()
-        .copied()
-        .find(|(position, offset)| *position > source_position && *offset != source_offset)
-        .ok_or("two causally ordered distinct frames are unavailable")?;
-    if source_position >= query_position || source_offset == query_offset {
-        return Err("frame-permutation liveness pair is not causally ordered and distinct".into());
+
+    // The exhaustive covariance census above is deliberately synthetic. Keep
+    // destructive-control liveness on a separate, naturally reached causal
+    // atlas so direct registry enumeration cannot make the intervention live.
+    let mut atlas = R4SpinFrameAtlas::new(maximum_token_id, 3)?;
+    for (position, token) in [5, 9, 2].into_iter().enumerate() {
+        atlas.begin_position(token, position)?;
     }
+    let source_position = 0;
+    let query_position = 2;
     let block = [0.25, -0.5, 0.75, 0.125];
     let local = atlas.encode_model_block(source_position, block)?;
     let coherent = atlas.transport_local_block(
@@ -2440,16 +2426,16 @@ fn registered_frame_covariance_preflight(
 
 fn construction_preflight(
     captures: &[CapturedDocument],
-    maximum_token_id: u32,
     rope_theta: f32,
     rope_interleaved: bool,
+    registered_frame_preflight: (usize, f64, f64, f64, f64, bool),
 ) -> TestResult<GeometryPreflight> {
     let golden_maximum_error = pinned_golden_preflight()?;
     let finite_difference_maximum_error = finite_difference_gradient_preflight()?;
     let identity_ordering_compared_lanes =
         identity_projection_ordering_preflight(captures, rope_theta, rope_interleaved)?;
     let (registered_frames, score, weight, centroid, output, source_frame_permutation_live) =
-        registered_frame_covariance_preflight(maximum_token_id)?;
+        registered_frame_preflight;
     Ok(GeometryPreflight {
         golden_maximum_error,
         finite_difference_maximum_error,
@@ -3679,6 +3665,22 @@ fn helm_d_learned_manifold_r4_construction_golden_operator_is_pinned() -> TestRe
 }
 
 #[test]
+fn helm_d_learned_manifold_r4_construction_registered_frame_preflight_passes() -> TestResult {
+    let (frames, score, weight, residual, centroid, permutation_live) =
+        registered_frame_covariance_preflight(9)?;
+    if frames != 120
+        || score > 1.0e-8
+        || weight > 1.0e-8
+        || residual > 1.0e-8
+        || centroid > 1.0e-8
+        || !permutation_live
+    {
+        return Err("repaired registered-frame covariance/liveness preflight failed".into());
+    }
+    Ok(())
+}
+
+#[test]
 fn helm_d_learned_manifold_r4_construction_public_identities_and_work_counts_are_pinned(
 ) -> TestResult {
     let parameters = HelmDLearnedManifoldParameters::identity(
@@ -3810,6 +3812,12 @@ fn run_helm_d_learned_manifold_r4_construction(
     let rope_theta = config.rope_theta;
     let rope_interleaved = config.rope_interleaved;
     let maximum_token_id = u32::try_from(config.vocab.checked_sub(1).ok_or("empty vocab")?)?;
+    // This registry-wide structural gate is independent of donor traces. Run
+    // it before the expensive construction-fit capture and carry its result
+    // forward so a static census defect cannot consume the fit-trace budget.
+    let registered_frame_started = Instant::now();
+    let registered_frame_preflight = registered_frame_covariance_preflight(maximum_token_id)?;
+    let registered_frame_preflight_seconds = registered_frame_started.elapsed().as_secs_f64();
     let preparation = oracle.prepare_exact_execution(1)?;
     if preparation.workers_observed != SHARDS || !preparation.backend_exercised {
         return Err("exact eight-worker donor preparation was not exercised".into());
@@ -3829,10 +3837,15 @@ fn run_helm_d_learned_manifold_r4_construction(
     let fit_trace_seconds = fit_trace_started.elapsed().as_secs_f64();
 
     let preflight_started = Instant::now();
-    let preflight =
-        construction_preflight(&captures, maximum_token_id, rope_theta, rope_interleaved)?;
+    let preflight = construction_preflight(
+        &captures,
+        rope_theta,
+        rope_interleaved,
+        registered_frame_preflight,
+    )?;
     let canary = objective_canary(&captures, rope_theta, rope_interleaved)?;
-    let preflight_and_canary_seconds = preflight_started.elapsed().as_secs_f64();
+    let preflight_and_canary_seconds =
+        registered_frame_preflight_seconds + preflight_started.elapsed().as_secs_f64();
 
     let fit_started = Instant::now();
     let lorentz = fit_arm(

--- a/docs/helm_d_learned_manifold_r4_construction_973.md
+++ b/docs/helm_d_learned_manifold_r4_construction_973.md
@@ -413,3 +413,38 @@ execution. Its tracked envelope is
 The learned fit, validation materialization, D3, and decision terminal remain
 `NOT_RUN`. The implementation base revision and executable identity will be
 bound only after protected delivery of this contract and freezer.
+
+### 2026-08-29 attempt 01: unavailable synthetic-census implementation
+
+Attempt 01 launched from protected `main` revision
+`40d2c94259d34e153923835faf180b51130eac20` and stopped in the construction
+preflight before the fitter, checkpoint gate, or validation materializer. Its
+exact result is preserved in
+[`helm_d_learned_manifold_r4_construction_attempt_01_result_973.json`](helm_d_learned_manifold_r4_construction_attempt_01_result_973.json).
+
+- terminal: `UNAVAILABLE_HELM_D_MANIFOLD_CONSTRUCTION_EVIDENCE`;
+- reason: `only 12 of 120 registered H4 frames were reachable`;
+- result self-CID:
+  `blake3:34adff54bd6ce7986f3e03bf8cc579c02441582d14db28ddd062f74236bc82a3`;
+- construction validation materialized: `false`;
+- checkpoint exists: `false`; and
+- D3: `NOT_RUN`.
+
+This is an unavailable evidence attempt, not a learned-manifold, population,
+or attention result. The synthetic census implementation tried to discover all
+120 registered frames through one cumulative `token = position` atlas walk.
+The frozen lexical leaf map assigns only four Hurwitz-unit roots, whose full
+closure is the 24-state binary-tetrahedral subgroup; that particular periodic
+walk visits exactly 12 states. It therefore cannot enumerate the 120-state
+binary-icosahedral registry required by the synthetic covariance census.
+
+The frozen contract already declares the applicable action: repair the
+evidence/preflight without reading validation. Attempt 02 may replace only the
+synthetic census enumerator with direct canonical registry enumeration and
+exercise source-frame-permutation liveness on a separate real causal atlas.
+That registry-wide gate runs before the expensive donor-trace capture and its
+result is carried into the unchanged combined preflight.
+The population, model, operator, fitter, thresholds, decision branches, and
+validation seal remain unchanged. Requiring all 120 frames to be naturally
+token-reachable would instead change the leaf-assignment mechanism and is not
+authorized by this repair.

--- a/docs/helm_d_learned_manifold_r4_construction_attempt_01_result_973.json
+++ b/docs/helm_d_learned_manifold_r4_construction_attempt_01_result_973.json
@@ -1,0 +1,10 @@
+{
+  "schema": "uor-r4.helm-d-learned-manifold-r4-construction-result/2",
+  "issue": 973,
+  "terminal": "UNAVAILABLE_HELM_D_MANIFOLD_CONSTRUCTION_EVIDENCE",
+  "reason": "only 12 of 120 registered H4 frames were reachable",
+  "validation_materialized": false,
+  "checkpoint_exists": false,
+  "d3_status": "NOT_RUN",
+  "result_cid": "blake3:34adff54bd6ce7986f3e03bf8cc579c02441582d14db28ddd062f74236bc82a3"
+}


### PR DESCRIPTION
## Outcome

Repairs the Attempt 01 construction preflight without changing the frozen learned-manifold experiment.

The prior harness tried to discover all 120 registered H4 frames through one cumulative token walk. The frozen four lexical leaves generate a strict 24-element subgroup and that walk visits exactly 12 states, so the enumerator could never satisfy the synthetic registry-wide census.

This change:
- enumerates the exact canonical 120-frame H4 registry directly for covariance;
- keeps source-frame-permutation liveness on a separate real causal atlas;
- runs the cheap registry gate before expensive donor capture;
- preserves Attempt 01 byte-for-byte and records validation=false, checkpoint=false, D3=NOT_RUN;
- changes no population, donor, operator, fitter, threshold, decision branch, or validation seal.

## Verification

- RUST_TEST_THREADS=1 cargo test --workspace --offline --no-fail-fast
- cargo clippy --workspace --all-targets --all-features --offline -- -D warnings
- cargo fmt --check
- cargo check -p uor-r4-graph-format --no-default-features --offline
- cargo check -p uor-r4-graph-format --no-default-features --features alloc --offline
- cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib --offline
- python3 scripts/check_claim_wording.py
- exact repaired preflight: 120/120, PASS
- independent cross-review: no P0-P2 findings

References #973