### PR TITLE
CPU-native local generation with Apple Accelerate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,27 @@ mechanism and changes only decoder depth from six to twelve layers: exactly
 training tokens. Its population, fixed overfit smoke, and random-export
 all-twelve-layer Rust preflight parity passed. The signed MPS probe passed memory at
 `21.03%` but stopped `UNAVAILABLE_HARDWARE_BUDGET` on time at a safety-projected
-`20.66 h` against the `8 h` ceiling. MPS full training is unauthorized; full
-training, final parity, reveal, generation, and replay remain `NOT_RUN`. Work
-next only on the deterministic single-CUDA `f32` fallback after explicit owner
-authorization for external compute and any spend. Offline
+`20.66 h` against the `8 h` ceiling. That terminal applies only to the frozen
+offline PyTorch/MPS implementation; full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. UOR's deployed architecture and
+runtime remain CPU-native. Apple Accelerate/BLAS and MPS are permitted only for
+local offline training, compilation, and bounded tests; CUDA and external GPU
+execution are out of scope. A single isolated exact-shape MPS fast-path test
+(10 warmup plus 40 measured steps) combined fused AdamW with deferred logging
+and measured `4.485223 s/step`, slower than the signed `3.491307 s/step`;
+`fused=True` was removed immediately. This is a bounded fast-path negative, not
+a model result. Preserve the passed population, smoke, and parity artifacts,
+but stop #1019 tuning and full-run work; #1019 is optional and paused. The
+active next step is using and productizing the working #1017 generator through
+`r4 generate`, without recurring broad research gates. Prototype iteration uses
+one targeted compile plus one real behavior check; do not run a broad local
+suite or add a permanent gate until the mechanism is useful. The existing
+mandatory merge-queue CI remains the single integration boundary rather than an
+every-iteration loop. On the project M1, the opt-in
+`local-inference-accelerate` CPU-BLAS build preserved the four generated token
+IDs, output CID, and attention-audit CID while reducing internal generation
+from `3.060506042 s` to `0.116236875 s`; use it for local #1017 inference while
+keeping exact `uor-matmul` as the portable default. Offline
 teacher/compiler floats, matrix operations, and softmax are allowed; deployed
 runtime remains exact and source-free. The hosted Pages build is static,
 currently reports WASM offline, and has no functioning chat backend/artifact
@@ -91,18 +108,21 @@ functioning chat backend/artifact lowering. The feature is disabled by default
 and does not change the default engine. The teacher-trace/Q16 suffix student,
 its recurrent state successor, and #1012's observability rung are complete
 bounded negatives. #1014 established load-bearing attention; #1017 closed
-NLL-only negative; and the active step is #1019's frozen 12-layer
-parameter-capacity campaign: the model-side population/smoke/parity subgates
-passed, MPS is
-`UNAVAILABLE_HARDWARE_BUDGET`, and the full campaign remains `NOT_RUN` pending
-only an explicitly owner-authorized deterministic single-CUDA `f32` fallback.
-This reference remains
+NLL-only negative and remains the working bounded generator; #1019 is an
+optional frozen 12-layer parameter-capacity improvement whose model-side
+population/smoke/parity subgates
+passed, MPS is `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+implementation, and the full campaign remains `NOT_RUN`. The subsequent fused-
+AdamW/deferred-logging fast path was slower (`4.485223` versus signed
+`3.491307 s/step`), so `fused=True` was removed and #1019 is optional/paused.
+The active next step is the working #1017 `r4 generate` product path; CUDA and
+external GPU execution are out of scope. This reference remains
 transformer-compatible and `f32`/multiply/alloc/source-weight backed—not
 table-native, multiply-free, or transformerless. It does not establish geometry
 advantage, softmax removal, correctness, reasoning, frontier quality, release
-readiness, or a static-WASM decoder. Do not resume resonance substitutes or
-promote a product/release before #1019's decision; only its positive branch may
-open one separate softmax-replacement issue. Do not tune
+readiness, or a static-WASM decoder. Product work does not wait for #1019: use
+the bounded #1017 `r4 generate` path while keeping its claim limits explicit.
+Do not resume resonance substitutes. Do not tune
 the revealed V2/V3/V4 or learned-manifold
 fixtures, relax the V1 covariance bound, or scale #997's rejected
 componentwise-Frechet placement. The binding records are
@@ -237,12 +257,16 @@ wiring/readiness and static/WASM-isolation checks pass, while hosted Pages
 remains static/offline without a functioning chat backend/artifact lowering.
 The Q16 suffix trace student, its recurrent state successor, and #1012's
 observability rung are complete bounded negatives. #1014 established
-load-bearing attention and #1017 closed NLL-only negative. #973 is active only
-on #1019's frozen 12-layer parameter-capacity campaign. Its population, fixed
-overfit smoke, and random-export all-twelve-layer Rust preflight parity passed; MPS
-stopped `UNAVAILABLE_HARDWARE_BUDGET` on time, and full training through replay
-remains `NOT_RUN` pending only the owner-authorized deterministic single-CUDA
-`f32` fallback. Intrinsic/readout, resonance, recurrence,
+load-bearing attention and #1017 closed NLL-only negative. #1019's optional,
+paused 12-layer parameter-capacity campaign recorded population, fixed
+overfit smoke, and random-export all-twelve-layer Rust preflight parity passed;
+MPS stopped `UNAVAILABLE_HARDWARE_BUDGET` on time for the frozen eight-hour
+offline implementation, and full training through replay remains `NOT_RUN`.
+The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
+`3.491307 s/step`), so #1019 tuning/full-run work stops and remains
+optional/paused. The active next step is the #1017 `r4 generate` product path;
+CUDA and external GPU execution are out of scope.
+Intrinsic/readout, resonance, recurrence,
 and lowering are parked. D3 remains `NOT_RUN`, and #954 remains blocked.
 Do not add a second #953 intervention or reuse the #983/#986 populations. The
 complete #973 Gate 0 record is
@@ -607,12 +631,16 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   wiring/readiness and static/WASM-isolation checks pass; hosted Pages remains
   static/offline without a functioning chat backend/artifact lowering. The Q16
   suffix trace student is complete with bounded distillation but looping output.
-  The active step is #1019's frozen 12-layer, 13,130,784-parameter
-  ordinary-softmax R4/Spin quality campaign. The model-side
-  population/smoke/parity subgates passed; MPS
-  stopped `UNAVAILABLE_HARDWARE_BUDGET` on time, and full training through
-  replay remains `NOT_RUN` pending only an explicitly owner-authorized
-  deterministic single-CUDA `f32` fallback. Intrinsic/readout alternatives,
+  #1019 is an optional frozen 12-layer, 13,130,784-parameter ordinary-softmax
+  R4/Spin quality-capacity improvement. The model-side
+  population/smoke/parity subgates passed; MPS stopped
+  `UNAVAILABLE_HARDWARE_BUDGET` on time for the frozen eight-hour offline
+  implementation, and full training through replay remains `NOT_RUN`. The
+  fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
+  `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
+  optional/paused. The active next step is the #1017 `r4 generate` product path;
+  CUDA and external GPU execution are out of scope.
+  Intrinsic/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and
   exact deployment are parked. D3 remains `NOT_RUN`.
   #954 remains blocked behind #973.
@@ -635,8 +663,9 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   observability [COMPLETE; INSUFFICIENT SUPPORT] → #1014 direct attention
   [ATTENTION PASS; QUALITY FAIL] → #1017 exposure continuation [NLL-ONLY FAIL]
   → #1019 frozen 12-layer parameter-capacity campaign [MODEL SUBGATES PASS;
-  MPS UNAVAILABLE_HARDWARE_BUDGET; FULL CAMPAIGN NOT_RUN; OWNER-AUTHORIZED CUDA
-  F32 FALLBACK ONLY]) →
+  FROZEN OFFLINE MPS IMPLEMENTATION OVER 8 H; FUSED FAST PATH SLOWER; OPTIONAL/
+  PAUSED; FULL CAMPAIGN NOT_RUN; CUDA/EXTERNAL GPU OUT OF SCOPE]) →
+  active bounded #1017 `r4 generate` product path →
   correctness/abstention → reasoning → optimization/purity/release. The older placement/transport
   sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,14 @@ name = "r4"
 path = "src/main.rs"
 
 [features]
-# #804 measurement-only exception passthrough (maintainer-approved
-# 2026-08-18) — see uor-r4-model-source's feature of the same name.
-# Never a default; observation builds opt in explicitly:
+# CPU-native Apple Accelerate path for fast local source-backed inference on
+# macOS. This is an honest product/developer alias for the older #804 feature;
+# exact uor-matmul remains the portable default.
+#   cargo build --release --features local-inference-accelerate --bin r4
+local-inference-accelerate = ["observation-blas-exception"]
+# #804 Apple Accelerate passthrough (maintainer-approved 2026-08-18) — retained
+# as the historical feature name for local source-backed inference and
+# observation. Never a default; callers may still opt in explicitly:
 #   cargo build --release --features observation-blas-exception
 observation-blas-exception = [
     "uor-r4-model-source/observation-blas-exception",

--- a/README.md
+++ b/README.md
@@ -53,11 +53,18 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > random-export/all-12-layer Rust preflight parity is `PASS` with maximum absolute logit
 > delta `0.0000443459`. The signed 200-step MPS probe passed memory at `21.03%`
 > but failed time: its safety projection was `20.66 h`, above the `8 h` ceiling,
-> so the MPS path is terminal `UNAVAILABLE_HARDWARE_BUDGET` and MPS full
-> training is unauthorized. Full training, final qualification, sealed reveal,
-> generation, and replay remain `NOT_RUN`. The only eligible continuation is
-> the frozen deterministic single-CUDA `f32` fallback, after explicit owner
-> approval for external compute and spend.
+> so that frozen offline PyTorch/MPS implementation is terminal
+> `UNAVAILABLE_HARDWARE_BUDGET`. Full training, final qualification, sealed
+> reveal, generation, and replay remain `NOT_RUN`. This does not redirect UOR:
+> the deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+> and MPS are local offline training/compilation/test accelerators only; CUDA
+> and external GPU execution are out of scope. A single isolated exact-shape
+> MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW
+> with deferred logging and measured `4.485223 s/step`, slower than the signed
+> `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+> fast-path negative, not a model result. #1019 tuning/full-run work stops and
+> remains optional/paused. The active next step is using and productizing the
+> working #1017 `r4 generate` path.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
 > [#1017 structured aggregate](docs/r4_softmax_quality_capacity_continuation_1017_raw.json),
 > [#1019 frozen contract](docs/r4_softmax_parameter_capacity_1019.md),
@@ -65,6 +72,16 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json),
 > [#1014 record](docs/r4_softmax_end_to_end_attention_1014.md) and
 > [structured aggregate](docs/r4_softmax_end_to_end_attention_1014_raw.json).
+>
+> The completed #1017 checkpoint is the current working 7.15M
+> coherent-generation prototype. If its local export exists, run it directly
+> with `r4 generate --prompt "..."`; the alias defaults to
+> `.uor-models/research/issue-1017/export`. #1019 is now an optional
+> quality-capacity improvement and does not block using or productizing this
+> bounded #1017 path. It remains source-backed, floating-point/matmul/softmax,
+> and below the strict NLL target; it does not establish geometry advantage,
+> transformerlessness, correctness, reasoning, frontier quality, browser/WASM
+> readiness, or release readiness.
 >
 > The completed
 > `R4SoftmaxTraceStudentV1` then compiled construction-side teacher traces into
@@ -223,9 +240,12 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > 13,130,784 parameters over the qualified mechanism and runtime evidence path.
 > Population, the 400-step MPS overfit smoke, and random-export/all-12-layer
 > Rust parity passed, but the signed MPS probe stopped
-> `UNAVAILABLE_HARDWARE_BUDGET`; MPS full training is unauthorized and full
-> training through replay remains `NOT_RUN` unless the explicitly approved
-> deterministic single-CUDA `f32` fallback qualifies. No
+> `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+> implementation, and full training through replay remains `NOT_RUN`. The
+> fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
+> `3.491307 s/step`); #1019 is optional/paused and the active next step is the
+> #1017 `r4 generate` product path. CUDA and external GPU execution are out of
+> scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
 > product promotion remain parked. No tag, release, hosted
@@ -299,12 +319,15 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > attention-off intervention and Rust parity, but failed its full quality DoD
 > at enabled NLL `2.127407` and subject/scene retention `3/5`. It closes
 > negative. #1017's separate continuation then reached `5/5` retention but
-> failed NLL only at `1.5727521962806827`. #1019 now owns the single frozen
+> failed NLL only at `1.5727521962806827`. #1019 records an optional frozen
 > 12-layer, 13,130,784-parameter successor. Its population, MPS overfit smoke,
 > and random-export/all-12-layer Rust preflight parity passed, but its MPS hardware path
-> stopped `UNAVAILABLE_HARDWARE_BUDGET`; full training, final qualification,
-> reveal, generation, and replay remain `NOT_RUN`, with only an explicitly
-> owner-approved deterministic single-CUDA `f32` fallback eligible. #954
+> stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+> implementation; full training, final qualification, reveal, generation, and
+> replay remain `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower
+> (`4.485223` versus signed `3.491307 s/step`); #1019 is optional/paused and the
+> active next step is the #1017 `r4 generate` product path. CUDA and external
+> GPU execution are out of scope. #954
 > remains blocked.
 > See the
 > [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
@@ -433,12 +456,14 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > Dashboard wiring/readiness and static/WASM-isolation checks pass; browser E2E
 > is `NOT_RUN`. The trace/state observability audit later completed at
 > insufficient support; #1014 established load-bearing attention, and #1017
-> closed NLL-only negative. The current gate is #1019's frozen 12-layer,
-> 13,130,784-parameter campaign. Population, MPS overfit smoke, and
+> closed NLL-only negative. #1019's optional frozen 12-layer,
+> 13,130,784-parameter campaign recorded population, MPS overfit smoke, and
 > random-export/all-12-layer Rust preflight parity passed; the MPS hardware path stopped
-> `UNAVAILABLE_HARDWARE_BUDGET`, so the full campaign remains `NOT_RUN` unless
-> an explicitly owner-approved deterministic single-CUDA `f32` fallback
-> qualifies.
+> `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+> implementation, so the full campaign remains `NOT_RUN`. The fused-AdamW/
+> deferred-logging fast path was slower (`4.485223` versus signed
+> `3.491307 s/step`); #1019 is optional/paused and the active next step is the
+> #1017 `r4 generate` product path. CUDA and external GPU execution are out of scope.
 > #954 remains blocked behind #973. General higher-scope attention, correct
 > answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
@@ -466,6 +491,34 @@ To inspect one route from the command line instead:
 ```bash
 cargo run --bin r4 -- route "geometry is the route"
 ```
+
+To run the current working local 7.15M coherent-generation prototype:
+
+```bash
+r4 generate --prompt "Once upon a time in a quiet village"
+```
+
+`generate` defaults to `$UOR_MODEL_STORE/research/issue-1017/export` (or
+`.uor-models/research/issue-1017/export` when the variable is unset). It requires
+that local export and is a bounded #1017 prototype: provider-free at execution,
+but still source-backed, floating-point/matmul/softmax, and below the strict
+`<1.50` NLL target. #1019 is an optional capacity improvement, not a prerequisite
+for using or productizing this path.
+
+On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
+machine's Accelerate framework:
+
+```bash
+cargo build --release --offline --features local-inference-accelerate --bin r4
+target/release/r4 generate --prompt "Once upon a time"
+```
+
+On the project M1, the same four-token #1017 prompt produced token IDs
+`[14, 403, 285, 261]` and text `, there was a` under both exact `uor-matmul`
+and Accelerate. Output and attention-audit CIDs were identical. Accelerate cut
+measured generation from `3.060506042 s` to `0.116236875 s` (`26.33x`) and
+end-to-end wall time from `3.41 s` to `0.52 s` (`6.56x`). The complete report
+still differs intentionally because backend provenance and timing differ.
 
 To run the qualified source-backed R4/Spin softmax reference generator from an
 already-local pinned SmolLM2 snapshot:
@@ -706,9 +759,12 @@ exact-descriptor/entity-binding path selector apiece at their respective
    `5/5` and all mechanical gates but failed only sealed NLL at
    `1.5727521962806827`. #1019 now freezes that 12-layer parameter-capacity
    contract. Population, smoke, and random-export parity passed, but MPS
-   admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; full training through
-   replay remains `NOT_RUN` pending only an explicitly owner-approved
-   deterministic single-CUDA `f32` fallback. #954 stays blocked.
+   admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
+   offline implementation; full training through replay remains `NOT_RUN`.
+   The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
+   signed `3.491307 s/step`); #1019 is optional/paused and the active next step
+   is the #1017 `r4 generate` product path. CUDA and external GPU execution are
+   out of scope. #954 stays blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
@@ -848,14 +904,18 @@ not become substitutes for working intelligence:
    `2.127407` and prompt retention `3/5`. Close that campaign without rerun or
    tuning. #1017 then completed the one frozen exposure continuation: NLL
    `1.5727521962806827` failed the strict `<1.50` gate, while retention, parity,
-   causal audits, and replay passed. #1019 now freezes the sole 12-layer,
+   causal audits, and replay passed. #1019 now freezes an optional 12-layer,
    13,130,784-parameter increase over the same mechanism. Its population, MPS
    overfit smoke, and random-export/all-12-layer Rust preflight parity passed, but MPS
-   admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; the full train/final-
-   qualification/reveal/generation/replay path remains `NOT_RUN`, with no
-   further 7.15M exposure or LR tuning and only an explicitly owner-approved
-   deterministic single-CUDA `f32` fallback eligible.
-   Do not resume resonance substitutes or promote a product/release. This intermediate
+   admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
+   offline implementation; the full train/final-qualification/reveal/
+   generation/replay path remains `NOT_RUN`, with no further 7.15M exposure or
+   LR tuning. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
+   versus signed `3.491307 s/step`); #1019 is optional/paused and the active
+   next step is the #1017 `r4 generate` product path. CUDA and external GPU
+   execution are out of scope.
+   Do not resume resonance substitutes. Product development continues through
+   `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
    reference is transformer-compatible, `f32`/multiply/alloc and source-weight
    backed—not table-native, multiply-free, or transformerless. No tag, release,
    static web, or browser-WASM claim follows from the result.
@@ -910,13 +970,16 @@ attention-off penalty and exact Rust parity. Its full quality DoD is negative:
 enabled NLL `2.127407` exceeded `1.50`, and subject/scene retention was `3/5`
 versus `4/5`. #1017's separately frozen continuation improved those measurements
 to NLL `1.5727521962806827` and retention `5/5`, but its full DoD remains
-negative solely on the strict NLL ceiling. Advance only through #1019's frozen
-12-layer, 13,130,784-parameter campaign over the same attention/runtime path.
+negative solely on the strict NLL ceiling. #1019's optional frozen 12-layer,
+13,130,784-parameter campaign uses the same attention/runtime path.
 Its population, MPS overfit smoke, and random-export/all-12-layer Rust preflight parity
-passed, but the signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET`; MPS
-full training is unauthorized and the full campaign remains `NOT_RUN`. Only
-the deterministic single-CUDA `f32` fallback may continue after explicit owner
-approval for external compute and spend.
+passed, but the signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
+frozen eight-hour offline implementation; the full campaign remains `NOT_RUN`.
+UOR's deployed architecture/runtime remains CPU-native. Apple Accelerate/BLAS
+and MPS are local offline accelerators only. The fused-AdamW/deferred-logging
+fast path was slower (`4.485223` versus signed `3.491307 s/step`); #1019 is
+optional/paused and the active next step is the #1017 `r4 generate` product
+path. CUDA and external GPU execution are out of scope.
 #954 remains blocked behind #973. The exact contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,18 +82,24 @@ quality DoD. #1017 completed the one authorized continuation to
 `149,995,520` cumulative tokens: enabled Rust parity, all six R4/Spin layers,
 causal/external audits, `5/5` subject-or-scene retention, and `5/5` normalized
 replay passed, but fresh sealed NLL `1.5727521962806827` failed the strict
-`<1.50` criterion. The result is negative solely on NLL. The primary rung is
-now [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019), one frozen
+`<1.50` criterion. The result is negative solely on NLL. An optional capacity
+rung was frozen as [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019), one
 12-layer, 13,130,784-parameter campaign over the same attention and Rust path.
 Its fresh population passed; the 400-step, 64-sequence MPS overfit smoke passed
 with `81.9752%` loss reduction; and random-export/all-12-layer Rust preflight parity passed
 with maximum absolute logit delta `0.0000443459`. The signed 200-step MPS probe
 passed memory at `21.03%` but failed time with a safety projection of `20.66 h`
-against the `8 h` ceiling, terminating that path
-`UNAVAILABLE_HARDWARE_BUDGET`. MPS full training is
-unauthorized; full training, final qualification, sealed reveal, generation,
-and replay remain `NOT_RUN`. Only the deterministic single-CUDA `f32` fallback
-may continue after explicit owner approval for external compute and spend.
+against the `8 h` ceiling, terminating that frozen offline implementation
+`UNAVAILABLE_HARDWARE_BUDGET`. Full training, final qualification, sealed
+reveal, generation, and replay remain `NOT_RUN`. UOR's deployed
+architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS are
+local offline accelerators only. A single isolated exact-shape MPS fast-path
+test (10 warmup plus 40 measured steps) combined fused AdamW with deferred
+logging and measured `4.485223 s/step`, slower than the signed
+`3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+fast-path negative, not a model result. #1019 tuning/full-run work stops and
+remains optional/paused. The active next step is using and productizing the
+working #1017 `r4 generate` path. CUDA and external GPU execution are out of scope.
 Further 7.15M exposure and learning-rate tuning are prohibited. See the
 [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 D3 remains `NOT_RUN`, and #973 continues to block #954. Its current contract is
@@ -162,11 +168,14 @@ The completed continuation and its NLL-only negative are in
 > WASM-isolation checks pass, but the hosted Pages surface is static and has no
 > functioning chat backend/artifact lowering. The completed teacher-trace/Q16
 > suffix student has a bounded source-free distillation effect and looping
-> output. The active rung is #1019's frozen 12-layer parameter-capacity
-> campaign. Population, MPS overfit smoke, and random-export/all-12-layer Rust
-> parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; the
-> full campaign remains `NOT_RUN` unless an explicitly owner-approved
-> deterministic single-CUDA `f32` fallback qualifies.
+> output. #1019 is an optional frozen 12-layer parameter-capacity improvement.
+> Population, MPS overfit smoke, and random-export/all-12-layer Rust
+> parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
+> frozen eight-hour offline implementation. The full campaign remains
+> `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
+> versus signed `3.491307 s/step`), so #1019 is optional/paused and the active
+> next step is the #1017 `r4 generate` product path. CUDA and external GPU
+> execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
 > table-native, multiply-free, transformerless serving engine. D3 remains
@@ -250,9 +259,10 @@ trace distillation, with looping autonomous output, state-student and
 observability negatives, #1014 attention qualification, and #1017's NLL-only
 quality-capacity negative; **Active / MPS `UNAVAILABLE_HARDWARE_BUDGET`, full
 campaign `NOT_RUN`:** #1019's frozen 12-layer, 13,130,784-parameter campaign over
-the same attention/Rust path; population/smoke/random-export parity passed and
-only an explicitly owner-approved deterministic single-CUDA `f32` fallback may
-continue; **Parked:** further 7.15M exposure
+the same attention/Rust path; population/smoke/random-export parity passed, but
+its fused-AdamW/deferred-logging fast path was slower and #1019 is now
+optional/paused; **Active:** use and productize #1017 through `r4 generate`;
+CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
 deployment; **Blocked:** D3 and #954; **Later:**
@@ -282,10 +292,13 @@ completed the one exposure continuation with NLL `1.5727521962806827` (FAIL),
 retention `5/5` (PASS), enabled parity, all mechanical gates, and exact replay.
 #1019 now specifies that one increase: twelve layers, 13,130,784 parameters,
 seed 1019, 16,800 steps, and 275,251,200 tokens. Population, MPS overfit smoke,
-and random-export/all-12-layer Rust preflight parity passed, but MPS admission stopped
-`UNAVAILABLE_HARDWARE_BUDGET`; the full campaign remains `NOT_RUN` and only an
-explicitly owner-approved deterministic single-CUDA `f32` fallback may
-continue. Do not add exposure or tune the 7.15M model.
+and random-export/all-12-layer Rust preflight parity passed, but MPS admission
+stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+implementation. The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-
+logging fast path was slower (`4.485223` versus signed `3.491307 s/step`), so
+#1019 is optional/paused and the active next step is the #1017 `r4 generate`
+product path. CUDA and external GPU execution are out of scope. Do not add exposure or tune
+the 7.15M model.
 Intrinsic/resonance/replacement work is
 parked; D3 remains `NOT_RUN`. See the
 [#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
@@ -540,12 +553,15 @@ feasibility boundary remains in the
    observability successor then closed negative. #1014 established load-bearing
    ordinary attention. #1017's fixed continuation reached `149,995,520` tokens
    and passed retention `5/5`, parity, audits, and replay, but failed only the
-   strict NLL gate at `1.5727521962806827`. Build only #1019's frozen 12-layer,
-   13,130,784-parameter campaign over the same qualified mechanism and Rust
-   path. Population, MPS overfit smoke, and random-export/all-12-layer Rust
-   parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; full
-   training through replay remains `NOT_RUN`, with only an explicitly
-   owner-approved deterministic single-CUDA `f32` fallback eligible.
+   strict NLL gate at `1.5727521962806827`. #1019's optional frozen 12-layer,
+   13,130,784-parameter campaign preserves the same qualified mechanism and Rust
+   path. Its population, MPS overfit smoke, and random-export/all-12-layer Rust
+   parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for
+   the frozen eight-hour offline implementation. Full training through replay
+   remains `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower
+   (`4.485223` versus signed `3.491307 s/step`), so #1019 is optional/paused and
+   the active next step is the #1017 `r4 generate` product path. CUDA and
+   external GPU execution are out of scope.
    Intrinsic score/readout alternatives, paired-E8, resonance-based softmax
    replacement, and exact deployment are parked; #954 remains blocked. Every learned epoch receives a
    new kappa and reruns its owning
@@ -669,7 +685,7 @@ historical evidence and comparators.
   state-student and observability successors closed negative. #1014 established
   load-bearing ordinary attention. #1017 then completed at `149,995,520`
   cumulative tokens with NLL `1.5727521962806827` as its sole failed gate and
-  retention/parity/audits/replay passing. #1019 freezes the sole successor:
+  retention/parity/audits/replay passing. #1019 freezes an optional successor:
   depth 12, width 288, six 48-wide heads with twelve R4 blocks per head,
   13,130,784 parameters, seed 1019, 16,800 steps, and 275,251,200 tokens.
   Fresh development and confirmation tranches passed create-once population
@@ -677,12 +693,14 @@ historical evidence and comparators.
   `81.9752%` loss reduction, and random-export/all-12-layer Rust preflight parity passed
   with maximum absolute logit delta `0.0000443459`. The signed 200-step MPS
   probe passed memory at `21.03%` but failed time at a safety-projected
-  `20.66 h` against the `8 h` ceiling, ending the MPS path
-  `UNAVAILABLE_HARDWARE_BUDGET`. MPS full training
-  is unauthorized; full training, final trained-checkpoint qualification, the
-  strict `<1.50` sealed-NLL reveal, generation, and replay remain `NOT_RUN`.
-  Only the deterministic single-CUDA `f32` fallback may continue after explicit
-  owner approval for external compute and spend. See the
+  `20.66 h` against the `8 h` ceiling, ending that frozen offline implementation
+  `UNAVAILABLE_HARDWARE_BUDGET`. Full training, final trained-checkpoint
+  qualification, the strict `<1.50` sealed-NLL reveal, generation, and replay
+  remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower
+  (`4.485223` versus signed `3.491307 s/step`), so #1019 is optional/paused and
+  the active next step is the #1017 `r4 generate` product path. Apple
+  Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
+  external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
   [signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
   Do not extend
@@ -834,11 +852,13 @@ historical evidence and comparators.
   trace student is complete with bounded distillation but looping output;
   the state student and observability audit closed negative; #1014 established
   load-bearing attention; and #1017 closed NLL-only negative after passing
-  retention, parity, audits, and replay. #1019 is the active frozen
-  parameter-capacity campaign: population/smoke/random-export parity passed,
-  MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`, and the full campaign
-  remains `NOT_RUN` pending only an explicitly owner-approved deterministic
-  single-CUDA `f32` fallback; intrinsic score/readout alternatives,
+  retention, parity, audits, and replay. #1019 is an optional frozen
+  parameter-capacity improvement: population/smoke/random-export parity passed,
+  MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
+  offline implementation, and the full campaign remains `NOT_RUN`. Its fused-
+  AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and
+  the active next step is the #1017 `r4 generate` product path. CUDA and
+  external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact
   deployment are parked. D3 remains `NOT_RUN`; #954 remains blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.

--- a/crates/uor-r4-model-source/Cargo.toml
+++ b/crates/uor-r4-model-source/Cargo.toml
@@ -5,11 +5,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-# #804 measurement-only exception (maintainer-approved 2026-08-18): route
-# the TEACHER weight matmuls through Apple Accelerate for observation
-# passes. Never a default; the matrix_operation_census gate pins the
-# exception file, its feature gating, and its two dispatch sites. The
-# deployed serving runtime is unaffected by construction (P-4 contract).
+# #804 Apple Accelerate path (maintainer-approved 2026-08-18): route TEACHER
+# weight matmuls through CPU BLAS for explicitly built local source-backed
+# inference and observation. Never a default; the matrix_operation_census gate
+# pins the file, feature gating, and two dispatch sites. The deployed source-free
+# serving runtime is unaffected by construction (P-4 contract).
 observation-blas-exception = []
 
 [dependencies]

--- a/crates/uor-r4-model-source/src/exact_executor.rs
+++ b/crates/uor-r4-model-source/src/exact_executor.rs
@@ -252,8 +252,8 @@ pub struct ExactBackendReport {
     pub selection_status: String,
 }
 
-/// Report exact arithmetic ownership and observable uor-matmul availability.
-pub fn exact_backend_report() -> ExactBackendReport {
+/// Report arithmetic ownership for a selected source-backed forward mode.
+pub(crate) fn backend_report_for_fast_matmul(fast_matmul: bool) -> ExactBackendReport {
     let mut available_backends = Vec::new();
     for spec in uor_matmul::kernels::cached::available_reduce_i8().filter(|spec| spec.k_group == 1)
     {
@@ -263,17 +263,29 @@ pub fn exact_backend_report() -> ExactBackendReport {
         }
     }
     #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
-    let (arithmetic_owner, selected_backend, selection_status) = (
-        "Apple Accelerate observation BLAS exception".to_owned(),
-        Some("Apple Accelerate".to_owned()),
-        "AVAILABLE: explicitly selected by observation-blas-exception".to_owned(),
-    );
+    let (arithmetic_owner, selected_backend, selection_status) = if fast_matmul {
+        (
+            "Apple Accelerate CPU BLAS".to_owned(),
+            Some("Apple Accelerate".to_owned()),
+            "AVAILABLE: explicitly selected by observation-blas-exception".to_owned(),
+        )
+    } else {
+        (
+            "uor-matmul exact GEMM".to_owned(),
+            None,
+            "AVAILABLE_BUT_DISABLED: exact/canonical runtime selected".to_owned(),
+        )
+    };
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
-    let (arithmetic_owner, selected_backend, selection_status) = (
-        "uor-matmul exact GEMM".to_owned(),
-        None,
-        "UNAVAILABLE: uor-matmul does not expose the private float auto-selection cache".to_owned(),
-    );
+    let (arithmetic_owner, selected_backend, selection_status) = {
+        let _ = fast_matmul;
+        (
+            "uor-matmul exact GEMM".to_owned(),
+            None,
+            "UNAVAILABLE: uor-matmul does not expose the private float auto-selection cache"
+                .to_owned(),
+        )
+    };
 
     ExactBackendReport {
         arithmetic_owner,
@@ -285,6 +297,24 @@ pub fn exact_backend_report() -> ExactBackendReport {
         selected_backend,
         selection_status,
     }
+}
+
+/// Report the arithmetic owner selected by the current process environment.
+///
+/// The historical function name is retained for API compatibility. A macOS
+/// build with the Accelerate feature reports BLAS in normal fast mode, while
+/// either exact override reports the exact owner that will actually execute.
+pub fn exact_backend_report() -> ExactBackendReport {
+    #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
+    let fast_matmul = {
+        let canonical_math =
+            std::env::var("TLESS_CANONICAL_DETERMINISTIC").is_ok_and(|value| value != "0");
+        !canonical_math && std::env::var("TLESS_EXACT_SCALAR").is_err()
+    };
+    #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
+    let fast_matmul = false;
+
+    backend_report_for_fast_matmul(fast_matmul)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -17,8 +17,8 @@ pub mod geometric_training;
 pub mod geometry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod gpt2;
-/// #804 measurement-only BLAS exception — opt-in feature, macOS only,
-/// pinned by the `matrix_operation_census` gate. See the module docs.
+/// #804 local source-backed Apple Accelerate path — opt-in feature, macOS
+/// only, pinned by the `matrix_operation_census` gate. See the module docs.
 #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
 mod observation_blas_exception;
 pub mod progress;
@@ -27,7 +27,7 @@ pub mod teacher;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 use exact_executor::AtomicTeacherExecutionProgress;
-use exact_executor::ExactExecutor;
+use exact_executor::{backend_report_for_fast_matmul, ExactExecutor};
 pub use exact_executor::{
     exact_backend_report, ExactBackendReport, TeacherExecutionConfig, TeacherExecutionObserver,
     TeacherExecutionPreparation, TeacherExecutionSnapshot, UOR_MATMUL_REVISION,
@@ -951,28 +951,26 @@ pub(crate) fn softmax_with_mode(x: &mut [f32], canonical: bool) {
 /// GEMM (#655-B2). `gemm_float` accumulates every product into a complete
 /// accumulator and rounds once. The enforced output-bit contract is exercised
 /// across fixed worker counts by `exact_matmul_matches_serial_bits_for_1_2_4_8_workers`
-/// and by the fixture-present exact probe. The former
-/// `fast` (Accelerate BLAS `sgemv`) / hand-rolled canonical paths are gone;
-/// `_fast` is retained in the signature only so callers need not change.
-fn matmul(
-    _executor: &ExactExecutor,
-    xout: &mut [f32],
-    x: &[f32],
-    w: &[f32],
-    n: usize,
-    _fast: bool,
-) {
-    // #804 measurement-only exception (maintainer-approved 2026-08-18):
-    // under the opt-in feature, observation builds route through Apple
-    // Accelerate — see `observation_blas_exception`'s module docs. Every
-    // default build takes the owned exact GEMM below.
+/// and by the fixture-present exact probe. The opt-in local-inference feature
+/// uses `fast=true` to select Accelerate; canonical/exact callers pass `false`
+/// and retain the owned exact path.
+fn matmul(executor: &ExactExecutor, xout: &mut [f32], x: &[f32], w: &[f32], n: usize, fast: bool) {
+    // #804 Apple Accelerate path (maintainer-approved 2026-08-18): under the
+    // opt-in feature, normal local source-backed inference/observation routes
+    // through CPU BLAS — see `observation_blas_exception`'s module docs. Every
+    // default or explicitly exact build takes the owned exact GEMM below.
     #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
     {
-        observation_blas_exception::matmul(xout, x, w, n);
+        if fast {
+            observation_blas_exception::matmul(xout, x, w, n);
+        } else {
+            executor.matmul(xout, x, w, n);
+        }
     }
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
     {
-        _executor.matmul(xout, x, w, n);
+        let _ = fast;
+        executor.matmul(xout, x, w, n);
     }
 }
 
@@ -985,27 +983,33 @@ fn matmul(
 /// enforced contract covered by `exact_batched_matmul_matches_serial_bits_for_1_2_4_8_workers`
 /// and the fixture-present probe; unavailable live evidence is not a pass.
 fn matmul_batched(
-    _executor: &ExactExecutor,
+    executor: &ExactExecutor,
     xout: &mut [f32],
     x: &[f32],
     w: &[f32],
     n: usize,
     batch: usize,
+    fast: bool,
 ) {
     debug_assert!(batch > 0);
     debug_assert_eq!(xout.len() % batch, 0);
     let rows = xout.len() / batch;
     debug_assert!(w.len() >= rows * n);
     debug_assert_eq!(x.len(), batch * n);
-    // #804 measurement-only exception — see `matmul` above and the
+    // #804 opt-in Apple Accelerate path — see `matmul` above and the
     // `observation_blas_exception` module docs.
     #[cfg(all(feature = "observation-blas-exception", target_os = "macos"))]
     {
-        observation_blas_exception::matmul_batched(xout, x, w, n, batch);
+        if fast {
+            observation_blas_exception::matmul_batched(xout, x, w, n, batch);
+        } else {
+            executor.matmul_batched(xout, x, w, n, batch);
+        }
     }
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
     {
-        _executor.matmul_batched(xout, x, w, n, batch);
+        let _ = fast;
+        executor.matmul_batched(xout, x, w, n, batch);
     }
 }
 
@@ -1020,7 +1024,7 @@ fn fast_matmul_backend() -> &'static str {
     {
         // Loud per-run provenance: every "teacher model ready" line names
         // the exception so no corpus can be produced under it silently.
-        "Accelerate cblas (observation-only exception #804)"
+        "Accelerate cblas (local CPU inference/observation #804)"
     }
     #[cfg(not(all(feature = "observation-blas-exception", target_os = "macos")))]
     {
@@ -1893,8 +1897,9 @@ impl Llama {
     /// mirrors [`Llama::forward`] exactly. `matmul_batched` and the serial path
     /// share the pinned exact `uor-matmul` owner; exact bit agreement is an
     /// enforced contract checked by focused per-target tests and the live
-    /// probe, not a universal cross-target claim. `fast_matmul` is a
-    /// compatibility parameter and does not select another arithmetic owner.
+    /// probe, not a universal cross-target claim. Under the explicit Apple
+    /// Accelerate feature, `fast_matmul` selects CPU BLAS; canonical/exact mode
+    /// passes `false` and keeps the owned exact path.
     pub fn forward_batch(
         &self,
         states: &mut [State],
@@ -1920,7 +1925,6 @@ impl Llama {
             .forward_gate
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let _ = fast_matmul;
         let c = &self.cfg;
         let (dim, hid) = (c.dim, c.hidden);
         let kv_dim = c.dim * c.n_kv_heads / c.n_heads;
@@ -2002,6 +2006,7 @@ impl Llama {
                 &w[self.wq + l * dim * dim..],
                 dim,
                 b,
+                fast_matmul,
             );
             matmul_batched(
                 &self.exact_executor,
@@ -2010,6 +2015,7 @@ impl Llama {
                 &w[self.wk + l * dim * kv_dim..],
                 dim,
                 b,
+                fast_matmul,
             );
             matmul_batched(
                 &self.exact_executor,
@@ -2018,6 +2024,7 @@ impl Llama {
                 &w[self.wv + l * dim * kv_dim..],
                 dim,
                 b,
+                fast_matmul,
             );
             for bi in 0..b {
                 let loff = l * states[bi].sequence_capacity * kv_dim;
@@ -2117,6 +2124,7 @@ impl Llama {
                 &w[self.wo + l * dim * dim..],
                 dim,
                 b,
+                fast_matmul,
             );
             for bi in 0..b {
                 for i in 0..dim {
@@ -2139,6 +2147,7 @@ impl Llama {
                 &w[self.w1 + l * dim * hid..],
                 dim,
                 b,
+                fast_matmul,
             );
             matmul_batched(
                 &self.exact_executor,
@@ -2147,6 +2156,7 @@ impl Llama {
                 &w[self.w3 + l * dim * hid..],
                 dim,
                 b,
+                fast_matmul,
             );
             for idx in 0..b * hid {
                 let mut val = hb[idx];
@@ -2161,6 +2171,7 @@ impl Llama {
                 &w[self.w2 + l * hid * dim..],
                 hid,
                 b,
+                fast_matmul,
             );
             for bi in 0..b {
                 for i in 0..dim {
@@ -2182,6 +2193,7 @@ impl Llama {
             &w[self.wcls..],
             dim,
             b,
+            fast_matmul,
         );
         for bi in 0..b {
             states[bi]
@@ -4149,9 +4161,9 @@ impl HuggingFaceLlamaOracle {
             .exact_probe_trace_shape_bounded(sequence_capacity, positions, batch_width, top_k)
     }
 
-    /// Exact arithmetic owner and observable hosted-kernel availability.
+    /// Selected arithmetic owner and observable hosted-kernel availability.
     pub fn exact_backend_report(&self) -> ExactBackendReport {
-        exact_backend_report()
+        backend_report_for_fast_matmul(self.fast_matmul)
     }
 
     /// Enable or disable the experimental attention variant
@@ -4326,10 +4338,12 @@ impl HuggingFaceLlamaOracle {
         }
         let state = State::new(&model.cfg);
         let fast_matmul = !canonical_math && std::env::var("TLESS_EXACT_SCALAR").is_err();
-        let backend = if canonical_math {
+        let backend = if fast_matmul {
+            fast_matmul_backend()
+        } else if canonical_math {
             "uor-matmul exact GEMM + canonical libm scalar (D2)"
         } else {
-            fast_matmul_backend()
+            "uor-matmul exact GEMM"
         };
         eprintln!(
             "teacher model ready (κ {kappa}, matmul={backend}, exact_workers={})",
@@ -4615,7 +4629,7 @@ mod tests {
         let executor = ExactExecutor::new(TeacherExecutionConfig::sequential())
             .expect("serial exact executor");
         let mut batched = vec![0.0f32; BATCH * ROWS];
-        matmul_batched(&executor, &mut batched, &x, &weights, N, BATCH);
+        matmul_batched(&executor, &mut batched, &x, &weights, N, BATCH, false);
         for bi in 0..BATCH {
             let mut serial = [0.0f32; ROWS];
             matmul(
@@ -4691,10 +4705,7 @@ mod tests {
     #[test]
     fn observation_blas_exception_reports_non_exact_owner() {
         let report = exact_backend_report();
-        assert_eq!(
-            report.arithmetic_owner,
-            "Apple Accelerate observation BLAS exception"
-        );
+        assert_eq!(report.arithmetic_owner, "Apple Accelerate CPU BLAS");
         assert_eq!(report.selected_backend.as_deref(), Some("Apple Accelerate"));
         assert!(report.selection_status.starts_with("AVAILABLE:"));
         assert_eq!(report.target_os, std::env::consts::OS);

--- a/crates/uor-r4-model-source/src/observation_blas_exception.rs
+++ b/crates/uor-r4-model-source/src/observation_blas_exception.rs
@@ -1,19 +1,21 @@
-//! #804 measurement-only BLAS exception — maintainer-approved 2026-08-18.
+//! #804 Apple Accelerate CPU BLAS path — maintainer-approved 2026-08-18.
 //!
 //! Routes the TEACHER weight matmuls through Apple Accelerate
-//! (`cblas_sgemv`/`cblas_sgemm`) for **observation passes only**, restoring
+//! (`cblas_sgemv`/`cblas_sgemm`) for local source-backed inference and
+//! observation passes, restoring
 //! the pre-#655-B2 throughput (~50–100× over the owned exact GEMM on this
 //! class of machine) so corpus-scale teacher-forced observation remains
-//! feasible on the pinned measurement Mac. This is an explicit, pinned
-//! exception to the #655-B2 arithmetic-ownership migration, NOT a rollback:
+//! feasible and local generation uses the host efficiently. This is an
+//! explicit opt-in to ordinary f32 CPU BLAS, not a change to the portable
+//! exact or source-free runtime:
 //!
 //! - **Never a default.** This module only compiles under
 //!   `--features observation-blas-exception` on macOS; every default build
 //!   keeps the pinned `uor-matmul` exact GEMM everywhere. The
 //!   `matrix_operation_census` gate pins the file, its feature gating, and
 //!   its single dispatch site.
-//! - **Teacher data only.** Only the teacher forward used by
-//!   observation/compize passes dispatches here; the deployed
+//! - **Local source-backed work only.** Teacher observation/compile passes and
+//!   explicitly built local source-backed generation dispatch here; the deployed
 //!   transformerless serving runtime carries no dependency on this crate's
 //!   matmuls at all (P-4 contract, `INFERENCE_OPERATION_CONTRACT.md`).
 //! - **Provenance is loud.** `fast_matmul_backend()` reports the exception

--- a/crates/uor-r4-model-source/tests/matrix_operation_census.rs
+++ b/crates/uor-r4-model-source/tests/matrix_operation_census.rs
@@ -39,10 +39,10 @@ const BLAS_MATRIX_MARKERS: &[&str] =
 const SANCTIONED_SUFFIXES: &[&str] = &[
     "uor-r4-graph-compiler/src/dependency_audit.rs",
     "uor-r4-proof-model/src/inference_audit.rs",
-    // #804 measurement-only BLAS exception (maintainer-approved
-    // 2026-08-18): the ONE sanctioned library-BLAS use site, compiled
-    // only under the opt-in `observation-blas-exception` feature on
-    // macOS, for teacher-forced observation passes. Its gating and its
+    // #804 Apple Accelerate path (maintainer-approved 2026-08-18): the ONE
+    // sanctioned library-BLAS use site, compiled only under the opt-in
+    // `observation-blas-exception` feature on macOS, for local source-backed
+    // inference and teacher-forced observation. Its gating and its
     // single dispatch site are pinned by
     // `observation_blas_exception_is_opt_in_and_never_default` below —
     // adding this suffix does NOT exempt default builds from anything,
@@ -166,9 +166,8 @@ fn teacher_site_owns_no_blas_matrix_ffi() {
     );
 }
 
-/// #804: the measurement-only BLAS exception stays exactly what the
-/// maintainer approved — an opt-in, macOS-only, observation-side escape
-/// hatch — and can never silently widen:
+/// #804: the Apple Accelerate path stays opt-in, macOS-only, limited to the
+/// local source-backed model, and can never silently widen:
 ///
 /// - the exception module and every dispatch to it in `lib.rs` sit behind
 ///   `cfg(all(feature = "observation-blas-exception", target_os = "macos"))`

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -98,18 +98,34 @@ without rerun or tuning. Its one separately frozen exposure successor,
 audits, prompt retention `5/5`, and normalized replay `5/5` passed; sealed NLL
 `1.5727521962806827` failed the strict `<1.50` gate. The result is negative
 solely on NLL. [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
-now freezes the sole increase: twelve layers, 13,130,784 parameters, seed 1019,
+froze an optional increase: twelve layers, 13,130,784 parameters, seed 1019,
 16,800 steps, and 275,251,200 tokens over the same mechanism and Rust path.
 The exact population, 400-step fixed-sequence overfit, and random-export
 all-twelve-layer Rust parity preflights passed. The signed MPS gate stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time: its `20.66 h` safety projection exceeded
-the `8 h` ceiling, while memory passed at `21.03%`. Full training, final parity,
-reveal, generation, and replay remain `NOT_RUN`; only the deterministic
-single-CUDA `f32` fallback may proceed after explicit owner authorization for
-external compute and any spend. The MPS stop is not a model-quality negative,
+the `8 h` ceiling, while memory passed at `21.03%`. That terminal applies only
+to the frozen offline PyTorch/MPS implementation. Full training, final parity,
+reveal, generation, and replay remain `NOT_RUN`. A single isolated exact-shape
+MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
+deferred logging and measured `4.485223 s/step`, slower than the signed
+`3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+fast-path negative, not a model result. #1019 tuning/full-run work stops and
+remains optional/paused; the active next step is the working #1017 `r4 generate`
+product path. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS
+are local offline accelerators only; CUDA and external GPU execution are out of
+scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
 established attention result. See the
 [#1019 observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json).
+
+The #1017 export remains the current working 7.15M coherent-generation
+prototype. `r4 generate --prompt "..."` defaults to
+`.uor-models/research/issue-1017/export`. #1019 is an optional quality-capacity
+improvement and does not block using or productizing that bounded path. The
+prototype remains source-backed, floating-point/matmul/softmax, and below the
+strict NLL target; it does not establish geometry advantage,
+transformerlessness, correctness, reasoning, frontier quality, browser/WASM
+readiness, or release readiness.
 Further 7.15M exposure and learning-rate tuning remain prohibited.
 The reference remains transformer-compatible
 and `f32`/multiply/alloc/source-weight backed; it is not source-free,
@@ -1549,14 +1565,16 @@ D3 on construction covariance, with diagnostic curved NLL worse than donor and
   complete quality DoD at enabled NLL `2.127407` and prompt retention `3/5`.
   #1017's separate continuation then passed retention `5/5`, enabled parity,
   every mechanical gate, and replay, but failed solely on sealed NLL
-  `1.5727521962806827`. #1019 is the primary rung: one frozen 12-layer,
+  `1.5727521962806827`. #1019 is an optional, paused rung: one frozen 12-layer,
   13,130,784-parameter campaign over the unchanged attention and Rust execution
   path. Population, 400-step overfit, and random-export all-twelve-layer Rust
   parity passed. MPS stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
-  `20.66 h` safety projection exceeded `8 h`; memory passed at `21.03%`. Full
-  training, final parity, reveal, generation, and replay remain `NOT_RUN`.
-  Only the deterministic single-CUDA `f32` fallback may proceed after explicit
-  owner authorization for external compute and any spend. Further exposure and
+  `20.66 h` safety projection exceeded `8 h`; memory passed at `21.03%`. That
+  terminal applies only to the frozen offline implementation. Full training,
+  final parity, reveal, generation, and replay remain `NOT_RUN`. Its fused-
+  AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and
+  the active next step is the #1017 `r4 generate` product path. CUDA and
+  external GPU execution are out of scope. Further exposure and
   LR tuning of the 7.15M checkpoint are prohibited.
   Resonance substitutes, unrelated optimization, and release work
   remain parked. Lowering does not otherwise reactivate automatically on a

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,23 +99,37 @@ has now completed at `149,995,520` cumulative tokens. Enabled Rust parity,
 all-layer causal/R4 audits, `5/5` subject-or-scene retention, and `5/5` exact
 normalized replay passed; fresh sealed NLL `1.5727521962806827` failed the
 strict `<1.50` criterion. The result is negative solely on NLL. No more
-7.15M-parameter exposure or learning-rate tuning follows. The sole successor is
-now frozen under [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019):
+7.15M-parameter exposure or learning-rate tuning follows. An optional capacity
+successor was frozen under [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019):
 twelve layers, 13,130,784 parameters, seed 1019, 16,800 optimizer steps, and
 275,251,200 tokens over the same mechanism and Rust path. Its fresh population
 is `PASS`; the 400-step, 64-sequence MPS overfit smoke is `PASS` with `81.9752%`
 loss reduction; and random-export/all-12-layer Rust preflight parity is `PASS` with
 maximum absolute logit delta `0.0000443459`. The signed 200-step MPS probe
 passed memory at `21.03%` but failed time with a safety projection of `20.66 h`,
-above the `8 h` ceiling, so the MPS path is terminal
-`UNAVAILABLE_HARDWARE_BUDGET` and MPS full training is unauthorized. Full
-training, final qualification, sealed reveal, generation, and replay remain
-`NOT_RUN`. Only the deterministic single-CUDA `f32` fallback may continue after
-explicit owner approval for external compute and spend. See the
+above the `8 h` ceiling, so that frozen offline implementation is terminal
+`UNAVAILABLE_HARDWARE_BUDGET`. Full training, final qualification, sealed
+reveal, generation, and replay remain `NOT_RUN`. UOR's deployed
+architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS are
+local offline accelerators only. A single isolated exact-shape MPS fast-path
+test (10 warmup plus 40 measured steps) combined fused AdamW with deferred
+logging and measured `4.485223 s/step`, slower than the signed
+`3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+fast-path negative, not a model result. #1019 tuning/full-run work stops and
+remains optional/paused; the active next step is the working #1017 `r4 generate`
+product path. CUDA and external GPU execution are out of scope. See the
 [#1017 record](r4_softmax_quality_capacity_continuation_1017.md),
 [#1019 frozen contract](r4_softmax_parameter_capacity_1019.md), and
 [#1019 signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json). This stops
 one bounded model-capacity rung, not ordinary attention.
+#1017 remains the current working 7.15M coherent-generation prototype:
+`r4 generate --prompt "..."` defaults to
+`.uor-models/research/issue-1017/export`. #1019 is an optional capacity
+improvement and does not block using or productizing that bounded path. The
+#1017 prototype remains source-backed, floating-point/matmul/softmax, and below
+the strict NLL target; it is not geometry advantage, transformerlessness,
+correctness, reasoning, frontier quality, browser/WASM readiness, or release
+readiness.
 No tag, release, hosted promotion, or static-WASM claim is authorized. D3
 remains `NOT_RUN`; #973 remains open and #954 remains blocked.
 
@@ -146,12 +160,14 @@ Choose the shortest path that matches what you need:
   [ADR-0005](adr/0005-predictive-geometric-connection-memory.md), then
   [ADR-0004](adr/0004-geometric-intelligence-route-hierarchy.md), and use the
   [glossary](transformerless/GLOSSARY.md) for unfamiliar terms.
-- **Contribute to the active build:** start from live
+- **Improve the optional capacity rung:** start from live
   [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019) under #973 and
   programme root #820. Its population/smoke/random-export parity gates passed,
-  but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; execute the remaining
-  `NOT_RUN` campaign only through the deterministic single-CUDA `f32` fallback
-  after explicit owner approval for external compute and spend.
+  but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen
+  eight-hour offline implementation. Its fused-AdamW/deferred-logging fast path
+  was slower (`4.485223` versus signed `3.491307 s/step`), so the `NOT_RUN`
+  campaign is optional/paused and the active next step is the #1017
+  `r4 generate` product path. CUDA and external GPU execution are out of scope.
 - **Audit a result or claim:** use the [research ledger](RESEARCH.md), then open
   the exact issue-numbered evidence record it names.
 - **Run the existing interface:** return to the root
@@ -230,11 +246,13 @@ These are the small set of living documents that define the present work:
    attention intervention and negative first quality gate; the
    [#1017 record](r4_softmax_quality_capacity_continuation_1017.md) binds the
    completed NLL-only-negative continuation; the
-   [#1019 contract](r4_softmax_parameter_capacity_1019.md) binds the active,
+   [#1019 contract](r4_softmax_parameter_capacity_1019.md) binds the optional,
    partially executed parameter-capacity campaign: preliminary gates passed,
-   MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`, and the full campaign
-   remains `NOT_RUN` pending only an explicitly owner-approved deterministic
-   single-CUDA `f32` fallback.
+   MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
+   offline implementation, and the full campaign remains `NOT_RUN`. Its fused-
+   AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and
+   the active next step is the #1017 `r4 generate` product path. CUDA and
+   external GPU execution are out of scope.
    The bounded
    [multi-resonance reuse audit](multi_resonance_attention_sieve_audit_973.md)
    distinguishes the implemented sin/cos and Spin substrate from the still
@@ -274,7 +292,8 @@ reversible lexical geometry
   → audit signal loss across full trace, signed reduction, recurrent features, and readout [COMPLETE; INSUFFICIENT SUPPORT]
   → directly train end-to-end causal softmax attention in R4 coordinates [#1014; ATTENTION PASS, FULL QUALITY DOD FAIL]
   → continue the unchanged 7.15M model to 149,995,520 tokens [#1017; NLL-ONLY FAIL, RETENTION/PARITY/REPLAY PASS]
-  → #1019 frozen 12-layer, 13,130,784-parameter campaign over the same attention and Rust path [MODEL SUBGATES PASS; MPS UNAVAILABLE_HARDWARE_BUDGET; FULL CAMPAIGN NOT_RUN; OWNER-APPROVED CUDA F32 FALLBACK ONLY]
+  → #1019 frozen 12-layer, 13,130,784-parameter campaign over the same attention and Rust path [MODEL SUBGATES PASS; FROZEN OFFLINE MPS IMPLEMENTATION OVER 8 H; FUSED FAST PATH SLOWER; OPTIONAL/PAUSED; FULL CAMPAIGN NOT_RUN; CUDA/EXTERNAL GPU OUT OF SCOPE]
+  → active bounded #1017 `r4 generate` product path
   → park intrinsic/readout alternatives, resonance-based softmax replacement, full-model recurrent lowering, and exact deployment
   → correctness and abstention
   → multi-step reasoning

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -138,10 +138,17 @@ assumptions, or objectives rather than measured results.
 > and random-export/all-12-layer Rust preflight parity passed with maximum absolute logit
 > delta `0.0000443459`. The signed 200-step MPS probe passed memory at `21.03%`
 > but failed time with a safety projection of `20.66 h`, above the `8 h` ceiling,
-> terminating the MPS path `UNAVAILABLE_HARDWARE_BUDGET`. MPS full training is
-> unauthorized; full training, final qualification, sealed reveal, generation,
-> and replay remain `NOT_RUN`. Only the deterministic single-CUDA `f32` fallback
-> may continue after explicit owner approval for external compute and spend. See
+> terminating that frozen offline implementation
+> `UNAVAILABLE_HARDWARE_BUDGET`. Full training, final qualification, sealed
+> reveal, generation, and replay remain `NOT_RUN`. UOR's deployed
+> architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS are
+> local offline accelerators only. A single isolated exact-shape MPS fast-path
+> test (10 warmup plus 40 measured steps) combined fused AdamW with deferred
+> logging and measured `4.485223 s/step`, slower than the signed
+> `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+> fast-path negative, not a model result. #1019 tuning/full-run work stops and
+> remains optional/paused; the active next step is the working #1017
+> `r4 generate` product path. CUDA and external GPU execution are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
@@ -542,12 +549,14 @@ assumptions, or objectives rather than measured results.
 > enabled NLL `2.127407` and subject/scene retention `3/5`. Close the exact
 > campaign. #1017's separately frozen continuation then passed retention `5/5`,
 > enabled parity, all mechanical gates, and replay, but failed solely on sealed
-> NLL `1.5727521962806827`. #1019 now specifies the sole #973 capacity action:
+> NLL `1.5727521962806827`. #1019 now specifies an optional capacity improvement:
 > a frozen 12-layer, 13,130,784-parameter campaign over that unchanged
 > mechanism. Population, MPS overfit smoke, and random-export/all-12-layer Rust
-> parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET`; the
-> full campaign remains `NOT_RUN` unless an explicitly owner-approved
-> deterministic single-CUDA `f32` fallback qualifies.
+> parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
+> frozen eight-hour offline implementation. The full campaign remains
+> `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower, so #1019 is
+> optional/paused and the active next step is the #1017 `r4 generate` product
+> path. CUDA and external GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
 > exact deployment are parked. D3 remains
@@ -1132,10 +1141,12 @@ subject/scene retention `3/5`. #1017's one exposure continuation then improved
 retention to `5/5` but failed solely on NLL `1.5727521962806827`. #1019 is that
 new frozen contract: 12 layers, 13,130,784 parameters, seed 1019, 16,800 steps,
 and 275,251,200 tokens. Population, MPS overfit smoke, and
-random-export/all-12-layer Rust preflight parity passed, but MPS admission stopped
-`UNAVAILABLE_HARDWARE_BUDGET`; full training through replay remains `NOT_RUN`,
-with only an explicitly owner-approved deterministic single-CUDA `f32` fallback
-eligible. Fiber-preserving multi-resonance replacement, whole-decoder recurrent
+random-export/all-12-layer Rust preflight parity passed, but MPS admission
+stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
+implementation. Full training through replay remains `NOT_RUN`; its fused-
+AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and the
+active next step is the #1017 `r4 generate` product path. CUDA and external GPU
+execution are out of scope. Fiber-preserving multi-resonance replacement, whole-decoder recurrent
 factorization, and final requalification are parked.
 Dependable broad coherent text remains unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
@@ -1739,8 +1750,10 @@ closed NLL-only negative at `1.5727521962806827` with retention `5/5` and all
 other gates passing. #1019 now owns the one frozen 12-layer,
 13,130,784-parameter campaign over the unchanged mechanism. Its
 population/smoke/random-export parity gates passed, but MPS admission stopped
-`UNAVAILABLE_HARDWARE_BUDGET`; the full campaign remains `NOT_RUN` pending only
-an explicitly owner-approved deterministic single-CUDA `f32` fallback.
+`UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline implementation.
+The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-logging fast path
+was slower, so #1019 is optional/paused and the active next step is the #1017
+`r4 generate` product path. CUDA and external GPU execution are out of scope.
 Intrinsic/readout alternatives,
 multi-resonance replacement, whole-decoder recurrent factorization, and final
 requalification are parked. D3 remains `NOT_RUN`; #954 remains blocked.

--- a/docs/adr/0005-predictive-geometric-connection-memory.md
+++ b/docs/adr/0005-predictive-geometric-connection-memory.md
@@ -27,16 +27,24 @@
   `149,995,520` cumulative tokens it passed enabled parity, all mechanical
   gates, retention `5/5`, and normalized replay `5/5`, but failed solely on
   fresh sealed NLL `1.5727521962806827` against the strict `<1.50` gate.
-  [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019) now freezes the
-  sole increase: twelve layers, 13,130,784 parameters, seed 1019, 16,800 steps,
+  [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019) froze an
+  optional increase: twelve layers, 13,130,784 parameters, seed 1019, 16,800 steps,
   and 275,251,200 tokens over the same mechanism and Rust path. Exact
   population, 400-step fixed-sequence overfit, and random-export
   all-twelve-layer Rust parity passed. The signed MPS gate stopped
   `UNAVAILABLE_HARDWARE_BUDGET` on time: its `20.66 h` safety projection
-  exceeded the `8 h` ceiling, while memory passed at `21.03%`. Full training,
-  final parity, reveal, generation, and replay remain `NOT_RUN`; only the
-  deterministic single-CUDA `f32` fallback may proceed after explicit owner
-  authorization for external compute and any spend. The MPS stop is not a
+  exceeded the `8 h` ceiling, while memory passed at `21.03%`. That terminal
+  applies only to the frozen offline PyTorch/MPS implementation. Full training,
+  final parity, reveal, generation, and replay remain `NOT_RUN`. A single
+  isolated exact-shape MPS fast-path test (10 warmup plus 40 measured steps)
+  combined fused AdamW with deferred logging and measured `4.485223 s/step`,
+  slower than the signed `3.491307 s/step`; `fused=True` was removed
+  immediately. This is a bounded fast-path negative, not a model result. #1019
+  tuning/full-run work stops and remains optional/paused; the active next step
+  is the working #1017 `r4 generate` product path. UOR's deployed
+  architecture/runtime remains CPU-native;
+  Apple Accelerate/BLAS and MPS are local offline accelerators only; CUDA and
+  external GPU execution are out of scope. The MPS stop is not a
   model-quality negative, leaves the full-scale capacity hypothesis untested,
   and does not revoke the established attention result. See the
   [#1019 observed preflight](../r4_softmax_parameter_capacity_preflight_1019_raw.json).
@@ -151,12 +159,15 @@ learned R4/Spin scope. Its full quality DoD failed because enabled NLL was
 Close the exact campaign without rerun or tuning. The next action was one
 separately frozen quality-capacity rung over the unchanged mechanism. That rung,
 #1017, has now closed NLL-only negative at `1.5727521962806827`, with retention
-`5/5` and every other gate passing. #1019 now freezes the sole 12-layer,
-13,130,784-parameter successor. Population, 400-step overfit, and random-export
+`5/5` and every other gate passing. #1019 now freezes an optional 12-layer,
+13,130,784-parameter capacity improvement. Population, 400-step overfit, and random-export
 all-twelve-layer Rust parity passed; MPS is `UNAVAILABLE_HARDWARE_BUDGET` on
-time (`20.66 h > 8 h`) with memory passing at `21.03%`. Full training, final
-parity, reveal, generation, and replay remain `NOT_RUN`; only an
-owner-authorized deterministic single-CUDA `f32` fallback may proceed. No tag,
+time (`20.66 h > 8 h`) with memory passing at `21.03%`. That terminal applies
+only to the frozen offline implementation. Full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast
+path was slower, so #1019 is optional/paused and the active next step is the
+#1017 `r4 generate` product path. CUDA and external GPU execution are out of
+scope. No tag,
 release, hosted promotion, or static-WASM claim is authorized.
 Its architectural reference is the official MIT HELM-D source pinned at commit
 [`7501deca8f413848bfef804be64ce874b72a3cd7`](https://github.com/Graph-and-Geometric-Learning/helm/tree/7501deca8f413848bfef804be64ce874b72a3cd7).
@@ -209,9 +220,11 @@ The current sequence is strict:
    MPS time budget unavailable, full run `NOT_RUN`**. Population, 400-step overfit,
    and random-export all-twelve-layer Rust preflight parity passed. MPS stopped
    `UNAVAILABLE_HARDWARE_BUDGET` at `20.66 h > 8 h`, while memory passed at
-   `21.03%`. Full training, final parity, reveal, generation, and replay remain
-   `NOT_RUN`. Only the deterministic single-CUDA `f32` fallback may proceed
-   after explicit owner authorization for external compute and any spend.
+   `21.03%`. That terminal applies only to the frozen offline implementation.
+   Full training, final parity, reveal, generation, and replay remain `NOT_RUN`.
+   Its fused-AdamW/deferred-logging fast path was slower, so #1019 is optional/
+   paused and the active next step is the #1017 `r4 generate` product path.
+   CUDA and external GPU execution are out of scope.
 
 ### Qualified native endpoint and completed source-free trace rungs
 
@@ -870,13 +883,15 @@ The attention claim and the quality verdict are deliberately separate:
 The full issue result is therefore negative, but the attention mechanism is no
 longer ambiguous. #1017 then completed the separate exposure continuation with
 sealed NLL `1.5727521962806827` as its sole failed gate and retention/parity/
-audits/replay passing. #1019 is the next mechanism-building action: one frozen
-12-layer, 13,130,784-parameter campaign over the same attention/runtime path,
+audits/replay passing. #1019 is an optional/paused 12-layer,
+13,130,784-parameter campaign over the same attention/runtime path,
 with population, 400-step overfit, and random-export all-twelve-layer Rust
 parity passed. MPS is `UNAVAILABLE_HARDWARE_BUDGET` on time
-(`20.66 h > 8 h`) while memory passed at `21.03%`. Full training, final parity,
-reveal, generation, and replay remain `NOT_RUN`; only an owner-authorized
-deterministic single-CUDA `f32` fallback may proceed. It must not reopen
+(`20.66 h > 8 h`) while memory passed at `21.03%`. That terminal applies only
+to the frozen offline implementation. Full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast
+path was slower, so the active next step is the #1017 `r4 generate` product
+path. CUDA and external GPU execution are out of scope. It must not reopen
 folds, probes, transport permutations, alternative attention architectures,
 intrinsic geometry, resonance, or exact lowering. The
 [#1014 structured aggregate](../r4_softmax_end_to_end_attention_1014_raw.json)

--- a/docs/formal_vocabulary.md
+++ b/docs/formal_vocabulary.md
@@ -178,6 +178,25 @@ by wholesale rewrite.
 
 ## Changelog
 
+- **0.1.26** (2026-08-31) — Recorded the one bounded #1019 local fast-path
+  result: an isolated exact-shape MPS test with 10 warmup plus 40 measured steps
+  combined fused AdamW and deferred logging, measuring `4.485223 s/step` versus
+  the signed `3.491307 s/step`. Because it was slower, `fused=True` was removed
+  immediately. This is a bounded implementation negative, not a model or
+  attention result. #1019 tuning/full-run work stops and remains optional/
+  paused; product work and #973 no longer wait for it. The active next step is
+  using and productizing the bounded #1017 generator through `r4 generate`.
+- **0.1.25** (2026-08-31) — Corrected #1019's active execution scope without
+  rewriting its frozen contract or measured preflight: UOR's deployed
+  architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS are
+  permitted only for local offline training, compilation, and bounded tests;
+  CUDA and external GPU execution are out of scope. The observed
+  `UNAVAILABLE_HARDWARE_BUDGET` terminal applies only to the frozen eight-hour
+  offline implementation. Reuse the passed population/smoke/parity artifacts
+  and proceed prototype-first on the local M1: build, demonstrate, then harden
+  one working efficiency mechanism without recurring broad research gates.
+  #1019 is an optional quality-capacity improvement and no longer blocks use or
+  productization of the bounded #1017 generator through `r4 generate`.
 - **0.1.24** (2026-08-31) — Bound #1019 as the sole parameter-capacity
   successor: twelve layers, exactly 13,130,784 parameters, seed 1019, 16,800
   steps, and 275,251,200 tokens over the unchanged causal-softmax R4/Spin and

--- a/docs/geometric_intelligence_evaluation.md
+++ b/docs/geometric_intelligence_evaluation.md
@@ -183,9 +183,16 @@ verdict is negative solely on NLL. The next evaluation is now specified under
 fixed-sequence overfit, and random-export all-twelve-layer Rust preflight parity passed.
 The signed MPS gate stopped `UNAVAILABLE_HARDWARE_BUDGET` on time: its
 `20.66 h` safety projection exceeded the `8 h` ceiling, while memory passed at
-`21.03%`. Full training, final parity, reveal, generation, and replay remain
-`NOT_RUN`; only the deterministic single-CUDA `f32` fallback may proceed after
-explicit owner authorization for external compute and any spend. The MPS stop
+`21.03%`. That terminal applies only to the frozen offline PyTorch/MPS
+implementation. Full training, final parity, reveal, generation, and replay
+remain `NOT_RUN`. A single isolated exact-shape MPS fast-path test (10 warmup
+plus 40 measured steps) combined fused AdamW with deferred logging and measured
+`4.485223 s/step`, slower than the signed `3.491307 s/step`; `fused=True` was
+removed immediately. This is a bounded fast-path negative, not a model result.
+#1019 tuning/full-run work stops and remains optional/paused; the active next
+step is the working #1017 `r4 generate` product path. UOR's deployed architecture/runtime
+remains CPU-native; Apple Accelerate/BLAS and MPS are local offline accelerators
+only; CUDA and external GPU execution are out of scope. The MPS stop
 is not a model-quality negative, leaves the full-scale capacity hypothesis
 untested, and does not revoke the established attention result. This is not
 another attention diagnostic or more 7.15M exposure/LR tuning. See the
@@ -1045,13 +1052,16 @@ attention through a `2.677393`-nat attention-off penalty and exact Rust parity,
 but its enabled NLL `2.127407` and subject/scene retention `3/5` failed the full
 quality DoD. #1017's separately frozen continuation then passed retention
 `5/5`, parity, audits, and replay, but failed solely on NLL
-`1.5727521962806827`. #1019 now specifies the sole next evaluation action: a
-frozen 12-layer, 13,130,784-parameter campaign over that exact mechanism.
+`1.5727521962806827`. #1019 now specifies an optional evaluation action: a
+frozen 12-layer, 13,130,784-parameter capacity improvement over that exact
+mechanism.
 Population, 400-step overfit, and random-export all-twelve-layer Rust preflight parity
 passed. MPS stopped `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`),
-with memory passing at `21.03%`. Full training, final parity, reveal,
-generation, and replay remain `NOT_RUN`; only an owner-authorized deterministic
-single-CUDA `f32` fallback may proceed. D3 remains `NOT_RUN`;
+with memory passing at `21.03%`. That terminal applies only to the frozen
+offline implementation. Full training, final parity, reveal, generation, and
+replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower,
+so #1019 is optional/paused and the active next step is the #1017 `r4 generate`
+product path. CUDA and external GPU execution are out of scope. D3 remains `NOT_RUN`;
 intrinsic/readout alternatives,
 resonance-based softmax replacement, whole-decoder recurrent lowering, and
 exact deployment are parked.
@@ -1125,13 +1135,14 @@ established load-bearing ordinary causal attention through its
 its complete quality DoD at enabled NLL `2.127407` and prompt retention `3/5`.
 #1017's separate continuation then closed NLL-only negative at
 `1.5727521962806827`, with retention `5/5` and all other gates passing. #1019 is
-now active as the one frozen 12-layer, 13,130,784-parameter campaign over that
+an optional, paused frozen 12-layer, 13,130,784-parameter campaign over that
 unchanged mechanism. Population, 400-step overfit, and random-export
 all-twelve-layer Rust parity passed. MPS is `UNAVAILABLE_HARDWARE_BUDGET` on
-time (`20.66 h > 8 h`) with memory passing at `21.03%`. Full training, final
-parity, reveal, generation, and replay remain `NOT_RUN`; only the deterministic
-single-CUDA `f32` fallback may proceed after explicit owner authorization for
-external compute and any spend,
+time (`20.66 h > 8 h`) with memory passing at `21.03%`. That terminal applies
+only to the frozen offline implementation. Full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast
+path was slower, so #1019 is optional/paused and the active next step is the
+#1017 `r4 generate` product path. CUDA and external GPU execution are out of scope,
 while intrinsic/readout alternatives,
 resonance-based softmax replacement, whole-decoder recurrent lowering, and
 final requalification are parked.
@@ -1207,13 +1218,15 @@ subsequent #1014 campaign established load-bearing ordinary causal attention
 through a `2.677393`-nat attention-off penalty and exact Rust parity, but failed
 its full quality DoD at enabled NLL `2.127407` and prompt retention `3/5`. The
 subsequent #1017 continuation failed solely on NLL `1.5727521962806827` while
-retention, parity, audits, and replay passed. The current #973 decision is
-#1019's frozen 12-layer, 13,130,784-parameter campaign over that unchanged
+retention, parity, audits, and replay passed. #1019 records an optional, paused
+12-layer, 13,130,784-parameter campaign over that unchanged
 mechanism. Population, 400-step overfit, and random-export all-twelve-layer Rust
 parity passed; MPS is `UNAVAILABLE_HARDWARE_BUDGET` on time
-(`20.66 h > 8 h`) with memory passing at `21.03%`. Full training, final parity,
-reveal, generation, and replay remain `NOT_RUN`; only an owner-authorized
-deterministic single-CUDA `f32` fallback may proceed;
+(`20.66 h > 8 h`) with memory passing at `21.03%`. That terminal applies only
+to the frozen offline implementation. Full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast
+path was slower, so #1019 is optional/paused and the active next step is the
+#1017 `r4 generate` product path. CUDA and external GPU execution are out of scope;
 intrinsic/readout,
 multi-resonance, and recurrent lowering are parked. D3 remains `NOT_RUN` and
 #954 remains blocked. See the

--- a/docs/geometric_intelligence_programme.md
+++ b/docs/geometric_intelligence_programme.md
@@ -180,16 +180,23 @@ tokens. Enabled Rust parity, all-layer causal/R4 audits, subject-or-scene
 retention `5/5`, and normalized replay `5/5` passed. Fresh sealed NLL
 `1.5727521962806827` failed the strict `<1.50` criterion, making the overall
 result negative solely on NLL. Freeze it without rerun, further 7.15M exposure,
-or learning-rate tuning. The sole rung is now frozen under
+or learning-rate tuning. An optional capacity rung was frozen under
 [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019): twelve layers,
 13,130,784 parameters, seed 1019, 16,800 steps, and 275,251,200 tokens reusing
 the mechanism and Rust path. Exact population, 400-step fixed-sequence overfit,
 and random-export all-twelve-layer Rust preflight parity passed. The signed MPS gate
 stopped `UNAVAILABLE_HARDWARE_BUDGET` on time: its `20.66 h` safety projection
-exceeded the `8 h` ceiling, while memory passed at `21.03%`. Full training,
-final parity, reveal, generation, and replay remain `NOT_RUN`; only the
-deterministic single-CUDA `f32` fallback may proceed after explicit owner
-authorization for external compute and any spend. The MPS stop is not a
+exceeded the `8 h` ceiling, while memory passed at `21.03%`. That terminal
+applies only to the frozen offline PyTorch/MPS implementation. Full training,
+final parity, reveal, generation, and replay remain `NOT_RUN`. A single isolated
+exact-shape MPS fast-path test (10 warmup plus 40 measured steps) combined fused
+AdamW with deferred logging and measured `4.485223 s/step`, slower than the
+signed `3.491307 s/step`; `fused=True` was removed immediately. This is a
+bounded fast-path negative, not a model result. #1019 tuning/full-run work stops
+and remains optional/paused; the active next step is the working #1017
+`r4 generate` product path. UOR's deployed architecture/runtime remains CPU-native; Apple
+Accelerate/BLAS and MPS are local offline accelerators only; CUDA and external
+GPU execution are out of scope. The MPS stop is not a
 model-quality negative, leaves the full-scale capacity hypothesis untested, and
 does not revoke the established attention result. See the
 [#1019 observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json).
@@ -300,9 +307,11 @@ solely on NLL `1.5727521962806827`. #1019 now owns the single frozen 12-layer,
 13,130,784-parameter campaign over the unchanged mechanism. Its population,
 400-step overfit, and random-export all-twelve-layer Rust preflight parity passed; MPS
 stopped `UNAVAILABLE_HARDWARE_BUDGET` on its `20.66 h` time projection while
-memory passed at `21.03%`. Full training, final parity, reveal, generation, and
-replay remain `NOT_RUN`; only an owner-authorized deterministic single-CUDA
-`f32` fallback may proceed. Intrinsic/readout,
+memory passed at `21.03%`. That terminal applies only to the frozen offline
+implementation. Full training, final parity, reveal, generation, and replay
+remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower, so
+#1019 is optional/paused and the active next step is the #1017 `r4 generate`
+product path. CUDA and external GPU execution are out of scope. Intrinsic/readout,
 multi-resonance, recurrent lowering, and final requalification are parked;
 D3 remains `NOT_RUN` and #954 remains blocked.
 No new H4,
@@ -420,13 +429,16 @@ construction-bound exact-descriptor selector at each of paragraph and
   complete and failed its decision, material-control, and non-looping gates.
   The construction-only leave-one-document-out observability audit later
   completed at insufficient support, #1014 established load-bearing attention,
-  and #1017 closed NLL-only negative. The only active rung is #1019's frozen
-  12-layer parameter-capacity campaign. Population, 400-step overfit, and
+  and #1017 closed NLL-only negative while remaining the working bounded
+  generator. #1019 is an optional frozen 12-layer parameter-capacity
+  improvement. Population, 400-step overfit, and
   random-export all-twelve-layer Rust preflight parity passed; MPS is
   `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) with memory passing
-  at `21.03%`. Full training, final parity, reveal, generation, and replay are
-  `NOT_RUN`; only the deterministic single-CUDA `f32` fallback may proceed
-  after explicit owner authorization for external compute and any spend.
+  at `21.03%`. That terminal applies only to the frozen offline implementation.
+  Full training, final parity, reveal, generation, and replay are `NOT_RUN`.
+  Its fused-AdamW/deferred-logging fast path was slower, so #1019 is optional/
+  paused and the active next step is the #1017 `r4 generate` product path. CUDA
+  and external GPU execution are out of scope.
   Intrinsic/readout alternatives, resonance-based softmax
   replacement, new state dimensions, whole-decoder recurrent lowering, and
   exact deployment are parked. Calling a later
@@ -1423,13 +1435,15 @@ attention-off intervention and exact Rust parity, while its full quality DoD
 failed at enabled NLL `2.127407` and subject/scene retention `3/5`. Close that
 exact frozen campaign. #1017's exposure continuation then closed NLL-only
 negative at `1.5727521962806827`, with retention `5/5` and all other gates
-passing. #1019 is now active as the frozen 12-layer, 13,130,784-parameter
-campaign over the unchanged mechanism. Population, 400-step overfit, and
+passing. #1019 is an optional frozen 12-layer, 13,130,784-parameter capacity
+improvement over the unchanged mechanism. Population, 400-step overfit, and
 random-export all-twelve-layer Rust preflight parity passed. MPS stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) while memory passed at
-`21.03%`. Full training, final parity, reveal, generation, and replay remain
-`NOT_RUN`; only the deterministic single-CUDA `f32` fallback may proceed after
-explicit owner authorization for external compute and any spend.
+`21.03%`. That terminal applies only to the frozen offline implementation. Full
+training, final parity, reveal, generation, and replay remain `NOT_RUN`. Its
+fused-AdamW/deferred-logging fast path was slower, so #1019 is optional/paused
+and the active next step is the #1017 `r4 generate` product path. CUDA and
+external GPU execution are out of scope.
 Intrinsic/readout, resonance/recurrent lowering, and final
 requalification are parked.
 Product CLI/HTTP chat integration, restart-persistent conversation state, and
@@ -1836,12 +1850,14 @@ H4 connection against a working plain arm and a strong coherent-tangent
   continuation. The construction-only leave-one-document-out observability
   audit later completed at insufficient support; #1014 and #1017 then produced
   the attention-positive and NLL-only-negative results recorded above. #1019's
-  frozen parameter-capacity campaign is the current primary rung. Population,
+  frozen parameter-capacity campaign is optional and paused. Population,
   400-step overfit, and random-export all-twelve-layer Rust preflight parity passed; MPS
   is `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) with memory passing
-  at `21.03%`. Full training, final parity, reveal, generation, and replay
-  remain `NOT_RUN`; only an owner-authorized deterministic single-CUDA `f32`
-  fallback may proceed.
+  at `21.03%`. That terminal applies only to the frozen offline implementation.
+  Full training, final parity, reveal, generation, and replay remain `NOT_RUN`.
+  Its fused-AdamW/deferred-logging fast path was slower, so #1019 is optional/
+  paused and the active next step is the #1017 `r4 generate` product path. CUDA
+  and external GPU execution are out of scope.
 See ADR-0005 and the
 [#973 corpus-induced document placement record](corpus_induced_document_spin_placement_973.md).
 
@@ -1863,14 +1879,15 @@ bounded distillation but looping output. Its recurrent state successor is
 complete and failed promotion. The construction-only observability audit then
 closed at insufficient support; #1014 established load-bearing attention; and
 #1017 completed NLL-only negative at `1.5727521962806827` after passing
-retention, parity, audits, and replay. The sole next step is #1019's frozen
-12-layer, 13,130,784-parameter campaign over the same attention/Rust path.
+retention, parity, audits, and replay. #1019's optional frozen 12-layer,
+13,130,784-parameter campaign preserves the same attention/Rust path.
 Population, 400-step overfit, and random-export all-twelve-layer Rust preflight parity
 passed; MPS is `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) with
-memory passing at `21.03%`. Full training, final parity, reveal, generation,
-and replay remain `NOT_RUN`; only the deterministic single-CUDA `f32` fallback
-may proceed after explicit owner authorization for external compute and any
-spend. Intrinsic/readout alternatives,
+memory passing at `21.03%`. That terminal applies only to the frozen offline
+implementation. Full training, final parity, reveal, generation, and replay
+remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower, so
+#1019 is optional/paused and the active next step is the #1017 `r4 generate`
+product path. CUDA and external GPU execution are out of scope. Intrinsic/readout alternatives,
 resonance-based softmax replacement, new state dimensions, corpus scale,
 whole-decoder recurrent lowering, and exact deployment are parked, while D3
 remains `NOT_RUN`. The one

--- a/docs/matrix_operation_census.md
+++ b/docs/matrix_operation_census.md
@@ -111,22 +111,26 @@ No `cblas_*` symbol remains anywhere in the default production chain; the CI
 guard now enforces zero library-BLAS use (only the two dependency-audit files,
 which list BLAS crate names as denylist data, are exempt).
 
-### #804 measurement-only BLAS exception (maintainer-approved 2026-08-18)
+### #804 local source-backed Apple Accelerate path (maintainer-approved 2026-08-18)
 
 One additional, **opt-in** sanctioned site exists:
 `uor-r4-model-source/src/observation_blas_exception.rs` routes the teacher
 weight matmuls through Apple Accelerate (`cblas_sgemv`/`cblas_sgemm`) — but
-ONLY when a build explicitly passes `--features observation-blas-exception`
-on macOS, for corpus-scale teacher-forced **observation** passes whose
-wall-clock is infeasible under the exact GEMM (~50–100× slower on the pinned
-measurement Mac). Every default build keeps the uor-matmul owner everywhere;
+ONLY when a build explicitly passes `--features local-inference-accelerate`
+(or the historical alias `observation-blas-exception`)
+on macOS, for local source-backed inference and corpus-scale teacher-forced
+observation whose wall-clock is infeasible under the exact GEMM (~50–100×
+slower on the pinned measurement Mac). Every default build keeps the
+uor-matmul owner everywhere;
 the census gate (`observation_blas_exception_is_opt_in_and_never_default`)
 pins the file, its cfg gating, its exact two dispatch sites, and that no
 manifest default-enables the feature. Runtime provenance is loud: the
 "teacher model ready" line reports
-`Accelerate cblas (observation-only exception #804)` for every run built with
-the feature, and any corpus produced under it must record the backend in its
-run log / contract amendment (see #804/#605). Accelerate accumulation order
+`Accelerate cblas (local CPU inference/observation #804)` for a normal fast run
+built with the feature. `TLESS_CANONICAL_DETERMINISTIC` or
+`TLESS_EXACT_SCALAR` disables that dispatch and reports the exact owner instead.
+Any corpus produced under Accelerate must record the backend in its run log /
+contract amendment (see #804/#605). Accelerate accumulation order
 is machine-tuned, so logits differ from the exact GEMM in low-order bits —
 corpora produced under the exception are compared against traces from the
 SAME backend, never mixed silently with exact-GEMM corpora.

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -59,18 +59,26 @@
   causal/external audits, prompt retention `5/5`, and normalized replay `5/5`
   passed. Fresh sealed NLL `1.5727521962806827` failed the strict `<1.50`
   criterion, so #1017 is negative solely on NLL. Freeze that result without
-  rerun, further 7.15M exposure, or learning-rate tuning. The sole successor is
-  now frozen as [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019):
+  rerun, further 7.15M exposure, or learning-rate tuning. An optional capacity
+  successor was frozen as [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019):
   twelve layers, 13,130,784 parameters, seed 1019, 16,800 steps, and
   275,251,200 tokens using this attention and Rust execution path. It is not
   another attention diagnostic, geometry comparator, or softmax replacement.
   The exact population, 400-step fixed-sequence overfit, and random-export
   all-twelve-layer Rust parity preflights passed. The signed MPS gate stopped
   `UNAVAILABLE_HARDWARE_BUDGET` on time: its `20.66 h` safety projection
-  exceeded the `8 h` ceiling, while memory passed at `21.03%`. Full training,
-  final parity, reveal, generation, and replay remain `NOT_RUN`; only the
-  deterministic single-CUDA `f32` fallback may proceed after explicit owner
-  authorization for external compute and any spend. The MPS stop is not a
+  exceeded the `8 h` ceiling, while memory passed at `21.03%`. That terminal
+  applies only to the frozen offline PyTorch/MPS implementation. Full training,
+  final parity, reveal, generation, and replay remain `NOT_RUN`. A single
+  isolated exact-shape MPS fast-path test (10 warmup plus 40 measured steps)
+  combined fused AdamW with deferred logging and measured `4.485223 s/step`,
+  slower than the signed `3.491307 s/step`; `fused=True` was removed
+  immediately. This is a bounded fast-path negative, not a model result. #1019
+  tuning/full-run work stops and remains optional/paused; the active next step
+  is the working #1017 `r4 generate` product path. UOR's deployed
+  architecture/runtime remains CPU-native;
+  Apple Accelerate/BLAS and MPS are local offline accelerators only; CUDA and
+  external GPU execution are out of scope. The MPS stop is not a
   model-quality negative, leaves the full-scale capacity hypothesis untested,
   and does not revoke the established attention result.
   Offline teacher/compiler floats, matrix operations, and softmax are permitted
@@ -950,8 +958,9 @@ its evidence discipline from the start:
   instrument and its required verdict; predeclared thresholds and distinct positive/negative
   outcome branches; cost estimate; evidence-record path; and claim status.
 - **Implementation** — execution scope; dependencies/blockers; acceptance criteria; non-goals;
-  compatibility/migration; conformance mapping (RF IDs; the build order above); verification
-  (the four local gates + applicable ladder); documentation reconciliation; and claim status.
+  compatibility/migration; conformance mapping (RF IDs; the build order above); one targeted
+  compile plus one real behavior check during prototype work; deferred release verification;
+  documentation reconciliation; and claim status.
 
 ## Historical closure rule (superseded)
 

--- a/docs/r4_softmax_parameter_capacity_1019.md
+++ b/docs/r4_softmax_parameter_capacity_1019.md
@@ -1,7 +1,7 @@
 # Frozen 13.13M R4/Spin parameter-capacity campaign (#1019)
 
-- **Current status:** `MODEL_SUBGATES_PASS / MPS_UNAVAILABLE_HARDWARE_BUDGET /
-  FULL_CAMPAIGN_NOT_RUN`.
+- **Current status:** `OPTIONAL_PAUSED / MODEL_SUBGATES_PASS /
+  MPS_UNAVAILABLE_HARDWARE_BUDGET / FULL_CAMPAIGN_NOT_RUN`.
 - **Contract-freeze status (historical):** `FROZEN_PRE_RUN_CONTRACT / NOT_RUN`.
 - **Owner:** [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
   under attention issue #973 and programme root #820.
@@ -123,11 +123,27 @@ all-layer parity mean this preflight did not falsify the ordinary attention
 path or the 13.13M capacity hypothesis; they do not establish either final
 quality or geometry advantage.
 
-The failed signed MPS result now satisfies the prerequisite for at most one
-pinned deterministic single-CUDA float32 probe with TF32 disabled. No CUDA
-admission exists yet, and MPS cannot launch full training. Any paid external
-CUDA probe or training launch remains outside current authority and requires
-explicit owner approval before money is spent.
+The signed MPS terminal applies only to the frozen eight-hour offline
+PyTorch/MPS implementation. It does not redirect UOR's CPU-native deployed
+architecture/runtime and no longer authorizes the historical CUDA branch.
+Apple Accelerate/BLAS and MPS remain permitted only for local offline training,
+compilation, and bounded tests; CUDA and external GPU execution are out of
+scope. One subsequent isolated exact-shape MPS fast-path test used 10 warmup and
+40 measured steps with fused AdamW plus deferred logging. It measured
+`4.485223 s/step`, slower than the signed `3.491307 s/step`; `fused=True` was
+removed immediately. This is a bounded fast-path negative, not a model-quality
+or attention result. Preserve the passed population, smoke, and parity
+artifacts, but stop #1019 tuning and full-run work. #1019 is optional and
+paused; no recurring optimization or research gate follows from this result.
+
+#1019 is an optional, paused quality-capacity improvement. It does not block
+using or productizing the working #1017 7.15M coherent-generation prototype. The
+simple local entry point is `r4 generate --prompt "..."`, which defaults to
+`.uor-models/research/issue-1017/export`. That path remains a bounded,
+source-backed, floating-point/matmul/softmax prototype; it does not establish
+geometry advantage, transformerlessness, correctness, reasoning, frontier
+quality, browser/WASM readiness, or release readiness. This #1017 path is now
+the active next step.
 
 ## Frozen decision and evidence status at contract freeze (historical)
 
@@ -139,7 +155,8 @@ fresh sealed NLL `1.5727521962806827` failed the strict `<1.50` quality gate.
 That checkpoint will not receive more exposure, learning-rate tuning, another
 seed, or another reveal.
 
-#1019 is the one allowed parameter-capacity decision. It changes only decoder
+#1019 was the one allowed parameter-capacity decision at contract freeze. It
+changes only decoder
 depth from six to twelve layers. The attention mechanism, R4 block structure,
 tokenizer, split discipline, sampler, and Rust all-layer evidence path remain
 unchanged. This is a language-quality campaign, not another attention
@@ -223,7 +240,7 @@ slower measured save another 43 times as the worst-case initial/updated-best
 checkpoint cost, and includes 44 complete development evaluations before the
 `1.25` safety factor.
 
-**Hardware decision:** launch on the current MPS host only when the measured
+**Historical hardware decision at contract freeze (superseded):** launch on the current MPS host only when the measured
 projection, including a `1.25` safety factor, is at most eight hours. Peak
 accelerator memory must also be no more than 80% of the backend's reported
 available or recommended maximum. Otherwise require one pinned deterministic
@@ -234,10 +251,14 @@ backend qualifies, stop `UNAVAILABLE_HARDWARE_BUDGET`; a partial checkpoint is
 not evidence. No paid external launch is authorized without explicit owner
 approval.
 
-**Cost estimate:** prior M1 evidence projects this rung above the eight-hour
+**Historical cost estimate at contract freeze (superseded):** prior M1 evidence projects this rung above the eight-hour
 local ceiling, so a local full campaign is not authorized until a fresh probe
 contradicts that estimate. Any external campaign must project to at most eight
 hours and separately satisfy the monetary-approval gate.
+
+The CPU-native scope correction above supersedes this historical CUDA/external
+branch without changing the frozen contract or its observed evidence. No CUDA
+or external GPU probe or training run is an active #1019 action.
 
 ## Qualification and one-time reveal
 

--- a/docs/r4_softmax_quality_capacity_continuation_1017.md
+++ b/docs/r4_softmax_quality_capacity_continuation_1017.md
@@ -107,3 +107,34 @@ execution, dependable general-purpose generation, inference, correctness,
 reasoning, chat, browser-WASM operation, release readiness, or frontier
 capability. Five bounded rubric passes are evidence for those five frozen
 prompts only.
+
+## Owner direction and local M1 inference update — 2026-08-31
+
+The historical next-action paragraph above is superseded. #1019 is optional
+and paused after its MPS training projection and one slower fused-optimizer
+probe; it does not block use of this #1017 checkpoint. The active product path
+is `r4 generate --prompt "..."`. Broad qualification remains deferred until
+the prototype delivers useful behavior.
+
+The repository's existing Apple Accelerate `cblas_sgemv`/`cblas_sgemm` path
+was exercised on the project M1 rather than rejected by static analysis. For
+the same prompt `Once upon a time`, greedy four-token exact and Accelerate runs
+both produced IDs `[14, 403, 285, 261]`, decoded `, there was a`, output CID
+`blake3:ad043d419e9a3f30cc9be75d6a84f519d988e370a7288f6455763afe6257818e`,
+and attention-audit CID
+`blake3:1552cef6effdb28b3a4b5e1a29313a90beef7df0494ff7230040389c01d4fd78`.
+Exact `uor-matmul` required `3.060506042 s` of recorded generation and `3.41 s`
+wall time; Apple Accelerate required `0.116236875 s` and `0.52 s`, respectively:
+`26.33x` faster inside generation and `6.56x` end to end. Decision and
+persistent-state CIDs differ intentionally because they bind truthful backend
+and execution provenance.
+
+The local CPU-BLAS build is:
+
+```bash
+cargo build --release --offline --features local-inference-accelerate --bin r4
+target/release/r4 generate --prompt "Once upon a time"
+```
+
+This keeps exact `uor-matmul` as the portable default and uses Apple
+Accelerate only when explicitly requested for local source-backed inference.

--- a/docs/transformerless/COMPARISON.md
+++ b/docs/transformerless/COMPARISON.md
@@ -169,6 +169,13 @@ Use one path as the **portable baseline**, then add accelerated variants as
 separate rows. Do not merge CPU, Metal, CUDA, Vulkan, or other backends into
 one headline number: backend and machine class are part of the condition.
 
+The active UOR architecture/runtime direction is CPU-native. Apple
+Accelerate/BLAS and Metal/MPS may be used only for local offline compilation,
+training, or bounded comparison tests. The non-Apple accelerator recipes below
+are retained solely to reproduce historical external comparison rows; CUDA and
+external GPU execution are out of scope for current UOR development and are not
+an execution path for #1019.
+
 Before any `llama.cpp` conversion or benchmark command below, fetch the source
 checkpoint required by this repo's teacher path:
 
@@ -218,9 +225,10 @@ same benchmark arguments, but allow the Metal backend:
 Report these rows as `Metal` (or whatever backend string `llama-bench`
 prints), not as CPU rows.
 
-### x86/Linux accelerated variant: CUDA
+### Historical external comparison only: CUDA (out of current UOR scope)
 
-For NVIDIA systems, build the CUDA backend explicitly and allow GPU offload:
+The commands below reproduce the historical NVIDIA comparison condition. They
+are not an active UOR implementation, training, runtime, or #1019 path:
 
     git clone https://github.com/ggml-org/llama.cpp && cd llama.cpp
     git checkout e8f19cc

--- a/docs/transformerless/GLOSSARY.md
+++ b/docs/transformerless/GLOSSARY.md
@@ -269,14 +269,17 @@ substituted for one another.
   retention `3/5`. The exact campaign closes without rerun or tuning. #1017's
   separate exposure continuation then closed negative solely on sealed NLL
   `1.5727521962806827`; enabled parity, all mechanical gates, retention `5/5`,
-  and normalized replay `5/5` passed. #1019 now specifies the sole successor:
-  one fresh 12-layer, 13,130,784-parameter campaign over the same mechanism,
+  and normalized replay `5/5` passed. #1019 now specifies an optional capacity
+  improvement: one fresh 12-layer, 13,130,784-parameter campaign over the same mechanism,
   not further 7.15M exposure or LR tuning. Population, 400-step overfit, and
   random-export all-twelve-layer Rust preflight parity passed; MPS is
   `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) with memory passing
-  at `21.03%`. Full training, final parity, reveal, generation, and replay
-  remain `NOT_RUN`; only an owner-authorized deterministic single-CUDA `f32`
-  fallback may proceed.
+  at `21.03%`. That terminal applies only to the frozen offline implementation.
+  Full training, final parity, reveal, generation, and replay remain `NOT_RUN`.
+  Its fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
+  signed `3.491307 s/step`), so #1019 is optional/paused and the active next
+  step is the #1017 `r4 generate` product path. CUDA and external GPU execution
+  are out of scope.
 - **`R4SoftmaxQualityCapacityContinuationV1`** — #1017's completed, independently
   frozen continuation of the exact #1014 7,155,360-parameter model to
   `149,995,520` cumulative training tokens. Development selection froze at NLL
@@ -294,10 +297,18 @@ substituted for one another.
   400-step fixed-sequence overfit, and random-export all-twelve-layer Rust
   parity passed. The signed MPS gate stopped `UNAVAILABLE_HARDWARE_BUDGET` on
   time: its `20.66 h` safety projection exceeded the `8 h` ceiling, while
-  memory passed at `21.03%`. Full training, final parity, reveal, generation,
-  and replay remain `NOT_RUN`; only the deterministic single-CUDA `f32`
-  fallback may proceed after explicit owner authorization for external compute
-  and any spend. The MPS stop is not a model-quality negative, leaves the
+  memory passed at `21.03%`. That terminal applies only to the frozen offline
+  PyTorch/MPS implementation. Full training, final parity, reveal, generation,
+  and replay remain `NOT_RUN`. A single isolated exact-shape MPS fast-path test
+  (10 warmup plus 40 measured steps) combined fused AdamW with deferred logging
+  and measured `4.485223 s/step`, slower than the signed `3.491307 s/step`;
+  `fused=True` was removed immediately. This is a bounded fast-path negative,
+  not a model result. #1019 tuning/full-run work stops and remains optional/
+  paused; the active next step is the working #1017 `r4 generate` product path.
+  UOR's deployed
+  architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS are
+  local offline accelerators only; CUDA and external GPU execution are out of
+  scope. The MPS stop is not a model-quality negative, leaves the
   full-scale capacity hypothesis untested, and does not revoke the established
   attention result. See the
   [authoritative #1019 contract](../r4_softmax_parameter_capacity_1019.md) and
@@ -455,9 +466,12 @@ substituted for one another.
   13,130,784-parameter campaign over the unchanged mechanism. Population,
   400-step overfit, and random-export all-twelve-layer Rust preflight parity passed; MPS
   is `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) with memory
-  passing at `21.03%`. Full training, final parity, reveal, generation, and
-  replay remain `NOT_RUN`; only an owner-authorized deterministic single-CUDA
-  `f32` fallback may proceed. Intrinsic/readout,
+  passing at `21.03%`. That terminal applies only to the frozen offline
+  implementation. Full training, final parity, reveal, generation, and replay
+  remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower, so
+  #1019 is optional/paused and the active next step is the #1017 `r4 generate`
+  product path. CUDA and external GPU execution are out of scope.
+  Intrinsic/readout,
   fiber-preserving multi-resonance replacement,
   whole-decoder recurrent factorization, and final requalification are parked
   (#973);
@@ -539,9 +553,12 @@ retention `3/5`. #1017 then closed NLL-only negative at
 now owns the frozen 12-layer, 13,130,784-parameter campaign over the unchanged
 mechanism. Population, 400-step overfit, and random-export all-twelve-layer Rust
 parity passed; MPS is `UNAVAILABLE_HARDWARE_BUDGET` on time
-(`20.66 h > 8 h`) with memory passing at `21.03%`. Full training, final parity,
-reveal, generation, and replay remain `NOT_RUN`; only an owner-authorized
-deterministic single-CUDA `f32` fallback may proceed. Exact lowering,
+(`20.66 h > 8 h`) with memory passing at `21.03%`. That terminal applies only
+to the frozen offline implementation. Full training, final parity, reveal,
+generation, and replay remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast
+path was slower, so #1019 is optional/paused and the active next step is the
+#1017 `r4 generate` product path. CUDA and external GPU execution are out of
+scope. Exact lowering,
 resonance, WASM, release, correctness, and reasoning claims remain parked.
 
 ## Core roles

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,8 @@ use uor_r4_core::transformerless::hf_bpe::{resolve_source_tokenizer, TokenizerAd
 use uor_r4_graph_cli as transformerless_command;
 use uor_r4_wasm_router::chat::{ChatAnswer, ChatEngine, ChatError, DEFAULT_SAMPLE_SEED};
 use uor_r4_wasm_router::model::{
-    default_model_reference, download_source, evaluate_live_quality, ModelCapability, ModelError,
-    ModelManifest, ModelStore, QualityAttestation, SourceDownload,
+    default_model_reference, download_source, evaluate_live_quality, model_store_root,
+    ModelCapability, ModelError, ModelManifest, ModelStore, QualityAttestation, SourceDownload,
 };
 use uor_r4_wasm_router::release_bundle_loader::RELEASE_BUNDLE_SIDECAR_FILE_NAME;
 use uor_r4_wasm_router::release_bundle_packager::{self, PackageInputs};
@@ -112,7 +112,8 @@ enum Command {
     SourceFreeTable(SourceFreeTableArgs),
     /// Generate bounded text through all-layer R4/Spin causal softmax.
     R4SoftmaxGenerate(R4SoftmaxGenerateArgs),
-    /// Generate from a conformant local Llama checkpoint through all-layer R4/Spin causal softmax.
+    /// Generate from the local learned R4/Spin model through causal softmax.
+    #[command(visible_alias = "generate")]
     R4SoftmaxLocalGenerate(R4SoftmaxLocalGenerateArgs),
     /// Qualify one frozen #1014, #1017, or #1019 local causal-softmax campaign.
     R4SoftmaxLocalQualify(R4SoftmaxLocalQualifyArgs),
@@ -745,8 +746,8 @@ fn parse_r4_softmax_local_max_new_tokens(value: &str) -> Result<usize, String> {
 
 #[derive(Args, Debug)]
 struct R4SoftmaxLocalGenerateArgs {
-    /// Conformant local Hugging Face Llama checkpoint directory; no network fallback.
-    #[arg(long)]
+    /// Local learned checkpoint directory; defaults to the working #1017 model.
+    #[arg(long, default_value = ".uor-models/research/issue-1017/export")]
     model: PathBuf,
     /// Exact raw prompt; checkpoint BOS is prepended once and no chat template is applied.
     #[arg(long)]
@@ -2551,13 +2552,25 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             Ok(())
         }
         Some(Command::R4SoftmaxLocalGenerate(args)) => {
+            let default_model = Path::new(".uor-models/research/issue-1017/export");
+            let model = if args.model == default_model {
+                model_store_root().join("research/issue-1017/export")
+            } else {
+                args.model.clone()
+            };
+            if !model.join("model.safetensors").is_file() {
+                return Err(RunError::Command(format!(
+                    "no local #1017 model found at {}; set UOR_MODEL_STORE or pass --model",
+                    model.display()
+                )));
+            }
             let workers = std::num::NonZeroUsize::new(
                 uor_r4_wasm_router::r4_softmax_local_generation::DEFAULT_WORKERS,
             )
             .ok_or_else(|| RunError::Command("local generator worker count is zero".to_owned()))?;
             let report = uor_r4_wasm_router::r4_softmax_local_generation::run_r4_softmax_local_generation(
                 &uor_r4_wasm_router::r4_softmax_local_generation::R4SoftmaxLocalGeneratorConfig {
-                    model: args.model.clone(),
+                    model,
                     prompt: args.prompt.clone(),
                     max_new_tokens: args.max_new_tokens,
                     workers,

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -33,21 +33,39 @@ causal/external audit passed. The one-time fresh sealed NLL was
 retention and normalized replay both passed `5/5`.
 
 The #1017 result is negative solely on NLL. Do not rerun it, extend this
-7.15M-parameter checkpoint again, or tune its learning rate. #1019 is the sole
-successor: a fresh seed-1019, twelve-layer, 13,130,784-parameter run of exactly
+7.15M-parameter checkpoint again, or tune its learning rate. It remains the
+current working coherent-generation prototype: `r4 generate --prompt "..."`
+defaults to `$UOR_MODEL_STORE/research/issue-1017/export` (or the same path
+under `.uor-models` when unset). #1019 is an optional
+quality-capacity improvement: a fresh seed-1019, twelve-layer,
+13,130,784-parameter run of exactly
 16,800 steps and 275,251,200 tokens over the same qualified attention and Rust
 evidence path. The exact population, 400-step fixed-sequence overfit, and
 random-export all-twelve-layer Rust preflight parity passed. The signed MPS gate stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time: its `20.66 h` safety projection exceeded
-the `8 h` ceiling, while memory passed at `21.03%`. Full training, final parity,
-reveal, generation, and replay remain `NOT_RUN`. Only the deterministic
-single-CUDA `f32` fallback may proceed after explicit owner authorization for
-external compute and any spend. The MPS stop is not a model-quality negative,
+the `8 h` ceiling, while memory passed at `21.03%`. That terminal applies only
+to the frozen offline PyTorch/MPS implementation. Full training, final parity,
+reveal, generation, and replay remain `NOT_RUN`. A single isolated exact-shape
+MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
+deferred logging and measured `4.485223 s/step`, slower than the signed
+`3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
+fast-path negative, not a model result. #1019 tuning/full-run work stops and
+remains optional/paused; the active next step is the working #1017 `r4 generate`
+product path. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+and MPS are local offline accelerators only; CUDA and external GPU execution
+are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
 established attention result. See the
 [#1017 record](../../docs/r4_softmax_quality_capacity_continuation_1017.md) and
 [#1019 frozen contract](../../docs/r4_softmax_parameter_capacity_1019.md) plus
 its [observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
+
+For fast local #1017 inference on Apple Silicon, build the Rust CLI with
+`--features local-inference-accelerate`. The observed four-token comparison
+preserved generated IDs, output CID, and attention-audit CID while reducing
+internal generation from `3.060506042 s` to `0.116236875 s`. This is ordinary
+Apple CPU BLAS and carries distinct backend provenance; it is not a CUDA path
+or a change to the exact portable runtime contract.
 
 ## Isolated environment
 
@@ -68,9 +86,11 @@ package source file by a sorted BLAKE3 tree, in addition to dependency
 versions. Their MPS-only limits remain historical campaign constraints. #1019
 instead used its own eight-hour backend-admission gate. MPS stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) while memory passed at
-`21.03%`. The only permitted fallback is one pinned deterministic single-CUDA
-`f32` environment, after explicit owner authorization for external compute and
-any spend; TF32 remains disabled.
+`21.03%`. That result applies only to the frozen offline implementation. The
+subsequent fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
+signed `3.491307 s/step`), so #1019 is optional/paused and the active next step
+is the #1017 `r4 generate` product path. CUDA and external GPU execution are out
+of scope.
 
 ## One-way campaign
 
@@ -168,18 +188,19 @@ population or reveal.
 population, 64-sequence overfit test, random-export Python/Rust parity check,
 200-step hardware probe, full run, selected export, all-twelve-layer Rust
 qualification, one-time reveal, five seeds 3019 through 3023, and normalized
-replays are all `NOT_RUN` at contract freeze. Do not launch the full campaign
-until the preflight report admits a backend under the eight-hour ceiling. Do
-not start a paid job without explicit owner approval, and do not treat a
-hardware stop or partial checkpoint as language-quality evidence.
+replays were all `NOT_RUN` at contract freeze. The first four stages have since
+run as recorded below. Do not treat a hardware stop or partial checkpoint as
+language-quality evidence.
 
 The observed preflight has since passed the exact population, 400-step
 fixed-sequence overfit, and random-export all-twelve-layer Rust preflight parity gates.
 Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
-`20.66 h` safety projection exceeded `8 h`; memory passed at `21.03%`. Full
-training, final parity, reveal, generation, and replay remain `NOT_RUN`. The
-only allowed next path is the deterministic single-CUDA `f32` fallback after
-explicit owner authorization for external compute and any spend. See the
+`20.66 h` safety projection exceeded `8 h`; memory passed at `21.03%`. That
+terminal applies only to the frozen offline implementation. Full training,
+final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
+fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
+`3.491307 s/step`), so #1019 is optional/paused and the active next step is the
+#1017 `r4 generate` product path. CUDA and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 
 The Rust qualifier has a separate shape-bound campaign mode. After a #1019
@@ -215,18 +236,15 @@ cargo run --release --offline --bin r4 -- r4-softmax-local-qualify \
 
 That MPS probe wrote `UNAVAILABLE_HARDWARE_BUDGET` on time, so do not rerun its
 create-once population, smoke, Rust parity, admission, or MPS probe stages.
-Reuse the passed smoke admission and run only the probe in the one
-contract-permitted deterministic CUDA `f32` environment after explicit owner
-authorization for external compute and any spend. The create-once smoke must
-not be repeated. Do not improvise a CPU or mixed-precision fallback.
+Preserve the passed smoke admission. CUDA and external GPU execution are out of
+scope. The one fused-AdamW/deferred-logging fast-path test was slower than the
+signed baseline, so do not tune or launch the #1019 full run. #1019 is optional/
+paused; do not reopen recurring optimization or broad research gates. Use and
+productize the working #1017 path with `r4 generate --prompt "..."` instead.
+
+After a locally admitted full run produces an export, continue with:
 
 ```bash
-# Requires explicit owner authorization and the pinned deterministic CUDA f32 environment.
-"$CAPACITY_CLI" --root "$CAPACITY_ROOT" probe-capacity --backend cuda
-
-# Run only if the signed CUDA probe returns PASS_HARDWARE_ADMISSION.
-"$CAPACITY_CLI" --root "$CAPACITY_ROOT" train-capacity --backend cuda
-
 cargo run --release --offline --bin r4 -- r4-softmax-local-qualify \
   --model "$CAPACITY_ROOT/export" \
   --python-prefix-logits "$CAPACITY_ROOT/qualification/python-capacity-prefix-logits.json" \
@@ -241,7 +259,6 @@ cargo run --release --offline --bin r4 -- r4-softmax-local-qualify \
   --baseline-1017-root "$CONTINUATION_ROOT"
 ```
 
-Use `train-capacity --backend cuda` only when the signed CUDA probe passed.
 `--resume` may continue only the authenticated byte-identical frozen run and
 backend; elapsed wall time remains monotone across an interruption. After a
 positive NLL reveal, the following is the exact generation and replay stage.

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/capacity.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/capacity.py
@@ -8,7 +8,6 @@ import math
 import os
 import platform
 import struct
-import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -115,43 +114,41 @@ REVEAL_OPENED_RELATIVE_PATH = Path("reveal/capacity-opened.json")
 REVEAL_RESULT_RELATIVE_PATH = Path("reveal/capacity-reveal-result.json")
 REVEAL_MANIFEST_RELATIVE_PATH = Path("reveal/capacity-reveal-manifest.json")
 
-Backend = Literal["mps", "cuda"]
+Backend = Literal["mps"]
+
+
+def _require_mps_backend(backend: object) -> None:
+    if backend != "mps":
+        raise ValueError("#1019 backend must be mps")
 
 
 def hardware_result_relative_path(backend: Backend) -> Path:
-    if backend not in {"mps", "cuda"}:
-        raise ValueError("#1019 backend must be mps or cuda")
+    _require_mps_backend(backend)
     return Path(f"preflight/capacity-hardware-{backend}.json")
 
 
 def hardware_checkpoint_relative_path(backend: Backend) -> Path:
-    if backend not in {"mps", "cuda"}:
-        raise ValueError("#1019 backend must be mps or cuda")
+    _require_mps_backend(backend)
     return Path(f"preflight/capacity-hardware-{backend}-checkpoint.pt")
 
 
 def hardware_elapsed_sample_relative_path(backend: Backend) -> Path:
-    if backend not in {"mps", "cuda"}:
-        raise ValueError("#1019 backend must be mps or cuda")
+    _require_mps_backend(backend)
     return Path(f"preflight/capacity-hardware-{backend}-elapsed-sample.json")
 
 
 def hardware_evidence_relative_paths(backend: Backend) -> list[str]:
     """Return the complete probe chain that a frozen selection must bind."""
-    if backend not in {"mps", "cuda"}:
-        raise ValueError("#1019 backend must be mps or cuda")
-    backends: tuple[Backend, ...] = ("mps", "cuda") if backend == "cuda" else ("mps",)
+    _require_mps_backend(backend)
     paths: list[str] = []
-    for evidence_backend in backends:
-        paths.extend(
-            [
-                str(hardware_result_relative_path(evidence_backend)),
-                str(hardware_checkpoint_relative_path(evidence_backend)),
-                str(hardware_checkpoint_relative_path(evidence_backend))
-                + ".manifest.json",
-                str(hardware_elapsed_sample_relative_path(evidence_backend)),
-            ]
-        )
+    paths.extend(
+        [
+            str(hardware_result_relative_path(backend)),
+            str(hardware_checkpoint_relative_path(backend)),
+            str(hardware_checkpoint_relative_path(backend)) + ".manifest.json",
+            str(hardware_elapsed_sample_relative_path(backend)),
+        ]
+    )
     return paths
 
 
@@ -229,6 +226,7 @@ def _dependency_versions() -> dict[str, str]:
 
 def _validate_backend_identity(identity: Any, backend: Backend) -> None:
     """Require the complete deterministic accelerator identity for one backend."""
+    _require_mps_backend(backend)
     common = {
         "backend",
         "device_count",
@@ -236,19 +234,7 @@ def _validate_backend_identity(identity: Any, backend: Backend) -> None:
         "deterministic_algorithms",
         "dtype",
     }
-    backend_specific = (
-        {
-            "compute_capability",
-            "total_memory_bytes",
-            "driver_version",
-            "torch_cuda",
-            "cublas_workspace_config",
-            "tf32",
-            "cudnn_benchmark",
-        }
-        if backend == "cuda"
-        else {"recommended_max_memory_bytes", "macos"}
-    )
+    backend_specific = {"recommended_max_memory_bytes", "macos"}
     if not isinstance(identity, dict) or set(identity) != common | backend_specific:
         raise ValueError(f"#1019 {backend} backend identity fields differ")
     if (
@@ -260,39 +246,20 @@ def _validate_backend_identity(identity: Any, backend: Backend) -> None:
         or identity.get("dtype") != "float32"
     ):
         raise ValueError(f"#1019 {backend} backend identity differs")
-    if backend == "cuda":
-        capability = identity.get("compute_capability")
-        if (
-            not isinstance(capability, list)
-            or len(capability) != 2
-            or any(
-                isinstance(value, bool) or not isinstance(value, int) or value < 0
-                for value in capability
-            )
-            or isinstance(identity.get("total_memory_bytes"), bool)
-            or not isinstance(identity.get("total_memory_bytes"), int)
-            or identity["total_memory_bytes"] <= 0
-            or not isinstance(identity.get("driver_version"), str)
-            or not identity["driver_version"]
-            or not isinstance(identity.get("torch_cuda"), str)
-            or not identity["torch_cuda"]
-            or identity.get("cublas_workspace_config") != ":4096:8"
-            or identity.get("tf32") is not False
-            or identity.get("cudnn_benchmark") is not False
-        ):
-            raise ValueError("#1019 CUDA identity is not deterministic F32")
-    else:
-        recommended = identity.get("recommended_max_memory_bytes")
-        if (
-            (recommended is not None and (
+    recommended = identity.get("recommended_max_memory_bytes")
+    if (
+        (
+            recommended is not None
+            and (
                 isinstance(recommended, bool)
                 or not isinstance(recommended, int)
                 or recommended <= 0
-            ))
-            or not isinstance(identity.get("macos"), str)
-            or not identity["macos"]
-        ):
-            raise ValueError("#1019 MPS identity differs")
+            )
+        )
+        or not isinstance(identity.get("macos"), str)
+        or not identity["macos"]
+    ):
+        raise ValueError("#1019 MPS identity differs")
 
 
 def _tool_root() -> Path:
@@ -344,38 +311,7 @@ def _validate_runtime_environment_envelope(
 
 
 def _device_identity(device: torch.device, backend: Backend) -> dict[str, Any]:
-    if backend == "cuda":
-        properties = torch.cuda.get_device_properties(device)
-        driver = subprocess.run(
-            [
-                "nvidia-smi",
-                "--query-gpu=driver_version",
-                "--format=csv,noheader",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        driver_versions = [
-            line.strip() for line in driver.stdout.splitlines() if line.strip()
-        ]
-        if len(driver_versions) != 1:
-            raise RuntimeError("#1019 requires exactly one reported CUDA driver")
-        return {
-            "backend": "cuda",
-            "device_count": torch.cuda.device_count(),
-            "device_name": properties.name,
-            "compute_capability": [properties.major, properties.minor],
-            "total_memory_bytes": properties.total_memory,
-            "driver_version": driver_versions[0],
-            "torch_cuda": torch.version.cuda,
-            "cublas_workspace_config": os.environ["CUBLAS_WORKSPACE_CONFIG"],
-            "tf32": False,
-            "cudnn_benchmark": False,
-            "deterministic_algorithms": True,
-            "dtype": "float32",
-        }
+    _require_mps_backend(backend)
     recommended = (
         int(torch.mps.recommended_max_memory())
         if hasattr(torch.mps, "recommended_max_memory")
@@ -393,48 +329,27 @@ def _device_identity(device: torch.device, backend: Backend) -> dict[str, Any]:
 
 
 def require_backend(seed: int, backend: Backend) -> tuple[torch.device, dict[str, Any]]:
-    if backend == "mps":
-        if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK", "0") not in {"", "0"}:
-            raise RuntimeError("PYTORCH_ENABLE_MPS_FALLBACK must be unset or 0")
-        if not torch.backends.mps.is_built() or not torch.backends.mps.is_available():
-            raise RuntimeError("PyTorch MPS is unavailable; refusing CPU fallback")
-        device = torch.device("mps")
-        if hasattr(torch.mps, "manual_seed"):
-            torch.mps.manual_seed(seed)
-    elif backend == "cuda":
-        if not torch.cuda.is_available():
-            raise RuntimeError("PyTorch CUDA is unavailable; refusing CPU fallback")
-        if torch.cuda.device_count() != 1:
-            raise RuntimeError("#1019 requires exactly one visible CUDA device")
-        workspace = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
-        if workspace not in {None, ":4096:8"}:
-            raise RuntimeError(
-                "CUBLAS_WORKSPACE_CONFIG must be unset or exactly :4096:8"
-            )
-        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-        torch.backends.cuda.matmul.allow_tf32 = False
-        torch.backends.cudnn.allow_tf32 = False
-        torch.backends.cudnn.benchmark = False
-        torch.backends.cudnn.deterministic = True
-        torch.cuda.manual_seed_all(seed)
-        device = torch.device("cuda:0")
-    else:
-        raise ValueError("#1019 backend must be mps or cuda")
+    _require_mps_backend(backend)
+    if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK", "0") not in {"", "0"}:
+        raise RuntimeError("PYTORCH_ENABLE_MPS_FALLBACK must be unset or 0")
+    if not torch.backends.mps.is_built() or not torch.backends.mps.is_available():
+        raise RuntimeError("PyTorch MPS is unavailable; refusing CPU fallback")
+    device = torch.device("mps")
+    if hasattr(torch.mps, "manual_seed"):
+        torch.mps.manual_seed(seed)
     torch.use_deterministic_algorithms(True)
     torch.manual_seed(seed)
     return device, _device_identity(device, backend)
 
 
 def _sync(backend: Backend) -> None:
-    if backend == "cuda":
-        torch.cuda.synchronize()
-    elif hasattr(torch, "mps"):
+    _require_mps_backend(backend)
+    if hasattr(torch, "mps"):
         torch.mps.synchronize()
 
 
 def _memory_sample(backend: Backend, identity: dict[str, Any]) -> tuple[int, int | None]:
-    if backend == "cuda":
-        return int(torch.cuda.max_memory_allocated()), int(identity["total_memory_bytes"])
+    _require_mps_backend(backend)
     allocated = (
         int(torch.mps.driver_allocated_memory())
         if hasattr(torch.mps, "driver_allocated_memory")
@@ -457,8 +372,7 @@ def _cpu_tree(value: Any) -> Any:
 
 
 def _accelerator_rng_state(backend: Backend) -> Any:
-    if backend == "cuda":
-        return _cpu_tree(torch.cuda.get_rng_state_all())
+    _require_mps_backend(backend)
     if hasattr(torch.mps, "get_rng_state"):
         return torch.mps.get_rng_state().cpu()
     return None
@@ -467,9 +381,8 @@ def _accelerator_rng_state(backend: Backend) -> Any:
 def _restore_accelerator_rng_state(backend: Backend, state: Any) -> None:
     if state is None:
         return
-    if backend == "cuda":
-        torch.cuda.set_rng_state_all(state)
-    elif hasattr(torch.mps, "set_rng_state"):
+    _require_mps_backend(backend)
+    if hasattr(torch.mps, "set_rng_state"):
         torch.mps.set_rng_state(state)
 
 
@@ -1330,26 +1243,10 @@ def run_capacity_hardware_probe(
     steps: int = 200,
 ) -> dict[str, Any]:
     """Measure the exact full-shape optimizer step before authorizing the main run."""
+    _require_mps_backend(backend)
     if steps != 200:
         raise ValueError("#1019 hardware probe is exactly 200 optimizer steps")
-    mps_failure_prerequisite: dict[str, Any] | None = None
-    if backend == "cuda":
-        if not (root / hardware_result_relative_path("mps")).is_file():
-            raise RuntimeError("#1019 CUDA fallback requires the completed failed MPS probe")
-        mps = load_capacity_hardware_admission(
-            root, backend="mps", require_pass=False
-        )
-        if (
-            mps.get("terminal") != "UNAVAILABLE_HARDWARE_BUDGET"
-            or mps.get("main_run_authorized") is not False
-        ):
-            raise ValueError("#1019 CUDA fallback lacks an exact failed MPS admission")
-        mps_failure_prerequisite = {
-            "path": str(hardware_result_relative_path("mps")),
-            "result_cid": mps["result_cid"],
-            "terminal": "UNAVAILABLE_HARDWARE_BUDGET",
-            "main_run_authorized": False,
-        }
+    mps_failure_prerequisite = None
     result_path = root / hardware_result_relative_path(backend)
     if result_path.exists():
         raise FileExistsError(f"#1019 {backend} hardware probe is create-once")
@@ -1359,8 +1256,6 @@ def run_capacity_hardware_probe(
     if current_tree["tree_cid"] != smoke_admission["trainer_implementation_tree_cid"]:
         raise ValueError("trainer changed after #1019 smoke admission")
     device, identity = require_backend(1019, backend)
-    if backend == "cuda":
-        torch.cuda.reset_peak_memory_stats(device)
     store = TokenStore(root / TOKEN_RELATIVE_PATHS["train"])
     dev_store = TokenStore(root / TOKEN_RELATIVE_PATHS["dev"])
     model = R4SoftmaxForCausalLM(CAPACITY_MODEL_CONFIG).to(device)
@@ -1396,7 +1291,7 @@ def run_capacity_hardware_probe(
     for step in range(1, steps + 1):
         model.train()
         optimizer.zero_grad(set_to_none=True)
-        accumulated_loss = 0.0
+        microbatch_losses: list[Tensor] = []
         for accumulation in range(4):
             inputs, targets = store.random_batch(
                 seed=1019,
@@ -1406,21 +1301,22 @@ def run_capacity_hardware_probe(
             output = model(inputs.to(device), targets.to(device))
             assert output.loss is not None
             (output.loss / 4).backward()
-            accumulated_loss += float(output.loss.detach().cpu())
+            microbatch_losses.append(output.loss.detach())
         torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
         optimizer.step()
-        _write_signed(
-            root / hardware_elapsed_sample_relative_path(backend),
-            {
-                "schema": "uor-r4-softmax-trainer-capacity-hardware-elapsed-sample/1",
-                "issue": ISSUE,
-                "backend": backend,
-                "probe_contract_cid": probe_contract_cid,
-                "optimizer_step": step,
-                "train_tokens": step * TOKENS_PER_OPTIMIZER_STEP,
-                "elapsed_seconds": time.monotonic() - started,
-            },
-        )
+        if step % 10 == 0 or step == steps:
+            _write_signed(
+                root / hardware_elapsed_sample_relative_path(backend),
+                {
+                    "schema": "uor-r4-softmax-trainer-capacity-hardware-elapsed-sample/1",
+                    "issue": ISSUE,
+                    "backend": backend,
+                    "probe_contract_cid": probe_contract_cid,
+                    "optimizer_step": step,
+                    "train_tokens": step * TOKENS_PER_OPTIMIZER_STEP,
+                    "elapsed_seconds": time.monotonic() - started,
+                },
+            )
         allocated, _ = _memory_sample(backend, identity)
         peak = max(peak, allocated)
         if step % 100 == 0:
@@ -1444,6 +1340,7 @@ def run_capacity_hardware_probe(
             _sync(backend)
             elapsed_so_far = time.monotonic() - started
             rate = step / elapsed_so_far if elapsed_so_far > 0 else 0.0
+            mean_microbatch_loss = float(torch.stack(microbatch_losses).mean().cpu())
             progress = {
                 "schema": "uor-r4-softmax-trainer-capacity-hardware-progress/1",
                 "issue": ISSUE,
@@ -1451,7 +1348,7 @@ def run_capacity_hardware_probe(
                 "optimizer_step": step,
                 "optimizer_steps_total": steps,
                 "optimizer_steps_remaining": steps - step,
-                "mean_microbatch_loss": accumulated_loss / 4,
+                "mean_microbatch_loss": mean_microbatch_loss,
                 "elapsed_seconds": elapsed_so_far,
                 "optimizer_steps_per_second": rate,
                 "probe_eta_seconds": (steps - step) / rate if rate > 0 else None,
@@ -1590,6 +1487,7 @@ def _validate_capacity_hardware_evidence(
     require_current_environment: bool,
 ) -> dict[str, Any]:
     """Recompute one signed hardware decision without touching sealed inputs."""
+    _require_mps_backend(backend)
     _verify_signed(result, label="#1019 hardware probe")
     backend_identity = result.get("backend")
     _validate_backend_identity(backend_identity, backend)
@@ -1672,38 +1570,8 @@ def _validate_capacity_hardware_evidence(
     mps_prerequisite = result.get("mps_failure_prerequisite")
     if probe_contract.get("mps_failure_prerequisite") != mps_prerequisite:
         raise ValueError("#1019 hardware prerequisite identities differ")
-    if backend == "mps":
-        if mps_prerequisite is not None:
-            raise ValueError("#1019 MPS probe cannot have an MPS-failure prerequisite")
-    else:
-        expected_mps_path = str(hardware_result_relative_path("mps"))
-        if (
-            not isinstance(mps_prerequisite, dict)
-            or set(mps_prerequisite)
-            != {"path", "result_cid", "terminal", "main_run_authorized"}
-            or mps_prerequisite.get("path") != expected_mps_path
-            or mps_prerequisite.get("terminal") != "UNAVAILABLE_HARDWARE_BUDGET"
-            or mps_prerequisite.get("main_run_authorized") is not False
-        ):
-            raise ValueError("#1019 CUDA probe lacks its exact MPS-failure prerequisite")
-        mps_result = json.loads((root / expected_mps_path).read_text(encoding="utf-8"))
-        if not isinstance(mps_result, dict):
-            raise ValueError("#1019 MPS prerequisite must be a JSON object")
-        _validate_capacity_hardware_evidence(
-            root,
-            backend="mps",
-            training_view=training_view,
-            smoke_admission=smoke_admission,
-            result=mps_result,
-            require_pass=False,
-            require_current_environment=require_current_environment,
-        )
-        if (
-            mps_result.get("result_cid") != mps_prerequisite.get("result_cid")
-            or mps_result.get("terminal") != "UNAVAILABLE_HARDWARE_BUDGET"
-            or mps_result.get("main_run_authorized") is not False
-        ):
-            raise ValueError("#1019 CUDA MPS-failure prerequisite differs")
+    if mps_prerequisite is not None:
+        raise ValueError("#1019 MPS probe cannot have an MPS-failure prerequisite")
     probe_contract_cid = cid_bytes(canonical_json_bytes(probe_contract))
     checkpoint_path = root / hardware_checkpoint_relative_path(backend)
     checkpoint_manifest_path = checkpoint_path.with_suffix(
@@ -1899,7 +1767,7 @@ def build_capacity_run_contract(
     if not isinstance(backend_identity, dict):
         raise ValueError("#1019 hardware admission has no backend identity")
     backend = backend_identity.get("backend")
-    if backend not in {"mps", "cuda"}:
+    if backend != "mps":
         raise ValueError("#1019 hardware admission backend differs")
     _validate_backend_identity(backend_identity, backend)
     probe_contract = hardware.get("probe_contract")
@@ -2192,7 +2060,7 @@ def train_capacity(
     for step in range(optimizer_step + 1, config.optimizer_steps + 1):
         model.train()
         optimizer.zero_grad(set_to_none=True)
-        accumulated_loss = 0.0
+        microbatch_losses: list[Tensor] = []
         for accumulation in range(config.gradient_accumulation_steps):
             inputs, targets = train_store.random_batch(
                 seed=config.seed,
@@ -2202,7 +2070,7 @@ def train_capacity(
             output = model(inputs.to(device), targets.to(device))
             assert output.loss is not None
             (output.loss / config.gradient_accumulation_steps).backward()
-            accumulated_loss += float(output.loss.detach().cpu())
+            microbatch_losses.append(output.loss.detach())
         torch.nn.utils.clip_grad_norm_(model.parameters(), config.gradient_clip)
         learning_rate = capacity_learning_rate(step, config)
         for group in optimizer.param_groups:
@@ -2210,7 +2078,14 @@ def train_capacity(
         optimizer.step()
         optimizer_step = step
         highest_optimizer_step_attempted = max(highest_optimizer_step_attempted, step)
-        if step % config.evaluation_interval == 0 or step == config.optimizer_steps:
+        should_evaluate = (
+            step % config.evaluation_interval == 0 or step == config.optimizer_steps
+        )
+        should_checkpoint = (
+            step % config.checkpoint_interval == 0 or step == config.optimizer_steps
+        )
+        should_report = step % config.progress_interval == 0 or step == config.optimizer_steps
+        if should_evaluate:
             dev_loss = evaluate(model, dev_store, device, config.batch_size)
             candidates.append(
                 {
@@ -2233,7 +2108,7 @@ def train_capacity(
                     run_contract_cid=run_contract_cid,
                     backend=backend,
                 )
-        if step % config.checkpoint_interval == 0 or step == config.optimizer_steps:
+        if should_checkpoint:
             _save_checkpoint(
                 latest_path,
                 model=model,
@@ -2246,15 +2121,20 @@ def train_capacity(
                 run_contract_cid=run_contract_cid,
                 backend=backend,
             )
-        ledger = _write_elapsed_ledger(
-            root,
-            run_contract_cid=run_contract_cid,
-            backend=backend,
-            optimizer_step=highest_optimizer_step_attempted,
-            campaign_started_unix_seconds=campaign_started_unix_seconds,
-            elapsed_seconds=elapsed_before + (time.monotonic() - started),
+        elapsed = max(
+            elapsed_before + (time.monotonic() - started),
+            time.time() - campaign_started_unix_seconds,
         )
-        elapsed = float(ledger["elapsed_seconds"])
+        if should_report or should_checkpoint or should_evaluate:
+            ledger = _write_elapsed_ledger(
+                root,
+                run_contract_cid=run_contract_cid,
+                backend=backend,
+                optimizer_step=highest_optimizer_step_attempted,
+                campaign_started_unix_seconds=campaign_started_unix_seconds,
+                elapsed_seconds=elapsed,
+            )
+            elapsed = float(ledger["elapsed_seconds"])
         if elapsed >= config.wall_ceiling_seconds:
             _save_checkpoint(
                 latest_path,
@@ -2268,6 +2148,14 @@ def train_capacity(
                 run_contract_cid=run_contract_cid,
                 backend=backend,
             )
+            _write_elapsed_ledger(
+                root,
+                run_contract_cid=run_contract_cid,
+                backend=backend,
+                optimizer_step=highest_optimizer_step_attempted,
+                campaign_started_unix_seconds=campaign_started_unix_seconds,
+                elapsed_seconds=elapsed,
+            )
             _write_training_unavailable(
                 root,
                 run_contract_cid=run_contract_cid,
@@ -2276,9 +2164,10 @@ def train_capacity(
                 wall_ceiling_seconds=config.wall_ceiling_seconds,
             )
             raise RuntimeError("UNAVAILABLE_HARDWARE_BUDGET")
-        if step % config.progress_interval == 0 or step == config.optimizer_steps:
+        if should_report:
             rate = step / elapsed if elapsed > 0 else 0.0
             eta = (config.optimizer_steps - step) / rate if rate > 0 else None
+            mean_microbatch_loss = float(torch.stack(microbatch_losses).mean().cpu())
             progress = {
                 "schema": "uor-r4-softmax-trainer-capacity-progress/1",
                 "issue": ISSUE,
@@ -2287,7 +2176,7 @@ def train_capacity(
                 "optimizer_steps_remaining": config.optimizer_steps - step,
                 "train_tokens": step * config.tokens_per_optimizer_step,
                 "train_tokens_total": config.train_tokens,
-                "mean_microbatch_loss": accumulated_loss / config.gradient_accumulation_steps,
+                "mean_microbatch_loss": mean_microbatch_loss,
                 "best_dev_loss": best_dev_loss,
                 "learning_rate": learning_rate,
                 "elapsed_seconds": elapsed,
@@ -2378,11 +2267,7 @@ def train_capacity(
             "run_contract_cid": run_contract_cid,
             "hardware_admission_result_cid": hardware["result_cid"],
             "hardware_admission_path": str(hardware_result_relative_path(backend)),
-            "mps_failure_prerequisite_result_cid": (
-                hardware["mps_failure_prerequisite"]["result_cid"]
-                if backend == "cuda"
-                else None
-            ),
+            "mps_failure_prerequisite_result_cid": None,
             "selected_checkpoint_cid": selected_checkpoint_cid,
             "selected_checkpoint_step": selected_step,
             "selected_dev_loss": selected_dev,
@@ -2415,17 +2300,10 @@ def train_capacity(
 def load_frozen_capacity_selection(root: Path) -> dict[str, Any]:
     selection = verify_bound_manifest(root / SELECTION_RELATIVE_PATH, artifact_root=root)
     hardware_relative = selection.get("hardware_admission_path")
-    allowed_hardware_paths = {
-        str(hardware_result_relative_path("mps")),
-        str(hardware_result_relative_path("cuda")),
-    }
-    if hardware_relative not in allowed_hardware_paths:
+    expected_hardware_path = str(hardware_result_relative_path("mps"))
+    if hardware_relative != expected_hardware_path:
         raise ValueError("#1019 selection has an invalid hardware path")
-    hardware_backend: Backend = (
-        "mps"
-        if hardware_relative == str(hardware_result_relative_path("mps"))
-        else "cuda"
-    )
+    hardware_backend: Backend = "mps"
     expected_selection_paths = {
         *hardware_evidence_relative_paths(hardware_backend),
         "checkpoints/best.pt",
@@ -2469,7 +2347,7 @@ def load_frozen_capacity_selection(root: Path) -> dict[str, Any]:
         raise ValueError("#1019 selected hardware result must be a JSON object")
     _verify_signed(hardware, label="#1019 selected hardware probe")
     backend = hardware.get("backend", {}).get("backend")
-    if backend not in {"mps", "cuda"}:
+    if backend != "mps":
         raise ValueError("#1019 selected hardware backend differs")
     smoke_admission = load_capacity_smoke_admission(root)
     _validate_capacity_hardware_evidence(
@@ -2481,11 +2359,7 @@ def load_frozen_capacity_selection(root: Path) -> dict[str, Any]:
         require_pass=True,
         require_current_environment=False,
     )
-    expected_mps_prerequisite_cid = (
-        hardware["mps_failure_prerequisite"]["result_cid"]
-        if hardware_backend == "cuda"
-        else None
-    )
+    expected_mps_prerequisite_cid = None
     expected_run_contract = build_capacity_run_contract(
         training_view, hardware, CapacityTrainConfig()
     )

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -151,7 +151,7 @@ def parser() -> argparse.ArgumentParser:
     smoke_capacity = subcommands.add_parser(
         "smoke-capacity", help="run #1019's create-once 64-sequence overfit smoke"
     )
-    smoke_capacity.add_argument("--backend", choices=["mps", "cuda"], required=True)
+    smoke_capacity.add_argument("--backend", choices=["mps"], required=True)
     smoke_capacity.add_argument("--max-seconds", type=float, default=600.0)
 
     admit_capacity = subcommands.add_parser(
@@ -164,12 +164,12 @@ def parser() -> argparse.ArgumentParser:
         "probe-capacity",
         help="run #1019's exact 200-step accelerator time/memory admission",
     )
-    probe_capacity.add_argument("--backend", choices=["mps", "cuda"], required=True)
+    probe_capacity.add_argument("--backend", choices=["mps"], required=True)
 
     train_capacity_parser = subcommands.add_parser(
         "train-capacity", help="run or resume the one frozen #1019 campaign"
     )
-    train_capacity_parser.add_argument("--backend", choices=["mps", "cuda"], required=True)
+    train_capacity_parser.add_argument("--backend", choices=["mps"], required=True)
     train_capacity_parser.add_argument("--resume", action="store_true")
 
     admit_capacity_parity = subcommands.add_parser(

--- a/tools/r4-softmax-trainer/tests/test_capacity.py
+++ b/tools/r4-softmax-trainer/tests/test_capacity.py
@@ -46,7 +46,6 @@ from r4_softmax_trainer.capacity import (
     hardware_elapsed_sample_relative_path,
     hardware_result_relative_path,
     load_capacity_hardware_admission,
-    run_capacity_hardware_probe,
     train_capacity,
 )
 from r4_softmax_trainer.capacity_data import (
@@ -343,131 +342,6 @@ def _write_valid_mps_hardware_evidence(
     return training_view, smoke
 
 
-def _rewrite_mps_hardware_as_valid_failure(root: Path) -> dict[str, object]:
-    result_path = root / hardware_result_relative_path("mps")
-    result = json.loads(result_path.read_text(encoding="utf-8"))
-    optimizer_seconds = 400.0
-    checkpoint_seconds = float(result["checkpoint_reload_seconds"])
-    development_seconds = float(result["complete_dev_evaluation_seconds"])
-    checkpoint_samples = list(result["checkpoint_save_seconds_samples"])
-    projected_optimizer = optimizer_seconds / 200 * OPTIMIZER_STEPS
-    projected_development = development_seconds * (2 + OPTIMIZER_STEPS // 400)
-    projected_best = max(checkpoint_samples) * MAXIMUM_BEST_CHECKPOINT_SAVES
-    projected = (
-        projected_optimizer
-        + projected_development
-        + projected_best
-        + checkpoint_seconds
-    )
-    result.update(
-        {
-            "terminal": "UNAVAILABLE_HARDWARE_BUDGET",
-            "main_run_authorized": False,
-            "time_passed": False,
-            "elapsed_seconds": (
-                optimizer_seconds + checkpoint_seconds + development_seconds
-            ),
-            "optimizer_loop_seconds": optimizer_seconds,
-            "optimizer_steps_per_second": 200 / optimizer_seconds,
-            "projected_optimizer_and_checkpoint_seconds": projected_optimizer,
-            "projected_development_evaluation_seconds": projected_development,
-            "projected_best_checkpoint_seconds": projected_best,
-            "projected_training_seconds": projected,
-            "safety_projected_training_seconds": projected * 1.25,
-        }
-    )
-    result.pop("result_cid")
-    return _write_signed(result_path, result)
-
-
-def _cuda_identity() -> dict[str, object]:
-    return {
-        "backend": "cuda",
-        "device_count": 1,
-        "device_name": "synthetic-cuda",
-        "compute_capability": [8, 0],
-        "total_memory_bytes": 10_000,
-        "driver_version": "synthetic-driver",
-        "torch_cuda": "synthetic-toolkit",
-        "cublas_workspace_config": ":4096:8",
-        "tf32": False,
-        "cudnn_benchmark": False,
-        "deterministic_algorithms": True,
-        "dtype": "float32",
-    }
-
-
-def _write_valid_cuda_hardware_evidence(
-    root: Path,
-    *,
-    pass_template: dict[str, object],
-    mps_failure: dict[str, object],
-) -> dict[str, object]:
-    prerequisite = {
-        "path": str(hardware_result_relative_path("mps")),
-        "result_cid": mps_failure["result_cid"],
-        "terminal": "UNAVAILABLE_HARDWARE_BUDGET",
-        "main_run_authorized": False,
-    }
-    identity = _cuda_identity()
-    environment = _runtime_environment_identity(identity, "cuda")
-    probe_contract = json.loads(json.dumps(pass_template["probe_contract"]))
-    probe_contract["backend"] = identity
-    probe_contract["environment"] = environment
-    probe_contract["mps_failure_prerequisite"] = prerequisite
-    probe_contract_cid = cid_bytes(canonical_json_bytes(probe_contract))
-
-    checkpoint_path = root / hardware_checkpoint_relative_path("cuda")
-    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-    checkpoint_path.write_bytes(b"cuda probe checkpoint")
-    checkpoint_manifest_path = checkpoint_path.with_suffix(".pt.manifest.json")
-    _write_signed(
-        checkpoint_manifest_path,
-        {
-            "schema": CAPACITY_CHECKPOINT_MANIFEST_SCHEMA,
-            "issue": 1019,
-            "checkpoint_filename": checkpoint_path.name,
-            "checkpoint_cid": cid_file(checkpoint_path),
-            "run_contract_cid": probe_contract_cid,
-            "optimizer_step": 200,
-            "tokens_seen": 200 * TOKENS_PER_OPTIMIZER_STEP,
-            "backend": "cuda",
-        },
-    )
-    elapsed_sample_path = root / hardware_elapsed_sample_relative_path("cuda")
-    _write_signed(
-        elapsed_sample_path,
-        {
-            "schema": "uor-r4-softmax-trainer-capacity-hardware-elapsed-sample/1",
-            "issue": 1019,
-            "backend": "cuda",
-            "probe_contract_cid": probe_contract_cid,
-            "optimizer_step": 200,
-            "train_tokens": 200 * TOKENS_PER_OPTIMIZER_STEP,
-            "elapsed_seconds": float(pass_template["optimizer_loop_seconds"]),
-        },
-    )
-    result = json.loads(json.dumps(pass_template))
-    result.pop("result_cid")
-    result.update(
-        {
-            "backend": identity,
-            "mps_failure_prerequisite": prerequisite,
-            "probe_contract": probe_contract,
-            "probe_contract_cid": probe_contract_cid,
-            "probe_checkpoint_path": str(hardware_checkpoint_relative_path("cuda")),
-            "probe_checkpoint_cid": cid_file(checkpoint_path),
-            "probe_checkpoint_manifest_path": (
-                str(hardware_checkpoint_relative_path("cuda")) + ".manifest.json"
-            ),
-            "probe_checkpoint_manifest_cid": cid_file(checkpoint_manifest_path),
-            "elapsed_sample_path": str(hardware_elapsed_sample_relative_path("cuda")),
-            "elapsed_sample_cid": cid_file(elapsed_sample_path),
-        }
-    )
-    return _write_signed(root / hardware_result_relative_path("cuda"), result)
-
-
 class CapacityArithmeticTests(unittest.TestCase):
     def test_hardware_admission_rejects_resigned_malformed_backend_identity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -618,94 +492,6 @@ class CapacityArithmeticTests(unittest.TestCase):
                             require_current_environment=False,
                         )
 
-    def test_cuda_evidence_binds_a_validated_failed_mps_prerequisite(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            trainer_tree = trainer_implementation_contract()
-            mps_environment = _runtime_environment_identity(_mps_identity(), "mps")
-            training_view, smoke = _write_valid_mps_hardware_evidence(
-                root,
-                environment=mps_environment,
-                trainer_tree=trainer_tree,
-            )
-            pass_template = json.loads(
-                (root / hardware_result_relative_path("mps")).read_text(
-                    encoding="utf-8"
-                )
-            )
-            mps_failure = _rewrite_mps_hardware_as_valid_failure(root)
-            self.assertEqual(
-                _validate_capacity_hardware_evidence(
-                    root,
-                    backend="mps",
-                    training_view=training_view,
-                    smoke_admission=smoke,
-                    result=mps_failure,
-                    require_pass=False,
-                    require_current_environment=False,
-                )["terminal"],
-                "UNAVAILABLE_HARDWARE_BUDGET",
-            )
-            cuda_result = _write_valid_cuda_hardware_evidence(
-                root,
-                pass_template=pass_template,
-                mps_failure=mps_failure,
-            )
-            self.assertEqual(
-                _validate_capacity_hardware_evidence(
-                    root,
-                    backend="cuda",
-                    training_view=training_view,
-                    smoke_admission=smoke,
-                    result=cuda_result,
-                    require_pass=True,
-                    require_current_environment=False,
-                )["terminal"],
-                "PASS_HARDWARE_ADMISSION",
-            )
-
-            def resigned_prerequisite_tamper(
-                *, path: str | None = None, result_cid: str | None = None
-            ) -> dict[str, object]:
-                tampered = json.loads(json.dumps(cuda_result))
-                tampered.pop("result_cid")
-                prerequisite = tampered["mps_failure_prerequisite"]
-                contract_prerequisite = tampered["probe_contract"][
-                    "mps_failure_prerequisite"
-                ]
-                if path is not None:
-                    prerequisite["path"] = path
-                    contract_prerequisite["path"] = path
-                if result_cid is not None:
-                    prerequisite["result_cid"] = result_cid
-                    contract_prerequisite["result_cid"] = result_cid
-                tampered["result_cid"] = cid_bytes(canonical_json_bytes(tampered))
-                return tampered
-
-            for label, tampered in (
-                (
-                    "path",
-                    resigned_prerequisite_tamper(
-                        path="preflight/not-the-failed-mps-result.json"
-                    ),
-                ),
-                (
-                    "cid",
-                    resigned_prerequisite_tamper(result_cid="blake3:" + "0" * 64),
-                ),
-            ):
-                with self.subTest(binding=label):
-                    with self.assertRaisesRegex(ValueError, "MPS-failure prerequisite"):
-                        _validate_capacity_hardware_evidence(
-                            root,
-                            backend="cuda",
-                            training_view=training_view,
-                            smoke_admission=smoke,
-                            result=tampered,
-                            require_pass=True,
-                            require_current_environment=False,
-                        )
-
     def test_exact_frozen_capacity_and_training_arithmetic(self) -> None:
         config = CapacityTrainConfig()
         config.validate()
@@ -731,11 +517,6 @@ class CapacityArithmeticTests(unittest.TestCase):
             CapacityTrainConfig(seed=1020).validate()
         with self.assertRaises(ValueError):
             capacity_learning_rate(OPTIMIZER_STEPS + 1, config)
-
-    def test_cuda_fallback_requires_a_completed_failed_mps_probe(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            with self.assertRaisesRegex(RuntimeError, "failed MPS probe"):
-                run_capacity_hardware_probe(Path(directory), backend="cuda")
 
     def test_terminal_wall_budget_cannot_resume(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1317,10 +1098,10 @@ class CapacityCliTests(unittest.TestCase):
             )
             print_result.assert_called_once_with(expected)
 
-    def test_capacity_commands_require_closed_backend_and_inputs(self) -> None:
-        train = parser().parse_args(["train-capacity", "--backend", "cuda"])
+    def test_capacity_commands_require_mps_backend_and_closed_inputs(self) -> None:
+        train = parser().parse_args(["train-capacity", "--backend", "mps"])
         self.assertEqual(train.command, "train-capacity")
-        self.assertEqual(train.backend, "cuda")
+        self.assertEqual(train.backend, "mps")
         qualify = parser().parse_args(
             ["admit-capacity-parity", "--rust-qualification", "/tmp/report.json"]
         )


### PR DESCRIPTION
## Outcome

- exposes the learned #1017 R4/Spin causal-softmax checkpoint through the short r4 generate alias and honors UOR_MODEL_STORE
- adds an explicit opt-in local-inference-accelerate feature for Apple Accelerate CPU BLAS while preserving exact uor-matmul as the portable default
- makes canonical and exact overrides bypass BLAS and report the arithmetic that actually executes
- removes the out-of-scope CUDA fallback from the optional #1019 trainer and keeps MPS as its only accelerator
- synchronizes the README, research record, roadmap, programme documents, glossary, ADR, lifecycle, and issue records around #1017 as the active usable model and #1019 as optional/paused

## Actual M1 measurement

Prompt: Once upon a time; 4 generated tokens.

- exact: token IDs [14, 403, 285, 261], text , there was a, generation 3.060506042 s, wall 3.41 s
- Apple Accelerate: identical token IDs and text, generation 0.116236875 s, wall 0.52 s
- speedup: 26.33x generation, 6.56x wall
- identical output CID: blake3:ad043d419e9a3f30cc9be75d6a84f519d988e370a7288f6455763afe6257818e
- identical attention-audit CID: blake3:1552cef6effdb28b3a4b5e1a29313a90beef7df0494ff7230040389c01d4fd78

Full report CIDs intentionally differ because backend provenance, counters, timing, decision identity, and persistent-state identity remain truthful.

## Focused verification

- cargo check --release --offline --features local-inference-accelerate --bin r4
- cargo check --release --offline --bin r4
- cargo fmt --all -- --check
- python3 scripts/check_claim_wording.py
- git diff --check
- paired real-model exact/Accelerate prompt run above

The broad workspace suite was intentionally not duplicated locally. The protected merge queue runs it once as the binding verdict.

References #973
References #1019