### PR TITLE
C1: add bounded fail-closed grounded answer prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW
 > with deferred logging and measured `4.485223 s/step`, slower than the signed
 > `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-> fast-path negative, not a model result. #1019 tuning/full-run work stops and
-> remains optional/paused. The active next step is using and productizing the
-> working #1017 `r4 generate` path.
+> fast-path negative, not a model result. #1019 closed without a full run. The
+> active next step is #954's bounded source-grounding fine-tune and fail-closed
+> `r4 answer` product check over the working #1017 model.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
 > [#1017 structured aggregate](docs/r4_softmax_quality_capacity_continuation_1017_raw.json),
 > [#1019 frozen contract](docs/r4_softmax_parameter_capacity_1019.md),
@@ -76,8 +76,8 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > The completed #1017 checkpoint is the current working 7.15M
 > coherent-generation prototype. If its local export exists, run it directly
 > with `r4 generate --prompt "..."`; the alias defaults to
-> `.uor-models/research/issue-1017/export`. #1019 is now an optional
-> quality-capacity improvement and does not block using or productizing this
+> `.uor-models/research/issue-1017/export`. #1019 closed without a full run and
+> does not block using or productizing this
 > bounded #1017 path. It remains source-backed, floating-point/matmul/softmax,
 > and below the strict NLL target; it does not establish geometry advantage,
 > transformerlessness, correctness, reasoning, frontier quality, browser/WASM
@@ -220,7 +220,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `NOT_RUN`. The feature is disabled by default and does not change the default
 > engine. This remains a native CPU research reference,
 > not a source-free, transformerless, static-WASM, release, or frontier-model
-> result. #973 remains open and #954 remains blocked. The trace/compiler rung
+> result. #973 remains open for its intrinsic/source-free terminal; #954's
+> bounded source-backed grounding phase is active while its final source-free
+> terminal remains blocked. The trace/compiler rung
 > that followed that checkpoint is now complete: `R4SoftmaxTeacherTraceV1`
 > supplied construction traces and
 > `R4SoftmaxTraceStudentV1` compiled a source-free Q16 suffix artifact with a
@@ -243,8 +245,8 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation, and full training through replay remains `NOT_RUN`. The
 > fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-> `3.491307 s/step`); #1019 is optional/paused and the active next step is the
-> #1017 `r4 generate` product path. CUDA and external GPU execution are out of
+> `3.491307 s/step`); #1019 closed without a full run and #954's bounded
+> source-grounding product phase is active over #1017. CUDA and external GPU execution are out of
 > scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
@@ -325,10 +327,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation; full training, final qualification, reveal, generation, and
 > replay remain `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower
-> (`4.485223` versus signed `3.491307 s/step`); #1019 is optional/paused and the
-> active next step is the #1017 `r4 generate` product path. CUDA and external
-> GPU execution are out of scope. #954
-> remains blocked.
+> (`4.485223` versus signed `3.491307 s/step`); #1019 closed without a full run
+> and #954's bounded source-backed grounding phase is active. CUDA and external
+> GPU execution are out of scope. #954's final source-free terminal remains
+> blocked by the parked #973 replacement terminal.
 > See the
 > [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
 
@@ -391,8 +393,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `R4SoftmaxReferenceGeneratorV1` (`HELM-D-R4`) generation subsequently passed.
 > Its opt-in, loopback-only dedicated native HTTP endpoint then passed exact CLI
 > canary parity. Dashboard wiring/readiness and static/WASM-isolation checks
-> passed; browser E2E remains `NOT_RUN`. Construction-only trace capture and source-free student
-> compilation are next; #954 remains blocked. See the
+> passed; browser E2E remains `NOT_RUN`. The source-free trace/state attempts
+> are preserved negatives; #954's bounded source-backed grounding phase is
+> active while its final source-free terminal remains blocked. See the
 > [conversation record](docs/conversation_entity_spin_path_attention_973.md).
 
 > **Accepted capability-first evidence (2026-08-28):** #953's frozen
@@ -462,9 +465,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation, so the full campaign remains `NOT_RUN`. The fused-AdamW/
 > deferred-logging fast path was slower (`4.485223` versus signed
-> `3.491307 s/step`); #1019 is optional/paused and the active next step is the
-> #1017 `r4 generate` product path. CUDA and external GPU execution are out of scope.
-> #954 remains blocked behind #973. General higher-scope attention, correct
+> `3.491307 s/step`); #1019 closed without a full run and #954's bounded
+> source-backed grounding phase is active over #1017. CUDA and external GPU execution are out of scope.
+> #954's final source-free terminal remains blocked behind #973. General higher-scope attention, correct
 > answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
@@ -502,8 +505,38 @@ r4 generate --prompt "Once upon a time in a quiet village"
 `.uor-models/research/issue-1017/export` when the variable is unset). It requires
 that local export and is a bounded #1017 prototype: provider-free at execution,
 but still source-backed, floating-point/matmul/softmax, and below the strict
-`<1.50` NLL target. #1019 is an optional capacity improvement, not a prerequisite
-for using or productizing this path.
+`<1.50` NLL target. #1019 was closed without another capacity run; it is not a
+prerequisite for using or productizing this path.
+
+To ask against one exact local source while refusing unsupported generated text:
+
+```bash
+r4 answer --source-file facts.txt --question "Which key opens the north door?" \
+  --json-output grounded-answer.json
+```
+
+`answer` applies one fixed source/question prompt to the bounded #954 grounding
+fine-tune descended from #1017.
+It serves ordinary text only when the complete trimmed response is an exact,
+case-sensitive contiguous span of the source. Exact `ABSTAIN`, exact
+`CONTRADICTION`, empty output, and non-source output become typed non-answer
+outcomes; unsupported raw text remains visible only inside the optional nested
+audit report. The source must be a regular non-symlink UTF-8 file of at most
+4 KiB, is content-addressed, and is read again after generation to detect a
+change. The assembled prompt plus requested output must also fit the checkpoint's
+256-token context; oversized requests fail before an answer is served. This is
+fail-closed extractive provenance, not semantic-entailment or general-correctness
+evidence.
+
+The first fixed #954 MPS fine-tune completed in 14 minutes 44 seconds on the
+project M1, but its frozen Rust product population failed `1/3`: all three
+prompts decoded `ABSTAIN`, so only the unsupported question passed. The command
+therefore fails safely, but this checkpoint is not a usable answer model. It is
+not rerun or tuned. The active #954 successor is a learned source-span
+pointer/copy head with explicit abstention and conflict scores over the existing
+causal R4/Spin states. See the
+[#954 record](docs/r4_grounded_correctness_954.md) and
+[structured result](docs/r4_grounded_correctness_954_raw.json).
 
 On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
 machine's Accelerate framework:
@@ -762,9 +795,9 @@ exact-descriptor/entity-binding path selector apiece at their respective
    admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
    offline implementation; full training through replay remains `NOT_RUN`.
    The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
-   signed `3.491307 s/step`); #1019 is optional/paused and the active next step
-   is the #1017 `r4 generate` product path. CUDA and external GPU execution are
-   out of scope. #954 stays blocked.
+   signed `3.491307 s/step`); #1019 closed without a full run and #954's bounded
+   source-backed grounding phase is active over #1017. CUDA and external GPU
+   execution are out of scope. #954's final source-free terminal stays blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
@@ -911,9 +944,9 @@ not become substitutes for working intelligence:
    offline implementation; the full train/final-qualification/reveal/
    generation/replay path remains `NOT_RUN`, with no further 7.15M exposure or
    LR tuning. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
-   versus signed `3.491307 s/step`); #1019 is optional/paused and the active
-   next step is the #1017 `r4 generate` product path. CUDA and external GPU
-   execution are out of scope.
+   versus signed `3.491307 s/step`); #1019 closed without a full run and #954's
+   bounded source-grounding product phase is active over #1017. CUDA and external
+   GPU execution are out of scope.
    Do not resume resonance substitutes. Product development continues through
    `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
    reference is transformer-compatible, `f32`/multiply/alloc and source-weight
@@ -977,10 +1010,10 @@ passed, but the signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
 frozen eight-hour offline implementation; the full campaign remains `NOT_RUN`.
 UOR's deployed architecture/runtime remains CPU-native. Apple Accelerate/BLAS
 and MPS are local offline accelerators only. The fused-AdamW/deferred-logging
-fast path was slower (`4.485223` versus signed `3.491307 s/step`); #1019 is
-optional/paused and the active next step is the #1017 `r4 generate` product
-path. CUDA and external GPU execution are out of scope.
-#954 remains blocked behind #973. The exact contract is
+fast path was slower (`4.485223` versus signed `3.491307 s/step`); #1019 closed
+without a full run and #954's bounded source-grounding product phase is active
+over #1017. CUDA and external GPU execution are out of scope.
+#954's final source-free terminal remains blocked behind #973. The exact contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).
 
 ## Find your way around

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,12 +97,15 @@ local offline accelerators only. A single isolated exact-shape MPS fast-path
 test (10 warmup plus 40 measured steps) combined fused AdamW with deferred
 logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-fast-path negative, not a model result. #1019 tuning/full-run work stops and
-remains optional/paused. The active next step is using and productizing the
-working #1017 `r4 generate` path. CUDA and external GPU execution are out of scope.
+fast-path negative, not a model result. #1019 closed without a full run. #954's
+first fixed MPS grounding SFT then completed but failed its frozen Rust product
+population `1/3` through universal `ABSTAIN`. The active next step is a learned
+source-span pointer/copy head over #1017's R4/Spin states. CUDA and external GPU
+execution are out of scope.
 Further 7.15M exposure and learning-rate tuning are prohibited. See the
 [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
-D3 remains `NOT_RUN`, and #973 continues to block #954. Its current contract is
+D3 remains `NOT_RUN`, and #973 continues to block #954's final source-free
+terminal while the bounded source-backed correctness phase proceeds. Its current contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md), with the
 binding reference result in
 [`helm_d_r4_softmax_decoder_973.md`](docs/helm_d_r4_softmax_decoder_973.md)._
@@ -173,13 +176,15 @@ The completed continuation and its NLL-only negative are in
 > parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
 > frozen eight-hour offline implementation. The full campaign remains
 > `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
-> versus signed `3.491307 s/step`), so #1019 is optional/paused and the active
-> next step is the #1017 `r4 generate` product path. CUDA and external GPU
-> execution are out of scope.
+> versus signed `3.491307 s/step`), and #1019 closed without a full run. #954's
+> first fixed MPS grounding SFT subsequently failed its frozen Rust product
+> population `1/3`; the active successor is a source-span pointer/copy head.
+> CUDA and external GPU execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
 > table-native, multiply-free, transformerless serving engine. D3 remains
-> `NOT_RUN`; #954 remains blocked.
+> `NOT_RUN`; #954's final source-free terminal remains blocked while its bounded
+> source-backed phase is active.
 
 > **Admission/influence split:** exact causal/index rows decide which routes are
 > lawful candidates. Harmonic/neighbor influence may transform the state used
@@ -257,15 +262,16 @@ pass, while the hosted static Pages surface currently has no working chat
 backend/artifact lowering; **Completed bounded step:** source-free Q16 suffix
 trace distillation, with looping autonomous output, state-student and
 observability negatives, #1014 attention qualification, and #1017's NLL-only
-quality-capacity negative; **Active / MPS `UNAVAILABLE_HARDWARE_BUDGET`, full
-campaign `NOT_RUN`:** #1019's frozen 12-layer, 13,130,784-parameter campaign over
-the same attention/Rust path; population/smoke/random-export parity passed, but
-its fused-AdamW/deferred-logging fast path was slower and #1019 is now
-optional/paused; **Active:** use and productize #1017 through `r4 generate`;
+quality-capacity negative; **Closed without a full run:** #1019's frozen
+12-layer, 13,130,784-parameter capacity campaign after its MPS hardware-budget
+stop; **Observed #954 negative:** the fixed 384-step MPS grounding SFT completed
+in `883.773549 s`, but all three frozen Rust prompts decoded `ABSTAIN` (`1/3`);
+**Active:** build a learned source-span pointer/copy head with explicit
+abstention and conflict scores over #1017's established R4/Spin states;
 CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
-deployment; **Blocked:** D3 and #954; **Later:**
+deployment; **Blocked:** D3, #954's final source-free terminal, and #955; **Later:**
 #955 → #962 → #963 → #964 → #965.
 
 This capability-first reset supersedes the old forward action implied by the
@@ -295,10 +301,12 @@ seed 1019, 16,800 steps, and 275,251,200 tokens. Population, MPS overfit smoke,
 and random-export/all-12-layer Rust preflight parity passed, but MPS admission
 stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 implementation. The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-
-logging fast path was slower (`4.485223` versus signed `3.491307 s/step`), so
-#1019 is optional/paused and the active next step is the #1017 `r4 generate`
-product path. CUDA and external GPU execution are out of scope. Do not add exposure or tune
-the 7.15M model.
+logging fast path was slower (`4.485223` versus signed `3.491307 s/step`), and
+#1019 closed without a full run. #954's fixed MPS grounding SFT then completed,
+but the frozen Rust product population failed `1/3` because every prompt decoded
+`ABSTAIN`. Do not rerun or tune either campaign. The active successor is a
+source-span pointer/copy head over #1017's established states. CUDA and external
+GPU execution are out of scope.
 Intrinsic/resonance/replacement work is
 parked; D3 remains `NOT_RUN`. See the
 [#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
@@ -559,20 +567,28 @@ feasibility boundary remains in the
    parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for
    the frozen eight-hour offline implementation. Full training through replay
    remains `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower
-   (`4.485223` versus signed `3.491307 s/step`), so #1019 is optional/paused and
-   the active next step is the #1017 `r4 generate` product path. CUDA and
-   external GPU execution are out of scope.
+   (`4.485223` versus signed `3.491307 s/step`), and #1019 closed without a full
+   run. #954's first fixed grounding SFT completed through MPS, but the frozen
+   Accelerate-backed Rust product population failed `1/3` because all prompts
+   decoded `ABSTAIN`. Do not rerun or tune it. CUDA and external GPU execution
+   are out of scope.
    Intrinsic score/readout alternatives, paired-E8, resonance-based softmax
-   replacement, and exact deployment are parked; #954 remains blocked. Every learned epoch receives a
+   replacement, and exact deployment are parked; #954's final source-free
+   terminal remains blocked while its source-backed pointer/copy successor is
+   active. Every learned epoch receives a
    new kappa and reruns its owning
    construction gate. More documents, table density, or trace activity are
    capacity, not attention.
-10. **GI-4 / #954 — correctness and abstention:** test held-out answer
-   correctness, relevance, abstention, and causal use of required context only
-   through the accepted selector/#953/#973 artifact while binding evidence
-   provenance #969 → #983 → #986. Teacher weights may label or compare
-   offline only after the source-free report freezes, and the #954 oracle cannot
-   tune the artifact.
+10. **GI-4 / #954 — correctness and abstention:** the first bounded source-backed
+   generative SFT is complete negative at
+   `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE` (`1/3`). Preserve its
+   fail-closed `r4 answer` surface and exact source/audit binding. The active
+   successor replaces free-form answer generation with a learned source-span
+   pointer/copy head plus explicit abstention and conflict scores over the
+   established R4/Spin states, frozen on new lexical families before reveal.
+   The final source-free terminal still requires the accepted
+   selector/#953/#973 artifact and evidence provenance #969 → #983 → #986;
+   source-backed prototype evidence does not satisfy it.
 11. **GI-5 / #955 — reasoning:** invoke the accepted
    selector/#953/#973/#954 consumer at
    every bounded goal-directed route-composition step. Compare cloned
@@ -654,8 +670,8 @@ historical evidence and comparators.
 
 ## Active
 
-- [ ] **#1019 frozen 13.13M parameter-capacity campaign (MPS
-  `UNAVAILABLE_HARDWARE_BUDGET`; full campaign `NOT_RUN`)** — retain the
+- [ ] **#954 grounded correctness: source-span pointer/copy successor after
+  `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE`** — retain the
   bounded positives, #997 placement negative, bounded gated-delta negative, V2
   budget invalidation, equal-manifold-budget V3 mixed-gauge H4 negative, and
   V4's held-out 13/24 functional/control negative. The positive attention
@@ -697,8 +713,12 @@ historical evidence and comparators.
   `UNAVAILABLE_HARDWARE_BUDGET`. Full training, final trained-checkpoint
   qualification, the strict `<1.50` sealed-NLL reveal, generation, and replay
   remain `NOT_RUN`. Its fused-AdamW/deferred-logging fast path was slower
-  (`4.485223` versus signed `3.491307 s/step`), so #1019 is optional/paused and
-  the active next step is the #1017 `r4 generate` product path. Apple
+  (`4.485223` versus signed `3.491307 s/step`), and #1019 closed without a full
+  run. #954's fixed 384-step MPS grounding SFT then completed in `883.773549 s`,
+  but all three frozen Accelerate-backed Rust prompts decoded `ABSTAIN`; only
+  the unsupported prompt passed (`1/3`). Do not rerun or tune that SFT. Build
+  the learned source-span pointer/copy successor with explicit abstention and
+  conflict scores over the existing R4/Spin states. Apple
   Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
   external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
@@ -706,7 +726,9 @@ historical evidence and comparators.
   Do not extend
   exposure or tune learning rate on the 7.15M checkpoint. Intrinsic score/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
-  lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954 remains blocked.
+  lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954's final
+  source-free terminal remains blocked while its bounded source-backed phase is
+  active.
 
 ## Landed
 
@@ -856,11 +878,13 @@ historical evidence and comparators.
   parameter-capacity improvement: population/smoke/random-export parity passed,
   MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
   offline implementation, and the full campaign remains `NOT_RUN`. Its fused-
-  AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and
-  the active next step is the #1017 `r4 generate` product path. CUDA and
-  external GPU execution are out of scope. Intrinsic score/readout alternatives,
+  AdamW/deferred-logging fast path was slower, and #1019 closed without a full
+  run. #954's first fixed grounding SFT completed but failed its frozen Rust
+  population `1/3`; the active successor is a source-span pointer/copy head.
+  CUDA and external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact
-  deployment are parked. D3 remains `NOT_RUN`; #954 remains blocked.
+  deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
+  terminal remains blocked while its bounded source-backed phase is active.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -146,9 +146,11 @@ assumptions, or objectives rather than measured results.
 > test (10 warmup plus 40 measured steps) combined fused AdamW with deferred
 > logging and measured `4.485223 s/step`, slower than the signed
 > `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-> fast-path negative, not a model result. #1019 tuning/full-run work stops and
-> remains optional/paused; the active next step is the working #1017
-> `r4 generate` product path. CUDA and external GPU execution are out of scope. See
+> fast-path negative, not a model result. #1019 closed without a full run. #954's
+> first fixed MPS grounding SFT then failed its frozen Rust product population
+> `1/3` through universal `ABSTAIN`; the active successor is a source-span
+> pointer/copy head over #1017's R4/Spin states. CUDA and external GPU execution
+> are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
@@ -554,13 +556,15 @@ assumptions, or objectives rather than measured results.
 > mechanism. Population, MPS overfit smoke, and random-export/all-12-layer Rust
 > parity passed, but MPS admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the
 > frozen eight-hour offline implementation. The full campaign remains
-> `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower, so #1019 is
-> optional/paused and the active next step is the #1017 `r4 generate` product
-> path. CUDA and external GPU execution are out of scope.
+> `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower, and #1019
+> closed without a full run. #954's first fixed grounding SFT subsequently
+> failed its frozen Rust population `1/3`; the active successor is a source-span
+> pointer/copy head. CUDA and external GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
-> exact deployment are parked. D3 remains
-> `NOT_RUN`; #954 remains blocked behind #973.
+> exact deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
+> terminal remains blocked behind #973 while its bounded source-backed phase is
+> active.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1084,7 +1088,11 @@ up to the point where a structure predicts at all, and not past it.**
 
 ## Which track can actually produce coherent text — the honest current answer
 
-This project's immediate goal is source-free recursive geometric attention.
+The project's ultimate runtime goal remains source-free recursive geometric
+attention, but load-bearing ordinary causal attention is now established in the
+R4/Spin reference. The immediate active goal is #954 grounded correctness: a
+source-span pointer/copy successor after the first bounded generative SFT failed
+its frozen transfer population.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
 reusable summaries erased earlier causal order, terminating as
@@ -1138,17 +1146,20 @@ construction-only observability audit completed with
 causal attention through a `2.677393`-nat attention-off penalty and exact Rust
 parity, while failing its complete quality DoD at enabled NLL `2.127407` and
 subject/scene retention `3/5`. #1017's one exposure continuation then improved
-retention to `5/5` but failed solely on NLL `1.5727521962806827`. #1019 is that
-new frozen contract: 12 layers, 13,130,784 parameters, seed 1019, 16,800 steps,
-and 275,251,200 tokens. Population, MPS overfit smoke, and
-random-export/all-12-layer Rust preflight parity passed, but MPS admission
-stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
-implementation. Full training through replay remains `NOT_RUN`; its fused-
-AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and the
-active next step is the #1017 `r4 generate` product path. CUDA and external GPU
-execution are out of scope. Fiber-preserving multi-resonance replacement, whole-decoder recurrent
-factorization, and final requalification are parked.
-Dependable broad coherent text remains unestablished.
+retention to `5/5` but failed solely on NLL `1.5727521962806827`. #1019's larger
+frozen contract passed its population, MPS smoke, and Rust preflight, then
+stopped on the eight-hour hardware budget and closed without a full run. The
+first #954 grounding SFT used the project M1 through MPS and completed 384 steps
+in `883.773549` seconds, but the frozen Accelerate-backed Rust product population
+failed `1/3`: supported, unsupported, and conflict prompts all decoded
+`ABSTAIN`. The terminal is
+`FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE`; no rerun or tuning is
+authorized. The active successor is a learned source-span pointer/copy head
+with explicit abstention and conflict scores over the existing R4/Spin states.
+CUDA and external GPU execution remain out of scope. Fiber-preserving
+multi-resonance replacement, whole-decoder recurrent factorization, capacity
+expansion, and final source-free requalification are parked. Dependable broad
+coherent text and grounded correctness remain unestablished.
 The final serving path has no source weights, transformer/self-attention, dense
 matrix intelligence, MoE, or sparse learned router. Compiler-side floating
 point remains allowed for witnessed chart construction; serving arithmetic is
@@ -1752,11 +1763,15 @@ other gates passing. #1019 now owns the one frozen 12-layer,
 population/smoke/random-export parity gates passed, but MPS admission stopped
 `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline implementation.
 The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-logging fast path
-was slower, so #1019 is optional/paused and the active next step is the #1017
-`r4 generate` product path. CUDA and external GPU execution are out of scope.
-Intrinsic/readout alternatives,
+was slower, and #1019 closed without a full run. #954's first source-backed
+grounding SFT subsequently completed but failed its frozen product transfer
+population `1/3` through universal `ABSTAIN`. The active successor is a learned
+source-span pointer/copy head with explicit abstention and conflict scores.
+CUDA and external GPU execution are out of scope. Intrinsic/readout alternatives,
 multi-resonance replacement, whole-decoder recurrent factorization, and final
-requalification are parked. D3 remains `NOT_RUN`; #954 remains blocked.
+requalification are parked. D3 remains `NOT_RUN`; #954's final source-free
+terminal remains blocked while the bounded source-backed correctness phase is
+active.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/r4_grounded_correctness_954.md
+++ b/docs/r4_grounded_correctness_954.md
@@ -1,0 +1,97 @@
+# C1-SB0: source-backed grounded answer prototype (#954)
+
+Status: **ACTIVE / PRODUCT PROTOTYPE**
+Parent programme: #820
+Working model: #1017 six-layer R4/Spin causal-softmax checkpoint
+Final source-free correctness terminal: still blocked by parked #973
+
+## Why this is the next build
+
+PR #1022 made the #1017 checkpoint directly usable through `r4 generate` and
+added an opt-in Apple Accelerate CPU-BLAS build for local Apple Silicon use.
+On the project M1, a 64-token continuation completed in `0.220401125` seconds
+of recorded generation time (`0.67` seconds process wall time) and remained a
+coherent child/mother/oak-tree scene. All six R4/Spin attention layers ran, the
+causal and R4 audits matched, and future reads were zero.
+
+The same checkpoint did not yet behave as an answer model:
+
+- `Context: The sky is blue. Question: What color is the sky? Answer:` did not
+  produce the supplied answer; and
+- a natural cloze ending in `the sky was` generated `dark`, contradicting the
+  supplied sentence.
+
+Those observations locate the product seam. Attention and fluent generation
+work; grounded answer formatting and abstention have not been taught. No new
+attention mechanism, capacity run, or backend comparison is needed first.
+
+## Prototype
+
+`C1-SB0` adds two deliberately small pieces:
+
+1. `r4 answer --source-file <path> --question <text>` binds exact source bytes,
+   runs the existing #1017 R4/Spin generator once, and serves only an exact
+   contiguous source span. `ABSTAIN`, `CONTRADICTION`, empty output, and
+   unsupported generated text remain typed outcomes. Raw model text is retained
+   only in the audit report.
+2. One fixed MPS supervised fine-tune starts from a copy of #1017 and teaches
+   the exact answer interface using deterministic supported, unsupported, and
+   conflicting-context examples. It does not alter the architecture, tokenizer,
+   R4/Spin attention path, or Rust loader.
+
+The training budget is fixed at 384 optimizer steps with no sweep. At the
+measured conservative #1019 rate of `3.491307 s/step`, the upper estimate is
+about 22 minutes 21 seconds. Apple Accelerate is used for the subsequent local
+Rust behavior run; MPS is used only for this offline fine-tune.
+
+## Decision
+
+All three frozen unseen product probes must pass in the same run: the supported
+question must return its exact source span, the unsupported question must return
+typed `ABSTAIN`, and the conflicting source must return typed `CONTRADICTION`.
+Failure keeps work at this answer-format/data seam; it does not trigger another
+attention, geometry, capacity, or hardware campaign.
+
+## Scope boundary
+
+A positive result establishes only a source-backed prototype answer/abstention
+surface for this small model and prompt policy. It does not establish semantic
+entailment, general factual correctness, reasoning, intrinsic-geometric
+advantage, source-free/table-native inference, transformerlessness, browser or
+WASM readiness, frontier quality, or release readiness.
+
+## Observed result — 2026-08-31
+
+The fixed run completed on the project Apple M1 through PyTorch MPS without CPU
+fallback or CUDA. All 384 optimizer steps finished in `883.7735486670863`
+seconds (14 minutes 44 seconds), versus the conservative 22-minute estimate.
+Answer-token development loss was `0.0013607110659437775` at step 192 and
+`0.00014458666336423967` at step 384. The export is bound by:
+
+- weights CID `blake3:0949d925c1189cdc784a4b93bbb9119da5c1a573fe3385c3b3c8f82a299c9439`;
+- final manifest CID `blake3:c2c5b163485e39f14ba0a7869d83fab8c641ed061b5c0e8e5783924aff187b2f`;
+- run-contract CID `blake3:31b6d7776a42779d0b8daddfc8034f9984dc9f85476eb0bd5df713cd7624f589`; and
+- training-result CID `blake3:f957c11f668a9a81098f4b2ad9cac9af75d3636b5a2c6cc1a796c5817be10ac9`.
+
+The Rust product command then loaded that exact weight CID through Apple
+Accelerate CPU BLAS and ran all three frozen prompts. It emitted exact
+`ABSTAIN` plus EOS for every prompt:
+
+| Frozen prompt | Required outcome | Observed outcome | Verdict | Decision CID |
+| --- | --- | --- | --- | --- |
+| supported amber-coin source | exact supported sentence | typed `ABSTAIN` | FAIL | `blake3:63024db98ceb1cfdae5b106ddae0d611a027cc160578452c78ef6f4fda18bfe7` |
+| unsupported velvet-ribbon question | typed `ABSTAIN` | typed `ABSTAIN` | PASS | `blake3:de1baea232dcb93bbae199e48ea3cdddc5c10de7da7c59e0b416dd0454eae35a` |
+| conflicting amber-coin source | typed `CONTRADICTION` | typed `ABSTAIN` | FAIL | `blake3:b89b10fcff8c88cc7ed0d39c3d9c3293e0aa619d2fe34d7d044e6f00dfec4383` |
+
+Terminal: **`FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE`** (`1/3`).
+The low same-vocabulary teacher-forced development loss did not transfer to the
+reserved lexical items under autonomous decoding. This is a copying/generalized
+span-selection failure at the answer interface, not an attention-backend or
+hardware failure. The run is not retuned or repeated.
+
+The next successor should replace free-form answer generation with a learned
+source-span pointer/copy head plus explicit abstention and conflict scores over
+the already established causal R4/Spin states. That mechanism must be frozen on
+new lexical families before a newly reserved product population is revealed.
+Do not return to #1019 capacity, resonance, intrinsic-attention substitution, or
+backend comparison for this failure.

--- a/docs/r4_grounded_correctness_954_raw.json
+++ b/docs/r4_grounded_correctness_954_raw.json
@@ -1,0 +1,61 @@
+{
+  "schema": "uor-r4.grounded-correctness-result/1",
+  "issue": 954,
+  "date": "2026-08-31",
+  "terminal": "FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE",
+  "product_probes_passed": 1,
+  "product_probes_total": 3,
+  "training": {
+    "backend": "Apple M1 PyTorch MPS",
+    "cpu_fallback": false,
+    "cuda": false,
+    "optimizer_steps": 384,
+    "elapsed_seconds": 883.7735486670863,
+    "development_answer_token_loss_step_192": 0.0013607110659437775,
+    "development_answer_token_loss_step_384": 0.00014458666336423967,
+    "weights_cid": "blake3:0949d925c1189cdc784a4b93bbb9119da5c1a573fe3385c3b3c8f82a299c9439",
+    "final_manifest_cid": "blake3:c2c5b163485e39f14ba0a7869d83fab8c641ed061b5c0e8e5783924aff187b2f",
+    "run_contract_cid": "blake3:31b6d7776a42779d0b8daddfc8034f9984dc9f85476eb0bd5df713cd7624f589",
+    "training_result_cid": "blake3:f957c11f668a9a81098f4b2ad9cac9af75d3636b5a2c6cc1a796c5817be10ac9"
+  },
+  "inference": {
+    "backend": "Apple Accelerate CPU BLAS",
+    "generated_token_ids_all_probes": [35, 36, 53, 54, 35, 43, 48, 1],
+    "decoded_text_all_probes": "ABSTAIN",
+    "probes": [
+      {
+        "name": "supported",
+        "required": "The amber coin is inside the green basket.",
+        "observed": "ABSTAIN",
+        "passed": false,
+        "decision_cid": "blake3:63024db98ceb1cfdae5b106ddae0d611a027cc160578452c78ef6f4fda18bfe7",
+        "output_cid": "blake3:e76ecee0eaed19fe459d992a4c80029bc290bdf969e21fb57cb3fd3ff812e84d",
+        "audit_cid": "blake3:9c3915bbe21ae33ae376eb9356c80ed4ee47ddeb9de37e0a07f51c1a9305b5bc"
+      },
+      {
+        "name": "unsupported",
+        "required": "ABSTAIN",
+        "observed": "ABSTAIN",
+        "passed": true,
+        "decision_cid": "blake3:de1baea232dcb93bbae199e48ea3cdddc5c10de7da7c59e0b416dd0454eae35a",
+        "output_cid": "blake3:e76ecee0eaed19fe459d992a4c80029bc290bdf969e21fb57cb3fd3ff812e84d",
+        "audit_cid": "blake3:3bc01dad29ae784a7dcda559ca15994dcfed9f6dd009df58319b7d40bc604364"
+      },
+      {
+        "name": "conflict",
+        "required": "CONTRADICTION",
+        "observed": "ABSTAIN",
+        "passed": false,
+        "decision_cid": "blake3:b89b10fcff8c88cc7ed0d39c3d9c3293e0aa619d2fe34d7d044e6f00dfec4383",
+        "output_cid": "blake3:e76ecee0eaed19fe459d992a4c80029bc290bdf969e21fb57cb3fd3ff812e84d",
+        "audit_cid": "blake3:87e2e7aa59b3fb523d1fa8803448f290ec98a5ee88d072e1a4ff7baefad41d0d"
+      }
+    ]
+  },
+  "decision": "Do not rerun or tune this SFT. Build a source-span pointer/copy successor with explicit abstention and conflict scores over the established causal R4/Spin states, then freeze a new lexical population.",
+  "nonclaims": [
+    "This negative does not revoke established load-bearing causal attention.",
+    "The result does not establish general correctness, reasoning, source-free inference, or transformerlessness.",
+    "MPS and Apple Accelerate are local compilation, training, and inference accelerators; the deployed UOR target remains CPU-native."
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod geometric_mixer_qualification;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod model;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod r4_grounded_answer;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod r4_softmax_local_generation;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4_softmax_reference_generation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use uor_r4_wasm_router::tless_uor;
     name = "r4",
     version,
     about,
-    long_about = "Build the current source-free lexical table baseline or inspect the preserved geometric router.\n\n`source-free-table` is the active capability-first path: it learns construction-only integer lexical transition tables, measures held-out next-route choices, and emits bounded decoded text. It is a statistical lexical baseline, not semantics, attention, correctness, reasoning, product chat, or release readiness. Preserved compiler and certification commands remain available through `r4 research-tools`."
+    long_about = "Run the working R4/Spin causal-attention generator, ask a fail-closed question against one local source, or inspect the preserved geometric research surfaces.\n\n`generate` uses the coherent #1017 reference; `answer` uses the bounded #954 grounded export and serves only exact source spans or typed non-answers. Both remain source-backed floating-point/softmax references, not the final source-free transformerless runtime. Preserved compiler and certification commands remain available through `r4 research-tools`."
 )]
 struct Cli {
     /// Increase log verbosity (-v info, -vv debug, -vvv trace).
@@ -115,6 +115,8 @@ enum Command {
     /// Generate from the local learned R4/Spin model through causal softmax.
     #[command(visible_alias = "generate")]
     R4SoftmaxLocalGenerate(R4SoftmaxLocalGenerateArgs),
+    /// Answer from one exact local source span or fail closed with a typed outcome.
+    Answer(GroundedAnswerArgs),
     /// Qualify one frozen #1014, #1017, or #1019 local causal-softmax campaign.
     R4SoftmaxLocalQualify(R4SoftmaxLocalQualifyArgs),
     /// Compile and score the first source-free student of R4/Spin softmax traces.
@@ -766,6 +768,32 @@ struct R4SoftmaxLocalGenerateArgs {
     #[arg(long)]
     seed: Option<u64>,
     /// Optional path for the complete checkpoint/policy/token/audit JSON report.
+    #[arg(long)]
+    json_output: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct GroundedAnswerArgs {
+    /// Local grounded checkpoint directory; defaults to the bounded #954 export.
+    #[arg(long, default_value = ".uor-models/research/issue-954/export")]
+    model: PathBuf,
+    /// Exact regular, non-symlink UTF-8 source file used to ground the answer.
+    #[arg(long)]
+    source_file: PathBuf,
+    /// Exact question placed after the source by the fixed grounding prompt policy.
+    #[arg(long)]
+    question: String,
+    /// Maximum generated tokens (1..=128); the grounded surface defaults to 32.
+    #[arg(
+        long,
+        default_value_t = uor_r4_wasm_router::r4_grounded_answer::DEFAULT_MAX_NEW_TOKENS,
+        value_parser = parse_r4_softmax_local_max_new_tokens
+    )]
+    max_new_tokens: usize,
+    /// Stable seed for the versioned temperature-0.8/top-k-40 sampler; omit for greedy.
+    #[arg(long)]
+    seed: Option<u64>,
+    /// Optional path for the complete source binding, typed outcome, and inner audit.
     #[arg(long)]
     json_output: Option<PathBuf>,
 }
@@ -2498,6 +2526,38 @@ fn print_research_tools() {
 
 /// Default location of the reference teacher checkpoint used by `certify`/`compare`.
 const DEFAULT_REFERENCE_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
+const DEFAULT_R4_SOFTMAX_LOCAL_MODEL: &str = ".uor-models/research/issue-1017/export";
+const DEFAULT_GROUNDED_ANSWER_MODEL: &str = ".uor-models/research/issue-954/export";
+
+fn resolve_r4_softmax_local_model(configured: &Path) -> Result<PathBuf, RunError> {
+    let model = if configured == Path::new(DEFAULT_R4_SOFTMAX_LOCAL_MODEL) {
+        model_store_root().join("research/issue-1017/export")
+    } else {
+        configured.to_path_buf()
+    };
+    if !model.join("model.safetensors").is_file() {
+        return Err(RunError::Command(format!(
+            "no local #1017 model found at {}; set UOR_MODEL_STORE or pass --model",
+            model.display()
+        )));
+    }
+    Ok(model)
+}
+
+fn resolve_grounded_answer_model(configured: &Path) -> Result<PathBuf, RunError> {
+    let model = if configured == Path::new(DEFAULT_GROUNDED_ANSWER_MODEL) {
+        model_store_root().join("research/issue-954/export")
+    } else {
+        configured.to_path_buf()
+    };
+    if !model.join("model.safetensors").is_file() {
+        return Err(RunError::Command(format!(
+            "no grounded #954 model found at {}; set UOR_MODEL_STORE or pass --model",
+            model.display()
+        )));
+    }
+    Ok(model)
+}
 
 /// Resolve the reference teacher checkpoint path, honoring the `TLESS_CHECKPOINT`
 /// override, and confirm it exists before handing it to `LlamaOracle::load`
@@ -2552,18 +2612,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             Ok(())
         }
         Some(Command::R4SoftmaxLocalGenerate(args)) => {
-            let default_model = Path::new(".uor-models/research/issue-1017/export");
-            let model = if args.model == default_model {
-                model_store_root().join("research/issue-1017/export")
-            } else {
-                args.model.clone()
-            };
-            if !model.join("model.safetensors").is_file() {
-                return Err(RunError::Command(format!(
-                    "no local #1017 model found at {}; set UOR_MODEL_STORE or pass --model",
-                    model.display()
-                )));
-            }
+            let model = resolve_r4_softmax_local_model(&args.model)?;
             let workers = std::num::NonZeroUsize::new(
                 uor_r4_wasm_router::r4_softmax_local_generation::DEFAULT_WORKERS,
             )
@@ -2584,6 +2633,48 @@ fn run(cli: &Cli) -> Result<(), RunError> {
                     .map_err(|error| RunError::Command(error.to_string()))?;
             }
             println!("{}", report.transcript.response_text);
+            Ok(())
+        }
+        Some(Command::Answer(args)) => {
+            let model = resolve_grounded_answer_model(&args.model)?;
+            if let Some(path) = &args.json_output {
+                uor_r4_wasm_router::r4_grounded_answer::require_distinct_output_path(
+                    &args.source_file,
+                    path,
+                )
+                .map_err(|error| RunError::Command(error.to_string()))?;
+            }
+            let workers = std::num::NonZeroUsize::new(
+                uor_r4_wasm_router::r4_softmax_local_generation::DEFAULT_WORKERS,
+            )
+            .ok_or_else(|| RunError::Command("local generator worker count is zero".to_owned()))?;
+            let report = uor_r4_wasm_router::r4_grounded_answer::run_grounded_answer(
+                &uor_r4_wasm_router::r4_grounded_answer::GroundedAnswerConfig {
+                    model,
+                    source_file: args.source_file.clone(),
+                    question: args.question.clone(),
+                    max_new_tokens: args.max_new_tokens,
+                    workers,
+                    seed: args.seed,
+                },
+            )
+            .map_err(|error| RunError::Command(error.to_string()))?;
+            if let Some(path) = &args.json_output {
+                uor_r4_wasm_router::r4_grounded_answer::write_json_report(path, &report)
+                    .map_err(|error| RunError::Command(error.to_string()))?;
+            }
+            match &report.outcome {
+                uor_r4_wasm_router::r4_grounded_answer::GroundedAnswerOutcome::Answered {
+                    answer,
+                    ..
+                } => println!("{answer}"),
+                uor_r4_wasm_router::r4_grounded_answer::GroundedAnswerOutcome::Contradiction => {
+                    println!("CONTRADICTION")
+                }
+                uor_r4_wasm_router::r4_grounded_answer::GroundedAnswerOutcome::Abstained {
+                    reason,
+                } => println!("ABSTAIN[{}]", reason.as_str()),
+            }
             Ok(())
         }
         Some(Command::R4SoftmaxLocalQualify(args)) => {

--- a/src/r4_grounded_answer.rs
+++ b/src/r4_grounded_answer.rs
@@ -1,0 +1,523 @@
+//! Fail-closed, source-bound answers over the working #1017 local generator.
+//!
+//! The model may propose text, `ABSTAIN`, or `CONTRADICTION`, but this surface
+//! serves ordinary text only when it is an exact, case-sensitive contiguous
+//! byte span of the caller-supplied source. The complete underlying generation
+//! report remains nested for audit without exposing unsupported text on stdout.
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read};
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::r4_softmax_local_generation::{
+    run_r4_softmax_local_generation, R4SoftmaxLocalGenerationError, R4SoftmaxLocalGenerationReport,
+    R4SoftmaxLocalGeneratorConfig, MAX_NEW_TOKENS,
+};
+
+pub const REPORT_SCHEMA: &str = "uor-r4.grounded-answer/1";
+pub const PROMPT_POLICY: &str = "R4GroundedExtractivePromptV1";
+pub const DEFAULT_MAX_NEW_TOKENS: usize = 32;
+pub const MAX_SOURCE_BYTES: usize = 4 * 1024;
+pub const MAX_QUESTION_BYTES: usize = 1024;
+
+pub const PROMPT_POLICY_TEMPLATE: &str = concat!(
+    "Use only the context. Copy one exact contiguous answer span from the context. ",
+    "If the context does not answer the question, write ABSTAIN. ",
+    "If the context gives conflicting answers, write CONTRADICTION.",
+    "\nContext:\n{source}\nQuestion:\n{question}\nAnswer:\n",
+);
+
+const PROMPT_POLICY_INSTRUCTION: &str = concat!(
+    "Use only the context. Copy one exact contiguous answer span from the context. ",
+    "If the context does not answer the question, write ABSTAIN. ",
+    "If the context gives conflicting answers, write CONTRADICTION.",
+);
+
+#[derive(Clone, Debug)]
+pub struct GroundedAnswerConfig {
+    pub model: PathBuf,
+    pub source_file: PathBuf,
+    pub question: String,
+    pub max_new_tokens: usize,
+    pub workers: NonZeroUsize,
+    pub seed: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroundingSourceBinding {
+    pub path: String,
+    pub source_cid: String,
+    pub byte_length: usize,
+    pub regular_non_symlink: bool,
+    pub utf8: bool,
+    pub reads: u64,
+    pub unchanged_after_run: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceSpan {
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GroundedAbstentionReason {
+    EmptyGeneratedText,
+    InsufficientEvidence,
+    UnsupportedGeneratedText,
+}
+
+impl GroundedAbstentionReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EmptyGeneratedText => "empty_generated_text",
+            Self::InsufficientEvidence => "insufficient_evidence",
+            Self::UnsupportedGeneratedText => "unsupported_generated_text",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum GroundedAnswerOutcome {
+    Answered {
+        answer: String,
+        source_span: SourceSpan,
+    },
+    Contradiction,
+    Abstained {
+        reason: GroundedAbstentionReason,
+    },
+}
+
+#[derive(Serialize)]
+struct GroundedDecisionIdentity<'a> {
+    schema: &'static str,
+    prompt_policy: &'static str,
+    prompt_policy_cid: &'a str,
+    assembled_prompt_cid: &'a str,
+    source_cid: &'a str,
+    source_byte_length: usize,
+    question: &'a str,
+    inner_decision_cid: &'a str,
+    inner_output_cid: &'a str,
+    inner_audit_cid: &'a str,
+    outcome: &'a GroundedAnswerOutcome,
+}
+
+#[derive(Serialize)]
+pub struct GroundedAnswerReport {
+    pub schema: String,
+    pub decision_cid: String,
+    pub claim_scope: String,
+    pub prompt_policy: String,
+    pub prompt_policy_cid: String,
+    pub assembled_prompt_cid: String,
+    pub source: GroundingSourceBinding,
+    pub question: String,
+    pub outcome: GroundedAnswerOutcome,
+    /// The full #1017 generation report, including the raw candidate and every
+    /// causal-attention, execution, checkpoint, and decode audit.
+    pub generation: R4SoftmaxLocalGenerationReport,
+    pub nonclaims: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum GroundedAnswerError {
+    InvalidRequest(String),
+    InvalidSource(String),
+    Generation(R4SoftmaxLocalGenerationError),
+    Audit(String),
+    Io(io::Error),
+}
+
+impl fmt::Display for GroundedAnswerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest(reason) => write!(formatter, "invalid grounded answer: {reason}"),
+            Self::InvalidSource(reason) => write!(formatter, "invalid grounding source: {reason}"),
+            Self::Generation(error) => error.fmt(formatter),
+            Self::Audit(reason) => write!(formatter, "grounded answer audit failed: {reason}"),
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for GroundedAnswerError {}
+
+impl From<R4SoftmaxLocalGenerationError> for GroundedAnswerError {
+    fn from(error: R4SoftmaxLocalGenerationError) -> Self {
+        Self::Generation(error)
+    }
+}
+
+impl From<io::Error> for GroundedAnswerError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub fn run_grounded_answer(
+    config: &GroundedAnswerConfig,
+) -> Result<GroundedAnswerReport, GroundedAnswerError> {
+    validate_request(config)?;
+    let source_before = read_source_file(&config.source_file)?;
+    let source_text = std::str::from_utf8(&source_before).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!(
+            "{} is not exact UTF-8: {error}",
+            config.source_file.display()
+        ))
+    })?;
+    let source_cid = raw_cid(&source_before);
+    let prompt = assemble_prompt(source_text, &config.question);
+    let prompt_policy_cid = raw_cid(PROMPT_POLICY_TEMPLATE.as_bytes());
+    let assembled_prompt_cid = raw_cid(prompt.as_bytes());
+
+    let generation = run_r4_softmax_local_generation(&R4SoftmaxLocalGeneratorConfig {
+        model: config.model.clone(),
+        prompt,
+        max_new_tokens: config.max_new_tokens,
+        workers: config.workers,
+        attention_off: false,
+        seed: config.seed,
+    })?;
+
+    let source_after = read_source_file(&config.source_file)?;
+    if source_before != source_after {
+        return Err(GroundedAnswerError::Audit(format!(
+            "source {} changed during generation (before {}, after {})",
+            config.source_file.display(),
+            source_cid,
+            raw_cid(&source_after)
+        )));
+    }
+
+    let outcome = if generation.transcript.utf8_decodable {
+        classify_candidate(source_text, &generation.transcript.response_text)
+    } else {
+        GroundedAnswerOutcome::Abstained {
+            reason: GroundedAbstentionReason::UnsupportedGeneratedText,
+        }
+    };
+    let source = GroundingSourceBinding {
+        path: config.source_file.display().to_string(),
+        source_cid,
+        byte_length: source_before.len(),
+        regular_non_symlink: true,
+        utf8: true,
+        reads: 2,
+        unchanged_after_run: true,
+    };
+    let decision_cid = cid_serializable(&GroundedDecisionIdentity {
+        schema: REPORT_SCHEMA,
+        prompt_policy: PROMPT_POLICY,
+        prompt_policy_cid: &prompt_policy_cid,
+        assembled_prompt_cid: &assembled_prompt_cid,
+        source_cid: &source.source_cid,
+        source_byte_length: source.byte_length,
+        question: &config.question,
+        inner_decision_cid: &generation.decision_cid,
+        inner_output_cid: &generation.output_cid,
+        inner_audit_cid: &generation.audit_cid,
+        outcome: &outcome,
+    })?;
+
+    Ok(GroundedAnswerReport {
+        schema: REPORT_SCHEMA.to_owned(),
+        decision_cid,
+        claim_scope: "fail-closed local #1017 answer serving with exact source-byte provenance and exact case-sensitive contiguous-span admission".to_owned(),
+        prompt_policy: PROMPT_POLICY.to_owned(),
+        prompt_policy_cid,
+        assembled_prompt_cid,
+        source,
+        question: config.question.clone(),
+        outcome,
+        generation,
+        nonclaims: vec![
+            "Exact source-span membership establishes provenance, not semantic entailment or general correctness.".to_owned(),
+            "A CONTRADICTION result is the model's typed response to the fixed prompt; this wrapper does not independently prove a semantic conflict.".to_owned(),
+            "This #1017 path remains source-backed, floating-point, multiplication-using, and ordinary-softmax based.".to_owned(),
+        ],
+    })
+}
+
+pub fn write_json_report(
+    path: &Path,
+    report: &GroundedAnswerReport,
+) -> Result<(), GroundedAnswerError> {
+    let bytes = serde_json::to_vec_pretty(report)
+        .map_err(|error| GroundedAnswerError::Io(io::Error::other(error)))?;
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+/// Reject an audit output that already names the same file as the bound source.
+/// This check runs before generation so report emission cannot overwrite the
+/// source after the unchanged-source audit has completed.
+pub fn require_distinct_output_path(
+    source: &Path,
+    output: &Path,
+) -> Result<(), GroundedAnswerError> {
+    let source_metadata = std::fs::metadata(source).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!(
+            "cannot inspect {} before selecting audit output: {error}",
+            source.display()
+        ))
+    })?;
+    let output_metadata = match std::fs::metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(GroundedAnswerError::InvalidRequest(format!(
+                "cannot inspect --json-output {}: {error}",
+                output.display()
+            )))
+        }
+    };
+    if same_file_identity(source, &source_metadata, output, &output_metadata)? {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--json-output must not name or alias --source-file".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn same_file_identity(
+    _left_path: &Path,
+    left: &std::fs::Metadata,
+    _right_path: &Path,
+    right: &std::fs::Metadata,
+) -> Result<bool, GroundedAnswerError> {
+    use std::os::unix::fs::MetadataExt;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(not(unix))]
+fn same_file_identity(
+    left_path: &Path,
+    _left: &std::fs::Metadata,
+    right_path: &Path,
+    _right: &std::fs::Metadata,
+) -> Result<bool, GroundedAnswerError> {
+    Ok(std::fs::canonicalize(left_path)? == std::fs::canonicalize(right_path)?)
+}
+
+fn validate_request(config: &GroundedAnswerConfig) -> Result<(), GroundedAnswerError> {
+    if config.question.trim().is_empty() {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--question must not be empty or whitespace-only".to_owned(),
+        ));
+    }
+    if config.question.len() > MAX_QUESTION_BYTES {
+        return Err(GroundedAnswerError::InvalidRequest(format!(
+            "--question is {} bytes; maximum is {MAX_QUESTION_BYTES}",
+            config.question.len()
+        )));
+    }
+    if config.max_new_tokens == 0 || config.max_new_tokens > MAX_NEW_TOKENS {
+        return Err(GroundedAnswerError::InvalidRequest(format!(
+            "--max-new-tokens must be in 1..={MAX_NEW_TOKENS}"
+        )));
+    }
+    Ok(())
+}
+
+fn read_source_file(path: &Path) -> Result<Vec<u8>, GroundedAnswerError> {
+    let file = open_source_no_follow(path)?;
+    let metadata = file.metadata().map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!("cannot inspect {}: {error}", path.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+    if metadata.len() > MAX_SOURCE_BYTES as u64 {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} is {} bytes; maximum is {MAX_SOURCE_BYTES}",
+            path.display(),
+            metadata.len()
+        )));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_SOURCE_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            GroundedAnswerError::InvalidSource(format!("cannot read {}: {error}", path.display()))
+        })?;
+    if bytes.is_empty() {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} is empty",
+            path.display()
+        )));
+    }
+    if bytes.len() > MAX_SOURCE_BYTES {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} grew past the {MAX_SOURCE_BYTES}-byte maximum while being read",
+            path.display()
+        )));
+    }
+    let source = std::str::from_utf8(&bytes).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!(
+            "{} is not exact UTF-8: {error}",
+            path.display()
+        ))
+    })?;
+    if source.trim().is_empty() {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} is whitespace-only",
+            path.display()
+        )));
+    }
+    Ok(bytes)
+}
+
+#[cfg(unix)]
+fn open_source_no_follow(path: &Path) -> Result<File, GroundedAnswerError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| {
+            GroundedAnswerError::InvalidSource(format!(
+                "cannot open {} as a regular non-symlink file: {error}",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+fn open_source_no_follow(path: &Path) -> Result<File, GroundedAnswerError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!("cannot inspect {}: {error}", path.display()))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(GroundedAnswerError::InvalidSource(format!(
+            "{} is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+    File::open(path).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!("cannot open {}: {error}", path.display()))
+    })
+}
+
+fn assemble_prompt(source: &str, question: &str) -> String {
+    format!("{PROMPT_POLICY_INSTRUCTION}\nContext:\n{source}\nQuestion:\n{question}\nAnswer:\n")
+}
+
+fn classify_candidate(source: &str, candidate: &str) -> GroundedAnswerOutcome {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return GroundedAnswerOutcome::Abstained {
+            reason: GroundedAbstentionReason::EmptyGeneratedText,
+        };
+    }
+    if candidate == "ABSTAIN" {
+        return GroundedAnswerOutcome::Abstained {
+            reason: GroundedAbstentionReason::InsufficientEvidence,
+        };
+    }
+    if candidate == "CONTRADICTION" {
+        return GroundedAnswerOutcome::Contradiction;
+    }
+    if let Some(byte_start) = source.find(candidate) {
+        return GroundedAnswerOutcome::Answered {
+            answer: candidate.to_owned(),
+            source_span: SourceSpan {
+                byte_start,
+                byte_end: byte_start + candidate.len(),
+            },
+        };
+    }
+    GroundedAnswerOutcome::Abstained {
+        reason: GroundedAbstentionReason::UnsupportedGeneratedText,
+    }
+}
+
+fn raw_cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn cid_serializable<T: Serialize>(value: &T) -> Result<String, GroundedAnswerError> {
+    let bytes = serde_json::to_vec(value).map_err(|error| {
+        GroundedAnswerError::Audit(format!("cannot serialize decision identity: {error}"))
+    })?;
+    Ok(raw_cid(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifier_serves_only_exact_case_sensitive_source_spans() {
+        let source = "The silver key opens the north door.";
+        assert_eq!(
+            classify_candidate(source, "silver key"),
+            GroundedAnswerOutcome::Answered {
+                answer: "silver key".to_owned(),
+                source_span: SourceSpan {
+                    byte_start: 4,
+                    byte_end: 14,
+                },
+            }
+        );
+        assert_eq!(
+            classify_candidate(source, "Silver key"),
+            GroundedAnswerOutcome::Abstained {
+                reason: GroundedAbstentionReason::UnsupportedGeneratedText,
+            }
+        );
+    }
+
+    #[test]
+    fn classifier_types_every_non_answer_terminal() {
+        assert_eq!(
+            classify_candidate("source", "  "),
+            GroundedAnswerOutcome::Abstained {
+                reason: GroundedAbstentionReason::EmptyGeneratedText,
+            }
+        );
+        assert_eq!(
+            classify_candidate("source", " ABSTAIN "),
+            GroundedAnswerOutcome::Abstained {
+                reason: GroundedAbstentionReason::InsufficientEvidence,
+            }
+        );
+        assert_eq!(
+            classify_candidate("source", " CONTRADICTION "),
+            GroundedAnswerOutcome::Contradiction
+        );
+        assert_eq!(
+            classify_candidate("source", "unsupported"),
+            GroundedAnswerOutcome::Abstained {
+                reason: GroundedAbstentionReason::UnsupportedGeneratedText,
+            }
+        );
+    }
+
+    #[test]
+    fn prompt_assembly_matches_the_frozen_policy() {
+        assert_eq!(
+            assemble_prompt("exact source", "exact question"),
+            PROMPT_POLICY_TEMPLATE
+                .replace("{source}", "exact source")
+                .replace("{question}", "exact question")
+        );
+    }
+}

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -1,10 +1,11 @@
-# R4 causal-softmax trainer (#1014 / #1017 / #1019)
+# R4 causal-softmax trainer (#1014 / #1017 / #1019 / #954)
 
 This package contains the bounded offline training paths authorized by issues
 [#1014](https://github.com/UOR-Foundation/uor-r4/issues/1014) and
 [#1017](https://github.com/UOR-Foundation/uor-r4/issues/1017), plus the frozen,
 preflight-recorded [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
-parameter-capacity campaign. They train and continue ordinary causal-softmax
+parameter-capacity campaign, and the bounded [#954](https://github.com/UOR-Foundation/uor-r4/issues/954)
+grounding fine-tune. They train and continue ordinary causal-softmax
 Llama-family models, export them in the existing Rust loaders' Hugging Face
 format, and freeze evidence before each sealed test is opened. They contain no
 teacher, trace-distillation, comparison-arm, resonance, or routing experiment.
@@ -49,9 +50,9 @@ reveal, generation, and replay remain `NOT_RUN`. A single isolated exact-shape
 MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
 deferred logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-fast-path negative, not a model result. #1019 tuning/full-run work stops and
-remains optional/paused; the active next step is the working #1017 `r4 generate`
-product path. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+fast-path negative, not a model result. #1019 closed without a full run; the
+active next step is #954's one bounded grounding fine-tune and Rust product
+check over the working #1017 model. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
 and MPS are local offline accelerators only; CUDA and external GPU execution
 are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
@@ -66,6 +67,47 @@ preserved generated IDs, output CID, and attention-audit CID while reducing
 internal generation from `3.060506042 s` to `0.116236875 s`. This is ordinary
 Apple CPU BLAS and carries distinct backend provenance; it is not a CUDA path
 or a change to the exact portable runtime contract.
+
+## Bounded #954 grounding fine-tune
+
+`finetune-grounding` is the next product-facing step over the completed #1017
+model. It runs one fixed 384-step MPS fine-tune with a fresh AdamW optimizer;
+there is no sweep. Every example uses this exact contract:
+
+```text
+Use only the context. Copy one exact contiguous answer span from the context. If the context does not answer the question, write ABSTAIN. If the context gives conflicting answers, write CONTRADICTION.
+Context:
+{source}
+Question:
+{question}
+Answer:
+```
+
+The corpus deterministically balances supported, unsupported, and conflicting
+examples. Loss applies only to answer and EOS tokens; prompt and padding targets
+are masked. Three reserved prompts remain absent from training and development
+for the subsequent Rust product check. The run reuses the #1017 tokenizer,
+six-layer model shape and standard Hugging Face export. It also writes a
+Python prefix-logit fixture as a diagnostic artifact; no separate Rust parity
+campaign is required for this product gate. At the conservative measured `3.491307 s/step`, the 384 optimizer
+steps are about 22 minutes 21 seconds before the small development evaluations
+and export.
+
+From any worktree root, point at the shared model store and run:
+
+```bash
+export UOR_MODEL_STORE=/Users/casey.allard/uor-r4/.uor-models
+PYTHONPATH="$PWD/tools/r4-softmax-trainer/src" \
+  "$UOR_MODEL_STORE/research/issue-1014/venv/bin/python" \
+  -m r4_softmax_trainer finetune-grounding
+```
+
+The defaults read
+`$UOR_MODEL_STORE/research/issue-1017/export` and write
+`$UOR_MODEL_STORE/research/issue-954`. If interrupted after a checkpoint, rerun
+the same command with `--resume`. Completion exports `issue-954/export` and the
+enabled-only Python prefix fixture; grounded generation remains `NOT_RUN` until
+the Rust product command passes all three reserved prompts.
 
 ## Isolated environment
 
@@ -88,9 +130,9 @@ instead used its own eight-hour backend-admission gate. MPS stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) while memory passed at
 `21.03%`. That result applies only to the frozen offline implementation. The
 subsequent fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
-signed `3.491307 s/step`), so #1019 is optional/paused and the active next step
-is the #1017 `r4 generate` product path. CUDA and external GPU execution are out
-of scope.
+signed `3.491307 s/step`), so #1019 closed without a full run. The active next
+step is #954's bounded grounding fine-tune and Rust product check over #1017.
+CUDA and external GPU execution are out of scope.
 
 ## One-way campaign
 
@@ -199,8 +241,8 @@ Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
 terminal applies only to the frozen offline implementation. Full training,
 final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
 fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-`3.491307 s/step`), so #1019 is optional/paused and the active next step is the
-#1017 `r4 generate` product path. CUDA and external GPU execution are out of scope. See the
+`3.491307 s/step`), so #1019 closed without a full run and #954's bounded
+source-grounding product phase is active over #1017. CUDA and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 
 The Rust qualifier has a separate shape-bound campaign mode. After a #1019
@@ -238,9 +280,9 @@ That MPS probe wrote `UNAVAILABLE_HARDWARE_BUDGET` on time, so do not rerun its
 create-once population, smoke, Rust parity, admission, or MPS probe stages.
 Preserve the passed smoke admission. CUDA and external GPU execution are out of
 scope. The one fused-AdamW/deferred-logging fast-path test was slower than the
-signed baseline, so do not tune or launch the #1019 full run. #1019 is optional/
-paused; do not reopen recurring optimization or broad research gates. Use and
-productize the working #1017 path with `r4 generate --prompt "..."` instead.
+signed baseline, so do not tune or launch the #1019 full run. #1019 is closed;
+do not reopen recurring optimization or broad research gates. Continue the one
+bounded #954 grounding phase over the working #1017 model instead.
 
 After a locally admitted full run produces an export, continue with:
 

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -1,4 +1,4 @@
-"""Command line for the frozen #1014, #1017, and #1019 campaigns."""
+"""Command line for the bounded #1014, #1017, #1019, and #954 campaigns."""
 
 from __future__ import annotations
 
@@ -36,7 +36,14 @@ from .continuation_data import (
 )
 from .data import download_source, load_dataset_manifest, prepare_dataset
 from .finalize import finalize_continuation
-from .paths import default_capacity_root, default_continuation_root, default_research_root
+from .grounding import train_grounding
+from .paths import (
+    default_capacity_root,
+    default_continuation_root,
+    default_grounding_predecessor_root,
+    default_grounding_root,
+    default_research_root,
+)
 from .provenance import verify_bound_manifest
 from .train import TrainConfig, reveal_sealed_test, run_overfit_smoke, train_main
 
@@ -206,6 +213,22 @@ def parser() -> argparse.ArgumentParser:
         help="bind #1019's reveal, ten Rust generation reports, and human rubric",
     )
     finalize_capacity_parser.add_argument("--rubric", type=_root, required=True)
+
+    grounding = subcommands.add_parser(
+        "finetune-grounding",
+        help="run the fixed 384-step MPS context-grounding SFT over #1017",
+    )
+    grounding.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="completed #1017 Hugging Face export",
+    )
+    grounding.add_argument(
+        "--resume",
+        action="store_true",
+        help="resume the identical fixed run from checkpoints/latest.pt",
+    )
     return command
 
 
@@ -232,12 +255,15 @@ def main() -> None:
         "verify-capacity-generation-ready",
         "finalize-capacity",
     }
+    grounding_commands = {"finetune-grounding"}
     if arguments.root:
         root = arguments.root
     elif arguments.command in capacity_commands:
         root = default_capacity_root()
     elif arguments.command in continuation_commands:
         root = default_continuation_root()
+    elif arguments.command in grounding_commands:
+        root = default_grounding_root()
     else:
         root = default_research_root()
     if arguments.command == "download":
@@ -345,5 +371,14 @@ def main() -> None:
         return
     if arguments.command == "finalize-capacity":
         _print_result(finalize_capacity(root, arguments.rubric))
+        return
+    if arguments.command == "finetune-grounding":
+        _print_result(
+            train_grounding(
+                root,
+                predecessor=arguments.predecessor,
+                resume=arguments.resume,
+            )
+        )
         return
     raise AssertionError(f"unhandled command: {arguments.command}")

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/grounding.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/grounding.py
@@ -1,0 +1,484 @@
+"""One bounded MPS fine-tune that adds grounded answer/abstain behavior to #1017."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file
+from torch import Tensor
+
+from .constants import FROZEN_MODEL_CONFIG
+from .export import export_hugging_face_snapshot
+from .grounding_data import GroundingStore, build_grounding_corpus, grounding_split_policy
+from .model import R4SoftmaxForCausalLM
+from .provenance import (
+    atomic_write,
+    atomic_write_json,
+    canonical_json_bytes,
+    cid_bytes,
+    cid_file,
+    trainer_implementation_contract,
+    verify_bound_manifest,
+    write_bound_manifest,
+)
+from .train import require_mps
+
+
+ISSUE = 954
+GROUNDING_RUN_SCHEMA = "uor-r4-softmax-grounding-run/1"
+GROUNDING_CHECKPOINT_SCHEMA = "uor-r4-softmax-grounding-checkpoint/1"
+GROUNDING_RESULT_SCHEMA = "uor-r4-softmax-grounding-result/1"
+GROUNDING_PREFIX_SCHEMA = "uor-r4.r4-softmax-python-grounding-prefix-logits/1"
+GROUNDING_DATASET_MANIFEST_SCHEMA = "uor-r4-softmax-grounding-dataset-manifest/1"
+GROUNDING_FINAL_MANIFEST_SCHEMA = "uor-r4-softmax-grounding-final-manifest/1"
+PREFIX_LOGIT_ABS_TOLERANCE = 0.005
+
+
+@dataclass(frozen=True, slots=True)
+class GroundingConfig:
+    """The fixed, no-sweep #954 product-grounding optimization contract."""
+
+    seed: int = 954
+    batch_size: int = 16
+    gradient_accumulation_steps: int = 4
+    optimizer_steps: int = 384
+    learning_rate: float = 5e-5
+    minimum_learning_rate: float = 5e-6
+    warmup_steps: int = 32
+    weight_decay: float = 0.01
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.95
+    adam_epsilon: float = 1e-8
+    gradient_clip: float = 1.0
+    progress_interval: int = 16
+    checkpoint_interval: int = 64
+    evaluation_steps: tuple[int, ...] = (192, 384)
+    wall_ceiling_seconds: float = 45 * 60
+    conservative_seconds_per_step: float = 3.491307
+
+    def validate(self) -> None:
+        if self != GroundingConfig():
+            raise ValueError("#954 exposes one fixed grounding fine-tune, not a sweep")
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        value = asdict(self)
+        value["evaluation_steps"] = list(self.evaluation_steps)
+        value["estimated_training_seconds"] = (
+            self.optimizer_steps * self.conservative_seconds_per_step
+        )
+        return value
+
+
+def _learning_rate(step: int, config: GroundingConfig) -> float:
+    if not 1 <= step <= config.optimizer_steps:
+        raise ValueError("grounding step is outside the fixed schedule")
+    if step <= config.warmup_steps:
+        return config.learning_rate * step / config.warmup_steps
+    progress = (step - config.warmup_steps) / (
+        config.optimizer_steps - config.warmup_steps
+    )
+    cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+    return config.minimum_learning_rate + cosine * (
+        config.learning_rate - config.minimum_learning_rate
+    )
+
+
+def _cpu_tree(value: Any) -> Any:
+    if isinstance(value, Tensor):
+        return value.detach().cpu()
+    if isinstance(value, dict):
+        return {key: _cpu_tree(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_cpu_tree(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_cpu_tree(item) for item in value)
+    return value
+
+
+def _optimizer_to_device(optimizer: torch.optim.Optimizer, device: torch.device) -> None:
+    for state in optimizer.state.values():
+        for key, value in state.items():
+            if isinstance(value, Tensor):
+                state[key] = value.to(device)
+
+
+def _write_or_verify_json(path: Path, value: dict[str, Any]) -> None:
+    encoded = canonical_json_bytes(value)
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ValueError(f"existing grounding artifact differs: {path}")
+        return
+    atomic_write(path, encoded)
+
+
+def _save_checkpoint(
+    path: Path,
+    *,
+    model: R4SoftmaxForCausalLM,
+    optimizer: torch.optim.Optimizer,
+    step: int,
+    elapsed_seconds: float,
+    evaluations: list[dict[str, Any]],
+    run_contract_cid: str,
+) -> None:
+    payload = {
+        "schema": GROUNDING_CHECKPOINT_SCHEMA,
+        "issue": ISSUE,
+        "run_contract_cid": run_contract_cid,
+        "optimizer_step": step,
+        "elapsed_seconds": elapsed_seconds,
+        "evaluations": evaluations,
+        "model": _cpu_tree(model.state_dict()),
+        "optimizer": _cpu_tree(optimizer.state_dict()),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.part")
+    torch.save(payload, temporary)
+    os.replace(temporary, path)
+
+
+def _load_checkpoint(
+    path: Path,
+    *,
+    model: R4SoftmaxForCausalLM,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    run_contract_cid: str,
+) -> tuple[int, float, list[dict[str, Any]]]:
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    if (
+        not isinstance(checkpoint, dict)
+        or checkpoint.get("schema") != GROUNDING_CHECKPOINT_SCHEMA
+        or checkpoint.get("issue") != ISSUE
+        or checkpoint.get("run_contract_cid") != run_contract_cid
+    ):
+        raise ValueError("grounding resume checkpoint belongs to another run")
+    model.load_state_dict(checkpoint["model"], strict=True)
+    optimizer.load_state_dict(checkpoint["optimizer"])
+    _optimizer_to_device(optimizer, device)
+    step = int(checkpoint.get("optimizer_step", -1))
+    if not 0 <= step <= GroundingConfig().optimizer_steps:
+        raise ValueError("grounding checkpoint step is outside the fixed run")
+    return (
+        step,
+        float(checkpoint.get("elapsed_seconds", 0.0)),
+        list(checkpoint.get("evaluations", [])),
+    )
+
+
+@torch.no_grad()
+def _evaluate_answer_loss(
+    model: R4SoftmaxForCausalLM,
+    store: GroundingStore,
+    device: torch.device,
+    batch_size: int,
+) -> float:
+    model.eval()
+    total_loss = 0.0
+    total_tokens = 0
+    for inputs, targets in store.sequential_batches(batch_size):
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+        output = model(inputs, targets)
+        assert output.loss is not None
+        supervised = int((targets != -100).sum().detach().cpu())
+        total_loss += float(output.loss.detach().cpu()) * supervised
+        total_tokens += supervised
+    if total_tokens == 0:
+        raise RuntimeError("grounding development set has no supervised answer tokens")
+    return total_loss / total_tokens
+
+
+def _write_prefix_fixture(
+    root: Path,
+    *,
+    model: R4SoftmaxForCausalLM,
+    development_store: GroundingStore,
+    device: torch.device,
+    weights_cid: str,
+    dataset_cid: str,
+) -> dict[str, Any]:
+    prefix_token_ids = development_store.parity_prefix()
+    with torch.no_grad():
+        inputs = torch.tensor([prefix_token_ids], dtype=torch.long, device=device)
+        logits = model(inputs).logits[0, -1].float().cpu()
+    if logits.numel() != FROZEN_MODEL_CONFIG.vocab_size or not torch.isfinite(logits).all():
+        raise RuntimeError("grounding parity prefix produced invalid logits")
+    value: dict[str, Any] = {
+        "schema": GROUNDING_PREFIX_SCHEMA,
+        "token_store_cid": dataset_cid,
+        "weights_cid": weights_cid,
+        "prefix_token_ids": prefix_token_ids,
+        "maximum_absolute_logit_delta_limit": PREFIX_LOGIT_ABS_TOLERANCE,
+        "enabled": {
+            "top1_token_id": int(torch.argmax(logits).item()),
+            "logits": logits.tolist(),
+        },
+    }
+    value["result_cid"] = cid_bytes(canonical_json_bytes(value))
+    atomic_write_json(root / "qualification/python-grounding-prefix-logits.json", value)
+    return value
+
+
+def _validated_predecessor(predecessor: Path) -> dict[str, Any]:
+    manifest = verify_bound_manifest(
+        predecessor / "export-manifest.json", artifact_root=predecessor
+    )
+    if manifest.get("model_contract") != FROZEN_MODEL_CONFIG.as_contract():
+        raise ValueError("grounding predecessor is not the six-layer #1017 architecture")
+    for path in ("config.json", "model.safetensors", "tokenizer.json"):
+        if not (predecessor / path).is_file():
+            raise FileNotFoundError(predecessor / path)
+    return manifest
+
+
+def train_grounding(
+    root: Path,
+    *,
+    predecessor: Path,
+    resume: bool = False,
+    config: GroundingConfig = GroundingConfig(),
+) -> dict[str, Any]:
+    """Run the fixed 384-step #954 MPS SFT and export the standard local model."""
+    config.validate()
+    root = root.expanduser().resolve()
+    predecessor = predecessor.expanduser().resolve()
+    if root == predecessor or predecessor in root.parents:
+        raise ValueError("grounding output must not overwrite the #1017 predecessor")
+    final_manifest_path = root / "grounding-final-manifest.json"
+    if final_manifest_path.exists():
+        raise FileExistsError("the #954 grounding export is already complete")
+
+    predecessor_manifest = _validated_predecessor(predecessor)
+    corpus = build_grounding_corpus()
+    root.mkdir(parents=True, exist_ok=True)
+    dataset_path = root / "grounding-dataset.json"
+    _write_or_verify_json(dataset_path, corpus)
+    split_policy = grounding_split_policy()
+    split_policy_cid = cid_bytes(canonical_json_bytes(split_policy))
+    dataset_manifest = write_bound_manifest(
+        root / "grounding-dataset-manifest.json",
+        {
+            "schema": GROUNDING_DATASET_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "dataset_cid": corpus["dataset_cid"],
+            "split_policy": split_policy,
+            "split_policy_cid": split_policy_cid,
+            "predecessor_tokenizer_cid": predecessor_manifest["tokenizer_cid"],
+        },
+        artifact_root=root,
+        relative_paths=["grounding-dataset.json"],
+    )
+
+    run_contract: dict[str, Any] = {
+        "schema": GROUNDING_RUN_SCHEMA,
+        "issue": ISSUE,
+        "predecessor": {
+            "export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "weights_cid": predecessor_manifest["weights_cid"],
+            "tokenizer_cid": predecessor_manifest["tokenizer_cid"],
+            "optimizer_state": "fresh AdamW; #1017 moments are not inherited",
+        },
+        "model": FROZEN_MODEL_CONFIG.as_contract(),
+        "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+        "split_policy_cid": split_policy_cid,
+        "optimization": config.as_contract(),
+        "loss": (
+            "causal cross entropy on answer and EOS tokens only; context, question, "
+            "instruction, and right padding targets are -100"
+        ),
+        "implementation": trainer_implementation_contract(),
+        "product_gate": corpus["product_probes"],
+    }
+    run_contract_cid = cid_bytes(canonical_json_bytes(run_contract))
+
+    tokenizer_path = predecessor / "tokenizer.json"
+    train_store = GroundingStore(corpus["train"], tokenizer_path)
+    development_store = GroundingStore(corpus["development"], tokenizer_path)
+    device = require_mps(config.seed)
+    model = R4SoftmaxForCausalLM()
+    predecessor_state = load_file(str(predecessor / "model.safetensors"), device="cpu")
+    model.load_state_dict(predecessor_state, strict=True)
+    model = model.to(device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.learning_rate,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_epsilon,
+        weight_decay=config.weight_decay,
+    )
+
+    latest_path = root / "checkpoints/latest.pt"
+    step = 0
+    elapsed_before_resume = 0.0
+    evaluations: list[dict[str, Any]] = []
+    if resume:
+        if not latest_path.is_file():
+            raise FileNotFoundError("--resume requires checkpoints/latest.pt")
+        step, elapsed_before_resume, evaluations = _load_checkpoint(
+            latest_path,
+            model=model,
+            optimizer=optimizer,
+            device=device,
+            run_contract_cid=run_contract_cid,
+        )
+    elif latest_path.exists():
+        raise FileExistsError("grounding checkpoint exists; use --resume")
+
+    started = time.monotonic()
+    last_loss: Tensor | None = None
+    for optimizer_step in range(step + 1, config.optimizer_steps + 1):
+        model.train()
+        optimizer.zero_grad(set_to_none=True)
+        for accumulation in range(config.gradient_accumulation_steps):
+            batch_index = (
+                (optimizer_step - 1) * config.gradient_accumulation_steps + accumulation
+            )
+            inputs, targets = train_store.deterministic_batch(
+                seed=config.seed,
+                batch_index=batch_index,
+                batch_size=config.batch_size,
+            )
+            output = model(inputs.to(device), targets.to(device))
+            assert output.loss is not None
+            (output.loss / config.gradient_accumulation_steps).backward()
+            last_loss = output.loss.detach()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), config.gradient_clip)
+        learning_rate = _learning_rate(optimizer_step, config)
+        for group in optimizer.param_groups:
+            group["lr"] = learning_rate
+        optimizer.step()
+        step = optimizer_step
+        elapsed = elapsed_before_resume + (time.monotonic() - started)
+
+        if step in config.evaluation_steps:
+            evaluations.append(
+                {
+                    "optimizer_step": step,
+                    "answer_token_development_loss": _evaluate_answer_loss(
+                        model, development_store, device, config.batch_size
+                    ),
+                }
+            )
+            elapsed = elapsed_before_resume + (time.monotonic() - started)
+
+        if step % config.checkpoint_interval == 0 or step == config.optimizer_steps:
+            _save_checkpoint(
+                latest_path,
+                model=model,
+                optimizer=optimizer,
+                step=step,
+                elapsed_seconds=elapsed,
+                evaluations=evaluations,
+                run_contract_cid=run_contract_cid,
+            )
+        if step % config.progress_interval == 0 or step == config.optimizer_steps:
+            observed_loss = float(last_loss.cpu()) if last_loss is not None else math.nan
+            print(
+                f"grounding_step={step}/{config.optimizer_steps} "
+                f"answer_loss={observed_loss:.6f} lr={learning_rate:.8f} "
+                f"elapsed_seconds={elapsed:.1f}",
+                flush=True,
+            )
+        if elapsed >= config.wall_ceiling_seconds:
+            raise RuntimeError("UNAVAILABLE_GROUNDING_WALL_BUDGET")
+
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    elapsed = elapsed_before_resume + (time.monotonic() - started)
+    final_checkpoint_path = root / "checkpoints/final.pt"
+    _save_checkpoint(
+        final_checkpoint_path,
+        model=model,
+        optimizer=optimizer,
+        step=step,
+        elapsed_seconds=elapsed,
+        evaluations=evaluations,
+        run_contract_cid=run_contract_cid,
+    )
+    selected_checkpoint_cid = cid_file(final_checkpoint_path)
+
+    result: dict[str, Any] = {
+        "schema": GROUNDING_RESULT_SCHEMA,
+        "terminal": "GROUNDING_SFT_COMPLETE_AWAITING_RUST_PRODUCT_CHECK",
+        "issue": ISSUE,
+        "run_contract": run_contract,
+        "run_contract_cid": run_contract_cid,
+        "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+        "split_policy_cid": split_policy_cid,
+        "predecessor_weights_cid": predecessor_manifest["weights_cid"],
+        "selected_checkpoint_cid": selected_checkpoint_cid,
+        "optimizer_steps_completed": step,
+        "elapsed_training_seconds": elapsed,
+        "development_evaluations": evaluations,
+        "product_probes": corpus["product_probes"],
+        "product_behavior_status": "NOT_RUN",
+        "rust_prefix_parity_status": "NOT_RUN",
+    }
+    result["result_cid"] = cid_bytes(canonical_json_bytes(result))
+    atomic_write_json(root / "grounding-training-result.json", result)
+
+    export = export_hugging_face_snapshot(
+        model,
+        output_dir=root / "export",
+        tokenizer_path=tokenizer_path,
+        training_result=result,
+        dataset_manifest_cid=dataset_manifest["manifest_cid"],
+        training_view_manifest_cid=dataset_manifest["manifest_cid"],
+        split_policy_cid=split_policy_cid,
+        run_contract_cid=run_contract_cid,
+        selected_checkpoint_cid=selected_checkpoint_cid,
+    )
+    prefix = _write_prefix_fixture(
+        root,
+        model=model,
+        development_store=development_store,
+        device=device,
+        weights_cid=str(export["weights_cid"]),
+        dataset_cid=str(corpus["dataset_cid"]),
+    )
+    final_manifest = write_bound_manifest(
+        final_manifest_path,
+        {
+            "schema": GROUNDING_FINAL_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "run_contract_cid": run_contract_cid,
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "training_result_cid": result["result_cid"],
+            "export_manifest_cid": export["manifest_cid"],
+            "weights_cid": export["weights_cid"],
+            "tokenizer_cid": export["tokenizer_cid"],
+            "python_prefix_result_cid": prefix["result_cid"],
+            "product_behavior_status": "AWAITING_RUST",
+        },
+        artifact_root=root,
+        relative_paths=[
+            "grounding-dataset.json",
+            "grounding-dataset-manifest.json",
+            "grounding-training-result.json",
+            "checkpoints/final.pt",
+            "export/config.json",
+            "export/model.safetensors",
+            "export/tokenizer.json",
+            "export/training-result.json",
+            "export/export-manifest.json",
+            "qualification/python-grounding-prefix-logits.json",
+        ],
+    )
+    return {
+        "terminal": result["terminal"],
+        "optimizer_steps_completed": step,
+        "elapsed_training_seconds": elapsed,
+        "export": str(root / "export"),
+        "weights_cid": export["weights_cid"],
+        "python_prefix_result_cid": prefix["result_cid"],
+        "final_manifest_cid": final_manifest["manifest_cid"],
+        "product_behavior_status": "AWAITING_RUST",
+    }

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/grounding_data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/grounding_data.py
@@ -1,0 +1,360 @@
+"""Deterministic context-grounding examples for the bounded #954 SFT run."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+import torch
+from blake3 import blake3
+from tokenizers import Tokenizer
+from torch import Tensor
+
+from .constants import BOS_TOKEN_ID, EOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .provenance import canonical_json_bytes, cid_bytes
+
+
+GROUNDING_DATASET_SCHEMA = "uor-r4-softmax-grounding-dataset/1"
+GROUNDING_SPLIT_POLICY_SCHEMA = "uor-r4-softmax-grounding-split/1"
+GROUNDING_PROMPT = (
+    "Use only the context. Copy one exact contiguous answer span from the context. "
+    "If the context does not answer the question, write ABSTAIN. If the context gives "
+    "conflicting answers, write CONTRADICTION."
+)
+ABSTAIN = "ABSTAIN"
+CONTRADICTION = "CONTRADICTION"
+TRAIN_EXAMPLES_PER_CLASS = 1_024
+DEV_EXAMPLES_PER_CLASS = 128
+GROUNDING_CLASSES = ("supported", "unsupported", "contradiction")
+
+
+_OBJECTS = (
+    "blue book",
+    "red scarf",
+    "brass bell",
+    "white shell",
+    "purple kite",
+    "small drum",
+    "green cup",
+    "black stone",
+    "yellow ribbon",
+    "paper crown",
+    "wooden horse",
+    "orange ball",
+    "glass bead",
+    "tin whistle",
+    "brown basket",
+    "pink flower",
+    "gray feather",
+    "golden button",
+)
+
+_LOCATIONS = (
+    "inside the wicker chest",
+    "under the kitchen chair",
+    "beside the oak door",
+    "on the library shelf",
+    "behind the blue curtain",
+    "near the stone fountain",
+    "inside the paper bag",
+    "under the narrow bridge",
+    "beside the apple tree",
+    "on the bedroom desk",
+    "behind the garden shed",
+    "near the quiet pond",
+    "inside the wooden cupboard",
+    "under the red blanket",
+    "beside the front window",
+    "on the round stool",
+    "behind the tall clock",
+    "near the little boat",
+)
+
+
+def render_grounding_prompt(source: str, question: str) -> str:
+    """Return the one exact prompt contract shared by training and Rust inference."""
+    return (
+        f"{GROUNDING_PROMPT}\n"
+        f"Context:\n{source}\n"
+        f"Question:\n{question}\n"
+        "Answer:\n"
+    )
+
+
+def _fact(object_name: str, location: str) -> str:
+    return f"The {object_name} is {location}."
+
+
+def _question(object_name: str) -> str:
+    return f"Where is the {object_name}?"
+
+
+def _record(category: str, source: str, question: str, answer: str) -> dict[str, str]:
+    if category not in GROUNDING_CLASSES:
+        raise ValueError(f"unknown grounding category: {category}")
+    if category == "supported" and answer not in source:
+        raise ValueError("supported answer is not an exact contiguous source span")
+    if category == "unsupported" and answer != ABSTAIN:
+        raise ValueError("unsupported records must target ABSTAIN")
+    if category == "contradiction" and answer != CONTRADICTION:
+        raise ValueError("contradiction records must target CONTRADICTION")
+    value = {
+        "category": category,
+        "source": source,
+        "question": question,
+        "prompt": render_grounding_prompt(source, question),
+        "answer": answer,
+    }
+    return {"record_cid": cid_bytes(canonical_json_bytes(value)), **value}
+
+
+def _rotated_facts(facts: list[str], variant: int) -> str:
+    offset = variant % len(facts)
+    ordered = facts[offset:] + facts[:offset]
+    return " ".join(ordered)
+
+
+def _other_object(query_index: int, offset: int, *, exclude: set[int]) -> int:
+    candidate = (query_index + offset) % len(_OBJECTS)
+    while candidate in exclude:
+        candidate = (candidate + 1) % len(_OBJECTS)
+    return candidate
+
+
+def _candidate_records() -> dict[str, list[dict[str, str]]]:
+    candidates: dict[str, dict[str, dict[str, str]]] = {
+        category: {} for category in GROUNDING_CLASSES
+    }
+    for query_index, object_name in enumerate(_OBJECTS):
+        for location_index, location in enumerate(_LOCATIONS):
+            for variant in range(8):
+                first_index = _other_object(
+                    query_index, variant * 5 + 1, exclude={query_index}
+                )
+                second_index = _other_object(
+                    query_index,
+                    variant * 7 + 2,
+                    exclude={query_index, first_index},
+                )
+                first_location = _LOCATIONS[(location_index + variant * 3 + 1) % len(_LOCATIONS)]
+                second_location = _LOCATIONS[(location_index + variant * 5 + 2) % len(_LOCATIONS)]
+
+                answer = _fact(object_name, location)
+                supported_source = _rotated_facts(
+                    [
+                        answer,
+                        _fact(_OBJECTS[first_index], first_location),
+                        _fact(_OBJECTS[second_index], second_location),
+                    ],
+                    variant,
+                )
+                supported = _record(
+                    "supported", supported_source, _question(object_name), answer
+                )
+                candidates["supported"][supported["record_cid"]] = supported
+
+                unsupported_source = _rotated_facts(
+                    [
+                        _fact(_OBJECTS[first_index], first_location),
+                        _fact(_OBJECTS[second_index], second_location),
+                    ],
+                    variant,
+                )
+                unsupported = _record(
+                    "unsupported",
+                    unsupported_source,
+                    _question(object_name),
+                    ABSTAIN,
+                )
+                candidates["unsupported"][unsupported["record_cid"]] = unsupported
+
+                conflicting_location = _LOCATIONS[
+                    (location_index + variant + 1) % len(_LOCATIONS)
+                ]
+                if conflicting_location == location:
+                    raise AssertionError("contradiction generator selected one location twice")
+                contradiction_source = _rotated_facts(
+                    [
+                        _fact(object_name, location),
+                        _fact(object_name, conflicting_location),
+                        _fact(_OBJECTS[first_index], first_location),
+                    ],
+                    variant,
+                )
+                contradiction = _record(
+                    "contradiction",
+                    contradiction_source,
+                    _question(object_name),
+                    CONTRADICTION,
+                )
+                candidates["contradiction"][contradiction["record_cid"]] = contradiction
+    return {
+        category: sorted(records.values(), key=lambda record: record["record_cid"])
+        for category, records in candidates.items()
+    }
+
+
+def product_probes() -> list[dict[str, str]]:
+    """Return three fixed prompts whose object/location combinations never train."""
+    shared_source = (
+        "The amber coin is inside the green basket. "
+        "The silver key is beside the garden gate."
+    )
+    probes = [
+        _record(
+            "supported",
+            shared_source,
+            "Where is the amber coin?",
+            "The amber coin is inside the green basket.",
+        ),
+        _record(
+            "unsupported",
+            shared_source,
+            "Where is the velvet ribbon?",
+            ABSTAIN,
+        ),
+        _record(
+            "contradiction",
+            (
+                "The amber coin is inside the green basket. "
+                "The amber coin is under the wooden table."
+            ),
+            "Where is the amber coin?",
+            CONTRADICTION,
+        ),
+    ]
+    return [
+        {"probe": f"grounding-{index + 1}", **probe}
+        for index, probe in enumerate(probes)
+    ]
+
+
+def grounding_split_policy() -> dict[str, Any]:
+    return {
+        "schema": GROUNDING_SPLIT_POLICY_SCHEMA,
+        "selection": (
+            "enumerate deterministic templates, deduplicate by record CID, sort by CID, "
+            "take 128 development records then 1024 training records independently per class"
+        ),
+        "classes": list(GROUNDING_CLASSES),
+        "train_examples_per_class": TRAIN_EXAMPLES_PER_CLASS,
+        "development_examples_per_class": DEV_EXAMPLES_PER_CLASS,
+        "product_probe_policy": (
+            "three fixed reserved object/location combinations excluded from all generated "
+            "training and development templates"
+        ),
+    }
+
+
+def build_grounding_corpus() -> dict[str, Any]:
+    candidates = _candidate_records()
+    train: list[dict[str, str]] = []
+    development: list[dict[str, str]] = []
+    required = TRAIN_EXAMPLES_PER_CLASS + DEV_EXAMPLES_PER_CLASS
+    for category in GROUNDING_CLASSES:
+        records = candidates[category]
+        if len(records) < required:
+            raise RuntimeError(f"grounding generator produced too few {category} records")
+        development.extend(records[:DEV_EXAMPLES_PER_CLASS])
+        train.extend(records[DEV_EXAMPLES_PER_CLASS:required])
+    train.sort(key=lambda record: record["record_cid"])
+    development.sort(key=lambda record: record["record_cid"])
+    probes = product_probes()
+    seen_prompts = {record["prompt"] for record in [*train, *development]}
+    if any(probe["prompt"] in seen_prompts for probe in probes):
+        raise RuntimeError("a frozen product probe leaked into the grounding corpus")
+    value: dict[str, Any] = {
+        "schema": GROUNDING_DATASET_SCHEMA,
+        "prompt_contract": GROUNDING_PROMPT,
+        "split_policy": grounding_split_policy(),
+        "counts": {
+            "train": len(train),
+            "development": len(development),
+            "product_probes": len(probes),
+        },
+        "train": train,
+        "development": development,
+        "product_probes": probes,
+    }
+    value["dataset_cid"] = cid_bytes(canonical_json_bytes(value))
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedGroundingExample:
+    inputs: Tensor
+    targets: Tensor
+    supervised_tokens: int
+
+
+class GroundingStore:
+    """In-memory, fixed-context SFT examples with prompt and padding loss masked."""
+
+    def __init__(self, records: Sequence[dict[str, str]], tokenizer_path: Path) -> None:
+        self.tokenizer = Tokenizer.from_file(str(tokenizer_path))
+        self.records = list(records)
+        self.examples = [self._encode(record) for record in self.records]
+        if not self.examples:
+            raise ValueError("grounding store is empty")
+
+    def _encode(self, record: dict[str, str]) -> EncodedGroundingExample:
+        prompt_ids = self.tokenizer.encode(
+            record["prompt"], add_special_tokens=False
+        ).ids
+        answer_ids = self.tokenizer.encode(
+            record["answer"], add_special_tokens=False
+        ).ids
+        full = [BOS_TOKEN_ID, *prompt_ids, *answer_ids, EOS_TOKEN_ID]
+        context = FROZEN_MODEL_CONFIG.max_position_embeddings
+        if len(full) - 1 > context:
+            raise ValueError(
+                f"grounding record {record['record_cid']} exceeds {context} input tokens"
+            )
+        answer_start = 1 + len(prompt_ids)
+        inputs = full[:-1]
+        targets = full[1:]
+        first_answer_target = answer_start - 1
+        targets[:first_answer_target] = [-100] * first_answer_target
+        supervised_tokens = len(answer_ids) + 1
+        padding = context - len(inputs)
+        inputs.extend([EOS_TOKEN_ID] * padding)
+        targets.extend([-100] * padding)
+        if sum(target != -100 for target in targets) != supervised_tokens:
+            raise RuntimeError("grounding answer-mask arithmetic differs")
+        return EncodedGroundingExample(
+            inputs=torch.tensor(inputs, dtype=torch.long),
+            targets=torch.tensor(targets, dtype=torch.long),
+            supervised_tokens=supervised_tokens,
+        )
+
+    def deterministic_batch(
+        self, *, seed: int, batch_index: int, batch_size: int
+    ) -> tuple[Tensor, Tensor]:
+        selected: list[EncodedGroundingExample] = []
+        for lane in range(batch_size):
+            material = struct.pack(">QQQ", seed, batch_index, lane)
+            index = int.from_bytes(blake3(material).digest(), "big") % len(self.examples)
+            selected.append(self.examples[index])
+        return (
+            torch.stack([example.inputs for example in selected]),
+            torch.stack([example.targets for example in selected]),
+        )
+
+    def sequential_batches(self, batch_size: int) -> Iterator[tuple[Tensor, Tensor]]:
+        for base in range(0, len(self.examples), batch_size):
+            selected = self.examples[base : base + batch_size]
+            yield (
+                torch.stack([example.inputs for example in selected]),
+                torch.stack([example.targets for example in selected]),
+            )
+
+    def parity_prefix(self, record_index: int = 0, count: int = 32) -> list[int]:
+        prompt_ids = self.tokenizer.encode(
+            self.records[record_index]["prompt"], add_special_tokens=False
+        ).ids
+        prefix = [BOS_TOKEN_ID, *prompt_ids]
+        if len(prefix) < count:
+            raise ValueError("grounding prompt cannot supply the parity prefix")
+        return prefix[:count]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
@@ -25,3 +26,19 @@ def default_continuation_root() -> Path:
 
 def default_capacity_root() -> Path:
     return repository_root() / ".uor-models" / "research" / "issue-1019"
+
+
+def model_store_root() -> Path:
+    """Honor the shared model store when commands run from an isolated worktree."""
+    configured = os.environ.get("UOR_MODEL_STORE")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return repository_root() / ".uor-models"
+
+
+def default_grounding_predecessor_root() -> Path:
+    return model_store_root() / "research" / "issue-1017" / "export"
+
+
+def default_grounding_root() -> Path:
+    return model_store_root() / "research" / "issue-954"


### PR DESCRIPTION
## Outcome

Adds the first bounded #954 source-backed correctness prototype without claiming that it passed.

- adds `r4 answer`, bound to the #954 export by default
- serves only exact source spans or typed `ABSTAIN` / `CONTRADICTION`
- binds and rechecks exact non-symlink UTF-8 source bytes
- rejects audit-output/source aliasing and lossy UTF-8 model output
- adds one fixed 384-step MPS grounding SFT path with no CUDA and no sweep
- records the observed frozen product result: `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE` (`1/3`)
- updates README, research direction, and roadmap: #1019 is closed; the active #954 successor is a learned source-span pointer/copy head over the established R4/Spin states

## Actual M1 evidence

- 384/384 MPS optimizer steps in `883.7735486670863 s`
- final development answer-token loss `0.00014458666336423967`
- weights `blake3:0949d925c1189cdc784a4b93bbb9119da5c1a573fe3385c3b3c8f82a299c9439`
- Rust product inference selected Apple Accelerate CPU BLAS
- all three frozen prompts decoded `ABSTAIN`; only the unsupported prompt passed
- direct Python generation reproduced the same token sequence, ruling out a Rust/Accelerate/file-boundary mismatch for this result

## Verification

- release `r4` build with `local-inference-accelerate`: PASS
- three frozen real Rust product runs: observed and recorded (`1/3`)
- fixed MPS training run: COMPLETE
- Python syntax/data/model/MPS preflight: PASS
- Rust formatting and diff hygiene: PASS
- claim-wording gate: PASS
- broad workspace suite: delegated once to the protected merge queue

References #954