### PR TITLE
feat: add and bound R4 source-span pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,11 @@ the readable mirror of programme root #820.** The
 is the current architecture and claim-boundary companion.
 The active mechanism contract is
 [`ADR-0005`](docs/adr/0005-predictive-geometric-connection-memory.md). The
-current evidence handoff is the frozen
-[#1019 parameter-capacity contract](docs/r4_softmax_parameter_capacity_1019.md)
-and its [signed preflight result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
+current evidence handoff is the append-only
+[#954 grounded-correctness record](docs/r4_grounded_correctness_954.md). The
+earlier frozen [#1019 parameter-capacity contract](docs/r4_softmax_parameter_capacity_1019.md)
+and its [signed preflight result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json)
+remain reference history.
 It keeps the established ordinary causal R4/Spin Q/K/V plus stable-softmax
 mechanism and changes only decoder depth from six to twelve layers: exactly
 13,130,784 parameters, seed 1019, 16,800 optimizer steps, and 275,251,200
@@ -27,9 +29,18 @@ execution are out of scope. A single isolated exact-shape MPS fast-path test
 and measured `4.485223 s/step`, slower than the signed `3.491307 s/step`;
 `fused=True` was removed immediately. This is a bounded fast-path negative, not
 a model result. Preserve the passed population, smoke, and parity artifacts,
-but stop #1019 tuning and full-run work; #1019 is optional and paused. The
-active next step is using and productizing the working #1017 generator through
-`r4 generate`, without recurring broad research gates. Prototype iteration uses
+but stop #1019 tuning and full-run work; #1019 is optional and paused. #954's
+first grounding SFT failed `1/3`; `R4SourceSpanPointerV1` then passed 12/12
+overfit and Python/Rust parity but failed all four frozen development gates
+after its sole 256-step fit. The terminal is
+`FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`; no final pointer artifact was
+emitted, and product probes plus browser/HTTP wiring were `NOT_RUN`. Do not tune
+or retry the revealed cosine head. The next proposed mechanism is a
+source-relative learned relation/entailment head preserving exact R4/Spin state
+capture and deterministic source-copy semantics; it must be independently
+frozen before execution, and no successor run or product wiring is active.
+The #1017 `r4 generate` path remains the working coherent-generation prototype.
+Prototype iteration uses
 one targeted compile plus one real behavior check; do not run a broad local
 suite or add a permanent gate until the mechanism is useful. The existing
 mandatory merge-queue CI remains the single integration boundary rather than an
@@ -115,8 +126,9 @@ passed, MPS is `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 implementation, and the full campaign remains `NOT_RUN`. The subsequent fused-
 AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so `fused=True` was removed and #1019 is optional/paused.
-The active next step is the working #1017 `r4 generate` product path; CUDA and
-external GPU execution are out of scope. This reference remains
+The #1017 `r4 generate` path remains the working coherent-generation prototype;
+the next proposed #954 relation/entailment mechanism must be independently
+frozen before any run. CUDA and external GPU execution are out of scope. This reference remains
 transformer-compatible and `f32`/multiply/alloc/source-weight backed—not
 table-native, multiply-free, or transformerless. It does not establish geometry
 advantage, softmax removal, correctness, reasoning, frontier quality, release
@@ -134,8 +146,9 @@ the [generation record](docs/r4_softmax_reference_generation_973.md), its
 the [native bridge result](docs/r4_softmax_reference_http_bridge_973.md),
 and the V1/V2 negative records remain linked from there.
 Intrinsic/readout alternatives, multi-resonance softmax replacement,
-full-model recurrent lowering, and exact deployment are parked; #954 remains blocked;
-implementation progress is not a result.
+full-model recurrent lowering, and exact deployment are parked; #954's final
+source-free terminal remains blocked and no successor run/product wiring is
+active. Implementation progress is not a result.
 The geometric causal decoder plan, prior S0–S7 completion plan, and
 graph-compiler implementation plan are retained as historical
 engineering/evidence records; none decides what is built next. Native GitHub
@@ -264,10 +277,12 @@ MPS stopped `UNAVAILABLE_HARDWARE_BUDGET` on time for the frozen eight-hour
 offline implementation, and full training through replay remains `NOT_RUN`.
 The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
-optional/paused. The active next step is the #1017 `r4 generate` product path;
-CUDA and external GPU execution are out of scope.
+optional/paused. The #1017 `r4 generate` path remains the working prototype;
+the next proposed #954 relation/entailment mechanism must be independently
+frozen before execution. CUDA and external GPU execution are out of scope.
 Intrinsic/readout, resonance, recurrence,
-and lowering are parked. D3 remains `NOT_RUN`, and #954 remains blocked.
+and lowering are parked. D3 remains `NOT_RUN`; #954's final source-free
+terminal remains blocked and no successor run is active.
 Do not add a second #953 intervention or reuse the #983/#986 populations. The
 complete #973 Gate 0 record is
 [`docs/prior_sentence_count_radius_attention_973.md`](docs/prior_sentence_count_radius_attention_973.md).
@@ -638,12 +653,14 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   implementation, and full training through replay remains `NOT_RUN`. The
   fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
   `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
-  optional/paused. The active next step is the #1017 `r4 generate` product path;
-  CUDA and external GPU execution are out of scope.
+  optional/paused. The #1017 `r4 generate` path remains the working prototype;
+  the next proposed #954 relation/entailment mechanism must be independently
+  frozen before execution. CUDA and external GPU execution are out of scope.
   Intrinsic/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and
   exact deployment are parked. D3 remains `NOT_RUN`.
-  #954 remains blocked behind #973.
+  #954's final source-free terminal remains blocked behind #973; no successor
+  source-backed run or product wiring is active.
   #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
@@ -665,7 +682,8 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   → #1019 frozen 12-layer parameter-capacity campaign [MODEL SUBGATES PASS;
   FROZEN OFFLINE MPS IMPLEMENTATION OVER 8 H; FUSED FAST PATH SLOWER; OPTIONAL/
   PAUSED; FULL CAMPAIGN NOT_RUN; CUDA/EXTERNAL GPU OUT OF SCOPE]) →
-  active bounded #1017 `r4 generate` product path →
+  working bounded #1017 `r4 generate` prototype → #954 pointer development
+  negative → independently freeze the proposed relation/entailment mechanism →
   correctness/abstention → reasoning → optimization/purity/release. The older placement/transport
   sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic

--- a/README.md
+++ b/README.md
@@ -62,9 +62,18 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW
 > with deferred logging and measured `4.485223 s/step`, slower than the signed
 > `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-> fast-path negative, not a model result. #1019 closed without a full run. The
-> active next step is #954's bounded source-grounding fine-tune and fail-closed
-> `r4 answer` product check over the working #1017 model.
+> fast-path negative, not a model result. #1019 closed without a full run.
+> #954's first bounded grounding SFT then failed product transfer at `1/3`.
+> Its `R4SourceSpanPointerV1` successor passed the 12/12 overfit preflight and
+> Python/Rust score parity, but its sole 256-step fit stopped
+> `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`: answer, abstain, conflict,
+> and supported-pointer development accuracy were `69.53125%`, `89.0625%`,
+> `91.40625%`, and `94.53125%`, all below the frozen `>=95%` gates. No final
+> pointer artifact was emitted and the reserved product probes were `NOT_RUN`.
+> The next proposed #954 mechanism is a source-relative learned
+> relation/entailment head that preserves exact R4/Spin state capture and copy
+> semantics; it must be independently frozen before execution, and no successor
+> run or product wiring is active. Do not tune or retry the revealed cosine head.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
 > [#1017 structured aggregate](docs/r4_softmax_quality_capacity_continuation_1017_raw.json),
 > [#1019 frozen contract](docs/r4_softmax_parameter_capacity_1019.md),
@@ -221,8 +230,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > engine. This remains a native CPU research reference,
 > not a source-free, transformerless, static-WASM, release, or frontier-model
 > result. #973 remains open for its intrinsic/source-free terminal; #954's
-> bounded source-backed grounding phase is active while its final source-free
-> terminal remains blocked. The trace/compiler rung
+> cosine source-span pointer stopped at its development gate. The proposed
+> source-relative relation/entailment head must be independently frozen; no
+> successor run is active, and the final source-free terminal remains blocked.
+> The trace/compiler rung
 > that followed that checkpoint is now complete: `R4SoftmaxTeacherTraceV1`
 > supplied construction traces and
 > `R4SoftmaxTraceStudentV1` compiled a source-free Q16 suffix artifact with a
@@ -245,9 +256,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation, and full training through replay remains `NOT_RUN`. The
 > fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-> `3.491307 s/step`); #1019 closed without a full run and #954's bounded
-> source-grounding product phase is active over #1017. CUDA and external GPU execution are out of
-> scope. No
+> `3.491307 s/step`); #1019 closed without a full run. #954's cosine pointer
+> stopped before final artifact or product reveal. A source-relative learned
+> relation/entailment successor over #1017's exact R4/Spin state and copy seams
+> is proposed but not frozen or active. CUDA and external GPU execution are out
+> of scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
 > product promotion remain parked. No tag, release, hosted
@@ -327,9 +340,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation; full training, final qualification, reveal, generation, and
 > replay remain `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower
-> (`4.485223` versus signed `3.491307 s/step`); #1019 closed without a full run
-> and #954's bounded source-backed grounding phase is active. CUDA and external
-> GPU execution are out of scope. #954's final source-free terminal remains
+> (`4.485223` versus signed `3.491307 s/step`); #1019 closed without a full run.
+> #954's cosine pointer stopped at its development gate; the proposed
+> source-relative relation/entailment successor is not yet frozen or active.
+> CUDA and external GPU
+> execution are out of scope. #954's final source-free terminal remains
 > blocked by the parked #973 replacement terminal.
 > See the
 > [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
@@ -394,8 +409,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > Its opt-in, loopback-only dedicated native HTTP endpoint then passed exact CLI
 > canary parity. Dashboard wiring/readiness and static/WASM-isolation checks
 > passed; browser E2E remains `NOT_RUN`. The source-free trace/state attempts
-> are preserved negatives; #954's bounded source-backed grounding phase is
-> active while its final source-free terminal remains blocked. See the
+> are preserved negatives; #954's cosine pointer is also a bounded negative.
+> Its proposed source-relative learned relation/entailment successor must be
+> independently frozen, and the final source-free terminal remains blocked.
+> See the
 > [conversation record](docs/conversation_entity_spin_path_attention_973.md).
 
 > **Accepted capability-first evidence (2026-08-28):** #953's frozen
@@ -465,8 +482,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 > implementation, so the full campaign remains `NOT_RUN`. The fused-AdamW/
 > deferred-logging fast path was slower (`4.485223` versus signed
-> `3.491307 s/step`); #1019 closed without a full run and #954's bounded
-> source-backed grounding phase is active over #1017. CUDA and external GPU execution are out of scope.
+> `3.491307 s/step`); #1019 closed without a full run. #954's cosine pointer
+> stopped before final artifact or reveal; its proposed source-relative learned
+> relation/entailment successor is not yet frozen or active. CUDA and external GPU
+> execution are out of scope.
 > #954's final source-free terminal remains blocked behind #973. General higher-scope attention, correct
 > answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
@@ -508,35 +527,43 @@ but still source-backed, floating-point/matmul/softmax, and below the strict
 `<1.50` NLL target. #1019 was closed without another capacity run; it is not a
 prerequisite for using or productizing this path.
 
-To ask against one exact local source while refusing unsupported generated text:
+The bounded `answer` interface now admits only an exact
+`Where is the <subject>?` question and punctuation-terminated source spans:
 
 ```bash
-r4 answer --source-file facts.txt --question "Which key opens the north door?" \
+r4 answer --source-file facts.txt --question "Where is the copper compass?" \
+  --head /path/to/qualified-pointer-head.json \
   --json-output grounded-answer.json
 ```
 
-`answer` applies one fixed source/question prompt to the bounded #954 grounding
-fine-tune descended from #1017.
-It serves ordinary text only when the complete trimmed response is an exact,
-case-sensitive contiguous span of the source. Exact `ABSTAIN`, exact
-`CONTRADICTION`, empty output, and non-source output become typed non-answer
-outcomes; unsupported raw text remains visible only inside the optional nested
-audit report. The source must be a regular non-symlink UTF-8 file of at most
-4 KiB, is content-addressed, and is read again after generation to detect a
-change. The assembled prompt plus requested output must also fit the checkpoint's
-256-token context; oversized requests fail before an answer is served. This is
-fail-closed extractive provenance, not semantic-entailment or general-correctness
-evidence.
+`answer` captures the #1017 model's normalized causal R4/Spin states for the
+subject and two to eight exact punctuation-terminated source sentences, then
+uses the explicitly supplied `--head` artifact to choose an exact source span,
+typed abstention, or typed conflict. The source is content-addressed and read
+again after evaluation to detect change. This is fail-closed extractive
+provenance, not semantic-entailment or general-correctness evidence.
 
 The first fixed #954 MPS fine-tune completed in 14 minutes 44 seconds on the
 project M1, but its frozen Rust product population failed `1/3`: all three
 prompts decoded `ABSTAIN`, so only the unsupported question passed. The command
 therefore fails safely, but this checkpoint is not a usable answer model. It is
-not rerun or tuned. The active #954 successor is a learned source-span
-pointer/copy head with explicit abstention and conflict scores over the existing
-causal R4/Spin states. See the
+not rerun or tuned. The subsequent `R4SourceSpanPointerV1` preflight passed
+12/12, and Python/Rust parity passed with maximum score delta
+`1.234420776e-7` and maximum logit delta `1.428717041e-6`, both inside `0.01`.
+The sole 256-step fit nevertheless missed every frozen development gate:
+answer `89/128` (`69.53125%`), abstain `114/128` (`89.0625%`), conflict
+`117/128` (`91.40625%`), and supported pointer `121/128` (`94.53125%`) versus
+`>=95%` each. It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`
+before producing a final pointer artifact; the three reserved product probes
+and browser/HTTP wiring are `NOT_RUN`. Consequently the default `r4 answer`
+surface is unavailable unless an explicitly qualified head artifact exists.
+Do not tune or retry the revealed cosine head. The next proposed #954 mechanism
+is a source-relative learned relation/entailment head preserving exact R4/Spin
+state capture and deterministic source-copy semantics; it must be independently
+frozen before execution, and no successor run or product wiring is active. See the
 [#954 record](docs/r4_grounded_correctness_954.md) and
-[structured result](docs/r4_grounded_correctness_954_raw.json).
+[C1-SB0 structured result](docs/r4_grounded_correctness_954_raw.json) plus the
+[C1-SB1 pointer result](docs/r4_source_span_pointer_954_raw.json).
 
 On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
 machine's Accelerate framework:
@@ -795,9 +822,11 @@ exact-descriptor/entity-binding path selector apiece at their respective
    admission stopped `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour
    offline implementation; full training through replay remains `NOT_RUN`.
    The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
-   signed `3.491307 s/step`); #1019 closed without a full run and #954's bounded
-   source-backed grounding phase is active over #1017. CUDA and external GPU
-   execution are out of scope. #954's final source-free terminal stays blocked.
+   signed `3.491307 s/step`); #1019 closed without a full run. #954's cosine
+   pointer stopped before final artifact or product reveal; its proposed
+   source-relative learned relation/entailment successor is not frozen or active.
+   CUDA and external
+   GPU execution are out of scope. #954's final source-free terminal stays blocked.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
@@ -944,9 +973,10 @@ not become substitutes for working intelligence:
    offline implementation; the full train/final-qualification/reveal/
    generation/replay path remains `NOT_RUN`, with no further 7.15M exposure or
    LR tuning. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
-   versus signed `3.491307 s/step`); #1019 closed without a full run and #954's
-   bounded source-grounding product phase is active over #1017. CUDA and external
-   GPU execution are out of scope.
+   versus signed `3.491307 s/step`); #1019 closed without a full run. #954's
+   cosine pointer stopped before final artifact or product reveal. Its proposed
+   source-relative learned relation/entailment successor is not frozen or active.
+   CUDA and external GPU execution are out of scope.
    Do not resume resonance substitutes. Product development continues through
    `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
    reference is transformer-compatible, `f32`/multiply/alloc and source-weight
@@ -1011,8 +1041,9 @@ frozen eight-hour offline implementation; the full campaign remains `NOT_RUN`.
 UOR's deployed architecture/runtime remains CPU-native. Apple Accelerate/BLAS
 and MPS are local offline accelerators only. The fused-AdamW/deferred-logging
 fast path was slower (`4.485223` versus signed `3.491307 s/step`); #1019 closed
-without a full run and #954's bounded source-grounding product phase is active
-over #1017. CUDA and external GPU execution are out of scope.
+without a full run. #954's cosine pointer stopped before final artifact or
+product reveal. Its proposed source-relative learned relation/entailment
+successor is not frozen or active. CUDA and external GPU execution are out of scope.
 #954's final source-free terminal remains blocked behind #973. The exact contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,9 +99,17 @@ logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
 fast-path negative, not a model result. #1019 closed without a full run. #954's
 first fixed MPS grounding SFT then completed but failed its frozen Rust product
-population `1/3` through universal `ABSTAIN`. The active next step is a learned
-source-span pointer/copy head over #1017's R4/Spin states. CUDA and external GPU
-execution are out of scope.
+population `1/3` through universal `ABSTAIN`. `R4SourceSpanPointerV1` next
+passed its 12/12 overfit preflight and Python/Rust score parity, but the sole
+256-step fit missed every `>=95%` development gate: answer `69.53125%`,
+abstain `89.0625%`, conflict `91.40625%`, and supported pointer `94.53125%`.
+It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` before a final
+artifact or product reveal. Do not tune or retry that cosine head. The active
+next proposed mechanism is a source-relative learned relation/entailment head
+preserving exact R4/Spin state capture and copy semantics. It must be
+independently frozen before execution; no successor run or product wiring is
+active. CUDA and
+external GPU execution are out of scope.
 Further 7.15M exposure and learning-rate tuning are prohibited. See the
 [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 D3 remains `NOT_RUN`, and #973 continues to block #954's final source-free
@@ -178,13 +186,16 @@ The completed continuation and its NLL-only negative are in
 > `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
 > versus signed `3.491307 s/step`), and #1019 closed without a full run. #954's
 > first fixed MPS grounding SFT subsequently failed its frozen Rust product
-> population `1/3`; the active successor is a source-span pointer/copy head.
+> population `1/3`. The cosine source-span pointer then passed preflight/parity
+> but failed its development gate before final artifact or reveal. The next
+> proposed mechanism is a source-relative learned relation/entailment head that
+> must be independently frozen; no successor run is active.
 > CUDA and external GPU execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
 > table-native, multiply-free, transformerless serving engine. D3 remains
-> `NOT_RUN`; #954's final source-free terminal remains blocked while its bounded
-> source-backed phase is active.
+> `NOT_RUN`; #954's final source-free terminal remains blocked. No
+> source-relative relation/entailment run is active.
 
 > **Admission/influence split:** exact causal/index rows decide which routes are
 > lawful candidates. Harmonic/neighbor influence may transform the state used
@@ -264,10 +275,14 @@ trace distillation, with looping autonomous output, state-student and
 observability negatives, #1014 attention qualification, and #1017's NLL-only
 quality-capacity negative; **Closed without a full run:** #1019's frozen
 12-layer, 13,130,784-parameter capacity campaign after its MPS hardware-budget
-stop; **Observed #954 negative:** the fixed 384-step MPS grounding SFT completed
-in `883.773549 s`, but all three frozen Rust prompts decoded `ABSTAIN` (`1/3`);
-**Active:** build a learned source-span pointer/copy head with explicit
-abstention and conflict scores over #1017's established R4/Spin states;
+stop; **Observed #954 negatives:** the fixed 384-step MPS grounding SFT
+completed in `883.773549 s`, but all three frozen Rust prompts decoded
+`ABSTAIN` (`1/3`); `R4SourceSpanPointerV1` passed preflight/parity but failed
+its development gate at answer/abstain/conflict/pointer accuracies of
+`69.53125%`/`89.0625%`/`91.40625%`/`94.53125%`, so no final artifact was
+emitted and product probes were `NOT_RUN`; **Proposed next:** independently
+freeze a source-relative learned relation/entailment head while preserving
+exact R4/Spin state capture and source-copy semantics; no successor run is active;
 CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
@@ -304,9 +319,13 @@ implementation. The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-
 logging fast path was slower (`4.485223` versus signed `3.491307 s/step`), and
 #1019 closed without a full run. #954's fixed MPS grounding SFT then completed,
 but the frozen Rust product population failed `1/3` because every prompt decoded
-`ABSTAIN`. Do not rerun or tune either campaign. The active successor is a
-source-span pointer/copy head over #1017's established states. CUDA and external
-GPU execution are out of scope.
+`ABSTAIN`. Its cosine source-span pointer successor passed preflight/parity but
+failed all four frozen development thresholds and stopped before final artifact
+or reveal. Do not rerun or tune either revealed mechanism. The next proposed
+successor is a source-relative learned relation/entailment head over #1017's
+exact R4/Spin state-capture and copy seams; it must be independently frozen and
+is not active. CUDA and external GPU
+execution are out of scope.
 Intrinsic/resonance/replacement work is
 parked; D3 remains `NOT_RUN`. See the
 [#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
@@ -570,22 +589,34 @@ feasibility boundary remains in the
    (`4.485223` versus signed `3.491307 s/step`), and #1019 closed without a full
    run. #954's first fixed grounding SFT completed through MPS, but the frozen
    Accelerate-backed Rust product population failed `1/3` because all prompts
-   decoded `ABSTAIN`. Do not rerun or tune it. CUDA and external GPU execution
-   are out of scope.
+   decoded `ABSTAIN`. Do not rerun or tune it. Its
+   `R4SourceSpanPointerV1` successor passed 12/12 preflight and Python/Rust
+   parity (maximum score/logit deltas `1.234420776e-7` and
+   `1.428717041e-6`, within `0.01`), but its sole 256-step fit reached only
+   `69.53125%` answer, `89.0625%` abstain, `91.40625%` conflict, and
+   `94.53125%` supported-pointer development accuracy. All missed the frozen
+   `>=95%` gates, so it stopped
+   `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` with no final artifact;
+   product probes and browser/HTTP wiring were `NOT_RUN`. Do not tune or retry
+   the revealed cosine head. CUDA and external GPU execution are out of scope.
    Intrinsic score/readout alternatives, paired-E8, resonance-based softmax
    replacement, and exact deployment are parked; #954's final source-free
-   terminal remains blocked while its source-backed pointer/copy successor is
-   active. Every learned epoch receives a
+   terminal remains blocked. The proposed source-relative learned
+   relation/entailment successor must be independently frozen; no run is active.
+   Every learned epoch receives a
    new kappa and reruns its owning
    construction gate. More documents, table density, or trace activity are
    capacity, not attention.
 10. **GI-4 / #954 — correctness and abstention:** the first bounded source-backed
    generative SFT is complete negative at
    `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE` (`1/3`). Preserve its
-   fail-closed `r4 answer` surface and exact source/audit binding. The active
-   successor replaces free-form answer generation with a learned source-span
-   pointer/copy head plus explicit abstention and conflict scores over the
-   established R4/Spin states, frozen on new lexical families before reveal.
+   fail-closed `r4 answer` source/audit binding. The subsequent cosine
+   source-span pointer passed preflight and cross-runtime parity but failed its
+   four development gates before final artifact or product reveal. Preserve
+   its exact R4/Spin state-capture and source-copy seams, but do not tune or
+   retry it. The next proposed successor is a source-relative learned
+   relation/entailment head on new lexical families; it must be independently
+   frozen before reveal and is not yet active.
    The final source-free terminal still requires the accepted
    selector/#953/#973 artifact and evidence provenance #969 → #983 → #986;
    source-backed prototype evidence does not satisfy it.
@@ -670,8 +701,8 @@ historical evidence and comparators.
 
 ## Active
 
-- [ ] **#954 grounded correctness: source-span pointer/copy successor after
-  `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE`** — retain the
+- [ ] **#954 grounded correctness: source-relative learned relation/entailment
+  successor after `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`** — retain the
   bounded positives, #997 placement negative, bounded gated-delta negative, V2
   budget invalidation, equal-manifold-budget V3 mixed-gauge H4 negative, and
   V4's held-out 13/24 functional/control negative. The positive attention
@@ -716,9 +747,15 @@ historical evidence and comparators.
   (`4.485223` versus signed `3.491307 s/step`), and #1019 closed without a full
   run. #954's fixed 384-step MPS grounding SFT then completed in `883.773549 s`,
   but all three frozen Accelerate-backed Rust prompts decoded `ABSTAIN`; only
-  the unsupported prompt passed (`1/3`). Do not rerun or tune that SFT. Build
-  the learned source-span pointer/copy successor with explicit abstention and
-  conflict scores over the existing R4/Spin states. Apple
+  the unsupported prompt passed (`1/3`). Do not rerun or tune that SFT. Its
+  `R4SourceSpanPointerV1` successor passed 12/12 overfit and Python/Rust parity,
+  then missed the frozen `>=95%` development gates at answer `89/128`, abstain
+  `114/128`, conflict `117/128`, and supported pointer `121/128`. No final head
+  was emitted; the product probes and browser/HTTP wiring are `NOT_RUN`. Do not
+  tune or retry the revealed cosine pointer. The next proposed mechanism is a
+  source-relative learned relation/entailment head preserving the exact R4/Spin
+  state-capture and source-copy seams; independently freeze it before any run.
+  No successor run or product wiring is active. Apple
   Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
   external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
@@ -727,8 +764,8 @@ historical evidence and comparators.
   exposure or tune learning rate on the 7.15M checkpoint. Intrinsic score/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
   lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954's final
-  source-free terminal remains blocked while its bounded source-backed phase is
-  active.
+  source-free terminal remains blocked; no source-relative relation/entailment
+  run is active.
 
 ## Landed
 
@@ -880,11 +917,15 @@ historical evidence and comparators.
   offline implementation, and the full campaign remains `NOT_RUN`. Its fused-
   AdamW/deferred-logging fast path was slower, and #1019 closed without a full
   run. #954's first fixed grounding SFT completed but failed its frozen Rust
-  population `1/3`; the active successor is a source-span pointer/copy head.
+  population `1/3`. Its cosine source-span pointer then passed preflight/parity
+  but failed the frozen development gate before a final artifact or product
+  reveal. The next proposed successor is a source-relative learned
+  relation/entailment head that must be independently frozen; no run is active.
   CUDA and external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact
   deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
-  terminal remains blocked while its bounded source-backed phase is active.
+  terminal remains blocked. No source-relative relation/entailment run is
+  active.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See

--- a/crates/uor-r4-model-source/src/lib.rs
+++ b/crates/uor-r4-model-source/src/lib.rs
@@ -601,6 +601,17 @@ impl CausalAttentionOutputPolicyAudit {
 }
 
 impl CausalAttentionTransportSession {
+    /// Final post-decoder-RMSNorm residual produced by the most recent
+    /// [`HuggingFaceLlamaOracle::step_causal_attention_transport`] call.
+    ///
+    /// This is a read-only view into the session-owned state. It is distinct
+    /// from [`TeacherOracle::hidden_state`], which belongs to the oracle's
+    /// independent default session and is not advanced by the transported
+    /// causal-attention API.
+    pub fn final_normalized_residual(&self) -> &[f32] {
+        &self.state.x
+    }
+
     /// Stable identity of the injected transport implementation and policy.
     pub fn policy_identity(&self) -> &str {
         self.transport.policy_identity()

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -148,9 +148,18 @@ assumptions, or objectives rather than measured results.
 > `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
 > fast-path negative, not a model result. #1019 closed without a full run. #954's
 > first fixed MPS grounding SFT then failed its frozen Rust product population
-> `1/3` through universal `ABSTAIN`; the active successor is a source-span
-> pointer/copy head over #1017's R4/Spin states. CUDA and external GPU execution
-> are out of scope. See
+> `1/3` through universal `ABSTAIN`. `R4SourceSpanPointerV1` next passed its
+> 12/12 overfit preflight and Python/Rust score parity (maximum score/logit
+> deltas `1.234420776e-7` and `1.428717041e-6`, within `0.01`), but the sole
+> 256-step fit missed all frozen `>=95%` development gates: answer `69.53125%`,
+> abstain `89.0625%`, conflict `91.40625%`, and supported pointer `94.53125%`.
+> It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`; no final pointer
+> artifact was emitted, and product probes plus browser/HTTP wiring were
+> `NOT_RUN`. Do not tune or retry that revealed cosine head. The proposed next
+> #954 mechanism is a source-relative learned relation/entailment head
+> preserving exact R4/Spin state capture and source-copy semantics; it must be
+> independently frozen and no successor run or product wiring is active. CUDA and
+> external GPU execution are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
@@ -558,13 +567,17 @@ assumptions, or objectives rather than measured results.
 > frozen eight-hour offline implementation. The full campaign remains
 > `NOT_RUN`; its fused-AdamW/deferred-logging fast path was slower, and #1019
 > closed without a full run. #954's first fixed grounding SFT subsequently
-> failed its frozen Rust population `1/3`; the active successor is a source-span
-> pointer/copy head. CUDA and external GPU execution are out of scope.
+> failed its frozen Rust population `1/3`. Its cosine source-span pointer passed
+> preflight and cross-runtime parity but failed its four development gates
+> before a final artifact or product reveal. The proposed next mechanism is a
+> source-relative learned relation/entailment head that must be independently
+> frozen; no successor run is active. CUDA and external
+> GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
 > exact deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
-> terminal remains blocked behind #973 while its bounded source-backed phase is
-> active.
+> terminal remains blocked behind #973; no source-relative relation/entailment
+> successor run is active.
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1090,9 +1103,11 @@ up to the point where a structure predicts at all, and not past it.**
 
 The project's ultimate runtime goal remains source-free recursive geometric
 attention, but load-bearing ordinary causal attention is now established in the
-R4/Spin reference. The immediate active goal is #954 grounded correctness: a
-source-span pointer/copy successor after the first bounded generative SFT failed
-its frozen transfer population.
+R4/Spin reference. The immediate goal is #954 grounded correctness: a proposed
+source-relative learned relation/entailment head after both the
+bounded generative SFT and the cosine source-span pointer failed their frozen
+transfer/development gates. It must be independently frozen; no successor run
+or product wiring is active.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
 reusable summaries erased earlier causal order, terminating as
@@ -1154,8 +1169,16 @@ in `883.773549` seconds, but the frozen Accelerate-backed Rust product populatio
 failed `1/3`: supported, unsupported, and conflict prompts all decoded
 `ABSTAIN`. The terminal is
 `FAIL_GROUNDING_PRODUCT_TRANSFER_ABSTENTION_COLLAPSE`; no rerun or tuning is
-authorized. The active successor is a learned source-span pointer/copy head
-with explicit abstention and conflict scores over the existing R4/Spin states.
+authorized. `R4SourceSpanPointerV1` then passed its 12/12 preflight and
+Python/Rust parity, but its sole 256-step fit reached answer `89/128`, abstain
+`114/128`, conflict `117/128`, and supported-pointer `121/128`; all were below
+the frozen `>=95%` gates. It stopped
+`FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` without a final head, so the
+reserved product probes and browser/HTTP wiring were `NOT_RUN`. Do not tune or
+retry the revealed cosine head. The proposed next mechanism is a source-relative
+learned relation/entailment head preserving the exact R4/Spin state capture and
+deterministic source-copy seams; it must be independently frozen, and no
+successor run is active.
 CUDA and external GPU execution remain out of scope. Fiber-preserving
 multi-resonance replacement, whole-decoder recurrent factorization, capacity
 expansion, and final source-free requalification are parked. Dependable broad
@@ -1765,13 +1788,16 @@ population/smoke/random-export parity gates passed, but MPS admission stopped
 The full campaign remains `NOT_RUN`; its fused-AdamW/deferred-logging fast path
 was slower, and #1019 closed without a full run. #954's first source-backed
 grounding SFT subsequently completed but failed its frozen product transfer
-population `1/3` through universal `ABSTAIN`. The active successor is a learned
-source-span pointer/copy head with explicit abstention and conflict scores.
+population `1/3` through universal `ABSTAIN`. Its cosine source-span pointer
+then passed preflight/parity but failed the frozen development gate before a
+final artifact or product reveal. The proposed next mechanism is a
+source-relative learned relation/entailment head that must be independently
+frozen; no successor run is active.
 CUDA and external GPU execution are out of scope. Intrinsic/readout alternatives,
 multi-resonance replacement, whole-decoder recurrent factorization, and final
 requalification are parked. D3 remains `NOT_RUN`; #954's final source-free
-terminal remains blocked while the bounded source-backed correctness phase is
-active.
+terminal remains blocked; no source-relative relation/entailment successor run
+is active.
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/r4_grounded_correctness_954.md
+++ b/docs/r4_grounded_correctness_954.md
@@ -1,11 +1,11 @@
-# C1-SB0: source-backed grounded answer prototype (#954)
+# Source-backed grounded answer campaigns (#954)
 
-Status: **ACTIVE / PRODUCT PROTOTYPE**
+Status: **C1-SB1 DEVELOPMENT GATE STOP / NO QUALIFIED ANSWER ARTIFACT**
 Parent programme: #820
 Working model: #1017 six-layer R4/Spin causal-softmax checkpoint
 Final source-free correctness terminal: still blocked by parked #973
 
-## Why this is the next build
+## C1-SB0 historical rationale
 
 PR #1022 made the #1017 checkpoint directly usable through `r4 generate` and
 added an opt-in Apple Accelerate CPU-BLAS build for local Apple Silicon use.
@@ -95,3 +95,40 @@ the already established causal R4/Spin states. That mechanism must be frozen on
 new lexical families before a newly reserved product population is revealed.
 Do not return to #1019 capacity, resonance, intrinsic-attention substitution, or
 backend comparison for this failure.
+
+## C1-SB1 observed result — 2026-08-31
+
+The independently frozen `R4SourceSpanPointerV1` successor retained the #1017
+weights, exact causal R4/Spin state capture, and deterministic source-copy
+surface. Its cheap 12-record overfit preflight passed `12/12`. The public
+Python/Rust score fixture also passed: maximum absolute score delta was
+`1.234420776e-7` and maximum absolute logit delta was `1.428717041e-6`, both
+within the frozen `0.01` ceiling.
+
+The sole 256-step fit then completed and produced these development results:
+
+| Frozen development gate | Observed | Required | Verdict |
+| --- | ---: | ---: | --- |
+| answer decision | `89/128` (`69.53125%`) | `>=95%` | FAIL |
+| abstain decision | `114/128` (`89.0625%`) | `>=95%` | FAIL |
+| conflict decision | `117/128` (`91.40625%`) | `>=95%` | FAIL |
+| supported source-span pointer | `121/128` (`94.53125%`) | `>=95%` | FAIL |
+
+Terminal: **`FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`**.
+
+Because every development threshold was binding, the run stopped before
+emitting a final pointer artifact. The three reserved product probes were
+`NOT_RUN`; browser and HTTP wiring were also `NOT_RUN`. The implementation now
+accepts the exact question form `Where is the <subject>?`, two to eight exact
+punctuation-terminated sentence spans, and an explicit `--head` artifact, but
+there is no qualified final head. The default `r4 answer` product surface is
+therefore unavailable because no explicitly qualified artifact exists.
+
+Do not tune or retry the revealed positive-diagonal weighted-cosine head. The
+next proposed mechanism is a source-relative learned relation/entailment head
+that preserves the exact R4/Spin state-capture and source-copy seams. It must
+receive its own independent frozen contract before execution; no successor run
+or product wiring is active. #1017 remains the working coherent-generation
+prototype, and ordinary causal attention remains established at its existing
+claim scope. The compact bound aggregate is
+[`r4_source_span_pointer_954_raw.json`](r4_source_span_pointer_954_raw.json).

--- a/docs/r4_source_span_pointer_954_raw.json
+++ b/docs/r4_source_span_pointer_954_raw.json
@@ -1,0 +1,72 @@
+{
+  "schema": "uor-r4.source-span-pointer-result/1",
+  "issue": 954,
+  "policy": "R4SourceSpanPointerV1",
+  "observed_at": "2026-08-31",
+  "model_weights_cid": "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d",
+  "tokenizer_cid": "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc",
+  "dataset_cid": "blake3:45e6bc4061e41685b07423d404be8bfbd28052c8cc829fdd7856d498b1d23ab1",
+  "run_contract_cid": "blake3:8085b2fddc62bd8c4b49af001f120a995b56de61764a650a08ed790471ad7bdb",
+  "preflight": {
+    "balanced_records": 12,
+    "outcome_correct": {
+      "answer": "4/4",
+      "abstain": "4/4",
+      "conflict": "4/4"
+    },
+    "supported_span_pointer_correct": "4/4",
+    "python_rust_score_parity": "PASS",
+    "maximum_absolute_score_delta": 1.234420776152767e-7,
+    "maximum_absolute_logit_delta": 1.4287170411186878e-6,
+    "maximum_absolute_tolerance": 0.01,
+    "parity_admission_cid": "blake3:60ff58faf6a9250e2f87354a0d9a54c3147e7df377d5382e899a6b6486d88c1a"
+  },
+  "optimization": {
+    "seed": 9541,
+    "optimizer_steps": 256,
+    "batch_size": 128,
+    "initial_combined_loss": 3.1189775466918945,
+    "final_combined_loss": 1.7038427591323853,
+    "sweep": false,
+    "retry": false
+  },
+  "development": {
+    "required_accuracy_per_gate": 0.95,
+    "answer": {
+      "correct": 89,
+      "total": 128,
+      "accuracy": 0.6953125,
+      "passed": false
+    },
+    "abstain": {
+      "correct": 114,
+      "total": 128,
+      "accuracy": 0.890625,
+      "passed": false
+    },
+    "conflict": {
+      "correct": 117,
+      "total": 128,
+      "accuracy": 0.9140625,
+      "passed": false
+    },
+    "supported_span_pointer": {
+      "correct": 121,
+      "total": 128,
+      "accuracy": 0.9453125,
+      "passed": false
+    }
+  },
+  "product_probe_commitments": [
+    "blake3:96e9178ca42fa68ffa040234937cea63b578f47bd1edf706c3fa23217a9cb6f3",
+    "blake3:185f255f505c1b898b1d5ea55a3727d98402f7b0f954ba01c43193619e3fe514",
+    "blake3:6f9474942227c64dddd2e0cf0704d72fb2c163eb3b4c5804ff3a5a9ac05f22b6"
+  ],
+  "product_behavior_status": "NOT_RUN",
+  "pointer_artifact_cid": null,
+  "training_result_cid": "blake3:0f4dd6082e0599d25df6a1dd127e384167c66796e5eaacf50a8e099ca8837476",
+  "final_manifest_cid": "blake3:6634743f87154587c7fad65e83a30808764a2488c1149e4b32ef9d52b24a6b0a",
+  "final_tree_cid": "blake3:888ef6c03a6686caf62b268fb05b8a4105040461fb43d0f52f18c052c1bea0bf",
+  "terminal": "FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP",
+  "browser_or_http_wiring": "NOT_RUN"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod r4_softmax_trace_observability_experiment;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4_softmax_trace_state_experiment;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod r4_source_span_pointer;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod r4g1;
 /// #655-D2: `release-bundle.json`'s shared filename constant is `pub`
 /// (rather than `pub(crate)`) because the CLI packaging command in the

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use uor_r4_wasm_router::tless_uor;
     name = "r4",
     version,
     about,
-    long_about = "Run the working R4/Spin causal-attention generator, ask a fail-closed question against one local source, or inspect the preserved geometric research surfaces.\n\n`generate` uses the coherent #1017 reference; `answer` uses the bounded #954 grounded export and serves only exact source spans or typed non-answers. Both remain source-backed floating-point/softmax references, not the final source-free transformerless runtime. Preserved compiler and certification commands remain available through `r4 research-tools`."
+    long_about = "Run the working R4/Spin causal-attention generator, exercise the fail-closed source-span-pointer research surface, or inspect the preserved geometric research tools.\n\n`generate` uses the coherent #1017 reference. `answer` accepts a #954 pointer artifact over independently encoded #1017 R4/Spin states and serves only an exact source sentence or a typed non-answer; the frozen C1-SB1 run failed its development gate and emitted no qualified final head. Both paths remain source-backed floating-point/softmax references, not the final source-free transformerless runtime. Preserved compiler and certification commands remain available through `r4 research-tools`."
 )]
 struct Cli {
     /// Increase log verbosity (-v info, -vv debug, -vvv trace).
@@ -115,7 +115,7 @@ enum Command {
     /// Generate from the local learned R4/Spin model through causal softmax.
     #[command(visible_alias = "generate")]
     R4SoftmaxLocalGenerate(R4SoftmaxLocalGenerateArgs),
-    /// Answer from one exact local source span or fail closed with a typed outcome.
+    /// Exercise a #954 source-span pointer; no qualified final head exists yet.
     Answer(GroundedAnswerArgs),
     /// Qualify one frozen #1014, #1017, or #1019 local causal-softmax campaign.
     R4SoftmaxLocalQualify(R4SoftmaxLocalQualifyArgs),
@@ -774,26 +774,22 @@ struct R4SoftmaxLocalGenerateArgs {
 
 #[derive(Args, Debug)]
 struct GroundedAnswerArgs {
-    /// Local grounded checkpoint directory; defaults to the bounded #954 export.
-    #[arg(long, default_value = ".uor-models/research/issue-954/export")]
+    /// Frozen local #1017 checkpoint directory used to encode pointer states.
+    #[arg(long, default_value = ".uor-models/research/issue-1017/export")]
     model: PathBuf,
+    /// Research #954 pointer artifact bound to the frozen checkpoint.
+    #[arg(
+        long,
+        default_value = ".uor-models/research/issue-954/source-span-pointer/source-span-pointer.json"
+    )]
+    head: PathBuf,
     /// Exact regular, non-symlink UTF-8 source file used to ground the answer.
     #[arg(long)]
     source_file: PathBuf,
-    /// Exact question placed after the source by the fixed grounding prompt policy.
+    /// Exact question in the sole admitted form: `Where is the <subject>?`.
     #[arg(long)]
     question: String,
-    /// Maximum generated tokens (1..=128); the grounded surface defaults to 32.
-    #[arg(
-        long,
-        default_value_t = uor_r4_wasm_router::r4_grounded_answer::DEFAULT_MAX_NEW_TOKENS,
-        value_parser = parse_r4_softmax_local_max_new_tokens
-    )]
-    max_new_tokens: usize,
-    /// Stable seed for the versioned temperature-0.8/top-k-40 sampler; omit for greedy.
-    #[arg(long)]
-    seed: Option<u64>,
-    /// Optional path for the complete source binding, typed outcome, and inner audit.
+    /// Optional path for the source binding, pointer scores, and R4 state audit.
     #[arg(long)]
     json_output: Option<PathBuf>,
 }
@@ -2527,7 +2523,9 @@ fn print_research_tools() {
 /// Default location of the reference teacher checkpoint used by `certify`/`compare`.
 const DEFAULT_REFERENCE_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
 const DEFAULT_R4_SOFTMAX_LOCAL_MODEL: &str = ".uor-models/research/issue-1017/export";
-const DEFAULT_GROUNDED_ANSWER_MODEL: &str = ".uor-models/research/issue-954/export";
+const DEFAULT_GROUNDED_ANSWER_MODEL: &str = ".uor-models/research/issue-1017/export";
+const DEFAULT_GROUNDED_ANSWER_HEAD: &str =
+    ".uor-models/research/issue-954/source-span-pointer/source-span-pointer.json";
 
 fn resolve_r4_softmax_local_model(configured: &Path) -> Result<PathBuf, RunError> {
     let model = if configured == Path::new(DEFAULT_R4_SOFTMAX_LOCAL_MODEL) {
@@ -2546,17 +2544,32 @@ fn resolve_r4_softmax_local_model(configured: &Path) -> Result<PathBuf, RunError
 
 fn resolve_grounded_answer_model(configured: &Path) -> Result<PathBuf, RunError> {
     let model = if configured == Path::new(DEFAULT_GROUNDED_ANSWER_MODEL) {
-        model_store_root().join("research/issue-954/export")
+        model_store_root().join("research/issue-1017/export")
     } else {
         configured.to_path_buf()
     };
     if !model.join("model.safetensors").is_file() {
         return Err(RunError::Command(format!(
-            "no grounded #954 model found at {}; set UOR_MODEL_STORE or pass --model",
+            "no frozen #1017 model found at {}; set UOR_MODEL_STORE or pass --model",
             model.display()
         )));
     }
     Ok(model)
+}
+
+fn resolve_grounded_answer_head(configured: &Path) -> Result<PathBuf, RunError> {
+    let head = if configured == Path::new(DEFAULT_GROUNDED_ANSWER_HEAD) {
+        model_store_root().join("research/issue-954/source-span-pointer/source-span-pointer.json")
+    } else {
+        configured.to_path_buf()
+    };
+    if !head.is_file() {
+        return Err(RunError::Command(format!(
+            "no #954 source-span pointer artifact found at {}; the bounded run emitted no qualified final head, so pass --head only for an explicit research artifact",
+            head.display()
+        )));
+    }
+    Ok(head)
 }
 
 /// Resolve the reference teacher checkpoint path, honoring the `TLESS_CHECKPOINT`
@@ -2637,9 +2650,12 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         }
         Some(Command::Answer(args)) => {
             let model = resolve_grounded_answer_model(&args.model)?;
+            let head = resolve_grounded_answer_head(&args.head)?;
             if let Some(path) = &args.json_output {
                 uor_r4_wasm_router::r4_grounded_answer::require_distinct_output_path(
                     &args.source_file,
+                    &head,
+                    &model,
                     path,
                 )
                 .map_err(|error| RunError::Command(error.to_string()))?;
@@ -2651,11 +2667,10 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             let report = uor_r4_wasm_router::r4_grounded_answer::run_grounded_answer(
                 &uor_r4_wasm_router::r4_grounded_answer::GroundedAnswerConfig {
                     model,
+                    head,
                     source_file: args.source_file.clone(),
                     question: args.question.clone(),
-                    max_new_tokens: args.max_new_tokens,
                     workers,
-                    seed: args.seed,
                 },
             )
             .map_err(|error| RunError::Command(error.to_string()))?;

--- a/src/r4_grounded_answer.rs
+++ b/src/r4_grounded_answer.rs
@@ -1,9 +1,10 @@
-//! Fail-closed, source-bound answers over the working #1017 local generator.
+//! Fail-closed exact source-span answers selected from #1017 R4/Spin states.
 //!
-//! The model may propose text, `ABSTAIN`, or `CONTRADICTION`, but this surface
-//! serves ordinary text only when it is an exact, case-sensitive contiguous
-//! byte span of the caller-supplied source. The complete underlying generation
-//! report remains nested for audit without exposing unsupported text on stdout.
+//! This surface does not ask the language-model decoder to invent an answer.
+//! It encodes the requested subject and each admitted source sentence through
+//! the established six-layer coherent R4/Spin causal-softmax executor, applies
+//! one learned pointer head, and either copies one original UTF-8 byte span or
+//! returns a typed abstention/conflict terminal.
 
 use std::fmt;
 use std::fs::{File, OpenOptions};
@@ -12,39 +13,30 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use uor_r4_model_source::TeacherExecutionSnapshot;
 
 use crate::r4_softmax_local_generation::{
-    run_r4_softmax_local_generation, R4SoftmaxLocalGenerationError, R4SoftmaxLocalGenerationReport,
-    R4SoftmaxLocalGeneratorConfig, MAX_NEW_TOKENS,
+    encode_r4_softmax_local_states, LocalCheckpointBinding, R4SoftmaxLocalGenerationError,
+    R4SoftmaxLocalStateEncodingConfig, R4SoftmaxLocalStateSequenceAudit, SourceReadAudit,
+};
+use crate::r4_softmax_reference_generation::ModelShape;
+use crate::r4_source_span_pointer::{
+    evaluate_source_span_pointer, load_source_span_pointer, SourceSpanPointerBinding,
+    SourceSpanPointerDecision, SourceSpanPointerError, SourceSpanPointerEvaluation, POINTER_POLICY,
 };
 
-pub const REPORT_SCHEMA: &str = "uor-r4.grounded-answer/1";
-pub const PROMPT_POLICY: &str = "R4GroundedExtractivePromptV1";
-pub const DEFAULT_MAX_NEW_TOKENS: usize = 32;
+pub const REPORT_SCHEMA: &str = "uor-r4.grounded-answer/2";
 pub const MAX_SOURCE_BYTES: usize = 4 * 1024;
 pub const MAX_QUESTION_BYTES: usize = 1024;
-
-pub const PROMPT_POLICY_TEMPLATE: &str = concat!(
-    "Use only the context. Copy one exact contiguous answer span from the context. ",
-    "If the context does not answer the question, write ABSTAIN. ",
-    "If the context gives conflicting answers, write CONTRADICTION.",
-    "\nContext:\n{source}\nQuestion:\n{question}\nAnswer:\n",
-);
-
-const PROMPT_POLICY_INSTRUCTION: &str = concat!(
-    "Use only the context. Copy one exact contiguous answer span from the context. ",
-    "If the context does not answer the question, write ABSTAIN. ",
-    "If the context gives conflicting answers, write CONTRADICTION.",
-);
+pub const MAX_SOURCE_SPANS: usize = 8;
 
 #[derive(Clone, Debug)]
 pub struct GroundedAnswerConfig {
     pub model: PathBuf,
+    pub head: PathBuf,
     pub source_file: PathBuf,
     pub question: String,
-    pub max_new_tokens: usize,
     pub workers: NonZeroUsize,
-    pub seed: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -64,20 +56,58 @@ pub struct SourceSpan {
     pub byte_end: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceSpanCandidateBinding {
+    pub candidate_index: usize,
+    pub source_span: SourceSpan,
+    pub text_cid: String,
+    pub state_cid: String,
+    pub content_token_count: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GroundedStateEncodingAudit {
+    pub schema: String,
+    pub audit_cid: String,
+    pub model_weights_cid: String,
+    pub tokenizer_cid: String,
+    pub hidden_size: usize,
+    pub checkpoint: LocalCheckpointBinding,
+    pub model_shape: ModelShape,
+    pub subject_text_cid: String,
+    pub subject_state_cid: String,
+    pub subject_content_token_count: usize,
+    pub sequence_audits: Vec<R4SoftmaxLocalStateSequenceAudit>,
+    pub source_read_audit: SourceReadAudit,
+    pub execution: TeacherExecutionSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GroundedPointerLogits {
+    pub answer: f32,
+    pub abstain: f32,
+    pub conflict: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GroundedPointerEvaluation {
+    pub candidate_scores: Vec<f32>,
+    pub ranked_candidate_indices: Vec<usize>,
+    pub logits: GroundedPointerLogits,
+    pub decision: String,
+    pub selected_span_index: Option<usize>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GroundedAbstentionReason {
-    EmptyGeneratedText,
-    InsufficientEvidence,
-    UnsupportedGeneratedText,
+    PointerAbstained,
 }
 
 impl GroundedAbstentionReason {
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::EmptyGeneratedText => "empty_generated_text",
-            Self::InsufficientEvidence => "insufficient_evidence",
-            Self::UnsupportedGeneratedText => "unsupported_generated_text",
+            Self::PointerAbstained => "pointer_abstained",
         }
     }
 }
@@ -98,15 +128,15 @@ pub enum GroundedAnswerOutcome {
 #[derive(Serialize)]
 struct GroundedDecisionIdentity<'a> {
     schema: &'static str,
-    prompt_policy: &'static str,
-    prompt_policy_cid: &'a str,
-    assembled_prompt_cid: &'a str,
+    pointer_policy: &'static str,
     source_cid: &'a str,
     source_byte_length: usize,
     question: &'a str,
-    inner_decision_cid: &'a str,
-    inner_output_cid: &'a str,
-    inner_audit_cid: &'a str,
+    subject: &'a str,
+    pointer_artifact_cid: &'a str,
+    state_encoding_audit_cid: &'a str,
+    candidate_spans: &'a [SourceSpanCandidateBinding],
+    pointer_evaluation: &'a GroundedPointerEvaluation,
     outcome: &'a GroundedAnswerOutcome,
 }
 
@@ -115,15 +145,16 @@ pub struct GroundedAnswerReport {
     pub schema: String,
     pub decision_cid: String,
     pub claim_scope: String,
-    pub prompt_policy: String,
-    pub prompt_policy_cid: String,
-    pub assembled_prompt_cid: String,
     pub source: GroundingSourceBinding,
     pub question: String,
+    pub subject: String,
+    pub candidate_spans: Vec<SourceSpanCandidateBinding>,
+    pub pointer: SourceSpanPointerBinding,
+    pub pointer_evaluation: GroundedPointerEvaluation,
+    /// Compact audit only. Raw width-288 state vectors are deliberately not
+    /// repeated in the public report, but their content CIDs remain bound.
+    pub state_encoding: GroundedStateEncodingAudit,
     pub outcome: GroundedAnswerOutcome,
-    /// The full #1017 generation report, including the raw candidate and every
-    /// causal-attention, execution, checkpoint, and decode audit.
-    pub generation: R4SoftmaxLocalGenerationReport,
     pub nonclaims: Vec<String>,
 }
 
@@ -131,7 +162,8 @@ pub struct GroundedAnswerReport {
 pub enum GroundedAnswerError {
     InvalidRequest(String),
     InvalidSource(String),
-    Generation(R4SoftmaxLocalGenerationError),
+    StateEncoding(R4SoftmaxLocalGenerationError),
+    Pointer(SourceSpanPointerError),
     Audit(String),
     Io(io::Error),
 }
@@ -141,7 +173,8 @@ impl fmt::Display for GroundedAnswerError {
         match self {
             Self::InvalidRequest(reason) => write!(formatter, "invalid grounded answer: {reason}"),
             Self::InvalidSource(reason) => write!(formatter, "invalid grounding source: {reason}"),
-            Self::Generation(error) => error.fmt(formatter),
+            Self::StateEncoding(error) => error.fmt(formatter),
+            Self::Pointer(error) => error.fmt(formatter),
             Self::Audit(reason) => write!(formatter, "grounded answer audit failed: {reason}"),
             Self::Io(error) => error.fmt(formatter),
         }
@@ -152,7 +185,13 @@ impl std::error::Error for GroundedAnswerError {}
 
 impl From<R4SoftmaxLocalGenerationError> for GroundedAnswerError {
     fn from(error: R4SoftmaxLocalGenerationError) -> Self {
-        Self::Generation(error)
+        Self::StateEncoding(error)
+    }
+}
+
+impl From<SourceSpanPointerError> for GroundedAnswerError {
+    fn from(error: SourceSpanPointerError) -> Self {
+        Self::Pointer(error)
     }
 }
 
@@ -173,37 +212,109 @@ pub fn run_grounded_answer(
             config.source_file.display()
         ))
     })?;
-    let source_cid = raw_cid(&source_before);
-    let prompt = assemble_prompt(source_text, &config.question);
-    let prompt_policy_cid = raw_cid(PROMPT_POLICY_TEMPLATE.as_bytes());
-    let assembled_prompt_cid = raw_cid(prompt.as_bytes());
-
-    let generation = run_r4_softmax_local_generation(&R4SoftmaxLocalGeneratorConfig {
-        model: config.model.clone(),
-        prompt,
-        max_new_tokens: config.max_new_tokens,
-        workers: config.workers,
-        attention_off: false,
-        seed: config.seed,
+    let head_before = std::fs::read(&config.head).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot read pointer head {}: {error}",
+            config.head.display()
+        ))
     })?;
+    let subject = parse_subject(&config.question)?;
+    let sentence_spans = split_sentence_spans(source_text)?;
+
+    let mut sequences = Vec::with_capacity(sentence_spans.len() + 1);
+    sequences.push(subject.clone());
+    sequences.extend(sentence_spans.iter().map(|(_, text)| (*text).to_owned()));
+    let encoded = encode_r4_softmax_local_states(&R4SoftmaxLocalStateEncodingConfig {
+        model: config.model.clone(),
+        sequences,
+        workers: config.workers,
+    })?;
+    if encoded.sequences.len() != sentence_spans.len() + 1 {
+        return Err(GroundedAnswerError::Audit(
+            "state encoder returned the wrong independent-sequence count".to_owned(),
+        ));
+    }
+
+    let pointer = load_source_span_pointer(
+        &config.head,
+        &encoded.checkpoint.weights_cid,
+        &encoded.checkpoint.tokenizer_cid,
+    )?;
+    if pointer.artifact.hidden_size != encoded.model_shape.dimension {
+        return Err(GroundedAnswerError::Audit(format!(
+            "pointer width {} differs from model width {}",
+            pointer.artifact.hidden_size, encoded.model_shape.dimension
+        )));
+    }
+
+    let subject_states = encoded.sequences[0].final_normalized_residuals.clone();
+    let candidate_states = encoded.sequences[1..]
+        .iter()
+        .map(|sequence| sequence.final_normalized_residuals.clone())
+        .collect::<Vec<_>>();
+    let internal_evaluation =
+        evaluate_source_span_pointer(&pointer.artifact, &subject_states, &candidate_states)?;
+    let pointer_evaluation = public_pointer_evaluation(&internal_evaluation);
+
+    let candidate_spans = sentence_spans
+        .iter()
+        .zip(&encoded.sequences[1..])
+        .enumerate()
+        .map(|(candidate_index, ((source_span, text), sequence))| {
+            if sequence.text_cid != raw_cid(text.as_bytes()) {
+                return Err(GroundedAnswerError::Audit(format!(
+                    "candidate {candidate_index} state text CID does not match its exact source span"
+                )));
+            }
+            Ok(SourceSpanCandidateBinding {
+                candidate_index,
+                source_span: *source_span,
+                text_cid: sequence.text_cid.clone(),
+                state_cid: sequence.audit.state_cid.clone(),
+                content_token_count: sequence.audit.content_token_count,
+            })
+        })
+        .collect::<Result<Vec<_>, GroundedAnswerError>>()?;
+
+    let outcome = match internal_evaluation.decision {
+        SourceSpanPointerDecision::Answer { candidate_index } => {
+            let candidate = sentence_spans.get(candidate_index).ok_or_else(|| {
+                GroundedAnswerError::Audit("pointer selected an absent source span".to_owned())
+            })?;
+            GroundedAnswerOutcome::Answered {
+                answer: candidate.1.to_owned(),
+                source_span: candidate.0,
+            }
+        }
+        SourceSpanPointerDecision::Abstain => GroundedAnswerOutcome::Abstained {
+            reason: GroundedAbstentionReason::PointerAbstained,
+        },
+        SourceSpanPointerDecision::Contradiction => GroundedAnswerOutcome::Contradiction,
+    };
 
     let source_after = read_source_file(&config.source_file)?;
+    let source_cid = raw_cid(&source_before);
     if source_before != source_after {
         return Err(GroundedAnswerError::Audit(format!(
-            "source {} changed during generation (before {}, after {})",
+            "source {} changed during selection (before {}, after {})",
             config.source_file.display(),
             source_cid,
             raw_cid(&source_after)
         )));
     }
+    let head_after = std::fs::read(&config.head).map_err(|error| {
+        GroundedAnswerError::Audit(format!(
+            "cannot rescan pointer head {}: {error}",
+            config.head.display()
+        ))
+    })?;
+    if head_before != head_after {
+        return Err(GroundedAnswerError::Audit(format!(
+            "pointer head {} changed during selection",
+            config.head.display()
+        )));
+    }
 
-    let outcome = if generation.transcript.utf8_decodable {
-        classify_candidate(source_text, &generation.transcript.response_text)
-    } else {
-        GroundedAnswerOutcome::Abstained {
-            reason: GroundedAbstentionReason::UnsupportedGeneratedText,
-        }
-    };
     let source = GroundingSourceBinding {
         path: config.source_file.display().to_string(),
         source_cid,
@@ -213,37 +324,81 @@ pub fn run_grounded_answer(
         reads: 2,
         unchanged_after_run: true,
     };
+    let sequence_audits = encoded
+        .sequences
+        .iter()
+        .map(|sequence| sequence.audit.clone())
+        .collect::<Vec<_>>();
+    let state_encoding = GroundedStateEncodingAudit {
+        schema: encoded.schema,
+        audit_cid: encoded.audit_cid,
+        model_weights_cid: encoded.checkpoint.weights_cid.clone(),
+        tokenizer_cid: encoded.checkpoint.tokenizer_cid.clone(),
+        hidden_size: encoded.model_shape.dimension,
+        checkpoint: encoded.checkpoint,
+        model_shape: encoded.model_shape,
+        subject_text_cid: encoded.sequences[0].text_cid.clone(),
+        subject_state_cid: encoded.sequences[0].audit.state_cid.clone(),
+        subject_content_token_count: encoded.sequences[0].audit.content_token_count,
+        sequence_audits,
+        source_read_audit: encoded.source_read_audit,
+        execution: encoded.execution,
+    };
     let decision_cid = cid_serializable(&GroundedDecisionIdentity {
         schema: REPORT_SCHEMA,
-        prompt_policy: PROMPT_POLICY,
-        prompt_policy_cid: &prompt_policy_cid,
-        assembled_prompt_cid: &assembled_prompt_cid,
+        pointer_policy: POINTER_POLICY,
         source_cid: &source.source_cid,
         source_byte_length: source.byte_length,
         question: &config.question,
-        inner_decision_cid: &generation.decision_cid,
-        inner_output_cid: &generation.output_cid,
-        inner_audit_cid: &generation.audit_cid,
+        subject: &subject,
+        pointer_artifact_cid: &pointer.binding.artifact_cid,
+        state_encoding_audit_cid: &state_encoding.audit_cid,
+        candidate_spans: &candidate_spans,
+        pointer_evaluation: &pointer_evaluation,
         outcome: &outcome,
     })?;
 
     Ok(GroundedAnswerReport {
         schema: REPORT_SCHEMA.to_owned(),
         decision_cid,
-        claim_scope: "fail-closed local #1017 answer serving with exact source-byte provenance and exact case-sensitive contiguous-span admission".to_owned(),
-        prompt_policy: PROMPT_POLICY.to_owned(),
-        prompt_policy_cid,
-        assembled_prompt_cid,
+        claim_scope: "one learned source-span pointer over frozen #1017 all-layer coherent R4/Spin causal-softmax states; output is an exact original source sentence or a typed non-answer".to_owned(),
         source,
         question: config.question.clone(),
+        subject,
+        candidate_spans,
+        pointer: pointer.binding,
+        pointer_evaluation,
+        state_encoding,
         outcome,
-        generation,
         nonclaims: vec![
-            "Exact source-span membership establishes provenance, not semantic entailment or general correctness.".to_owned(),
-            "A CONTRADICTION result is the model's typed response to the fixed prompt; this wrapper does not independently prove a semantic conflict.".to_owned(),
-            "This #1017 path remains source-backed, floating-point, multiplication-using, and ordinary-softmax based.".to_owned(),
+            "This bounded pointer result does not establish open-domain question answering, reasoning, or general semantic entailment.".to_owned(),
+            "The learned head and #1017 executor remain source-backed, floating-point, multiplication-using, and ordinary-softmax based.".to_owned(),
+            "This result does not establish the final source-free exact geometric runtime or a browser product surface.".to_owned(),
         ],
     })
+}
+
+fn public_pointer_evaluation(
+    evaluation: &SourceSpanPointerEvaluation,
+) -> GroundedPointerEvaluation {
+    let (decision, selected_span_index) = match evaluation.decision {
+        SourceSpanPointerDecision::Answer { candidate_index } => {
+            ("answer".to_owned(), Some(candidate_index))
+        }
+        SourceSpanPointerDecision::Abstain => ("abstain".to_owned(), None),
+        SourceSpanPointerDecision::Contradiction => ("conflict".to_owned(), None),
+    };
+    GroundedPointerEvaluation {
+        candidate_scores: evaluation.scores.candidate_scores.clone(),
+        ranked_candidate_indices: evaluation.scores.ranked_candidate_indices.clone(),
+        logits: GroundedPointerLogits {
+            answer: evaluation.scores.answer_logit,
+            abstain: evaluation.scores.abstain_logit,
+            conflict: evaluation.scores.conflict_logit,
+        },
+        decision,
+        selected_span_index,
+    }
 }
 
 pub fn write_json_report(
@@ -263,10 +418,10 @@ pub fn write_json_report(
 }
 
 /// Reject an audit output that already names the same file as the bound source.
-/// This check runs before generation so report emission cannot overwrite the
-/// source after the unchanged-source audit has completed.
 pub fn require_distinct_output_path(
     source: &Path,
+    head: &Path,
+    model: &Path,
     output: &Path,
 ) -> Result<(), GroundedAnswerError> {
     let source_metadata = std::fs::metadata(source).map_err(|error| {
@@ -275,6 +430,18 @@ pub fn require_distinct_output_path(
             source.display()
         ))
     })?;
+    let canonical_model = std::fs::canonicalize(model).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot resolve model directory {}: {error}",
+            model.display()
+        ))
+    })?;
+    let resolved_output = resolve_output_path(output)?;
+    if resolved_output.starts_with(&canonical_model) {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--json-output must remain outside the immutable model directory".to_owned(),
+        ));
+    }
     let output_metadata = match std::fs::metadata(output) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -289,6 +456,79 @@ pub fn require_distinct_output_path(
         return Err(GroundedAnswerError::InvalidRequest(
             "--json-output must not name or alias --source-file".to_owned(),
         ));
+    }
+    let head_metadata = std::fs::metadata(head).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot inspect pointer head {}: {error}",
+            head.display()
+        ))
+    })?;
+    if same_file_identity(head, &head_metadata, output, &output_metadata)? {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--json-output must not name or alias --head".to_owned(),
+        ));
+    }
+    reject_checkpoint_hardlink(model, output, &output_metadata)?;
+    Ok(())
+}
+
+fn resolve_output_path(path: &Path) -> Result<PathBuf, GroundedAnswerError> {
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--json-output must not contain `..` path traversal".to_owned(),
+        ));
+    }
+    if path.exists() {
+        return std::fs::canonicalize(path).map_err(GroundedAnswerError::Io);
+    }
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut ancestor = absolute.as_path();
+    let mut suffix = Vec::new();
+    while !ancestor.exists() {
+        let name = ancestor.file_name().ok_or_else(|| {
+            GroundedAnswerError::InvalidRequest(
+                "--json-output has no resolvable existing ancestor".to_owned(),
+            )
+        })?;
+        suffix.push(name.to_owned());
+        ancestor = ancestor.parent().ok_or_else(|| {
+            GroundedAnswerError::InvalidRequest(
+                "--json-output has no resolvable existing ancestor".to_owned(),
+            )
+        })?;
+    }
+    let mut resolved = std::fs::canonicalize(ancestor)?;
+    for component in suffix.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
+fn reject_checkpoint_hardlink(
+    directory: &Path,
+    output: &Path,
+    output_metadata: &std::fs::Metadata,
+) -> Result<(), GroundedAnswerError> {
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            reject_checkpoint_hardlink(&entry.path(), output, output_metadata)?;
+        } else if file_type.is_file() {
+            let metadata = entry.metadata()?;
+            if same_file_identity(&entry.path(), &metadata, output, output_metadata)? {
+                return Err(GroundedAnswerError::InvalidRequest(
+                    "--json-output must not name or alias a checkpoint file".to_owned(),
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -326,12 +566,77 @@ fn validate_request(config: &GroundedAnswerConfig) -> Result<(), GroundedAnswerE
             config.question.len()
         )));
     }
-    if config.max_new_tokens == 0 || config.max_new_tokens > MAX_NEW_TOKENS {
-        return Err(GroundedAnswerError::InvalidRequest(format!(
-            "--max-new-tokens must be in 1..={MAX_NEW_TOKENS}"
-        )));
-    }
     Ok(())
+}
+
+fn parse_subject(question: &str) -> Result<String, GroundedAnswerError> {
+    const PREFIX: &str = "Where is the ";
+    let subject = question
+        .strip_prefix(PREFIX)
+        .and_then(|rest| rest.strip_suffix('?'))
+        .ok_or_else(|| {
+            GroundedAnswerError::InvalidRequest(
+                "--question must match exactly `Where is the <subject>?`".to_owned(),
+            )
+        })?;
+    if subject.is_empty() || subject != subject.trim() || subject.contains(['?', '\n', '\r']) {
+        return Err(GroundedAnswerError::InvalidRequest(
+            "--question must match exactly `Where is the <subject>?`".to_owned(),
+        ));
+    }
+    Ok(subject.to_owned())
+}
+
+fn split_sentence_spans(source: &str) -> Result<Vec<(SourceSpan, &str)>, GroundedAnswerError> {
+    let mut spans = Vec::new();
+    let mut byte_start = None;
+    for (offset, character) in source.char_indices() {
+        if byte_start.is_none() {
+            if character.is_whitespace() {
+                continue;
+            }
+            byte_start = Some(offset);
+        }
+        if !matches!(character, '.' | '!' | '?') {
+            continue;
+        }
+        let Some(start) = byte_start else {
+            return Err(GroundedAnswerError::InvalidSource(
+                "source contains an empty punctuation-only sentence".to_owned(),
+            ));
+        };
+        let end = offset + character.len_utf8();
+        let text = &source[start..end];
+        if text[..text.len() - character.len_utf8()].trim().is_empty() {
+            return Err(GroundedAnswerError::InvalidSource(
+                "source contains an empty punctuation-only sentence".to_owned(),
+            ));
+        }
+        spans.push((
+            SourceSpan {
+                byte_start: start,
+                byte_end: end,
+            },
+            text,
+        ));
+        if spans.len() > MAX_SOURCE_SPANS {
+            return Err(GroundedAnswerError::InvalidSource(format!(
+                "source exceeds {MAX_SOURCE_SPANS} punctuation-terminated sentence spans"
+            )));
+        }
+        byte_start = None;
+    }
+    if byte_start.is_some() {
+        return Err(GroundedAnswerError::InvalidSource(
+            "source has a non-whitespace suffix without .!? termination".to_owned(),
+        ));
+    }
+    if spans.is_empty() {
+        return Err(GroundedAnswerError::InvalidSource(
+            "source has no punctuation-terminated sentence".to_owned(),
+        ));
+    }
+    Ok(spans)
 }
 
 fn read_source_file(path: &Path) -> Result<Vec<u8>, GroundedAnswerError> {
@@ -416,39 +721,6 @@ fn open_source_no_follow(path: &Path) -> Result<File, GroundedAnswerError> {
     })
 }
 
-fn assemble_prompt(source: &str, question: &str) -> String {
-    format!("{PROMPT_POLICY_INSTRUCTION}\nContext:\n{source}\nQuestion:\n{question}\nAnswer:\n")
-}
-
-fn classify_candidate(source: &str, candidate: &str) -> GroundedAnswerOutcome {
-    let candidate = candidate.trim();
-    if candidate.is_empty() {
-        return GroundedAnswerOutcome::Abstained {
-            reason: GroundedAbstentionReason::EmptyGeneratedText,
-        };
-    }
-    if candidate == "ABSTAIN" {
-        return GroundedAnswerOutcome::Abstained {
-            reason: GroundedAbstentionReason::InsufficientEvidence,
-        };
-    }
-    if candidate == "CONTRADICTION" {
-        return GroundedAnswerOutcome::Contradiction;
-    }
-    if let Some(byte_start) = source.find(candidate) {
-        return GroundedAnswerOutcome::Answered {
-            answer: candidate.to_owned(),
-            source_span: SourceSpan {
-                byte_start,
-                byte_end: byte_start + candidate.len(),
-            },
-        };
-    }
-    GroundedAnswerOutcome::Abstained {
-        reason: GroundedAbstentionReason::UnsupportedGeneratedText,
-    }
-}
-
 fn raw_cid(bytes: &[u8]) -> String {
     format!("blake3:{}", blake3::hash(bytes).to_hex())
 }
@@ -465,59 +737,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn classifier_serves_only_exact_case_sensitive_source_spans() {
-        let source = "The silver key opens the north door.";
+    fn question_and_sentence_policies_match_the_frozen_python_boundary() {
         assert_eq!(
-            classify_candidate(source, "silver key"),
-            GroundedAnswerOutcome::Answered {
-                answer: "silver key".to_owned(),
-                source_span: SourceSpan {
-                    byte_start: 4,
-                    byte_end: 14,
+            parse_subject("Where is the copper compass?").unwrap(),
+            "copper compass"
+        );
+        assert!(parse_subject("where is the copper compass?").is_err());
+
+        let source = "  Alpha is here.  Beta is there!\n";
+        let spans = split_sentence_spans(source).unwrap();
+        assert_eq!(
+            spans[0],
+            (
+                SourceSpan {
+                    byte_start: 2,
+                    byte_end: 16,
                 },
-            }
+                "Alpha is here."
+            )
         );
         assert_eq!(
-            classify_candidate(source, "Silver key"),
-            GroundedAnswerOutcome::Abstained {
-                reason: GroundedAbstentionReason::UnsupportedGeneratedText,
-            }
-        );
-    }
-
-    #[test]
-    fn classifier_types_every_non_answer_terminal() {
-        assert_eq!(
-            classify_candidate("source", "  "),
-            GroundedAnswerOutcome::Abstained {
-                reason: GroundedAbstentionReason::EmptyGeneratedText,
-            }
-        );
-        assert_eq!(
-            classify_candidate("source", " ABSTAIN "),
-            GroundedAnswerOutcome::Abstained {
-                reason: GroundedAbstentionReason::InsufficientEvidence,
-            }
-        );
-        assert_eq!(
-            classify_candidate("source", " CONTRADICTION "),
-            GroundedAnswerOutcome::Contradiction
-        );
-        assert_eq!(
-            classify_candidate("source", "unsupported"),
-            GroundedAnswerOutcome::Abstained {
-                reason: GroundedAbstentionReason::UnsupportedGeneratedText,
-            }
-        );
-    }
-
-    #[test]
-    fn prompt_assembly_matches_the_frozen_policy() {
-        assert_eq!(
-            assemble_prompt("exact source", "exact question"),
-            PROMPT_POLICY_TEMPLATE
-                .replace("{source}", "exact source")
-                .replace("{question}", "exact question")
+            spans[1],
+            (
+                SourceSpan {
+                    byte_start: 18,
+                    byte_end: 32,
+                },
+                "Beta is there!"
+            )
         );
     }
 }

--- a/src/r4_softmax_local_generation.rs
+++ b/src/r4_softmax_local_generation.rs
@@ -40,6 +40,8 @@ pub const POLICY_SCHEMA: &str = "R4SoftmaxLocalGeneratorV1";
 pub const DEFAULT_MAX_NEW_TOKENS: usize = 128;
 pub const MAX_NEW_TOKENS: usize = 128;
 pub const DEFAULT_WORKERS: usize = 4;
+pub const STATE_ENCODING_SCHEMA: &str = "uor-r4.r4-softmax-local-state-encoding/1";
+pub const MAX_STATE_ENCODING_SEQUENCES: usize = 9;
 pub const QUALIFICATION_REPORT_SCHEMA: &str = "uor-r4.r4-softmax-local-qualification/1";
 pub const PYTHON_PREFIX_LOGITS_SCHEMA: &str = "uor-r4.r4-softmax-python-prefix-logits/1";
 pub const ENABLED_ONLY_QUALIFICATION_REPORT_SCHEMA: &str =
@@ -123,6 +125,17 @@ pub struct R4SoftmaxLocalGeneratorConfig {
     pub seed: Option<u64>,
 }
 
+/// One bounded request for independent #1017 R4/Spin state sequences.
+///
+/// The checkpoint and oracle are loaded once. Every sequence receives a fresh
+/// reset of the same all-layer coherent transport session.
+#[derive(Clone, Debug)]
+pub struct R4SoftmaxLocalStateEncodingConfig {
+    pub model: PathBuf,
+    pub sequences: Vec<String>,
+    pub workers: NonZeroUsize,
+}
+
 #[derive(Clone, Debug)]
 pub struct R4SoftmaxLocalQualificationConfig {
     pub model: PathBuf,
@@ -194,6 +207,47 @@ pub struct AttentionOutputPolicyAuditRecord {
     pub applications_by_layer: Vec<u64>,
     pub maximum_query_position: Option<usize>,
     pub exact: bool,
+}
+
+/// Compact fail-closed evidence for one independently reset state sequence.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct R4SoftmaxLocalStateSequenceAudit {
+    pub positions_executed: usize,
+    pub content_token_count: usize,
+    pub residual_width: usize,
+    pub selected_layer_count: usize,
+    pub all_layers_selected: bool,
+    pub causal_audit_exact: bool,
+    pub projection_audit_exact: bool,
+    pub r4_audit_exact: bool,
+    pub output_policy_audit_exact: bool,
+    pub zero_future_reads: bool,
+    pub persistent_state_cid: String,
+    pub transport_evidence_cid: String,
+    pub state_cid: String,
+}
+
+/// Token-aligned post-final-RMSNorm states for one exact input text.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct R4SoftmaxLocalEncodedStateSequence {
+    pub text_cid: String,
+    /// Content ids only; the one checkpoint BOS step is intentionally omitted.
+    pub content_token_ids: Vec<u32>,
+    /// One width-`model_shape.dimension` state per content token.
+    pub final_normalized_residuals: Vec<Vec<f32>>,
+    pub audit: R4SoftmaxLocalStateSequenceAudit,
+}
+
+/// Bounded, serializable state-capture output for downstream learned heads.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct R4SoftmaxLocalStateEncodingReport {
+    pub schema: String,
+    pub audit_cid: String,
+    pub checkpoint: LocalCheckpointBinding,
+    pub model_shape: ModelShape,
+    pub sequences: Vec<R4SoftmaxLocalEncodedStateSequence>,
+    pub source_read_audit: SourceReadAudit,
+    pub execution: TeacherExecutionSnapshot,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
@@ -498,6 +552,321 @@ impl From<io::Error> for R4SoftmaxLocalGenerationError {
     fn from(error: io::Error) -> Self {
         Self::Io(error)
     }
+}
+
+/// Encode up to nine independent texts into token-aligned final residuals
+/// through the frozen six-layer #1017 coherent R4/Spin attention path.
+///
+/// The tokenizer, source checkpoint, and oracle are loaded exactly once. A
+/// single bounded session is reset and reused between texts, so no sequence can
+/// inherit another sequence's residual, KV cache, transport frames, or audit.
+pub fn encode_r4_softmax_local_states(
+    config: &R4SoftmaxLocalStateEncodingConfig,
+) -> Result<R4SoftmaxLocalStateEncodingReport, R4SoftmaxLocalGenerationError> {
+    if config.sequences.is_empty() || config.sequences.len() > MAX_STATE_ENCODING_SEQUENCES {
+        return Err(R4SoftmaxLocalGenerationError::InvalidRequest(format!(
+            "state encoding requires 1..={MAX_STATE_ENCODING_SEQUENCES} independent sequences"
+        )));
+    }
+
+    let before = checkpoint_tree_binding(&config.model)?;
+    let tokenizer = HfBpeTokenizer::from_dir(&config.model)
+        .map_err(|error| R4SoftmaxLocalGenerationError::Tokenizer(error.to_string()))?;
+    let tokenizer_cid = tokenizer.address();
+    let config_cid = required_file_cid(&before, "config.json")?;
+    let bound_tokenizer_cid = required_file_cid(&before, "tokenizer.json")?;
+    if tokenizer_cid != bound_tokenizer_cid {
+        return Err(R4SoftmaxLocalGenerationError::Audit(
+            "tokenizer parser identity differs from checkpoint-tree tokenizer bytes".to_owned(),
+        ));
+    }
+    require_weight_files(&before)?;
+
+    let mut encoded_inputs = Vec::with_capacity(config.sequences.len());
+    let mut maximum_content_tokens = 0usize;
+    for (index, text) in config.sequences.iter().enumerate() {
+        if text.is_empty() {
+            return Err(R4SoftmaxLocalGenerationError::InvalidRequest(format!(
+                "state-encoding sequence {index} is empty"
+            )));
+        }
+        let token_ids = tokenizer.encode(text);
+        if token_ids.is_empty() {
+            return Err(R4SoftmaxLocalGenerationError::Tokenizer(format!(
+                "state-encoding sequence {index} encoded to zero tokens"
+            )));
+        }
+        maximum_content_tokens = maximum_content_tokens.max(token_ids.len());
+        encoded_inputs.push((text, token_ids));
+    }
+    let sequence_capacity = maximum_content_tokens.checked_add(1).ok_or_else(|| {
+        R4SoftmaxLocalGenerationError::InvalidRequest(
+            "state-encoding sequence capacity overflowed".to_owned(),
+        )
+    })?;
+
+    let oracle = HuggingFaceLlamaOracle::load_with_sequence_length_and_execution(
+        &config.model,
+        sequence_capacity,
+        TeacherExecutionConfig::fixed_workers(config.workers),
+    )
+    .map_err(|error| R4SoftmaxLocalGenerationError::Source(error.to_string()))?;
+    if oracle.cfg().seq_len != sequence_capacity {
+        return Err(R4SoftmaxLocalGenerationError::InvalidRequest(format!(
+            "requested state horizon {sequence_capacity} exceeds checkpoint capacity {}",
+            oracle.cfg().seq_len
+        )));
+    }
+    if oracle.cfg().vocab != tokenizer.vocab_size() {
+        return Err(R4SoftmaxLocalGenerationError::InvalidCheckpoint(format!(
+            "model vocabulary {} != tokenizer vocabulary {}",
+            oracle.cfg().vocab,
+            tokenizer.vocab_size()
+        )));
+    }
+    let bos_token_id = u32::try_from(TeacherOracle::bos_token(&oracle)).map_err(|_| {
+        R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+            "checkpoint BOS token exceeds the u32 token namespace".to_owned(),
+        )
+    })?;
+    let eos_token_id = u32::try_from(TeacherOracle::eos_token(&oracle)).map_err(|_| {
+        R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+            "checkpoint EOS token exceeds the u32 token namespace".to_owned(),
+        )
+    })?;
+    let shape = model_shape(&oracle, sequence_capacity)
+        .map_err(|error| R4SoftmaxLocalGenerationError::InvalidCheckpoint(error.to_string()))?;
+    let mut frozen_shape = shape;
+    frozen_shape.sequence_capacity = PREFIX_PARITY_TOKENS;
+    enforce_campaign_shape(
+        &config.model,
+        &frozen_shape,
+        tokenizer.vocab_size(),
+        R4SoftmaxLocalQualificationCampaign::Issue1017EnabledOnly,
+    )?;
+    let maximum_token = u32::try_from(shape.vocabulary.checked_sub(1).ok_or_else(|| {
+        R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+            "checkpoint vocabulary is empty".to_owned(),
+        )
+    })?)
+    .map_err(|_| {
+        R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+            "checkpoint vocabulary exceeds the u32 token namespace".to_owned(),
+        )
+    })?;
+    if bos_token_id > maximum_token || eos_token_id > maximum_token {
+        return Err(R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+            "checkpoint BOS or EOS token lies outside its vocabulary".to_owned(),
+        ));
+    }
+
+    let transport = R4SpinCausalAttentionTransport::new(
+        maximum_token,
+        sequence_capacity,
+        R4SpinTransportIntervention::Coherent,
+    )
+    .map_err(|error| R4SoftmaxLocalGenerationError::Attention(error.to_string()))?;
+    let mut session = oracle
+        .new_causal_attention_transport_session_with_output_policy(
+            Box::new(transport),
+            CausalAttentionLayerSelection::All,
+            sequence_capacity,
+            CausalAttentionOutputPolicy::Enabled,
+        )
+        .map_err(|error| R4SoftmaxLocalGenerationError::Attention(error.to_string()))?;
+    let all_layers_selected = session.selected_layer_count() == shape.layers
+        && (0..shape.layers).all(|layer| session.layer_is_selected(layer));
+    if !all_layers_selected {
+        return Err(R4SoftmaxLocalGenerationError::Audit(
+            "state encoding did not select every decoder attention layer".to_owned(),
+        ));
+    }
+
+    let mut logits = vec![0.0_f32; shape.vocabulary];
+    let mut sequences = Vec::with_capacity(encoded_inputs.len());
+    let mut total_positions = 0usize;
+    for (sequence_index, (text, content_token_ids)) in encoded_inputs.into_iter().enumerate() {
+        session.reset();
+        oracle
+            .step_causal_attention_transport(&mut session, bos_token_id as usize, 0, &mut logits)
+            .map_err(|error| R4SoftmaxLocalGenerationError::Attention(error.to_string()))?;
+
+        let mut residuals = Vec::with_capacity(content_token_ids.len());
+        for (content_position, &token) in content_token_ids.iter().enumerate() {
+            let position = content_position.checked_add(1).ok_or_else(|| {
+                R4SoftmaxLocalGenerationError::InvalidRequest(
+                    "state-encoding token position overflowed".to_owned(),
+                )
+            })?;
+            oracle
+                .step_causal_attention_transport(
+                    &mut session,
+                    token as usize,
+                    position,
+                    &mut logits,
+                )
+                .map_err(|error| R4SoftmaxLocalGenerationError::Attention(error.to_string()))?;
+            let residual = session.final_normalized_residual();
+            if residual.len() != shape.dimension || residual.iter().any(|value| !value.is_finite())
+            {
+                return Err(R4SoftmaxLocalGenerationError::Audit(format!(
+                    "sequence {sequence_index} position {content_position} produced an invalid final residual"
+                )));
+            }
+            residuals.push(residual.to_vec());
+        }
+
+        let positions_executed = content_token_ids.len().checked_add(1).ok_or_else(|| {
+            R4SoftmaxLocalGenerationError::Audit(
+                "state-encoding position count overflowed".to_owned(),
+            )
+        })?;
+        total_positions = total_positions
+            .checked_add(positions_executed)
+            .ok_or_else(|| {
+                R4SoftmaxLocalGenerationError::Audit(
+                    "state-encoding total position count overflowed".to_owned(),
+                )
+            })?;
+        session
+            .transport_status()
+            .map_err(R4SoftmaxLocalGenerationError::Attention)?;
+        if session.policy_identity() != HELM_D_R4_GAUGE_SOFTMAX_POLICY
+            || session.output_policy() != CausalAttentionOutputPolicy::Enabled
+        {
+            return Err(R4SoftmaxLocalGenerationError::Audit(format!(
+                "sequence {sequence_index} did not retain the coherent enabled R4/Spin policy"
+            )));
+        }
+        let implementation_json = session
+            .transport_implementation_evidence()
+            .map_err(R4SoftmaxLocalGenerationError::Attention)?
+            .ok_or_else(|| {
+                R4SoftmaxLocalGenerationError::Audit(format!(
+                    "sequence {sequence_index} emitted no R4 transport evidence"
+                ))
+            })?;
+        let implementation: R4SpinTransportEvidence = serde_json::from_str(&implementation_json)
+            .map_err(|error| R4SoftmaxLocalGenerationError::Audit(error.to_string()))?;
+        let observed_causal: CausalAttentionAuditRecord = session.audit().into();
+        let observed_projection: ProjectionAuditRecord = session.pre_rope_projection_audit().into();
+        let expected_causal = expected_causal_audit(positions_executed, &shape)
+            .map_err(|error| R4SoftmaxLocalGenerationError::Audit(error.to_string()))?;
+        let expected_projection = expected_projection_audit(positions_executed, &shape)
+            .map_err(|error| R4SoftmaxLocalGenerationError::Audit(error.to_string()))?;
+        let expected_r4 = expected_r4_audit(positions_executed, &shape)
+            .map_err(|error| R4SoftmaxLocalGenerationError::Audit(error.to_string()))?;
+        let causal_audit_exact = observed_causal == expected_causal;
+        let projection_audit_exact = observed_projection == expected_projection;
+        let r4_audit_exact = implementation.policy_identity == HELM_D_R4_GAUGE_SOFTMAX_POLICY
+            && implementation.intervention == R4SpinTransportIntervention::Coherent
+            && implementation.frame_table_offsets.len() == positions_executed
+            && implementation.audit == expected_r4;
+        let zero_future_reads =
+            observed_causal.future_reads == 0 && implementation.audit.future_position_reads == 0;
+        let output_policy_audit = output_policy_audit_record(
+            session.output_policy_audit(),
+            positions_executed,
+            &shape,
+            CausalAttentionOutputPolicy::Enabled,
+        )?;
+        if !(causal_audit_exact
+            && projection_audit_exact
+            && r4_audit_exact
+            && output_policy_audit.exact
+            && zero_future_reads)
+        {
+            return Err(R4SoftmaxLocalGenerationError::Audit(format!(
+                "sequence {sequence_index} state audit mismatch: causal={causal_audit_exact}, projection={projection_audit_exact}, R4={r4_audit_exact}, output_policy={}, zero_future_reads={zero_future_reads}",
+                output_policy_audit.exact
+            )));
+        }
+        let text_cid = raw_cid(text.as_bytes());
+        let state_cid = cid_serializable(&(&text_cid, &content_token_ids, &residuals))?;
+        let audit = R4SoftmaxLocalStateSequenceAudit {
+            positions_executed,
+            content_token_count: content_token_ids.len(),
+            residual_width: shape.dimension,
+            selected_layer_count: session.selected_layer_count(),
+            all_layers_selected,
+            causal_audit_exact,
+            projection_audit_exact,
+            r4_audit_exact,
+            output_policy_audit_exact: output_policy_audit.exact,
+            zero_future_reads,
+            persistent_state_cid: session.persistent_state_cid(),
+            transport_evidence_cid: raw_cid(implementation_json.as_bytes()),
+            state_cid,
+        };
+        sequences.push(R4SoftmaxLocalEncodedStateSequence {
+            text_cid,
+            content_token_ids,
+            final_normalized_residuals: residuals,
+            audit,
+        });
+    }
+
+    let execution = oracle.execution_snapshot();
+    let after = checkpoint_tree_binding(&config.model)?;
+    if before != after {
+        return Err(R4SoftmaxLocalGenerationError::Audit(
+            "checkpoint tree changed during local state encoding".to_owned(),
+        ));
+    }
+    let file_reads = u64::try_from(before.files.len())
+        .ok()
+        .and_then(|count| count.checked_mul(2))
+        .ok_or_else(|| {
+            R4SoftmaxLocalGenerationError::Audit("source-read count overflowed".to_owned())
+        })?;
+    let source_read_audit = SourceReadAudit {
+        checkpoint_tree_scans: 2,
+        checkpoint_tree_file_reads: file_reads,
+        tokenizer_loads: 1,
+        oracle_loads: 1,
+        local_checkpoint_forward_steps: u64::try_from(total_positions).map_err(|_| {
+            R4SoftmaxLocalGenerationError::Audit("forward-step count overflowed".to_owned())
+        })?,
+        provider_calls: 0,
+        ollama_calls: 0,
+        prior_trace_reads: 0,
+        tree_unchanged_across_execution: true,
+    };
+    let checkpoint = LocalCheckpointBinding {
+        model_path: config.model.display().to_string(),
+        checkpoint_tree_cid: before.checkpoint_tree_cid,
+        config_cid,
+        tokenizer_cid,
+        weights_cid: oracle.source_cid().to_owned(),
+        weights_cid_scope: "Safetensors shard bytes in the loader's canonical shard order; not the checkpoint-tree CID".to_owned(),
+        files: before.files,
+        tokenizer: tokenizer.adapter(),
+        bos_token_id,
+        eos_token_id,
+        exact_backend: oracle.exact_backend_report(),
+    };
+    let sequence_audits = sequences
+        .iter()
+        .map(|sequence| &sequence.audit)
+        .collect::<Vec<_>>();
+    let audit_cid = cid_serializable(&(
+        STATE_ENCODING_SCHEMA,
+        &checkpoint,
+        shape,
+        sequence_audits,
+        source_read_audit,
+        &execution,
+    ))?;
+
+    Ok(R4SoftmaxLocalStateEncodingReport {
+        schema: STATE_ENCODING_SCHEMA.to_owned(),
+        audit_cid,
+        checkpoint,
+        model_shape: shape,
+        sequences,
+        source_read_audit,
+        execution,
+    })
 }
 
 pub fn run_r4_softmax_local_generation(

--- a/src/r4_source_span_pointer.rs
+++ b/src/r4_source_span_pointer.rs
@@ -1,0 +1,403 @@
+//! Learned, fail-closed source-span selection over #1017 R4/Spin states.
+//!
+//! The pointer never decodes an answer token. It scores exact source sentence
+//! spans from the final normalized token states produced by the established
+//! all-layer R4/Spin causal-softmax executor, then selects either one original
+//! byte span or an explicit abstention/conflict terminal.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+pub const POINTER_ARTIFACT_SCHEMA: &str = "uor-r4.source-span-pointer/1";
+pub const POINTER_POLICY: &str = "R4SourceSpanPointerV1";
+pub const QUESTION_POLICY: &str = "Where is the <subject>?";
+pub const SENTENCE_POLICY: &str = "exact .!? terminated UTF-8 byte spans";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpanPointerArtifact {
+    pub schema: String,
+    pub policy: String,
+    pub issue: u32,
+    pub model_weights_cid: String,
+    pub tokenizer_cid: String,
+    pub hidden_size: usize,
+    pub state_weights: Vec<f32>,
+    pub score_scale: f32,
+    pub answer_bias: f32,
+    pub abstain_bias: f32,
+    pub conflict_bias: f32,
+    pub maximum_source_spans: usize,
+    pub question_policy: String,
+    pub sentence_policy: String,
+    pub dataset_cid: String,
+    pub split_policy_cid: String,
+    pub run_contract_cid: String,
+    pub training_result_cid: String,
+    pub preflight: serde_json::Value,
+    pub development_metrics: serde_json::Value,
+    pub product_probe_commitments: Vec<String>,
+    pub artifact_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SourceSpanPointerScores {
+    pub candidate_scores: Vec<f32>,
+    pub ranked_candidate_indices: Vec<usize>,
+    pub answer_logit: f32,
+    pub abstain_logit: f32,
+    pub conflict_logit: f32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceSpanPointerDecision {
+    Answer { candidate_index: usize },
+    Abstain,
+    Contradiction,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SourceSpanPointerEvaluation {
+    pub scores: SourceSpanPointerScores,
+    pub decision: SourceSpanPointerDecision,
+}
+
+#[derive(Debug)]
+pub enum SourceSpanPointerError {
+    InvalidArtifact(String),
+    InvalidStates(String),
+    Io(std::io::Error),
+}
+
+impl fmt::Display for SourceSpanPointerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidArtifact(reason) => {
+                write!(formatter, "invalid source-span pointer: {reason}")
+            }
+            Self::InvalidStates(reason) => write!(formatter, "invalid R4 pointer states: {reason}"),
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SourceSpanPointerError {}
+
+impl From<std::io::Error> for SourceSpanPointerError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceSpanPointerBinding {
+    pub path: String,
+    pub artifact_cid: String,
+    pub policy: String,
+    pub model_weights_cid: String,
+    pub tokenizer_cid: String,
+    pub dataset_cid: String,
+    pub split_policy_cid: String,
+    pub run_contract_cid: String,
+    pub training_result_cid: String,
+}
+
+pub struct LoadedSourceSpanPointer {
+    pub artifact: SourceSpanPointerArtifact,
+    pub binding: SourceSpanPointerBinding,
+}
+
+pub fn load_source_span_pointer(
+    path: &Path,
+    expected_model_weights_cid: &str,
+    expected_tokenizer_cid: &str,
+) -> Result<LoadedSourceSpanPointer, SourceSpanPointerError> {
+    let bytes = std::fs::read(path)?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        SourceSpanPointerError::InvalidArtifact(format!("{} is not JSON: {error}", path.display()))
+    })?;
+    let embedded_cid = value
+        .get("artifact_cid")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            SourceSpanPointerError::InvalidArtifact("artifact_cid is absent".to_owned())
+        })?;
+    verify_embedded_cid(&bytes, embedded_cid)?;
+    let artifact: SourceSpanPointerArtifact = serde_json::from_value(value).map_err(|error| {
+        SourceSpanPointerError::InvalidArtifact(format!("artifact fields are invalid: {error}"))
+    })?;
+    validate_artifact(
+        &artifact,
+        expected_model_weights_cid,
+        expected_tokenizer_cid,
+    )?;
+    let binding = SourceSpanPointerBinding {
+        path: PathBuf::from(path).display().to_string(),
+        artifact_cid: artifact.artifact_cid.clone(),
+        policy: artifact.policy.clone(),
+        model_weights_cid: artifact.model_weights_cid.clone(),
+        tokenizer_cid: artifact.tokenizer_cid.clone(),
+        dataset_cid: artifact.dataset_cid.clone(),
+        split_policy_cid: artifact.split_policy_cid.clone(),
+        run_contract_cid: artifact.run_contract_cid.clone(),
+        training_result_cid: artifact.training_result_cid.clone(),
+    };
+    Ok(LoadedSourceSpanPointer { artifact, binding })
+}
+
+pub fn evaluate_source_span_pointer(
+    artifact: &SourceSpanPointerArtifact,
+    subject_states: &[Vec<f32>],
+    candidate_states: &[Vec<Vec<f32>>],
+) -> Result<SourceSpanPointerEvaluation, SourceSpanPointerError> {
+    if subject_states.is_empty() {
+        return Err(SourceSpanPointerError::InvalidStates(
+            "subject encoded to zero content-token states".to_owned(),
+        ));
+    }
+    if !(2..=artifact.maximum_source_spans).contains(&candidate_states.len()) {
+        return Err(SourceSpanPointerError::InvalidStates(format!(
+            "candidate span count must be in 2..={}, observed {}",
+            artifact.maximum_source_spans,
+            candidate_states.len()
+        )));
+    }
+    require_state_shape(artifact, subject_states, "subject")?;
+    for (index, states) in candidate_states.iter().enumerate() {
+        if states.is_empty() {
+            return Err(SourceSpanPointerError::InvalidStates(format!(
+                "candidate {index} encoded to zero content-token states"
+            )));
+        }
+        require_state_shape(artifact, states, "candidate")?;
+    }
+
+    let mut candidate_scores = Vec::with_capacity(candidate_states.len());
+    for states in candidate_states {
+        let mut sum = 0.0_f32;
+        for subject in subject_states {
+            let best = states
+                .iter()
+                .map(|candidate| weighted_cosine(&artifact.state_weights, subject, candidate))
+                .try_fold(f32::NEG_INFINITY, |best, score| {
+                    score.map(|score| best.max(score))
+                })?;
+            sum += best;
+        }
+        candidate_scores.push(sum / subject_states.len() as f32);
+    }
+
+    let mut ranked_candidate_indices = (0..candidate_scores.len()).collect::<Vec<_>>();
+    ranked_candidate_indices.sort_by(|left, right| {
+        candidate_scores[*right]
+            .total_cmp(&candidate_scores[*left])
+            .then_with(|| left.cmp(right))
+    });
+    let first = ranked_candidate_indices[0];
+    let answer_logit = artifact.score_scale * candidate_scores[first] + artifact.answer_bias;
+    let abstain_logit = artifact.abstain_bias;
+    let second = ranked_candidate_indices[1];
+    let conflict_logit = artifact.score_scale * candidate_scores[second] + artifact.conflict_bias;
+
+    // Safety precedence for exact ties: contradiction, then abstention, then
+    // an answer. This cannot turn an ambiguous equality into served text.
+    let mut class_scores = vec![(1_u8, abstain_logit)];
+    class_scores.push((0_u8, conflict_logit));
+    class_scores.push((2_u8, answer_logit));
+    class_scores.sort_by(|left, right| {
+        right
+            .1
+            .total_cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    let decision = match class_scores[0].0 {
+        0 => SourceSpanPointerDecision::Contradiction,
+        1 => SourceSpanPointerDecision::Abstain,
+        2 => SourceSpanPointerDecision::Answer {
+            candidate_index: first,
+        },
+        _ => {
+            return Err(SourceSpanPointerError::InvalidArtifact(
+                "pointer class ranking escaped the fixed three-class set".to_owned(),
+            ))
+        }
+    };
+
+    Ok(SourceSpanPointerEvaluation {
+        scores: SourceSpanPointerScores {
+            candidate_scores,
+            ranked_candidate_indices,
+            answer_logit,
+            abstain_logit,
+            conflict_logit,
+        },
+        decision,
+    })
+}
+
+fn validate_artifact(
+    artifact: &SourceSpanPointerArtifact,
+    expected_model_weights_cid: &str,
+    expected_tokenizer_cid: &str,
+) -> Result<(), SourceSpanPointerError> {
+    let invalid = |reason: &str| SourceSpanPointerError::InvalidArtifact(reason.to_owned());
+    if artifact.schema != POINTER_ARTIFACT_SCHEMA
+        || artifact.policy != POINTER_POLICY
+        || artifact.issue != 954
+    {
+        return Err(invalid("schema, policy, or issue does not match C1-SB1"));
+    }
+    if artifact.model_weights_cid != expected_model_weights_cid
+        || artifact.tokenizer_cid != expected_tokenizer_cid
+    {
+        return Err(invalid(
+            "head is not bound to the loaded #1017 weights/tokenizer",
+        ));
+    }
+    if artifact.hidden_size == 0 || artifact.state_weights.len() != artifact.hidden_size {
+        return Err(invalid("state-weight width does not match hidden_size"));
+    }
+    if artifact
+        .state_weights
+        .iter()
+        .any(|weight| !weight.is_finite() || *weight <= 0.0)
+    {
+        return Err(invalid(
+            "state weights must be finite and strictly positive",
+        ));
+    }
+    if !artifact.score_scale.is_finite() || artifact.score_scale <= 0.0 {
+        return Err(invalid("score_scale must be finite and positive"));
+    }
+    if [
+        artifact.answer_bias,
+        artifact.abstain_bias,
+        artifact.conflict_bias,
+    ]
+    .iter()
+    .any(|value| !value.is_finite())
+    {
+        return Err(invalid("pointer class biases must be finite"));
+    }
+    if artifact.maximum_source_spans != 8
+        || artifact.question_policy != QUESTION_POLICY
+        || artifact.sentence_policy != SENTENCE_POLICY
+    {
+        return Err(invalid(
+            "bounded source/question policy differs from the frozen contract",
+        ));
+    }
+    if artifact.product_probe_commitments.len() != 3
+        || artifact
+            .product_probe_commitments
+            .iter()
+            .any(|cid| !is_blake3_cid(cid))
+    {
+        return Err(invalid(
+            "exactly three valid product commitments are required",
+        ));
+    }
+    for (label, cid) in [
+        ("artifact", artifact.artifact_cid.as_str()),
+        ("model weights", artifact.model_weights_cid.as_str()),
+        ("tokenizer", artifact.tokenizer_cid.as_str()),
+        ("dataset", artifact.dataset_cid.as_str()),
+        ("split policy", artifact.split_policy_cid.as_str()),
+        ("run contract", artifact.run_contract_cid.as_str()),
+        ("training result", artifact.training_result_cid.as_str()),
+    ] {
+        if !is_blake3_cid(cid) {
+            return Err(invalid(&format!("{label} CID is invalid")));
+        }
+    }
+    Ok(())
+}
+
+fn require_state_shape(
+    artifact: &SourceSpanPointerArtifact,
+    states: &[Vec<f32>],
+    label: &str,
+) -> Result<(), SourceSpanPointerError> {
+    for (index, state) in states.iter().enumerate() {
+        if state.len() != artifact.hidden_size || state.iter().any(|value| !value.is_finite()) {
+            return Err(SourceSpanPointerError::InvalidStates(format!(
+                "{label} state {index} is not {} finite lanes",
+                artifact.hidden_size
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn weighted_cosine(
+    weights: &[f32],
+    left: &[f32],
+    right: &[f32],
+) -> Result<f32, SourceSpanPointerError> {
+    let mut dot = 0.0_f32;
+    let mut left_norm = 0.0_f32;
+    let mut right_norm = 0.0_f32;
+    for ((&weight, &left), &right) in weights.iter().zip(left).zip(right) {
+        dot += weight * left * right;
+        left_norm += weight * left * left;
+        right_norm += weight * right * right;
+    }
+    let denominator = left_norm.sqrt() * right_norm.sqrt();
+    if !denominator.is_finite() || denominator <= 0.0 {
+        return Err(SourceSpanPointerError::InvalidStates(
+            "weighted cosine has a nonpositive or nonfinite norm".to_owned(),
+        ));
+    }
+    let score = dot / denominator;
+    if !score.is_finite() {
+        return Err(SourceSpanPointerError::InvalidStates(
+            "weighted cosine is nonfinite".to_owned(),
+        ));
+    }
+    Ok(score.clamp(-1.0, 1.0))
+}
+
+fn verify_embedded_cid(bytes: &[u8], expected: &str) -> Result<(), SourceSpanPointerError> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        SourceSpanPointerError::InvalidArtifact(format!("artifact JSON is not UTF-8: {error}"))
+    })?;
+    let needle = format!("\"artifact_cid\":\"{expected}\"");
+    let start = text.find(&needle).ok_or_else(|| {
+        SourceSpanPointerError::InvalidArtifact(
+            "artifact does not contain its canonical artifact_cid".to_owned(),
+        )
+    })?;
+    if text[start + needle.len()..].contains(&needle) {
+        return Err(SourceSpanPointerError::InvalidArtifact(
+            "artifact contains duplicate artifact_cid values".to_owned(),
+        ));
+    }
+    let end = start + needle.len();
+    let mut unsigned = bytes.to_vec();
+    if start > 0 && unsigned[start - 1] == b',' {
+        unsigned.drain(start - 1..end);
+    } else if unsigned.get(end) == Some(&b',') {
+        unsigned.drain(start..=end);
+    } else {
+        return Err(SourceSpanPointerError::InvalidArtifact(
+            "artifact_cid is not one field of canonical JSON".to_owned(),
+        ));
+    }
+    let observed = format!("blake3:{}", blake3::hash(&unsigned).to_hex());
+    if observed != expected {
+        return Err(SourceSpanPointerError::InvalidArtifact(
+            "artifact_cid does not reproduce".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_blake3_cid(value: &str) -> bool {
+    value.len() == 71
+        && value
+            .strip_prefix("blake3:")
+            .is_some_and(|hex| hex.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -5,7 +5,8 @@ This package contains the bounded offline training paths authorized by issues
 [#1017](https://github.com/UOR-Foundation/uor-r4/issues/1017), plus the frozen,
 preflight-recorded [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
 parameter-capacity campaign, and the bounded [#954](https://github.com/UOR-Foundation/uor-r4/issues/954)
-grounding fine-tune. They train and continue ordinary causal-softmax
+grounding fine-tune plus its frozen source-span-pointer successor. They train
+and continue ordinary causal-softmax
 Llama-family models, export them in the existing Rust loaders' Hugging Face
 format, and freeze evidence before each sealed test is opened. They contain no
 teacher, trace-distillation, comparison-arm, resonance, or routing experiment.
@@ -50,9 +51,10 @@ reveal, generation, and replay remain `NOT_RUN`. A single isolated exact-shape
 MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
 deferred logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
-fast-path negative, not a model result. #1019 closed without a full run; the
-active next step is #954's one bounded grounding fine-tune and Rust product
-check over the working #1017 model. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+fast-path negative, not a model result. #1019 closed without a full run. #954's
+grounding fine-tune and positive-diagonal cosine pointer have also completed as
+bounded negatives. The next #954 mechanism must be frozen independently before
+use; it is not a retry of either revealed run. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
 and MPS are local offline accelerators only; CUDA and external GPU execution
 are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
@@ -68,7 +70,7 @@ internal generation from `3.060506042 s` to `0.116236875 s`. This is ordinary
 Apple CPU BLAS and carries distinct backend provenance; it is not a CUDA path
 or a change to the exact portable runtime contract.
 
-## Bounded #954 grounding fine-tune
+## Historical bounded #954 grounding fine-tune
 
 `finetune-grounding` is the next product-facing step over the completed #1017
 model. It runs one fixed 384-step MPS fine-tune with a fresh AdamW optimizer;
@@ -109,6 +111,31 @@ the same command with `--resume`. Completion exports `issue-954/export` and the
 enabled-only Python prefix fixture; grounded generation remains `NOT_RUN` until
 the Rust product command passes all three reserved prompts.
 
+## C1-SB1 source-span pointer result
+
+`train-source-span-pointer` implemented the frozen
+`R4SourceSpanPointerV1`: each exact subject and punctuation-terminated source
+sentence was encoded independently through the immutable #1017 model, then a
+positive 288-lane diagonal weighted cosine selected a source span while three
+explicit logits selected answer, abstain, or conflict. The two-invocation gate
+first emitted one 12-record overfit head, required a Rust `r4 answer` report,
+and admitted the sole full fit only after Python/Rust score parity.
+
+The preflight passed `12/12`; maximum absolute Rust/Python score and logit
+deltas were `1.234420776e-7` and `1.428717041e-6`, respectively, against the
+frozen `0.01` tolerance. The one 256-step fit then failed its development gate:
+answer classification was `89/128` (`69.53125%`), abstention `114/128`
+(`89.0625%`), conflict `117/128` (`91.40625%`), and supported span selection
+`121/128` (`94.53125%`), all below the required `95%`.
+
+Terminal: `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`. No final pointer
+artifact was emitted, and all three committed product probes remain `NOT_RUN`.
+Do not rerun, tune, or use the preflight head as a product head. The retained
+state-capture and parity seams may support a future independently frozen
+source-relative relation/entailment head that preserves exact copy semantics.
+See the [#954 record](../../docs/r4_grounded_correctness_954.md) and
+[structured C1-SB1 result](../../docs/r4_source_span_pointer_954_raw.json).
+
 ## Isolated environment
 
 Python is frozen to 3.12 and every dependency is exact in `pyproject.toml` and
@@ -130,8 +157,8 @@ instead used its own eight-hour backend-admission gate. MPS stopped
 `UNAVAILABLE_HARDWARE_BUDGET` on time (`20.66 h > 8 h`) while memory passed at
 `21.03%`. That result applies only to the frozen offline implementation. The
 subsequent fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
-signed `3.491307 s/step`), so #1019 closed without a full run. The active next
-step is #954's bounded grounding fine-tune and Rust product check over #1017.
+signed `3.491307 s/step`), so #1019 closed without a full run. #954's grounding
+fine-tune and source-span pointer also closed negative; neither is rerun.
 CUDA and external GPU execution are out of scope.
 
 ## One-way campaign
@@ -241,8 +268,8 @@ Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
 terminal applies only to the frozen offline implementation. Full training,
 final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
 fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-`3.491307 s/step`), so #1019 closed without a full run and #954's bounded
-source-grounding product phase is active over #1017. CUDA and external GPU execution are out of scope. See the
+`3.491307 s/step`), so #1019 closed without a full run. #954's two bounded
+source-grounding mechanisms subsequently closed negative. CUDA and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 
 The Rust qualifier has a separate shape-bound campaign mode. After a #1019
@@ -281,8 +308,8 @@ create-once population, smoke, Rust parity, admission, or MPS probe stages.
 Preserve the passed smoke admission. CUDA and external GPU execution are out of
 scope. The one fused-AdamW/deferred-logging fast-path test was slower than the
 signed baseline, so do not tune or launch the #1019 full run. #1019 is closed;
-do not reopen recurring optimization or broad research gates. Continue the one
-bounded #954 grounding phase over the working #1017 model instead.
+do not reopen recurring optimization or broad research gates. The later #954
+grounding campaigns are recorded separately and are not reasons to reopen #1019.
 
 After a locally admitted full run produces an export, continue with:
 

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -43,8 +43,10 @@ from .paths import (
     default_grounding_predecessor_root,
     default_grounding_root,
     default_research_root,
+    default_source_span_pointer_root,
 )
 from .provenance import verify_bound_manifest
+from .source_span_pointer import train_source_span_pointer
 from .train import TrainConfig, reveal_sealed_test, run_overfit_smoke, train_main
 
 
@@ -66,7 +68,8 @@ def parser() -> argparse.ArgumentParser:
         type=_root,
         help=(
             "untracked data/checkpoint root (defaults to issue-1014, issue-1017, "
-            "or issue-1019 according to the selected lifecycle)"
+            "issue-1019, or issue-954/source-span-pointer according to the selected "
+            "lifecycle)"
         ),
     )
     subcommands = command.add_subparsers(dest="command", required=True)
@@ -229,6 +232,27 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="resume the identical fixed run from checkpoints/latest.pt",
     )
+    pointer = subcommands.add_parser(
+        "train-source-span-pointer",
+        help=(
+            "extract immutable #1017 states, gate the C1-SB1 pointer, and run its "
+            "sole 256-step fit only after Rust score parity"
+        ),
+    )
+    pointer.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
+    pointer.add_argument(
+        "--rust-score-parity",
+        type=_root,
+        help=(
+            "uor-r4.grounded-answer/2 JSON from r4 answer using the emitted "
+            "preflight head/source; required only on the second invocation"
+        ),
+    )
     return command
 
 
@@ -256,6 +280,7 @@ def main() -> None:
         "finalize-capacity",
     }
     grounding_commands = {"finetune-grounding"}
+    pointer_commands = {"train-source-span-pointer"}
     if arguments.root:
         root = arguments.root
     elif arguments.command in capacity_commands:
@@ -264,6 +289,8 @@ def main() -> None:
         root = default_continuation_root()
     elif arguments.command in grounding_commands:
         root = default_grounding_root()
+    elif arguments.command in pointer_commands:
+        root = default_source_span_pointer_root()
     else:
         root = default_research_root()
     if arguments.command == "download":
@@ -378,6 +405,15 @@ def main() -> None:
                 root,
                 predecessor=arguments.predecessor,
                 resume=arguments.resume,
+            )
+        )
+        return
+    if arguments.command == "train-source-span-pointer":
+        _print_result(
+            train_source_span_pointer(
+                root,
+                predecessor=arguments.predecessor,
+                rust_score_parity=arguments.rust_score_parity,
             )
         )
         return

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
@@ -42,3 +42,7 @@ def default_grounding_predecessor_root() -> Path:
 
 def default_grounding_root() -> Path:
     return model_store_root() / "research" / "issue-954"
+
+
+def default_source_span_pointer_root() -> Path:
+    return model_store_root() / "research" / "issue-954" / "source-span-pointer"

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_span_data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_span_data.py
@@ -1,0 +1,274 @@
+"""Frozen construction, development, and sealed product data for C1-SB1."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .grounding_data import (
+    ABSTAIN,
+    CONTRADICTION,
+    build_grounding_corpus,
+)
+from .provenance import canonical_json_bytes, cid_bytes
+
+
+SOURCE_SPAN_DATASET_SCHEMA = "uor-r4.source-span-pointer-dataset/1"
+SOURCE_SPAN_SPLIT_POLICY_SCHEMA = "uor-r4.source-span-pointer-split/1"
+PRODUCT_PROBES_SCHEMA = "uor-r4.source-span-pointer-product-probes/1"
+QUESTION_POLICY = "Where is the <subject>?"
+SENTENCE_POLICY = "exact .!? terminated UTF-8 byte spans"
+MAXIMUM_SOURCE_SPANS = 8
+OUTCOMES = ("answer", "abstain", "conflict")
+
+
+def parse_subject(question: str) -> str:
+    """Parse the sole admitted question shape and reject every other form."""
+    prefix = "Where is the "
+    if not question.startswith(prefix) or not question.endswith("?"):
+        raise ValueError(f"question does not match {QUESTION_POLICY!r}")
+    subject = question[len(prefix) : -1]
+    if (
+        not subject
+        or subject != subject.strip()
+        or "?" in subject
+        or "\n" in subject
+        or "\r" in subject
+    ):
+        raise ValueError(f"question does not match {QUESTION_POLICY!r}")
+    return subject
+
+
+def split_sentence_spans(source: str) -> list[dict[str, Any]]:
+    """Split exact UTF-8 bytes on ASCII ``.``, ``!``, or ``?`` terminators."""
+    if not source:
+        raise ValueError("source is empty")
+    encoded = source.encode("utf-8")
+    spans: list[dict[str, Any]] = []
+    byte_offset = 0
+    byte_start: int | None = None
+    for character in source:
+        width = len(character.encode("utf-8"))
+        if byte_start is None:
+            if character.isspace():
+                byte_offset += width
+                continue
+            byte_start = byte_offset
+        byte_offset += width
+        if character not in ".!?":
+            continue
+        assert byte_start is not None
+        raw = encoded[byte_start:byte_offset]
+        text = raw.decode("utf-8")
+        if not text[:-1].strip():
+            raise ValueError("source contains an empty punctuation-only sentence")
+        spans.append(
+            {
+                "byte_start": byte_start,
+                "byte_end": byte_offset,
+                "text": text,
+            }
+        )
+        if len(spans) > MAXIMUM_SOURCE_SPANS:
+            raise ValueError(f"source exceeds {MAXIMUM_SOURCE_SPANS} sentence spans")
+        byte_start = None
+    if byte_start is not None:
+        raise ValueError("source has a non-whitespace suffix without .!? termination")
+    if not spans:
+        raise ValueError("source has no punctuation-terminated sentence")
+    for span in spans:
+        start = int(span["byte_start"])
+        end = int(span["byte_end"])
+        if encoded[start:end].decode("utf-8") != span["text"]:
+            raise RuntimeError("sentence byte span does not reproduce exact UTF-8")
+    return spans
+
+
+def _target_outcome(category: str) -> str:
+    mapping = {
+        "supported": "answer",
+        "unsupported": "abstain",
+        "contradiction": "conflict",
+    }
+    try:
+        return mapping[category]
+    except KeyError as error:
+        raise ValueError(f"unknown grounding category: {category}") from error
+
+
+def pointer_record(record: dict[str, str]) -> dict[str, Any]:
+    """Convert one existing #954 grounding record into the frozen pointer form."""
+    subject = parse_subject(record["question"])
+    spans = split_sentence_spans(record["source"])
+    outcome = _target_outcome(record["category"])
+    target_span_index: int | None = None
+    if outcome == "answer":
+        matches = [
+            index for index, span in enumerate(spans) if span["text"] == record["answer"]
+        ]
+        if len(matches) != 1:
+            raise ValueError("supported answer must equal exactly one admitted sentence span")
+        target_span_index = matches[0]
+    elif outcome == "abstain":
+        if record["answer"] != ABSTAIN:
+            raise ValueError("unsupported pointer record does not target ABSTAIN")
+        if any(subject in str(span["text"]) for span in spans):
+            raise ValueError("unsupported pointer record contains the queried subject")
+    else:
+        if record["answer"] != CONTRADICTION:
+            raise ValueError("contradiction pointer record does not target CONTRADICTION")
+        if sum(subject in str(span["text"]) for span in spans) < 2:
+            raise ValueError("conflict pointer record needs two subject-bearing spans")
+
+    value: dict[str, Any] = {
+        "source_record_cid": record["record_cid"],
+        "category": record["category"],
+        "target_outcome": outcome,
+        "source": record["source"],
+        "question": record["question"],
+        "subject": subject,
+        "sentence_spans": spans,
+        "target_span_index": target_span_index,
+    }
+    value["record_cid"] = cid_bytes(canonical_json_bytes(value))
+    return value
+
+
+def _probe_record(
+    *,
+    name: str,
+    category: str,
+    source: str,
+    question: str,
+    answer: str,
+) -> dict[str, Any]:
+    source_record = {
+        "record_cid": cid_bytes(
+            canonical_json_bytes(
+                {
+                    "category": category,
+                    "source": source,
+                    "question": question,
+                    "answer": answer,
+                    "population": "C1-SB1-reserved-product",
+                }
+            )
+        ),
+        "category": category,
+        "source": source,
+        "question": question,
+        "answer": answer,
+    }
+    return {"probe": name, **pointer_record(source_record)}
+
+
+def product_probes() -> dict[str, Any]:
+    """Return the three newly reserved records; callers must never fit on them."""
+    supported_source = (
+        "The ivory lantern is beside the river stone. "
+        "The copper compass is beneath the cedar bench."
+    )
+    unsupported_source = (
+        "The porcelain star is within the canvas satchel. "
+        "The willow flute is beyond the marble arch."
+    )
+    conflict_source = (
+        "The copper compass is beneath the cedar bench. "
+        "The copper compass is within the canvas satchel."
+    )
+    records = [
+        _probe_record(
+            name="copper-compass-supported",
+            category="supported",
+            source=supported_source,
+            question="Where is the copper compass?",
+            answer="The copper compass is beneath the cedar bench.",
+        ),
+        _probe_record(
+            name="linen-map-unsupported",
+            category="unsupported",
+            source=unsupported_source,
+            question="Where is the linen map?",
+            answer=ABSTAIN,
+        ),
+        _probe_record(
+            name="copper-compass-conflict",
+            category="contradiction",
+            source=conflict_source,
+            question="Where is the copper compass?",
+            answer=CONTRADICTION,
+        ),
+    ]
+    value: dict[str, Any] = {
+        "schema": PRODUCT_PROBES_SCHEMA,
+        "policy": "three exact records reserved before feature extraction and never evaluated by Python",
+        "records": records,
+    }
+    value["product_probes_cid"] = cid_bytes(canonical_json_bytes(value))
+    return value
+
+
+def source_span_split_policy(source_dataset_cid: str) -> dict[str, Any]:
+    return {
+        "schema": SOURCE_SPAN_SPLIT_POLICY_SCHEMA,
+        "source_grounding_dataset_cid": source_dataset_cid,
+        "selection": (
+            "reuse all 3072 construction and 384 development records from the "
+            "deterministic balanced #954 generator; transform without reordering"
+        ),
+        "question_policy": QUESTION_POLICY,
+        "sentence_policy": SENTENCE_POLICY,
+        "maximum_source_spans": MAXIMUM_SOURCE_SPANS,
+        "product_probe_policy": (
+            "commit three disjoint records in product-probes.json; exclude them from "
+            "feature extraction, preflight, fitting, and development evaluation"
+        ),
+    }
+
+
+def build_source_span_population() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the exact training view and separate sealed product-probe file."""
+    grounding = build_grounding_corpus()
+    construction = [pointer_record(record) for record in grounding["train"]]
+    development = [pointer_record(record) for record in grounding["development"]]
+    probes = product_probes()
+    commitments = [record["record_cid"] for record in probes["records"]]
+
+    if len(construction) != 3_072 or len(development) != 384:
+        raise RuntimeError("source-span population does not preserve the frozen counts")
+    all_records = [*construction, *development]
+    if len({record["record_cid"] for record in all_records}) != len(all_records):
+        raise RuntimeError("source-span construction/development records collide")
+    reserved_terms = (
+        "copper compass",
+        "linen map",
+        "beneath the cedar bench",
+        "within the canvas satchel",
+        "beyond the marble arch",
+        "beside the river stone",
+    )
+    training_text = "\n".join(
+        str(record[field])
+        for record in all_records
+        for field in ("source", "question", "subject")
+    )
+    if any(term in training_text for term in reserved_terms):
+        raise RuntimeError("reserved C1-SB1 product family leaked into training data")
+
+    split_policy = source_span_split_policy(str(grounding["dataset_cid"]))
+    split_policy_cid = cid_bytes(canonical_json_bytes(split_policy))
+    dataset: dict[str, Any] = {
+        "schema": SOURCE_SPAN_DATASET_SCHEMA,
+        "source_grounding_dataset_cid": grounding["dataset_cid"],
+        "split_policy": split_policy,
+        "split_policy_cid": split_policy_cid,
+        "counts": {
+            "construction": len(construction),
+            "development": len(development),
+            "product_probe_commitments": len(commitments),
+        },
+        "product_probe_commitments": commitments,
+        "construction": construction,
+        "development": development,
+    }
+    dataset["dataset_cid"] = cid_bytes(canonical_json_bytes(dataset))
+    return dataset, probes

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_span_pointer.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_span_pointer.py
@@ -1,0 +1,1382 @@
+"""Offline C1-SB1 frozen-state extraction and source-span pointer fitting."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import struct
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import torch
+from blake3 import blake3
+from safetensors.torch import load_file, save_file
+from tokenizers import Tokenizer
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from .constants import BOS_TOKEN_ID, EOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .model import R4SoftmaxForCausalLM
+from .provenance import (
+    atomic_write,
+    atomic_write_json,
+    canonical_json_bytes,
+    cid_bytes,
+    cid_file,
+    trainer_implementation_contract,
+    verify_bound_manifest,
+    verify_manifest_envelope,
+    write_bound_manifest,
+)
+from .source_span_data import (
+    MAXIMUM_SOURCE_SPANS,
+    OUTCOMES,
+    QUESTION_POLICY,
+    SENTENCE_POLICY,
+    build_source_span_population,
+)
+from .train import require_mps
+
+
+ISSUE = 954
+POLICY = "R4SourceSpanPointerV1"
+HEAD_SCHEMA = "uor-r4.source-span-pointer/1"
+DATASET_MANIFEST_SCHEMA = "uor-r4.source-span-pointer-dataset-manifest/1"
+FEATURE_INDEX_SCHEMA = "uor-r4.source-span-pointer-feature-index/1"
+FEATURE_MANIFEST_SCHEMA = "uor-r4.source-span-pointer-feature-manifest/1"
+RUN_SCHEMA = "uor-r4.source-span-pointer-run/1"
+PREFLIGHT_RESULT_SCHEMA = "uor-r4.source-span-pointer-preflight/1"
+PYTHON_SCORE_FIXTURE_SCHEMA = "uor-r4.source-span-pointer-python-score-fixture/1"
+PARITY_ADMISSION_SCHEMA = "uor-r4.source-span-pointer-parity-admission/1"
+TRAINING_RESULT_SCHEMA = "uor-r4.source-span-pointer-training-result/1"
+FINAL_MANIFEST_SCHEMA = "uor-r4.source-span-pointer-final-manifest/1"
+RUST_GROUNDED_REPORT_SCHEMA = "uor-r4.grounded-answer/2"
+EXPECTED_WEIGHTS_CID = (
+    "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d"
+)
+EXPECTED_TOKENIZER_CID = (
+    "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc"
+)
+OUTCOME_TO_ID = {name: index for index, name in enumerate(OUTCOMES)}
+PARITY_MAX_ABSOLUTE_TOLERANCE = 0.01
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSpanPointerConfig:
+    """The sole no-sweep C1-SB1 optimization and work contract."""
+
+    seed: int = 9_541
+    feature_batch_size: int = 128
+    preflight_records_per_class: int = 4
+    preflight_optimizer_steps: int = 256
+    optimizer_steps: int = 256
+    batch_size: int = 128
+    learning_rate: float = 0.025
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    adam_epsilon: float = 1e-8
+    progress_interval: int = 16
+    required_per_class_accuracy: float = 0.95
+    required_pointer_accuracy: float = 0.95
+
+    def validate(self) -> None:
+        if self != SourceSpanPointerConfig():
+            raise ValueError("C1-SB1 exposes one frozen pointer fit, not a sweep")
+        if self.batch_size != 128 or self.optimizer_steps != 256 or self.seed != 9_541:
+            raise AssertionError("C1-SB1 optimizer contract drifted")
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PointerBatch:
+    subject_states: Tensor
+    subject_mask: Tensor
+    candidate_states: Tensor
+    candidate_token_mask: Tensor
+    candidate_mask: Tensor
+    outcomes: Tensor
+    target_spans: Tensor
+
+
+@dataclass(slots=True)
+class PointerOutput:
+    candidate_scores: Tensor
+    outcome_logits: Tensor
+    top_candidate_indices: Tensor
+
+
+class R4SourceSpanPointer(nn.Module):
+    """Positive diagonal weighted cosine plus explicit three-way logits."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        width = FROZEN_MODEL_CONFIG.hidden_size
+        inverse_softplus_one = math.log(math.expm1(1.0))
+        inverse_softplus_ten = math.log(math.expm1(10.0))
+        self.raw_state_weights = nn.Parameter(
+            torch.full((width,), inverse_softplus_one, dtype=torch.float32)
+        )
+        self.raw_score_scale = nn.Parameter(
+            torch.tensor(inverse_softplus_ten, dtype=torch.float32)
+        )
+        self.class_biases = nn.Parameter(torch.zeros(len(OUTCOMES), dtype=torch.float32))
+
+    def state_weights(self) -> Tensor:
+        return F.softplus(self.raw_state_weights)
+
+    def score_scale(self) -> Tensor:
+        return F.softplus(self.raw_score_scale)
+
+    def forward(self, batch: PointerBatch) -> PointerOutput:
+        weights = self.state_weights()
+        square_root_weights = torch.sqrt(weights)
+        subject = batch.subject_states.float() * square_root_weights
+        candidates = batch.candidate_states.float() * square_root_weights
+        numerators = torch.einsum("bsh,bcth->bcst", subject, candidates)
+        subject_norms = torch.linalg.vector_norm(subject, dim=-1)
+        candidate_norms = torch.linalg.vector_norm(candidates, dim=-1)
+        # Padded rows are exactly zero. Give only those masked rows a neutral
+        # denominator before division; their scores are removed below. Dividing
+        # first and masking later would create NaNs in the autograd graph.
+        subject_norms = subject_norms.masked_fill(~batch.subject_mask, 1.0)
+        candidate_norms = candidate_norms.masked_fill(~batch.candidate_token_mask, 1.0)
+        denominators = subject_norms[:, None, :, None] * candidate_norms[:, :, None, :]
+        cosine = numerators / denominators
+        cosine = cosine.clamp(-1.0, 1.0)
+        cosine = cosine.masked_fill(
+            ~batch.candidate_token_mask[:, :, None, :], float("-inf")
+        )
+        subject_best = cosine.max(dim=-1).values
+        subject_best = subject_best.masked_fill(~batch.subject_mask[:, None, :], 0.0)
+        subject_counts = batch.subject_mask.sum(dim=-1).clamp_min(1).float()
+        candidate_scores = subject_best.sum(dim=-1) / subject_counts[:, None]
+        candidate_scores = candidate_scores.masked_fill(~batch.candidate_mask, float("-inf"))
+
+        ordered_scores = torch.sort(candidate_scores, dim=-1, descending=True).values
+        top_candidate_indices = candidate_scores.argmax(dim=-1)
+        if ordered_scores.shape[1] < 2:
+            second = torch.full_like(ordered_scores[:, 0], float("-inf"))
+        else:
+            second = ordered_scores[:, 1]
+        scale = self.score_scale()
+        outcome_logits = torch.stack(
+            (
+                scale * ordered_scores[:, 0] + self.class_biases[0],
+                self.class_biases[1].expand_as(ordered_scores[:, 0]),
+                scale * second + self.class_biases[2],
+            ),
+            dim=-1,
+        )
+        return PointerOutput(
+            candidate_scores=candidate_scores,
+            outcome_logits=outcome_logits,
+            top_candidate_indices=top_candidate_indices,
+        )
+
+
+def pointer_loss(output: PointerOutput, batch: PointerBatch) -> Tensor:
+    outcome = F.cross_entropy(output.outcome_logits, batch.outcomes)
+    supported = batch.outcomes == OUTCOME_TO_ID["answer"]
+    safe_targets = batch.target_spans.clamp_min(0)
+    pointer_per_record = -F.log_softmax(output.candidate_scores, dim=-1).gather(
+        dim=-1, index=safe_targets[:, None]
+    )[:, 0]
+    supported_float = supported.to(dtype=pointer_per_record.dtype)
+    pointer = (pointer_per_record * supported_float).sum() / supported_float.sum().clamp_min(1.0)
+    return outcome + pointer
+
+
+def safety_decisions(logits: Tensor) -> Tensor:
+    """Apply the frozen conflict, abstain, answer tie order."""
+    answer = logits[:, OUTCOME_TO_ID["answer"]]
+    abstain = logits[:, OUTCOME_TO_ID["abstain"]]
+    conflict = logits[:, OUTCOME_TO_ID["conflict"]]
+    decisions = torch.full_like(answer, OUTCOME_TO_ID["answer"], dtype=torch.long)
+    abstain_wins = (abstain >= answer) & (abstain >= conflict)
+    decisions[abstain_wins] = OUTCOME_TO_ID["abstain"]
+    conflict_wins = (conflict >= answer) & (conflict >= abstain)
+    decisions[conflict_wins] = OUTCOME_TO_ID["conflict"]
+    return decisions
+
+
+def _text_cid(text: str) -> str:
+    return cid_bytes(text.encode("utf-8"))
+
+
+def _canonical_with_cid(value: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _write_or_verify_json(path: Path, value: dict[str, Any]) -> None:
+    encoded = canonical_json_bytes(value)
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ValueError(f"existing C1-SB1 artifact differs: {path}")
+        return
+    atomic_write(path, encoded)
+
+
+def _validated_predecessor(predecessor: Path) -> dict[str, Any]:
+    manifest = verify_bound_manifest(
+        predecessor / "export-manifest.json", artifact_root=predecessor
+    )
+    if manifest.get("model_contract") != FROZEN_MODEL_CONFIG.as_contract():
+        raise ValueError("source-span predecessor is not the immutable six-layer #1017 model")
+    if manifest.get("weights_cid") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("source-span predecessor weights are not the frozen #1017 weights")
+    if manifest.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("source-span predecessor tokenizer is not the frozen #1017 tokenizer")
+    if cid_file(predecessor / "model.safetensors") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("#1017 model file CID does not reproduce")
+    if cid_file(predecessor / "tokenizer.json") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("#1017 tokenizer file CID does not reproduce")
+    return manifest
+
+
+def _training_texts(dataset: dict[str, Any]) -> list[str]:
+    texts: dict[str, str] = {}
+    for record in [*dataset["construction"], *dataset["development"]]:
+        values = [record["subject"]]
+        values.extend(span["text"] for span in record["sentence_spans"])
+        for text in values:
+            text = str(text)
+            text_cid = _text_cid(text)
+            prior = texts.setdefault(text_cid, text)
+            if prior != text:
+                raise RuntimeError("BLAKE3 collision in source-span text inventory")
+    return [texts[text_cid] for text_cid in sorted(texts)]
+
+
+def _progress(
+    phase: str,
+    *,
+    completed: int,
+    total: int,
+    started: float,
+    loss: float | None = None,
+) -> None:
+    elapsed = max(0.0, time.monotonic() - started)
+    rate = elapsed / completed if completed else 0.0
+    remaining = max(0, total - completed)
+    eta = rate * remaining
+    suffix = "" if loss is None else f" loss={loss:.6f}"
+    print(
+        f"pointer_phase={phase} completed={completed}/{total}{suffix} "
+        f"elapsed_seconds={elapsed:.1f} eta_seconds={eta:.1f}",
+        flush=True,
+    )
+
+
+@torch.no_grad()
+def _extract_features(
+    root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: dict[str, Any],
+    dataset: dict[str, Any],
+    dataset_manifest: dict[str, Any],
+    config: SourceSpanPointerConfig,
+) -> dict[str, Any]:
+    feature_manifest_path = root / "features/feature-manifest.json"
+    if feature_manifest_path.exists():
+        return verify_bound_manifest(feature_manifest_path, artifact_root=root / "features")
+
+    device = require_mps(config.seed)
+    tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+    texts = _training_texts(dataset)
+    encoded: list[list[int]] = []
+    for text in texts:
+        token_ids = tokenizer.encode(text, add_special_tokens=False).ids
+        if not token_ids:
+            raise ValueError("pointer content text encoded to zero tokens")
+        if len(token_ids) + 1 > FROZEN_MODEL_CONFIG.max_position_embeddings:
+            raise ValueError("pointer content text exceeds the frozen #1017 context")
+        encoded.append(token_ids)
+    maximum_tokens = max(map(len, encoded))
+    states = torch.zeros(
+        (len(texts), maximum_tokens, FROZEN_MODEL_CONFIG.hidden_size),
+        dtype=torch.float32,
+    )
+    lengths = torch.tensor([len(token_ids) for token_ids in encoded], dtype=torch.int64)
+
+    model = R4SoftmaxForCausalLM()
+    model.load_state_dict(
+        load_file(str(predecessor / "model.safetensors"), device="cpu"), strict=True
+    )
+    model.requires_grad_(False)
+    model.eval()
+    model = model.to(device)
+    started = time.monotonic()
+    batches = math.ceil(len(texts) / config.feature_batch_size)
+    for batch_index, base in enumerate(
+        range(0, len(texts), config.feature_batch_size), start=1
+    ):
+        batch_token_ids = encoded[base : base + config.feature_batch_size]
+        width = 1 + max(map(len, batch_token_ids))
+        inputs = torch.full(
+            (len(batch_token_ids), width),
+            EOS_TOKEN_ID,
+            dtype=torch.long,
+            device=device,
+        )
+        for lane, token_ids in enumerate(batch_token_ids):
+            inputs[lane, 0] = BOS_TOKEN_ID
+            inputs[lane, 1 : 1 + len(token_ids)] = torch.tensor(
+                token_ids, dtype=torch.long, device=device
+            )
+        hidden = model.model(inputs).float().cpu()
+        for lane, token_ids in enumerate(batch_token_ids):
+            content = hidden[lane, 1 : 1 + len(token_ids)]
+            if content.shape != (len(token_ids), FROZEN_MODEL_CONFIG.hidden_size):
+                raise RuntimeError("#1017 content-state extraction shape differs")
+            if not bool(torch.isfinite(content).all()):
+                raise RuntimeError("#1017 content-state extraction produced nonfinite values")
+            if not bool((torch.linalg.vector_norm(content, dim=-1) > 0).all()):
+                raise RuntimeError("#1017 content-state extraction produced a zero state")
+            states[base + lane, : len(token_ids)] = content
+        _progress(
+            "feature-extraction",
+            completed=batch_index,
+            total=batches,
+            started=started,
+        )
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    del model
+    if hasattr(torch, "mps"):
+        torch.mps.empty_cache()
+
+    entries = [
+        {
+            "row": row,
+            "text_cid": _text_cid(text),
+            "token_ids": encoded[row],
+            "token_count": len(encoded[row]),
+        }
+        for row, text in enumerate(texts)
+    ]
+    index = {
+        "schema": FEATURE_INDEX_SCHEMA,
+        "model_weights_cid": EXPECTED_WEIGHTS_CID,
+        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "state_definition": (
+            "every non-BOS content token's final RMS-normalized residual after all six "
+            "immutable #1017 R4/Spin causal-softmax layers; each text encoded independently"
+        ),
+        "hidden_size": FROZEN_MODEL_CONFIG.hidden_size,
+        "maximum_tokens": maximum_tokens,
+        "entries": entries,
+    }
+    feature_root = root / "features"
+    feature_root.mkdir(parents=True, exist_ok=True)
+    index_path = feature_root / "feature-index.json"
+    atomic_write_json(index_path, index)
+    state_path = feature_root / "states.safetensors"
+    temporary = feature_root / ".states.safetensors.part"
+    save_file(
+        {"states": states.contiguous(), "lengths": lengths.contiguous()},
+        str(temporary),
+        metadata={
+            "schema": FEATURE_INDEX_SCHEMA,
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        },
+    )
+    os.replace(temporary, state_path)
+    return write_bound_manifest(
+        feature_manifest_path,
+        {
+            "schema": FEATURE_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "text_count": len(texts),
+            "maximum_tokens": maximum_tokens,
+        },
+        artifact_root=feature_root,
+        relative_paths=["feature-index.json", "states.safetensors"],
+    )
+
+
+class FrozenFeatureStore:
+    """Read-only final-state table keyed by exact UTF-8 text CID."""
+
+    def __init__(self, root: Path) -> None:
+        verify_bound_manifest(root / "feature-manifest.json", artifact_root=root)
+        index = json.loads((root / "feature-index.json").read_text(encoding="utf-8"))
+        if index.get("schema") != FEATURE_INDEX_SCHEMA:
+            raise ValueError("source-span feature index schema differs")
+        tensors = load_file(str(root / "states.safetensors"), device="cpu")
+        self.states = tensors["states"].float().contiguous()
+        self.lengths = tensors["lengths"].to(dtype=torch.long).contiguous()
+        self.rows: dict[str, int] = {}
+        for entry in index["entries"]:
+            row = int(entry["row"])
+            text_cid = str(entry["text_cid"])
+            if text_cid in self.rows:
+                raise ValueError("duplicate source-span feature text CID")
+            if int(entry["token_count"]) != int(self.lengths[row]):
+                raise ValueError("source-span feature length/index mismatch")
+            content = self.states[row, : int(self.lengths[row])]
+            if not bool(torch.isfinite(content).all()) or not bool(
+                (torch.linalg.vector_norm(content, dim=-1) > 0).all()
+            ):
+                raise ValueError("source-span feature content states are invalid")
+            self.rows[text_cid] = row
+        if self.states.ndim != 3 or self.states.shape[2] != FROZEN_MODEL_CONFIG.hidden_size:
+            raise ValueError("source-span state tensor shape differs")
+        if self.states.shape[0] != len(self.rows) or self.lengths.shape != (
+            self.states.shape[0],
+        ):
+            raise ValueError("source-span feature inventory shape differs")
+
+    def get(self, text: str) -> Tensor:
+        try:
+            row = self.rows[_text_cid(text)]
+        except KeyError as error:
+            raise KeyError("text is absent from frozen source-span feature store") from error
+        length = int(self.lengths[row])
+        return self.states[row, :length]
+
+
+class PointerDataset:
+    """Records plus immutable base states, assembled into bounded padded batches."""
+
+    def __init__(self, records: Sequence[dict[str, Any]], features: FrozenFeatureStore) -> None:
+        self.records = list(records)
+        if not self.records:
+            raise ValueError("source-span pointer dataset is empty")
+        self.features = features
+        self.class_indices: dict[str, list[int]] = {name: [] for name in OUTCOMES}
+        for index, record in enumerate(self.records):
+            outcome = str(record["target_outcome"])
+            if outcome not in self.class_indices:
+                raise ValueError(f"unknown pointer outcome: {outcome}")
+            self.class_indices[outcome].append(index)
+        if any(not indices for indices in self.class_indices.values()):
+            raise ValueError("pointer dataset is not three-way populated")
+
+    def preflight_indices(self, per_class: int) -> list[int]:
+        selected: list[int] = []
+        for outcome in OUTCOMES:
+            ordered = sorted(
+                self.class_indices[outcome],
+                key=lambda index: str(self.records[index]["record_cid"]),
+            )
+            if len(ordered) < per_class:
+                raise ValueError("pointer dataset cannot populate balanced preflight")
+            selected.extend(ordered[:per_class])
+        return selected
+
+    def deterministic_indices(self, *, seed: int, step: int, batch_size: int) -> list[int]:
+        selected: list[int] = []
+        for lane in range(batch_size):
+            outcome = OUTCOMES[lane % len(OUTCOMES)]
+            population = self.class_indices[outcome]
+            material = struct.pack(">QQQ", seed, step, lane)
+            offset = int.from_bytes(blake3(material).digest(), "big") % len(population)
+            selected.append(population[offset])
+        return selected
+
+    def batch(self, indices: Sequence[int], *, device: torch.device) -> PointerBatch:
+        selected = [self.records[index] for index in indices]
+        subject_states = [self.features.get(str(record["subject"])) for record in selected]
+        candidate_states = [
+            [self.features.get(str(span["text"])) for span in record["sentence_spans"]]
+            for record in selected
+        ]
+        maximum_subject_tokens = max(state.shape[0] for state in subject_states)
+        maximum_candidates = max(len(states) for states in candidate_states)
+        maximum_candidate_tokens = max(
+            state.shape[0] for states in candidate_states for state in states
+        )
+        batch_size = len(selected)
+        hidden = FROZEN_MODEL_CONFIG.hidden_size
+        subjects = torch.zeros(
+            (batch_size, maximum_subject_tokens, hidden), dtype=torch.float32
+        )
+        subject_mask = torch.zeros(
+            (batch_size, maximum_subject_tokens), dtype=torch.bool
+        )
+        candidates = torch.zeros(
+            (batch_size, maximum_candidates, maximum_candidate_tokens, hidden),
+            dtype=torch.float32,
+        )
+        candidate_token_mask = torch.zeros(
+            (batch_size, maximum_candidates, maximum_candidate_tokens), dtype=torch.bool
+        )
+        candidate_mask = torch.zeros(
+            (batch_size, maximum_candidates), dtype=torch.bool
+        )
+        outcomes = torch.empty(batch_size, dtype=torch.long)
+        target_spans = torch.full((batch_size,), -1, dtype=torch.long)
+        for lane, record in enumerate(selected):
+            subject = subject_states[lane]
+            subjects[lane, : subject.shape[0]] = subject
+            subject_mask[lane, : subject.shape[0]] = True
+            for candidate_index, state in enumerate(candidate_states[lane]):
+                candidates[lane, candidate_index, : state.shape[0]] = state
+                candidate_token_mask[lane, candidate_index, : state.shape[0]] = True
+                candidate_mask[lane, candidate_index] = True
+            outcome = str(record["target_outcome"])
+            outcomes[lane] = OUTCOME_TO_ID[outcome]
+            if outcome == "answer":
+                target = record["target_span_index"]
+                if not isinstance(target, int) or not 0 <= target < len(candidate_states[lane]):
+                    raise ValueError("supported pointer target is outside candidate spans")
+                target_spans[lane] = target
+        return PointerBatch(
+            subject_states=subjects.to(device),
+            subject_mask=subject_mask.to(device),
+            candidate_states=candidates.to(device),
+            candidate_token_mask=candidate_token_mask.to(device),
+            candidate_mask=candidate_mask.to(device),
+            outcomes=outcomes.to(device),
+            target_spans=target_spans.to(device),
+        )
+
+
+@torch.no_grad()
+def evaluate_pointer(
+    model: R4SourceSpanPointer,
+    dataset: PointerDataset,
+    *,
+    device: torch.device,
+    batch_size: int,
+    indices: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    model.eval()
+    selected = list(range(len(dataset.records))) if indices is None else list(indices)
+    outcome_correct = {name: 0 for name in OUTCOMES}
+    outcome_total = {name: 0 for name in OUTCOMES}
+    pointer_correct = 0
+    pointer_total = 0
+    loss_sum = 0.0
+    examples = 0
+    for base in range(0, len(selected), batch_size):
+        batch_indices = selected[base : base + batch_size]
+        batch = dataset.batch(batch_indices, device=device)
+        output = model(batch)
+        loss = pointer_loss(output, batch)
+        predictions = safety_decisions(output.outcome_logits)
+        loss_sum += float(loss.detach().cpu()) * len(batch_indices)
+        examples += len(batch_indices)
+        predicted_outcomes = predictions.detach().cpu().tolist()
+        predicted_spans = output.top_candidate_indices.detach().cpu().tolist()
+        for lane, record_index in enumerate(batch_indices):
+            record = dataset.records[record_index]
+            outcome = str(record["target_outcome"])
+            expected = OUTCOME_TO_ID[outcome]
+            outcome_total[outcome] += 1
+            outcome_correct[outcome] += int(int(predicted_outcomes[lane]) == expected)
+            if outcome == "answer":
+                pointer_total += 1
+                pointer_correct += int(
+                    int(predicted_spans[lane]) == int(record["target_span_index"])
+                )
+    if not examples or not pointer_total:
+        raise RuntimeError("pointer evaluation population is incomplete")
+    per_class = {
+        outcome: {
+            "correct": outcome_correct[outcome],
+            "total": outcome_total[outcome],
+            "accuracy": outcome_correct[outcome] / outcome_total[outcome],
+        }
+        for outcome in OUTCOMES
+    }
+    return {
+        "mean_combined_loss": loss_sum / examples,
+        "outcome": per_class,
+        "supported_span_pointer": {
+            "correct": pointer_correct,
+            "total": pointer_total,
+            "accuracy": pointer_correct / pointer_total,
+        },
+    }
+
+
+def _development_gate(metrics: dict[str, Any], config: SourceSpanPointerConfig) -> bool:
+    return all(
+        float(metrics["outcome"][outcome]["accuracy"])
+        >= config.required_per_class_accuracy
+        for outcome in OUTCOMES
+    ) and (
+        float(metrics["supported_span_pointer"]["accuracy"])
+        >= config.required_pointer_accuracy
+    )
+
+
+def _fit_head(
+    model: R4SourceSpanPointer,
+    dataset: PointerDataset,
+    *,
+    device: torch.device,
+    steps: int,
+    batch_size: int,
+    config: SourceSpanPointerConfig,
+    phase: str,
+    fixed_indices: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    model.train()
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.learning_rate,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_epsilon,
+        weight_decay=0.0,
+    )
+    started = time.monotonic()
+    initial_loss: float | None = None
+    final_loss = math.nan
+    for step in range(1, steps + 1):
+        indices = (
+            list(fixed_indices)
+            if fixed_indices is not None
+            else dataset.deterministic_indices(
+                seed=config.seed, step=step, batch_size=batch_size
+            )
+        )
+        batch = dataset.batch(indices, device=device)
+        optimizer.zero_grad(set_to_none=True)
+        output = model(batch)
+        loss = pointer_loss(output, batch)
+        loss.backward()
+        optimizer.step()
+        report_step = initial_loss is None or step % config.progress_interval == 0 or step == steps
+        if report_step:
+            final_loss = float(loss.detach().cpu())
+            if not math.isfinite(final_loss):
+                raise RuntimeError("source-span pointer fit produced a nonfinite loss")
+            if initial_loss is None:
+                initial_loss = final_loss
+        if step % config.progress_interval == 0 or step == steps:
+            _progress(
+                phase,
+                completed=step,
+                total=steps,
+                started=started,
+                loss=final_loss,
+            )
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    return {
+        "optimizer_steps": steps,
+        "batch_size": batch_size,
+        "initial_combined_loss": initial_loss,
+        "final_combined_loss": final_loss,
+        "elapsed_seconds": time.monotonic() - started,
+    }
+
+
+def _finite_f32(value: Tensor, label: str, *, positive: bool = False) -> float:
+    scalar = float(value.detach().to(device="cpu", dtype=torch.float32).item())
+    if not math.isfinite(scalar) or (positive and scalar <= 0.0):
+        raise RuntimeError(f"pointer {label} is outside its finite contract")
+    return scalar
+
+
+def _head_payload(
+    model: R4SourceSpanPointer,
+    *,
+    dataset: dict[str, Any],
+    run_contract_cid: str,
+    training_result_cid: str,
+    preflight: dict[str, Any],
+    development_metrics: dict[str, Any],
+) -> dict[str, Any]:
+    weights_tensor = model.state_weights().detach().to(device="cpu", dtype=torch.float32)
+    weights = [float(value) for value in weights_tensor.tolist()]
+    if len(weights) != FROZEN_MODEL_CONFIG.hidden_size or any(
+        not math.isfinite(value) or value <= 0.0 for value in weights
+    ):
+        raise RuntimeError("pointer state weights violate the positive 288-lane contract")
+    biases = model.class_biases.detach().to(device="cpu", dtype=torch.float32)
+    value: dict[str, Any] = {
+        "schema": HEAD_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "model_weights_cid": EXPECTED_WEIGHTS_CID,
+        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "hidden_size": FROZEN_MODEL_CONFIG.hidden_size,
+        "state_weights": weights,
+        "score_scale": _finite_f32(model.score_scale(), "score scale", positive=True),
+        "answer_bias": _finite_f32(biases[0], "answer bias"),
+        "abstain_bias": _finite_f32(biases[1], "abstain bias"),
+        "conflict_bias": _finite_f32(biases[2], "conflict bias"),
+        "maximum_source_spans": MAXIMUM_SOURCE_SPANS,
+        "question_policy": QUESTION_POLICY,
+        "sentence_policy": SENTENCE_POLICY,
+        "dataset_cid": dataset["dataset_cid"],
+        "split_policy_cid": dataset["split_policy_cid"],
+        "run_contract_cid": run_contract_cid,
+        "training_result_cid": training_result_cid,
+        "preflight": preflight,
+        "development_metrics": development_metrics,
+        "product_probe_commitments": dataset["product_probe_commitments"],
+    }
+    return _canonical_with_cid(value, "artifact_cid")
+
+
+@torch.no_grad()
+def _score_record(
+    model: R4SourceSpanPointer,
+    dataset: PointerDataset,
+    *,
+    record_index: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    model.eval()
+    record = dataset.records[record_index]
+    batch = dataset.batch([record_index], device=device)
+    output = model(batch)
+    candidate_count = len(record["sentence_spans"])
+    scores = output.candidate_scores[0, :candidate_count].detach().cpu().float()
+    logits = output.outcome_logits[0].detach().cpu().float()
+    if not bool(torch.isfinite(scores).all()) or not bool(torch.isfinite(logits).all()):
+        raise RuntimeError("pointer score fixture produced nonfinite values")
+    decision_id = int(safety_decisions(logits[None, :])[0])
+    decision = OUTCOMES[decision_id]
+    top_candidate = int(output.top_candidate_indices[0].detach().cpu())
+    selected_span_index = top_candidate if decision == "answer" else None
+    return {
+        "candidate_scores": [float(value) for value in scores.tolist()],
+        "logits": {
+            "answer": float(logits[OUTCOME_TO_ID["answer"]]),
+            "abstain": float(logits[OUTCOME_TO_ID["abstain"]]),
+            "conflict": float(logits[OUTCOME_TO_ID["conflict"]]),
+        },
+        "decision": decision,
+        "selected_span_index": selected_span_index,
+    }
+
+
+def _run_preflight(
+    root: Path,
+    *,
+    dataset_value: dict[str, Any],
+    dataset_manifest: dict[str, Any],
+    feature_manifest: dict[str, Any],
+    run_contract: dict[str, Any],
+    config: SourceSpanPointerConfig,
+) -> dict[str, Any]:
+    device = require_mps(config.seed)
+    features = FrozenFeatureStore(root / "features")
+    construction = PointerDataset(dataset_value["construction"], features)
+    selected = construction.preflight_indices(config.preflight_records_per_class)
+    torch.manual_seed(config.seed)
+    if hasattr(torch.mps, "manual_seed"):
+        torch.mps.manual_seed(config.seed)
+    model = R4SourceSpanPointer().to(device)
+    fit = _fit_head(
+        model,
+        construction,
+        device=device,
+        steps=config.preflight_optimizer_steps,
+        batch_size=len(selected),
+        config=config,
+        phase="12-record-overfit",
+        fixed_indices=selected,
+    )
+    metrics = evaluate_pointer(
+        model,
+        construction,
+        device=device,
+        batch_size=len(selected),
+        indices=selected,
+    )
+    passed = all(
+        metrics["outcome"][outcome]["correct"]
+        == metrics["outcome"][outcome]["total"]
+        for outcome in OUTCOMES
+    ) and (
+        metrics["supported_span_pointer"]["correct"]
+        == metrics["supported_span_pointer"]["total"]
+    )
+    deterministic_fit = {key: value for key, value in fit.items() if key != "elapsed_seconds"}
+    preflight_result = _canonical_with_cid(
+        {
+            "schema": PREFLIGHT_RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": (
+                "PASS_12_RECORD_BALANCED_OVERFIT_AWAIT_RUST_SCORE_PARITY"
+                if passed
+                else "FAIL_12_RECORD_BALANCED_OVERFIT_STOP"
+            ),
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset_value["dataset_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "record_cids": [construction.records[index]["record_cid"] for index in selected],
+            "optimization": deterministic_fit,
+            "metrics": metrics,
+            "passed": passed,
+        },
+        "result_cid",
+    )
+    preflight_root = root / "preflight"
+    preflight_root.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(preflight_root / "preflight-result.json", preflight_result)
+    if not passed:
+        write_bound_manifest(
+            preflight_root / "preflight-manifest.json",
+            {
+                "schema": PREFLIGHT_RESULT_SCHEMA,
+                "terminal": preflight_result["terminal"],
+                "run_contract_cid": run_contract["run_contract_cid"],
+                "preflight_result_cid": preflight_result["result_cid"],
+            },
+            artifact_root=root,
+            relative_paths=[
+                "source-span-dataset.json",
+                "product-probes.json",
+                "source-span-dataset-manifest.json",
+                "source-span-run-contract.json",
+                "features/feature-index.json",
+                "features/states.safetensors",
+                "features/feature-manifest.json",
+                "preflight/preflight-result.json",
+            ],
+        )
+        return {
+            "terminal": preflight_result["terminal"],
+            "preflight_result_cid": preflight_result["result_cid"],
+        }
+
+    embedded_preflight = {
+        "status": "PASS_12_RECORD_BALANCED_OVERFIT",
+        "record_cids": preflight_result["record_cids"],
+        "optimizer_steps": config.preflight_optimizer_steps,
+        "metrics": metrics,
+        "preflight_result_cid": preflight_result["result_cid"],
+        "rust_score_parity": "AWAITING",
+    }
+    preflight_head = _head_payload(
+        model,
+        dataset=dataset_value,
+        run_contract_cid=run_contract["run_contract_cid"],
+        training_result_cid=preflight_result["result_cid"],
+        preflight=embedded_preflight,
+        development_metrics={"status": "NOT_RUN_BEFORE_SOLE_256_STEP_FIT"},
+    )
+    atomic_write_json(preflight_root / "preflight-head.json", preflight_head)
+
+    parity_index = next(
+        index
+        for index in selected
+        if construction.records[index]["target_outcome"] == "answer"
+    )
+    parity_record = construction.records[parity_index]
+    parity_source = str(parity_record["source"])
+    parity_source_path = preflight_root / "parity-source.txt"
+    atomic_write(parity_source_path, parity_source.encode("utf-8"))
+    evaluation = _score_record(
+        model,
+        construction,
+        record_index=parity_index,
+        device=device,
+    )
+    if (
+        evaluation["decision"] != "answer"
+        or evaluation["selected_span_index"] != parity_record["target_span_index"]
+    ):
+        raise RuntimeError("passing pointer preflight did not yield an answer parity record")
+    fixture = _canonical_with_cid(
+        {
+            "schema": PYTHON_SCORE_FIXTURE_SCHEMA,
+            "preflight_artifact_cid": preflight_head["artifact_cid"],
+            "source_cid": cid_bytes(parity_source.encode("utf-8")),
+            "source_path": "preflight/parity-source.txt",
+            "question": parity_record["question"],
+            "record_cid": parity_record["record_cid"],
+            **evaluation,
+            "maximum_absolute_tolerance": PARITY_MAX_ABSOLUTE_TOLERANCE,
+        },
+        "fixture_cid",
+    )
+    atomic_write_json(preflight_root / "python-score-fixture.json", fixture)
+    preflight_manifest = write_bound_manifest(
+        preflight_root / "preflight-manifest.json",
+        {
+            "schema": PREFLIGHT_RESULT_SCHEMA,
+            "terminal": "AWAITING_RUST_SCORE_PARITY",
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "preflight_result_cid": preflight_result["result_cid"],
+            "preflight_artifact_cid": preflight_head["artifact_cid"],
+            "python_score_fixture_cid": fixture["fixture_cid"],
+        },
+        artifact_root=root,
+        relative_paths=[
+            "source-span-dataset.json",
+            "product-probes.json",
+            "source-span-dataset-manifest.json",
+            "source-span-run-contract.json",
+            "features/feature-index.json",
+            "features/states.safetensors",
+            "features/feature-manifest.json",
+            "preflight/preflight-result.json",
+            "preflight/preflight-head.json",
+            "preflight/parity-source.txt",
+            "preflight/python-score-fixture.json",
+        ],
+    )
+    return {
+        "terminal": "AWAITING_RUST_SCORE_PARITY",
+        "preflight_artifact": str(preflight_root / "preflight-head.json"),
+        "preflight_artifact_cid": preflight_head["artifact_cid"],
+        "parity_source": str(parity_source_path),
+        "question": parity_record["question"],
+        "python_score_fixture": str(preflight_root / "python-score-fixture.json"),
+        "python_score_fixture_cid": fixture["fixture_cid"],
+        "preflight_manifest_cid": preflight_manifest["manifest_cid"],
+    }
+
+
+def _numeric_list(value: Any, label: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"Rust parity {label} must be a nonempty list")
+    values = [float(item) for item in value]
+    if any(not math.isfinite(item) for item in values):
+        raise ValueError(f"Rust parity {label} contains a nonfinite value")
+    return values
+
+
+def _numeric_logits(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict) or set(value) != set(OUTCOMES):
+        raise ValueError("Rust parity logits must contain answer, abstain, and conflict")
+    logits = {name: float(value[name]) for name in OUTCOMES}
+    if any(not math.isfinite(item) for item in logits.values()):
+        raise ValueError("Rust parity logits contain a nonfinite value")
+    return logits
+
+
+def _admit_rust_score_parity(root: Path, report_path: Path) -> dict[str, Any]:
+    fixture = json.loads(
+        (root / "preflight/python-score-fixture.json").read_text(encoding="utf-8")
+    )
+    preflight_head = json.loads(
+        (root / "preflight/preflight-head.json").read_text(encoding="utf-8")
+    )
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if report.get("schema") != RUST_GROUNDED_REPORT_SCHEMA:
+        raise ValueError("Rust parity report is not uor-r4.grounded-answer/2")
+    pointer = report.get("pointer")
+    evaluation = report.get("pointer_evaluation")
+    source = report.get("source")
+    state_encoding = report.get("state_encoding")
+    if not isinstance(pointer, dict) or not isinstance(evaluation, dict):
+        raise ValueError("Rust parity report omits pointer bindings/evaluation")
+    if not isinstance(source, dict) or not isinstance(state_encoding, dict):
+        raise ValueError("Rust parity report omits source/state encoding")
+    if pointer.get("artifact_cid") != preflight_head["artifact_cid"]:
+        raise ValueError("Rust parity loaded a different preflight pointer artifact")
+    if pointer.get("policy") != POLICY:
+        raise ValueError("Rust parity loaded a different pointer policy")
+    if source.get("source_cid") != fixture["source_cid"]:
+        raise ValueError("Rust parity source CID differs from the Python fixture")
+    if report.get("question") != fixture["question"]:
+        raise ValueError("Rust parity question differs from the Python fixture")
+    checkpoint = state_encoding.get("checkpoint")
+    model_shape = state_encoding.get("model_shape")
+    if not isinstance(checkpoint, dict) or not isinstance(model_shape, dict):
+        raise ValueError("Rust parity state encoding omits checkpoint/model shape")
+    if checkpoint.get("weights_cid") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("Rust parity state encoder loaded different model weights")
+    if checkpoint.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("Rust parity state encoder loaded a different tokenizer")
+    if int(model_shape.get("dimension", -1)) != FROZEN_MODEL_CONFIG.hidden_size:
+        raise ValueError("Rust parity state encoder hidden width differs")
+    if state_encoding.get("model_weights_cid") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("Rust parity public state binding names different weights")
+    if state_encoding.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("Rust parity public state binding names a different tokenizer")
+    if int(state_encoding.get("hidden_size", -1)) != FROZEN_MODEL_CONFIG.hidden_size:
+        raise ValueError("Rust parity public state binding names a different hidden width")
+
+    rust_scores = _numeric_list(
+        evaluation.get("candidate_scores"), "candidate scores"
+    )
+    python_scores = _numeric_list(fixture["candidate_scores"], "Python candidate scores")
+    if len(rust_scores) != len(python_scores):
+        raise ValueError("Rust parity candidate count differs")
+    rust_logits = _numeric_logits(evaluation.get("logits"))
+    python_logits = _numeric_logits(fixture["logits"])
+    score_delta = max(abs(left - right) for left, right in zip(rust_scores, python_scores))
+    logit_delta = max(
+        abs(rust_logits[outcome] - python_logits[outcome]) for outcome in OUTCOMES
+    )
+    tolerance = float(fixture["maximum_absolute_tolerance"])
+    if tolerance != PARITY_MAX_ABSOLUTE_TOLERANCE:
+        raise ValueError("Python score fixture parity tolerance differs")
+    if score_delta > tolerance or logit_delta > tolerance:
+        raise ValueError(
+            "Rust pointer score parity exceeded tolerance: "
+            f"scores={score_delta}, logits={logit_delta}, limit={tolerance}"
+        )
+    rust_decision = evaluation.get("decision")
+    if rust_decision not in OUTCOMES:
+        raise ValueError("Rust parity decision is outside answer/abstain/conflict")
+    rust_selected_span = evaluation.get("selected_span_index")
+    if rust_selected_span is not None and not isinstance(rust_selected_span, int):
+        raise ValueError("Rust parity selected span is not an integer or null")
+    if rust_decision != fixture["decision"]:
+        raise ValueError("Rust parity decision differs from Python")
+    if rust_selected_span != fixture["selected_span_index"]:
+        raise ValueError("Rust parity selected span differs from Python")
+
+    copied_report_path = root / "preflight/rust-score-parity.json"
+    atomic_write_json(copied_report_path, report)
+    admission = _canonical_with_cid(
+        {
+            "schema": PARITY_ADMISSION_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": "PASS_PYTHON_RUST_SOURCE_SPAN_SCORE_PARITY",
+            "preflight_artifact_cid": preflight_head["artifact_cid"],
+            "python_score_fixture_cid": fixture["fixture_cid"],
+            "rust_report_cid": cid_bytes(canonical_json_bytes(report)),
+            "maximum_absolute_score_delta": score_delta,
+            "maximum_absolute_logit_delta": logit_delta,
+            "maximum_absolute_tolerance": tolerance,
+            "decision": fixture["decision"],
+            "selected_span_index": fixture["selected_span_index"],
+        },
+        "admission_cid",
+    )
+    atomic_write_json(root / "preflight/score-parity-admission.json", admission)
+    return admission
+
+
+def _prepare_contract(
+    root: Path,
+    *,
+    predecessor_manifest: dict[str, Any],
+    config: SourceSpanPointerConfig,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    dataset, probes = build_source_span_population()
+    root.mkdir(parents=True, exist_ok=True)
+    _write_or_verify_json(root / "source-span-dataset.json", dataset)
+    _write_or_verify_json(root / "product-probes.json", probes)
+    dataset_manifest_path = root / "source-span-dataset-manifest.json"
+    if dataset_manifest_path.exists():
+        dataset_manifest = verify_bound_manifest(dataset_manifest_path, artifact_root=root)
+        if (
+            dataset_manifest.get("dataset_cid") != dataset["dataset_cid"]
+            or dataset_manifest.get("split_policy_cid") != dataset["split_policy_cid"]
+        ):
+            raise ValueError("existing source-span dataset manifest differs")
+    else:
+        dataset_manifest = write_bound_manifest(
+            dataset_manifest_path,
+            {
+                "schema": DATASET_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "dataset_cid": dataset["dataset_cid"],
+                "split_policy_cid": dataset["split_policy_cid"],
+                "product_probes_cid": probes["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+                "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            },
+            artifact_root=root,
+            relative_paths=["source-span-dataset.json", "product-probes.json"],
+        )
+
+    run_contract = _canonical_with_cid(
+        {
+            "schema": RUN_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "predecessor": {
+                "export_manifest_cid": predecessor_manifest["manifest_cid"],
+                "weights_cid": EXPECTED_WEIGHTS_CID,
+                "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                "failed_grounding_sft_weights": "EXCLUDED",
+            },
+            "model": FROZEN_MODEL_CONFIG.as_contract(),
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+            "state_extraction": (
+                "MPS-only immutable #1017 final normalized residual states for each "
+                "independently encoded subject and sentence; content tokens only"
+            ),
+            "mechanism": (
+                "positive 288-lane diagonal weighted cosine; subject-token maxima "
+                "averaged per candidate; positive score scale; answer/abstain/conflict biases"
+            ),
+            "loss": (
+                "three-way outcome cross entropy for every construction record plus "
+                "candidate-span cross entropy for supported records"
+            ),
+            "optimization": config.as_contract(),
+            "cheap_gate": {
+                "balanced_overfit_records": 12,
+                "required_outcome_accuracy": 1.0,
+                "required_supported_pointer_accuracy": 1.0,
+                "python_rust_score_tolerance": PARITY_MAX_ABSOLUTE_TOLERANCE,
+            },
+            "development_gate": {
+                "minimum_per_class_outcome_accuracy": config.required_per_class_accuracy,
+                "minimum_supported_span_pointer_accuracy": config.required_pointer_accuracy,
+            },
+            "implementation": trainer_implementation_contract(),
+        },
+        "run_contract_cid",
+    )
+    _write_or_verify_json(root / "source-span-run-contract.json", run_contract)
+    return dataset, probes, dataset_manifest, run_contract
+
+
+def _run_full_fit(
+    root: Path,
+    *,
+    dataset_value: dict[str, Any],
+    probes: dict[str, Any],
+    dataset_manifest: dict[str, Any],
+    feature_manifest: dict[str, Any],
+    run_contract: dict[str, Any],
+    parity_admission: dict[str, Any],
+    config: SourceSpanPointerConfig,
+) -> dict[str, Any]:
+    fit_marker = root / "fit-started.json"
+    if fit_marker.exists():
+        raise FileExistsError(
+            "the sole C1-SB1 fit was already started; no rerun or resume is authorized"
+        )
+    atomic_write_json(
+        fit_marker,
+        {
+            "schema": RUN_SCHEMA,
+            "phase": "SOLE_256_STEP_FIT_STARTED",
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "parity_admission_cid": parity_admission["admission_cid"],
+        },
+    )
+    device = require_mps(config.seed)
+    features = FrozenFeatureStore(root / "features")
+    construction = PointerDataset(dataset_value["construction"], features)
+    development = PointerDataset(dataset_value["development"], features)
+    torch.manual_seed(config.seed)
+    if hasattr(torch.mps, "manual_seed"):
+        torch.mps.manual_seed(config.seed)
+    model = R4SourceSpanPointer().to(device)
+    fit = _fit_head(
+        model,
+        construction,
+        device=device,
+        steps=config.optimizer_steps,
+        batch_size=config.batch_size,
+        config=config,
+        phase="sole-256-step-fit",
+    )
+    development_metrics = evaluate_pointer(
+        model,
+        development,
+        device=device,
+        batch_size=config.batch_size,
+    )
+    passed = _development_gate(development_metrics, config)
+    preflight_result = json.loads(
+        (root / "preflight/preflight-result.json").read_text(encoding="utf-8")
+    )
+    deterministic_fit = {key: value for key, value in fit.items() if key != "elapsed_seconds"}
+    result = _canonical_with_cid(
+        {
+            "schema": TRAINING_RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": (
+                "SOURCE_SPAN_POINTER_FIT_COMPLETE_AWAITING_RUST_PRODUCT_REVEAL"
+                if passed
+                else "FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP"
+            ),
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset_value["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "preflight_result_cid": preflight_result["result_cid"],
+            "rust_score_parity_admission_cid": parity_admission["admission_cid"],
+            "optimization": deterministic_fit,
+            "development_metrics": development_metrics,
+            "development_gate_passed": passed,
+            "product_probe_commitments": dataset_value["product_probe_commitments"],
+            "product_probe_file_cid": probes["product_probes_cid"],
+            "product_behavior_status": "NOT_RUN",
+        },
+        "result_cid",
+    )
+    atomic_write_json(root / "source-span-training-result.json", result)
+
+    final_paths = [
+        "source-span-dataset.json",
+        "product-probes.json",
+        "source-span-dataset-manifest.json",
+        "source-span-run-contract.json",
+        "features/feature-index.json",
+        "features/states.safetensors",
+        "features/feature-manifest.json",
+        "preflight/preflight-result.json",
+        "preflight/preflight-head.json",
+        "preflight/parity-source.txt",
+        "preflight/python-score-fixture.json",
+        "preflight/rust-score-parity.json",
+        "preflight/score-parity-admission.json",
+        "fit-started.json",
+        "source-span-training-result.json",
+    ]
+    head: dict[str, Any] | None = None
+    if passed:
+        embedded_preflight = {
+            "status": "PASS_12_RECORD_OVERFIT_AND_PYTHON_RUST_SCORE_PARITY",
+            "record_cids": preflight_result["record_cids"],
+            "optimizer_steps": config.preflight_optimizer_steps,
+            "metrics": preflight_result["metrics"],
+            "preflight_result_cid": preflight_result["result_cid"],
+            "rust_score_parity_admission_cid": parity_admission["admission_cid"],
+        }
+        head = _head_payload(
+            model,
+            dataset=dataset_value,
+            run_contract_cid=run_contract["run_contract_cid"],
+            training_result_cid=result["result_cid"],
+            preflight=embedded_preflight,
+            development_metrics=development_metrics,
+        )
+        atomic_write_json(root / "source-span-pointer.json", head)
+        final_paths.append("source-span-pointer.json")
+
+    final_manifest = write_bound_manifest(
+        root / "source-span-final-manifest.json",
+        {
+            "schema": FINAL_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": result["terminal"],
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset_value["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "training_result_cid": result["result_cid"],
+            "pointer_artifact_cid": None if head is None else head["artifact_cid"],
+            "development_gate_passed": passed,
+            "product_behavior_status": "NOT_RUN" if passed else "BLOCKED_BY_DEVELOPMENT",
+        },
+        artifact_root=root,
+        relative_paths=final_paths,
+    )
+    return {
+        "terminal": result["terminal"],
+        "optimizer_steps_completed": config.optimizer_steps,
+        "development_metrics": development_metrics,
+        "pointer_artifact": None if head is None else str(root / "source-span-pointer.json"),
+        "pointer_artifact_cid": None if head is None else head["artifact_cid"],
+        "training_result_cid": result["result_cid"],
+        "final_manifest_cid": final_manifest["manifest_cid"],
+        "product_behavior_status": "NOT_RUN" if passed else "BLOCKED_BY_DEVELOPMENT",
+    }
+
+
+def train_source_span_pointer(
+    root: Path,
+    *,
+    predecessor: Path,
+    rust_score_parity: Path | None = None,
+    config: SourceSpanPointerConfig = SourceSpanPointerConfig(),
+) -> dict[str, Any]:
+    """Advance the two-invocation C1-SB1 gate without opening product probes."""
+    config.validate()
+    root = root.expanduser().resolve()
+    predecessor = predecessor.expanduser().resolve()
+    if root == predecessor or predecessor in root.parents:
+        raise ValueError("source-span output must not overwrite immutable #1017")
+    if (root / "source-span-final-manifest.json").exists():
+        raise FileExistsError("the sole C1-SB1 pointer fit is already complete")
+
+    predecessor_manifest = _validated_predecessor(predecessor)
+    dataset_value, probes, dataset_manifest, run_contract = _prepare_contract(
+        root,
+        predecessor_manifest=predecessor_manifest,
+        config=config,
+    )
+    feature_manifest = _extract_features(
+        root,
+        predecessor=predecessor,
+        predecessor_manifest=predecessor_manifest,
+        dataset=dataset_value,
+        dataset_manifest=dataset_manifest,
+        config=config,
+    )
+
+    preflight_manifest_path = root / "preflight/preflight-manifest.json"
+    if not preflight_manifest_path.exists():
+        result = _run_preflight(
+            root,
+            dataset_value=dataset_value,
+            dataset_manifest=dataset_manifest,
+            feature_manifest=feature_manifest,
+            run_contract=run_contract,
+            config=config,
+        )
+        if rust_score_parity is not None:
+            result["note"] = (
+                "preflight was created in this invocation; run the emitted Rust command "
+                "and invoke this same subcommand again with --rust-score-parity"
+            )
+        return result
+
+    preflight_manifest = verify_bound_manifest(
+        preflight_manifest_path, artifact_root=root
+    )
+    if preflight_manifest.get("terminal") != "AWAITING_RUST_SCORE_PARITY":
+        return {
+            "terminal": preflight_manifest.get("terminal", "PREFLIGHT_STOPPED"),
+            "preflight_manifest_cid": preflight_manifest["manifest_cid"],
+        }
+    if rust_score_parity is None:
+        fixture = json.loads(
+            (root / "preflight/python-score-fixture.json").read_text(encoding="utf-8")
+        )
+        return {
+            "terminal": "AWAITING_RUST_SCORE_PARITY",
+            "preflight_artifact": str(root / "preflight/preflight-head.json"),
+            "preflight_artifact_cid": fixture["preflight_artifact_cid"],
+            "parity_source": str(root / fixture["source_path"]),
+            "question": fixture["question"],
+            "python_score_fixture": str(root / "preflight/python-score-fixture.json"),
+            "python_score_fixture_cid": fixture["fixture_cid"],
+        }
+
+    report_path = rust_score_parity.expanduser().resolve()
+    if not report_path.is_file():
+        raise FileNotFoundError(report_path)
+    parity_admission = _admit_rust_score_parity(root, report_path)
+    return _run_full_fit(
+        root,
+        dataset_value=dataset_value,
+        probes=probes,
+        dataset_manifest=dataset_manifest,
+        feature_manifest=feature_manifest,
+        run_contract=run_contract,
+        parity_admission=parity_admission,
+        config=config,
+    )

--- a/tools/r4-softmax-trainer/tests/test_source_span_data.py
+++ b/tools/r4-softmax-trainer/tests/test_source_span_data.py
@@ -1,0 +1,90 @@
+"""Contract tests for the frozen C1-SB1 population."""
+
+from __future__ import annotations
+
+import unittest
+
+from r4_softmax_trainer.source_span_data import (
+    build_source_span_population,
+    parse_subject,
+    split_sentence_spans,
+)
+
+
+class SourceSpanParsingTests(unittest.TestCase):
+    def test_question_policy_is_exact(self) -> None:
+        self.assertEqual(parse_subject("Where is the blue book?"), "blue book")
+        for rejected in [
+            "where is the blue book?",
+            "Where is blue book?",
+            "Where is the blue book ?",
+            "Where is the blue book? now",
+            "Where is the ?",
+        ]:
+            with self.subTest(rejected=rejected), self.assertRaises(ValueError):
+                parse_subject(rejected)
+
+    def test_sentence_spans_preserve_exact_utf8_bytes(self) -> None:
+        source = "  The café is here!\nThe key is there?  "
+        spans = split_sentence_spans(source)
+        encoded = source.encode("utf-8")
+        self.assertEqual([span["text"] for span in spans], ["The café is here!", "The key is there?"])
+        for span in spans:
+            self.assertEqual(
+                encoded[span["byte_start"] : span["byte_end"]].decode("utf-8"),
+                span["text"],
+            )
+
+    def test_unterminated_or_overwide_sources_fail_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            split_sentence_spans("The source has no terminator")
+        with self.assertRaises(ValueError):
+            split_sentence_spans(" ".join(f"Sentence {index}." for index in range(9)))
+
+
+class SourceSpanPopulationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset, cls.probes = build_source_span_population()
+
+    def test_population_preserves_frozen_balanced_counts(self) -> None:
+        self.assertEqual(self.dataset["counts"]["construction"], 3_072)
+        self.assertEqual(self.dataset["counts"]["development"], 384)
+        for records, per_class in [
+            (self.dataset["construction"], 1_024),
+            (self.dataset["development"], 128),
+        ]:
+            counts = {name: 0 for name in ["answer", "abstain", "conflict"]}
+            for record in records:
+                counts[record["target_outcome"]] += 1
+            self.assertEqual(counts, {name: per_class for name in counts})
+
+    def test_product_family_is_committed_but_absent_from_training(self) -> None:
+        commitments = [record["record_cid"] for record in self.probes["records"]]
+        self.assertEqual(self.dataset["product_probe_commitments"], commitments)
+        training = "\n".join(
+            record["source"]
+            for record in [
+                *self.dataset["construction"],
+                *self.dataset["development"],
+            ]
+        )
+        self.assertNotIn("copper compass", training)
+        self.assertNotIn("linen map", training)
+        self.assertEqual(
+            [record["probe"] for record in self.probes["records"]],
+            [
+                "copper-compass-supported",
+                "linen-map-unsupported",
+                "copper-compass-conflict",
+            ],
+        )
+
+    def test_dataset_and_probe_cids_reproduce(self) -> None:
+        other_dataset, other_probes = build_source_span_population()
+        self.assertEqual(other_dataset, self.dataset)
+        self.assertEqual(other_probes, self.probes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_source_span_pointer.py
+++ b/tools/r4-softmax-trainer/tests/test_source_span_pointer.py
@@ -1,0 +1,190 @@
+"""Dependency-light mechanism tests for R4SourceSpanPointerV1."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from r4_softmax_trainer.constants import FROZEN_MODEL_CONFIG
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+from r4_softmax_trainer.source_span_pointer import (
+    EXPECTED_TOKENIZER_CID,
+    EXPECTED_WEIGHTS_CID,
+    HEAD_SCHEMA,
+    OUTCOME_TO_ID,
+    POLICY,
+    PointerBatch,
+    R4SourceSpanPointer,
+    SourceSpanPointerConfig,
+    _admit_rust_score_parity,
+    _head_payload,
+    pointer_loss,
+    safety_decisions,
+)
+
+
+def synthetic_batch() -> PointerBatch:
+    hidden = FROZEN_MODEL_CONFIG.hidden_size
+    subjects = torch.zeros((1, 2, hidden), dtype=torch.float32)
+    subjects[0, 0, 0] = 1.0
+    candidates = torch.zeros((1, 2, 2, hidden), dtype=torch.float32)
+    candidates[0, 0, 0, 1] = 1.0
+    candidates[0, 1, 0, 0] = 1.0
+    return PointerBatch(
+        subject_states=subjects,
+        subject_mask=torch.tensor([[True, False]]),
+        candidate_states=candidates,
+        candidate_token_mask=torch.tensor([[[True, False], [True, False]]]),
+        candidate_mask=torch.ones((1, 2), dtype=torch.bool),
+        outcomes=torch.tensor([OUTCOME_TO_ID["answer"]], dtype=torch.long),
+        target_spans=torch.tensor([1], dtype=torch.long),
+    )
+
+
+class PointerMechanismTests(unittest.TestCase):
+    def test_weighted_cosine_selects_matching_candidate(self) -> None:
+        model = R4SourceSpanPointer()
+        output = model(synthetic_batch())
+        self.assertAlmostEqual(float(output.candidate_scores[0, 0]), 0.0, places=6)
+        self.assertAlmostEqual(float(output.candidate_scores[0, 1]), 1.0, places=6)
+        self.assertEqual(int(output.top_candidate_indices[0]), 1)
+        self.assertEqual(int(safety_decisions(output.outcome_logits)[0]), OUTCOME_TO_ID["answer"])
+        self.assertTrue(torch.isfinite(pointer_loss(output, synthetic_batch())))
+
+    def test_safety_ties_choose_conflict_then_abstain_then_answer(self) -> None:
+        logits = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [2.0, 1.0, 0.0],
+            ]
+        )
+        self.assertEqual(
+            safety_decisions(logits).tolist(),
+            [
+                OUTCOME_TO_ID["conflict"],
+                OUTCOME_TO_ID["abstain"],
+                OUTCOME_TO_ID["answer"],
+            ],
+        )
+
+    def test_serialized_head_has_exact_loader_contract_and_embedded_cid(self) -> None:
+        model = R4SourceSpanPointer()
+        dataset = {
+            "dataset_cid": "blake3:" + "1" * 64,
+            "split_policy_cid": "blake3:" + "2" * 64,
+            "product_probe_commitments": ["blake3:" + "3" * 64],
+        }
+        head = _head_payload(
+            model,
+            dataset=dataset,
+            run_contract_cid="blake3:" + "4" * 64,
+            training_result_cid="blake3:" + "5" * 64,
+            preflight={"status": "PASS"},
+            development_metrics={"status": "PASS"},
+        )
+        expected = {
+            "schema",
+            "policy",
+            "issue",
+            "model_weights_cid",
+            "tokenizer_cid",
+            "hidden_size",
+            "state_weights",
+            "score_scale",
+            "answer_bias",
+            "abstain_bias",
+            "conflict_bias",
+            "maximum_source_spans",
+            "question_policy",
+            "sentence_policy",
+            "dataset_cid",
+            "split_policy_cid",
+            "run_contract_cid",
+            "training_result_cid",
+            "preflight",
+            "development_metrics",
+            "product_probe_commitments",
+            "artifact_cid",
+        }
+        self.assertEqual(set(head), expected)
+        self.assertEqual(head["schema"], HEAD_SCHEMA)
+        self.assertEqual(head["policy"], POLICY)
+        self.assertEqual(len(head["state_weights"]), 288)
+        self.assertTrue(all(value > 0.0 for value in head["state_weights"]))
+        unsigned = dict(head)
+        artifact_cid = unsigned.pop("artifact_cid")
+        self.assertEqual(artifact_cid, cid_bytes(canonical_json_bytes(unsigned)))
+
+    def test_config_refuses_sweeps(self) -> None:
+        SourceSpanPointerConfig().validate()
+        with self.assertRaises(ValueError):
+            SourceSpanPointerConfig(optimizer_steps=255).validate()
+
+    def test_admits_exact_public_grounded_answer_report_shape(self) -> None:
+        artifact_cid = "blake3:" + "a" * 64
+        source_cid = "blake3:" + "b" * 64
+        fixture_cid = "blake3:" + "c" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            preflight = root / "preflight"
+            preflight.mkdir()
+            fixture = {
+                "preflight_artifact_cid": artifact_cid,
+                "source_cid": source_cid,
+                "question": "Where is the blue book?",
+                "candidate_scores": [0.25, 0.75],
+                "logits": {"answer": 1.0, "abstain": 0.0, "conflict": -1.0},
+                "decision": "answer",
+                "selected_span_index": 1,
+                "maximum_absolute_tolerance": 0.01,
+                "fixture_cid": fixture_cid,
+            }
+            head = {"artifact_cid": artifact_cid}
+            report = {
+                "schema": "uor-r4.grounded-answer/2",
+                "source": {"source_cid": source_cid},
+                "question": fixture["question"],
+                "pointer": {"artifact_cid": artifact_cid, "policy": POLICY},
+                "pointer_evaluation": {
+                    "candidate_scores": [0.2501, 0.7499],
+                    "ranked_candidate_indices": [1, 0],
+                    "logits": {"answer": 1.0001, "abstain": 0.0, "conflict": -1.0},
+                    "decision": "answer",
+                    "selected_span_index": 1,
+                },
+                "state_encoding": {
+                    "model_weights_cid": EXPECTED_WEIGHTS_CID,
+                    "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                    "hidden_size": 288,
+                    "checkpoint": {
+                        "weights_cid": EXPECTED_WEIGHTS_CID,
+                        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                    },
+                    "model_shape": {"dimension": 288},
+                },
+            }
+            (preflight / "python-score-fixture.json").write_text(
+                json.dumps(fixture), encoding="utf-8"
+            )
+            (preflight / "preflight-head.json").write_text(
+                json.dumps(head), encoding="utf-8"
+            )
+            report_path = root / "rust-parity.json"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            admission = _admit_rust_score_parity(root, report_path)
+
+            self.assertEqual(
+                admission["terminal"], "PASS_PYTHON_RUST_SOURCE_SPAN_SCORE_PARITY"
+            )
+            self.assertLessEqual(admission["maximum_absolute_score_delta"], 0.01)
+            self.assertLessEqual(admission["maximum_absolute_logit_delta"], 0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
References #954

## Outcome

Implements the frozen `R4SourceSpanPointerV1` research seam over the established #1017 causal R4/Spin states, records the sole bounded run, and fails closed before product wiring.

- Adds exact final normalized residual capture through all six R4/Spin layers.
- Adds strict canonical pointer-head loading, candidate-relative weighted-cosine scoring, explicit answer/abstain/conflict decisions, deterministic source copying, and a compact public parity report.
- Adds the two-stage frozen Python trainer/data contract and focused tests.
- Updates the CLI and project documentation to state that no qualified final head exists.
- Records the terminal `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`; no retry, product probes, browser wiring, or release claim.

## Evidence

- 12/12 overfit preflight: PASS
- Python/Rust parity: max score delta `1.234420776e-7`; max logit delta `1.428717041e-6`; tolerance `0.01`
- Sole full fit: answer `89/128`, abstain `114/128`, conflict `117/128`, supported pointer `121/128`; all frozen gates required at least 95%
- Final artifact: not emitted
- Product probes: `NOT_RUN`

## Focused verification

- `cargo fmt --all -- --check`
- `cargo check -p uor-r4-wasm-router --offline`
- `cargo clippy -p uor-r4-wasm-router --lib --offline -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p uor-r4-wasm-router --lib --offline`
- focused Rust policy-boundary test
- 11 focused Python tests
- `python3 scripts/check_claim_wording.py`
- JSON and diff validation
