### PR TITLE
Implement source-relative relation preflight for #954

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,19 @@ overfit and Python/Rust parity but failed all four frozen development gates
 after its sole 256-step fit. The terminal is
 `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`; no final pointer artifact was
 emitted, and product probes plus browser/HTTP wiring were `NOT_RUN`. Do not tune
-or retry the revealed cosine head. The next proposed mechanism is a
-source-relative learned relation/entailment head preserving exact R4/Spin state
-capture and deterministic source-copy semantics; it must be independently
-frozen before execution, and no successor run or product wiring is active.
-The #1017 `r4 generate` path remains the working coherent-generation prototype.
+or retry the revealed cosine head. Its frozen source-relative successor,
+`R4SourceRelativeRelationHeadV1` (C1-SB2), is implemented and completed only its
+cheap matched-transfer preflight. The fitted families scored 12/12 positive
+relations, 20/20 negatives, and 6/6 supported copies; the independently sealed
+families scored 5/12 positives, 14/20 negatives, and 0/6 copies. Same-source
+matched-pair, query-swap, duplicate-agreement, and distinct-conflict controls
+were false, so the run stopped before Rust parity, the sole 512-step full fit,
+development, and product reveal. No final relation head exists. The next
+proposed #954 mechanism trains relation supervision into the representation
+through the established R4/Spin attention path while retaining exact-source-copy
+and typed-nonanswer semantics. #954's final source-free terminal remains blocked
+behind #973, and #955 remains blocked behind #954. The #1017 `r4 generate` path
+remains the working coherent-generation prototype.
 Prototype iteration uses
 one targeted compile plus one real behavior check; do not run a broad local
 suite or add a permanent gate until the mechanism is useful. The existing
@@ -127,8 +135,10 @@ implementation, and the full campaign remains `NOT_RUN`. The subsequent fused-
 AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so `fused=True` was removed and #1019 is optional/paused.
 The #1017 `r4 generate` path remains the working coherent-generation prototype;
-the next proposed #954 relation/entailment mechanism must be independently
-frozen before any run. CUDA and external GPU execution are out of scope. This reference remains
+#954 C1-SB2 is an implemented matched-transfer preflight negative, not an active
+head. Its proposed representation-trained successor keeps the same established
+R4/Spin attention plus exact-copy/typed-nonanswer seam. CUDA and external GPU
+execution are out of scope. This reference remains
 transformer-compatible and `f32`/multiply/alloc/source-weight backed—not
 table-native, multiply-free, or transformerless. It does not establish geometry
 advantage, softmax removal, correctness, reasoning, frontier quality, release
@@ -146,9 +156,10 @@ the [generation record](docs/r4_softmax_reference_generation_973.md), its
 the [native bridge result](docs/r4_softmax_reference_http_bridge_973.md),
 and the V1/V2 negative records remain linked from there.
 Intrinsic/readout alternatives, multi-resonance softmax replacement,
-full-model recurrent lowering, and exact deployment are parked; #954's final
-source-free terminal remains blocked and no successor run/product wiring is
-active. Implementation progress is not a result.
+full-model recurrent lowering, and exact deployment are parked; #954's C1-SB2
+preflight stopped before Rust parity/full fit/development/product, with no final
+head. Its final source-free terminal remains blocked behind #973, and #955
+remains blocked behind #954. Implementation progress is not a result.
 The geometric causal decoder plan, prior S0–S7 completion plan, and
 graph-compiler implementation plan are retained as historical
 engineering/evidence records; none decides what is built next. Native GitHub
@@ -278,11 +289,14 @@ offline implementation, and full training through replay remains `NOT_RUN`.
 The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
 optional/paused. The #1017 `r4 generate` path remains the working prototype;
-the next proposed #954 relation/entailment mechanism must be independently
-frozen before execution. CUDA and external GPU execution are out of scope.
+#954 C1-SB2 is implemented but stopped at its failed matched-transfer preflight,
+before Rust parity/full fit/development/product and without a final head. The
+next proposed mechanism trains relation supervision into the existing R4/Spin
+attention representation while retaining exact-copy/typed-nonanswer behavior.
+CUDA and external GPU execution are out of scope.
 Intrinsic/readout, resonance, recurrence,
 and lowering are parked. D3 remains `NOT_RUN`; #954's final source-free
-terminal remains blocked and no successor run is active.
+terminal remains blocked behind #973, and #955 remains blocked behind #954.
 Do not add a second #953 intervention or reuse the #983/#986 populations. The
 complete #973 Gate 0 record is
 [`docs/prior_sentence_count_radius_attention_973.md`](docs/prior_sentence_count_radius_attention_973.md).
@@ -654,14 +668,16 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
   `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
   optional/paused. The #1017 `r4 generate` path remains the working prototype;
-  the next proposed #954 relation/entailment mechanism must be independently
-  frozen before execution. CUDA and external GPU execution are out of scope.
+  #954 C1-SB2 is implemented but stopped at its failed matched-transfer
+  preflight before Rust parity/full fit/development/product, with no final head.
+  The next proposed mechanism trains relation supervision into the existing
+  R4/Spin attention representation while retaining exact-copy/typed-nonanswer
+  behavior. CUDA and external GPU execution are out of scope.
   Intrinsic/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and
   exact deployment are parked. D3 remains `NOT_RUN`.
-  #954's final source-free terminal remains blocked behind #973; no successor
-  source-backed run or product wiring is active.
-  #954 and #955 own correctness and reasoning respectively.
+  #954's final source-free terminal remains blocked behind #973, and #955 remains
+  blocked behind #954. #954 and #955 own correctness and reasoning respectively.
   #962 owns durable multi-turn CLI/HTTP chat, persistence, isolation, and
   hive-memory; #963–#965 then own optimization, formal closure, and release.
 - Sequence strictly from the current reset: working source-free table baseline
@@ -683,8 +699,10 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   FROZEN OFFLINE MPS IMPLEMENTATION OVER 8 H; FUSED FAST PATH SLOWER; OPTIONAL/
   PAUSED; FULL CAMPAIGN NOT_RUN; CUDA/EXTERNAL GPU OUT OF SCOPE]) →
   working bounded #1017 `r4 generate` prototype → #954 pointer development
-  negative → independently freeze the proposed relation/entailment mechanism →
-  correctness/abstention → reasoning → optimization/purity/release. The older placement/transport
+  negative → C1-SB2 source-relative relation preflight negative → train
+  relation supervision into the established R4/Spin attention representation
+  while retaining exact-copy/typed-nonanswer semantics → correctness/abstention
+  → reasoning → optimization/purity/release. The older placement/transport
   sequence is retained as evidence, not an active implementation queue.
 - Kappa is canonical identity/serialization, never the tokenizer or semantic
   distance. The pinned lexical codec is provenance-bound but opens no weights.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,19 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > and supported-pointer development accuracy were `69.53125%`, `89.0625%`,
 > `91.40625%`, and `94.53125%`, all below the frozen `>=95%` gates. No final
 > pointer artifact was emitted and the reserved product probes were `NOT_RUN`.
-> The next proposed #954 mechanism is a source-relative learned
-> relation/entailment head that preserves exact R4/Spin state capture and copy
-> semantics; it must be independently frozen before execution, and no successor
-> run or product wiring is active. Do not tune or retry the revealed cosine head.
+> Its frozen source-relative successor, `R4SourceRelativeRelationHeadV1`
+> (C1-SB2), is implemented and completed only its cheap matched-transfer
+> preflight. The fitted families scored 12/12 positive relations, 20/20
+> negatives, and 6/6 supported copies; the independently sealed families scored
+> 5/12 positives, 14/20 negatives, and 0/6 copies. Same-source matched-pair,
+> query-swap, duplicate-agreement, and distinct-conflict controls were false.
+> C1-SB2 therefore stopped before Rust parity, the sole 512-step full fit,
+> development, and product reveal; no final relation head was emitted. Do not
+> tune or retry either revealed head. The next proposed #954 mechanism trains
+> relation supervision into the representation through the established R4/Spin
+> attention path while retaining exact-source-copy and typed-nonanswer semantics.
+> #954's final source-free terminal remains blocked behind #973, and #955
+> remains blocked behind #954.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
 > [#1017 structured aggregate](docs/r4_softmax_quality_capacity_continuation_1017_raw.json),
 > [#1019 frozen contract](docs/r4_softmax_parameter_capacity_1019.md),
@@ -230,9 +239,12 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > engine. This remains a native CPU research reference,
 > not a source-free, transformerless, static-WASM, release, or frontier-model
 > result. #973 remains open for its intrinsic/source-free terminal; #954's
-> cosine source-span pointer stopped at its development gate. The proposed
-> source-relative relation/entailment head must be independently frozen; no
-> successor run is active, and the final source-free terminal remains blocked.
+> cosine source-span pointer stopped at its development gate, and its implemented
+> C1-SB2 relation head then stopped at failed matched-transfer preflight before
+> Rust parity/full fit/development/product, without a final head. The proposed
+> representation-trained successor retains the established R4/Spin attention
+> plus exact-copy/typed-nonanswer seam. #954's final source-free terminal remains
+> blocked behind #973, and #955 remains blocked behind #954.
 > The trace/compiler rung
 > that followed that checkpoint is now complete: `R4SoftmaxTeacherTraceV1`
 > supplied construction traces and
@@ -257,10 +269,12 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > implementation, and full training through replay remains `NOT_RUN`. The
 > fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 > `3.491307 s/step`); #1019 closed without a full run. #954's cosine pointer
-> stopped before final artifact or product reveal. A source-relative learned
-> relation/entailment successor over #1017's exact R4/Spin state and copy seams
-> is proposed but not frozen or active. CUDA and external GPU execution are out
-> of scope. No
+> stopped before final artifact or product reveal. Its implemented C1-SB2
+> source-relative relation successor then failed matched-transfer preflight and
+> stopped before Rust parity/full fit/development/product, without a final head.
+> The next proposal trains relation supervision into the existing R4/Spin
+> attention representation while retaining exact-copy/typed-nonanswer behavior.
+> CUDA and external GPU execution are out of scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
 > product promotion remain parked. No tag, release, hosted
@@ -341,11 +355,13 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > implementation; full training, final qualification, reveal, generation, and
 > replay remain `NOT_RUN`. The fused-AdamW/deferred-logging fast path was slower
 > (`4.485223` versus signed `3.491307 s/step`); #1019 closed without a full run.
-> #954's cosine pointer stopped at its development gate; the proposed
-> source-relative relation/entailment successor is not yet frozen or active.
-> CUDA and external GPU
-> execution are out of scope. #954's final source-free terminal remains
-> blocked by the parked #973 replacement terminal.
+> #954's cosine pointer stopped at its development gate; its implemented C1-SB2
+> relation successor then failed matched-transfer preflight before Rust parity,
+> full fit, development, or product reveal, and emitted no final head. The next
+> proposal trains relation supervision into the existing R4/Spin attention
+> representation while retaining exact-copy/typed-nonanswer behavior. CUDA and
+> external GPU execution are out of scope. #954's final source-free terminal
+> remains blocked behind #973, and #955 remains blocked behind #954.
 > See the
 > [bounded-global record](docs/bounded_global_exact_spin_attention_973.md).
 
@@ -410,8 +426,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > canary parity. Dashboard wiring/readiness and static/WASM-isolation checks
 > passed; browser E2E remains `NOT_RUN`. The source-free trace/state attempts
 > are preserved negatives; #954's cosine pointer is also a bounded negative.
-> Its proposed source-relative learned relation/entailment successor must be
-> independently frozen, and the final source-free terminal remains blocked.
+> Its implemented C1-SB2 relation successor failed matched-transfer preflight
+> before Rust parity/full fit/development/product and emitted no final head. The
+> final source-free terminal remains blocked behind #973, and #955 remains
+> blocked behind #954.
 > See the
 > [conversation record](docs/conversation_entity_spin_path_attention_973.md).
 
@@ -483,11 +501,14 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > implementation, so the full campaign remains `NOT_RUN`. The fused-AdamW/
 > deferred-logging fast path was slower (`4.485223` versus signed
 > `3.491307 s/step`); #1019 closed without a full run. #954's cosine pointer
-> stopped before final artifact or reveal; its proposed source-relative learned
-> relation/entailment successor is not yet frozen or active. CUDA and external GPU
-> execution are out of scope.
-> #954's final source-free terminal remains blocked behind #973. General higher-scope attention, correct
-> answers, and reasoning do not exist yet. The
+> stopped before final artifact or reveal; its implemented C1-SB2 relation
+> successor then failed matched-transfer preflight before Rust parity/full
+> fit/development/product and emitted no final head. The next proposal trains
+> relation supervision into the existing R4/Spin attention representation while
+> retaining exact-copy/typed-nonanswer behavior. CUDA and external GPU execution
+> are out of scope. #954's final source-free terminal remains blocked behind
+> #973, and #955 remains blocked behind #954. General higher-scope attention,
+> correct answers, and reasoning do not exist yet. The
 > dashboard is an interactive window into the research substrate, not a
 > frontier model or a ChatGPT replacement.
 
@@ -532,16 +553,17 @@ The bounded `answer` interface now admits only an exact
 
 ```bash
 r4 answer --source-file facts.txt --question "Where is the copper compass?" \
-  --head /path/to/qualified-pointer-head.json \
+  --head /path/to/qualified-source-relation-head.json \
   --json-output grounded-answer.json
 ```
 
-`answer` captures the #1017 model's normalized causal R4/Spin states for the
-subject and two to eight exact punctuation-terminated source sentences, then
-uses the explicitly supplied `--head` artifact to choose an exact source span,
-typed abstention, or typed conflict. The source is content-addressed and read
-again after evaluation to detect change. This is fail-closed extractive
-provenance, not semantic-entailment or general-correctness evidence.
+For a source-relative relation head, `answer` pairs each of two to eight exact
+punctuation-terminated source sentences with the question, captures the #1017
+model's normalized causal R4/Spin state at the final question token, and uses
+the explicitly supplied qualified `--head` artifact to choose an exact source
+span, typed abstention, or typed conflict. The source is content-addressed and
+read again after evaluation to detect change. This is a fail-closed extractive
+seam, not semantic-entailment or general-correctness evidence.
 
 The first fixed #954 MPS fine-tune completed in 14 minutes 44 seconds on the
 project M1, but its frozen Rust product population failed `1/3`: all three
@@ -555,15 +577,24 @@ answer `89/128` (`69.53125%`), abstain `114/128` (`89.0625%`), conflict
 `117/128` (`91.40625%`), and supported pointer `121/128` (`94.53125%`) versus
 `>=95%` each. It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`
 before producing a final pointer artifact; the three reserved product probes
-and browser/HTTP wiring are `NOT_RUN`. Consequently the default `r4 answer`
-surface is unavailable unless an explicitly qualified head artifact exists.
-Do not tune or retry the revealed cosine head. The next proposed #954 mechanism
-is a source-relative learned relation/entailment head preserving exact R4/Spin
-state capture and deterministic source-copy semantics; it must be independently
-frozen before execution, and no successor run or product wiring is active. See the
+and browser/HTTP wiring are `NOT_RUN`. The implemented
+`R4SourceRelativeRelationHeadV1` C1-SB2 successor then fit 12/12 positive
+relations, 20/20 negatives, and 6/6 supported copies on its two fit families,
+but transferred only 5/12 positives, 14/20 negatives, and 0/6 copies to its two
+sealed families. Same-source matched-pair, query-swap, duplicate-agreement, and
+distinct-conflict controls were false, so C1-SB2 stopped before Rust parity,
+the sole 512-step full fit, development, and product reveal. It emitted no final
+head. Consequently the default `r4 answer` surface is unavailable unless an
+explicitly qualified relation-head artifact exists. Do not tune or retry either
+revealed head. The next proposed #954 mechanism trains relation supervision
+into the representation through the established R4/Spin attention path while
+retaining exact-source-copy and typed-nonanswer semantics. #954's final
+source-free terminal remains blocked behind #973, and #955 remains blocked
+behind #954. See the
 [#954 record](docs/r4_grounded_correctness_954.md) and
 [C1-SB0 structured result](docs/r4_grounded_correctness_954_raw.json) plus the
-[C1-SB1 pointer result](docs/r4_source_span_pointer_954_raw.json).
+[C1-SB1 pointer result](docs/r4_source_span_pointer_954_raw.json) and
+[C1-SB2 relation result](docs/r4_source_relation_head_954_raw.json).
 
 On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
 machine's Accelerate framework:
@@ -823,10 +854,13 @@ exact-descriptor/entity-binding path selector apiece at their respective
    offline implementation; full training through replay remains `NOT_RUN`.
    The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
    signed `3.491307 s/step`); #1019 closed without a full run. #954's cosine
-   pointer stopped before final artifact or product reveal; its proposed
-   source-relative learned relation/entailment successor is not frozen or active.
-   CUDA and external
-   GPU execution are out of scope. #954's final source-free terminal stays blocked.
+   pointer stopped before final artifact or product reveal; its implemented
+   C1-SB2 relation successor then failed matched-transfer preflight before Rust
+   parity/full fit/development/product and emitted no final head. The next
+   proposal trains relation supervision into the existing R4/Spin attention
+   representation while retaining exact-copy/typed-nonanswer behavior. CUDA and
+   external GPU execution are out of scope. #954's final source-free terminal
+   stays blocked behind #973, and #955 remains blocked behind #954.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
 See the [#973 Gate 0 record](docs/prior_sentence_count_radius_attention_973.md).
@@ -974,9 +1008,12 @@ not become substitutes for working intelligence:
    generation/replay path remains `NOT_RUN`, with no further 7.15M exposure or
    LR tuning. The fused-AdamW/deferred-logging fast path was slower (`4.485223`
    versus signed `3.491307 s/step`); #1019 closed without a full run. #954's
-   cosine pointer stopped before final artifact or product reveal. Its proposed
-   source-relative learned relation/entailment successor is not frozen or active.
-   CUDA and external GPU execution are out of scope.
+   cosine pointer stopped before final artifact or product reveal. Its
+   implemented C1-SB2 relation successor then failed matched-transfer preflight
+   before Rust parity/full fit/development/product and emitted no final head. The
+   next proposal trains relation supervision into the existing R4/Spin attention
+   representation while retaining exact-copy/typed-nonanswer behavior. CUDA and
+   external GPU execution are out of scope.
    Do not resume resonance substitutes. Product development continues through
    `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
    reference is transformer-compatible, `f32`/multiply/alloc and source-weight
@@ -1042,9 +1079,13 @@ UOR's deployed architecture/runtime remains CPU-native. Apple Accelerate/BLAS
 and MPS are local offline accelerators only. The fused-AdamW/deferred-logging
 fast path was slower (`4.485223` versus signed `3.491307 s/step`); #1019 closed
 without a full run. #954's cosine pointer stopped before final artifact or
-product reveal. Its proposed source-relative learned relation/entailment
-successor is not frozen or active. CUDA and external GPU execution are out of scope.
-#954's final source-free terminal remains blocked behind #973. The exact contract is
+product reveal. Its implemented C1-SB2 relation successor then failed
+matched-transfer preflight before Rust parity/full fit/development/product and
+emitted no final head. The next proposal trains relation supervision into the
+existing R4/Spin attention representation while retaining
+exact-copy/typed-nonanswer behavior. CUDA and external GPU execution are out of
+scope. #954's final source-free terminal remains blocked behind #973, and #955
+remains blocked behind #954. The exact contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).
 
 ## Find your way around

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,11 +104,17 @@ passed its 12/12 overfit preflight and Python/Rust score parity, but the sole
 256-step fit missed every `>=95%` development gate: answer `69.53125%`,
 abstain `89.0625%`, conflict `91.40625%`, and supported pointer `94.53125%`.
 It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` before a final
-artifact or product reveal. Do not tune or retry that cosine head. The active
-next proposed mechanism is a source-relative learned relation/entailment head
-preserving exact R4/Spin state capture and copy semantics. It must be
-independently frozen before execution; no successor run or product wiring is
-active. CUDA and
+artifact or product reveal. Do not tune or retry that cosine head. The
+`R4SourceRelativeRelationHeadV1` successor was then independently frozen and
+executed. Its construction fit passed `12/12` positive decisions, `20/20`
+negative labels, and `6/6` supported copies, but sealed transfer reached only
+`5/12`, `14/20`, and `0/6`; every semantic control except candidate order
+failed. It stopped before Python/Rust parity, the full fit, development, or
+product reveal, and emitted no final head. The next proposed mechanism is an
+independently frozen representation-trained or joint relation mechanism through
+the existing R4/Spin attention path, retaining the Rust exact-copy and typed
+non-answer seam. #954 remains open, #955 remains blocked, and #954's final
+source-free terminal remains behind #973. CUDA and
 external GPU execution are out of scope.
 Further 7.15M exposure and learning-rate tuning are prohibited. See the
 [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
@@ -187,15 +193,20 @@ The completed continuation and its NLL-only negative are in
 > versus signed `3.491307 s/step`), and #1019 closed without a full run. #954's
 > first fixed MPS grounding SFT subsequently failed its frozen Rust product
 > population `1/3`. The cosine source-span pointer then passed preflight/parity
-> but failed its development gate before final artifact or reveal. The next
-> proposed mechanism is a source-relative learned relation/entailment head that
-> must be independently frozen; no successor run is active.
+> but failed its development gate before final artifact or reveal. The frozen
+> `R4SourceRelativeRelationHeadV1` successor then passed construction fit at
+> `12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer fell
+> to `5/12`, `14/20`, and `0/6`; only candidate order survived the semantic
+> controls. It stopped before parity, full fit, development, or product reveal
+> and emitted no final head. The next proposal is a representation-trained or
+> joint relation mechanism through the existing R4/Spin attention path while
+> retaining Rust exact-copy and typed non-answer behavior.
 > CUDA and external GPU execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
 > table-native, multiply-free, transformerless serving engine. D3 remains
-> `NOT_RUN`; #954's final source-free terminal remains blocked. No
-> source-relative relation/entailment run is active.
+> `NOT_RUN`; #954 remains open, #955 remains blocked, and #954's final
+> source-free terminal remains behind #973.
 
 > **Admission/influence split:** exact causal/index rows decide which routes are
 > lawful candidates. Harmonic/neighbor influence may transform the state used
@@ -280,13 +291,20 @@ completed in `883.773549 s`, but all three frozen Rust prompts decoded
 `ABSTAIN` (`1/3`); `R4SourceSpanPointerV1` passed preflight/parity but failed
 its development gate at answer/abstain/conflict/pointer accuracies of
 `69.53125%`/`89.0625%`/`91.40625%`/`94.53125%`, so no final artifact was
-emitted and product probes were `NOT_RUN`; **Proposed next:** independently
-freeze a source-relative learned relation/entailment head while preserving
-exact R4/Spin state capture and source-copy semantics; no successor run is active;
+emitted and product probes were `NOT_RUN`; the independently frozen
+`R4SourceRelativeRelationHeadV1` then passed construction fit at
+`12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer reached
+only `5/12`, `14/20`, and `0/6`; every semantic control except candidate order
+failed, so parity, full fit, development, and product reveal were not run and
+no final head was emitted; **Proposed next:** independently freeze a
+representation-trained or joint relation mechanism through the existing
+R4/Spin attention path while preserving the Rust exact-copy and typed
+non-answer seam;
 CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
-deployment; **Blocked:** D3, #954's final source-free terminal, and #955; **Later:**
+deployment; **Blocked:** D3, #954's final source-free terminal behind #973, and
+#955 while #954 remains open; **Later:**
 #955 → #962 → #963 → #964 → #965.
 
 This capability-first reset supersedes the old forward action implied by the
@@ -321,11 +339,17 @@ logging fast path was slower (`4.485223` versus signed `3.491307 s/step`), and
 but the frozen Rust product population failed `1/3` because every prompt decoded
 `ABSTAIN`. Its cosine source-span pointer successor passed preflight/parity but
 failed all four frozen development thresholds and stopped before final artifact
-or reveal. Do not rerun or tune either revealed mechanism. The next proposed
-successor is a source-relative learned relation/entailment head over #1017's
-exact R4/Spin state-capture and copy seams; it must be independently frozen and
-is not active. CUDA and external GPU
-execution are out of scope.
+or reveal. Do not rerun or tune either revealed mechanism. That source-relative
+successor, `R4SourceRelativeRelationHeadV1`, was independently
+frozen and executed: construction fit passed at `12/12` positive, `20/20`
+negative, and `6/6` copy, while sealed transfer failed at `5/12`, `14/20`, and
+`0/6`. Every semantic control except candidate order failed, so the campaign
+stopped before parity, full fit, development, and product reveal with no final
+head. The new proposal is an independently frozen representation-trained or
+joint relation mechanism through the existing R4/Spin attention path, retaining
+Rust exact-copy and typed non-answer behavior. #954 remains open, #955 remains
+blocked, and the final source-free terminal remains behind #973. CUDA and
+external GPU execution are out of scope.
 Intrinsic/resonance/replacement work is
 parked; D3 remains `NOT_RUN`. See the
 [#989 evidence](docs/source_free_table_baseline_989.md); the completed #986
@@ -598,11 +622,18 @@ feasibility boundary remains in the
    `>=95%` gates, so it stopped
    `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` with no final artifact;
    product probes and browser/HTTP wiring were `NOT_RUN`. Do not tune or retry
-   the revealed cosine head. CUDA and external GPU execution are out of scope.
+   the revealed cosine head. `R4SourceRelativeRelationHeadV1` was then frozen
+   independently. It fit the construction gate at `12/12` positive, `20/20`
+   negative, and `6/6` copy, but transferred at only `5/12`, `14/20`, and
+   `0/6`; every semantic control except candidate order failed. It therefore
+   stopped before parity, full fit, development, or product reveal and emitted
+   no final head. CUDA and external GPU execution are out of scope.
    Intrinsic score/readout alternatives, paired-E8, resonance-based softmax
    replacement, and exact deployment are parked; #954's final source-free
-   terminal remains blocked. The proposed source-relative learned
-   relation/entailment successor must be independently frozen; no run is active.
+   terminal remains behind #973. The next proposed mechanism is an independently
+   frozen representation-trained or joint relation mechanism through the
+   existing R4/Spin attention path, retaining the Rust exact-copy and typed
+   non-answer seam. #954 remains open and #955 remains blocked.
    Every learned epoch receives a
    new kappa and reruns its owning
    construction gate. More documents, table density, or trace activity are
@@ -614,12 +645,18 @@ feasibility boundary remains in the
    source-span pointer passed preflight and cross-runtime parity but failed its
    four development gates before final artifact or product reveal. Preserve
    its exact R4/Spin state-capture and source-copy seams, but do not tune or
-   retry it. The next proposed successor is a source-relative learned
-   relation/entailment head on new lexical families; it must be independently
-   frozen before reveal and is not yet active.
+   retry it. The independently frozen `R4SourceRelativeRelationHeadV1`
+   successor then fit construction at `12/12` positive, `20/20` negative, and
+   `6/6` copy, but its sealed transfer was `5/12`, `14/20`, and `0/6`; every
+   semantic control except candidate order failed. It stopped before parity,
+   full fit, development, or product reveal and emitted no final head. The next
+   proposal is an independently frozen representation-trained or joint relation
+   mechanism through the existing R4/Spin attention path, retaining Rust
+   exact-copy and typed non-answer behavior.
    The final source-free terminal still requires the accepted
    selector/#953/#973 artifact and evidence provenance #969 → #983 → #986;
-   source-backed prototype evidence does not satisfy it.
+   source-backed prototype evidence does not satisfy it. #954 remains open and
+   #955 remains blocked.
 11. **GI-5 / #955 — reasoning:** invoke the accepted
    selector/#953/#973/#954 consumer at
    every bounded goal-directed route-composition step. Compare cloned
@@ -701,8 +738,8 @@ historical evidence and comparators.
 
 ## Active
 
-- [ ] **#954 grounded correctness: source-relative learned relation/entailment
-  successor after `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`** — retain the
+- [ ] **#954 grounded correctness: representation-trained or joint relation
+  successor after the source-relative transfer failure** — retain the
   bounded positives, #997 placement negative, bounded gated-delta negative, V2
   budget invalidation, equal-manifold-budget V3 mixed-gauge H4 negative, and
   V4's held-out 13/24 functional/control negative. The positive attention
@@ -752,10 +789,15 @@ historical evidence and comparators.
   then missed the frozen `>=95%` development gates at answer `89/128`, abstain
   `114/128`, conflict `117/128`, and supported pointer `121/128`. No final head
   was emitted; the product probes and browser/HTTP wiring are `NOT_RUN`. Do not
-  tune or retry the revealed cosine pointer. The next proposed mechanism is a
-  source-relative learned relation/entailment head preserving the exact R4/Spin
-  state-capture and source-copy seams; independently freeze it before any run.
-  No successor run or product wiring is active. Apple
+  tune or retry the revealed cosine pointer. The independently frozen
+  `R4SourceRelativeRelationHeadV1` successor then passed its construction fit at
+  `12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer reached
+  only `5/12`, `14/20`, and `0/6`; every semantic control except candidate
+  order failed. It stopped before Python/Rust parity, the full fit, development,
+  or product reveal and emitted no final head. The next proposed mechanism is
+  an independently frozen representation-trained or joint relation mechanism
+  through the existing R4/Spin attention path, retaining the Rust exact-copy
+  and typed non-answer seam. No product wiring is active. Apple
   Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
   external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
@@ -763,9 +805,9 @@ historical evidence and comparators.
   Do not extend
   exposure or tune learning rate on the 7.15M checkpoint. Intrinsic score/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
-  lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954's final
-  source-free terminal remains blocked; no source-relative relation/entailment
-  run is active.
+  lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954 remains
+  open, its final source-free terminal remains behind #973, and #955 remains
+  blocked.
 
 ## Landed
 
@@ -919,13 +961,18 @@ historical evidence and comparators.
   run. #954's first fixed grounding SFT completed but failed its frozen Rust
   population `1/3`. Its cosine source-span pointer then passed preflight/parity
   but failed the frozen development gate before a final artifact or product
-  reveal. The next proposed successor is a source-relative learned
-  relation/entailment head that must be independently frozen; no run is active.
+  reveal. The independently frozen `R4SourceRelativeRelationHeadV1` successor
+  then passed construction fit at `12/12` positive, `20/20` negative, and
+  `6/6` copy but failed sealed transfer at `5/12`, `14/20`, and `0/6`; every
+  semantic control except candidate order failed. It stopped before parity,
+  full fit, development, or product reveal and emitted no final head. The next
+  proposal is an independently frozen representation-trained or joint relation
+  mechanism through the existing R4/Spin attention path, retaining Rust
+  exact-copy and typed non-answer behavior.
   CUDA and external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact
-  deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
-  terminal remains blocked. No source-relative relation/entailment run is
-  active.
+  deployment are parked. D3 remains `NOT_RUN`; #954 remains open, its final
+  source-free terminal remains behind #973, and #955 remains blocked.
   Coherent product behavior, correctness, and reasoning remain unestablished.
   Historical canaries and pointwise results remain scoped evidence, not a
   claim that the current product works. See

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -7,7 +7,7 @@
 > architecture and claim boundaries live in the
 > [Geometric Intelligence Programme](geometric_intelligence_programme.md).
 
-> **Current evidence and direction (2026-08-30):** #989 established the frozen
+> **Current evidence and direction (2026-08-31):** #989 established the frozen
 > source-free table reference at 22.261404% held-out top-1 versus 5.413561%
 > unigram. The accepted #953 `MultiscaleCountRadiusR4V1` intervention raised the
 > same measure to 23.211797% (+4,242 correct) with equal candidate support/work
@@ -110,13 +110,27 @@ MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
 deferred logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
 fast-path negative, not a model result. #1019 tuning/full-run work stops and
-remains optional/paused; the active next step is the working #1017 `r4 generate`
-product path. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS
+remains optional/paused; #1017 remains the working generation base. UOR's
+deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS and MPS
 are local offline accelerators only; CUDA and external GPU execution are out of
 scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
 established attention result. See the
 [#1019 observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json).
+
+#954's first source-backed grounding SFT failed its frozen product population
+`1/3` through universal abstention. `R4SourceSpanPointerV1` then passed overfit
+preflight and Python/Rust parity but missed all four development gates and
+emitted no final head. Its independently frozen C1-SB2 successor,
+`R4SourceRelativeRelationHeadV1`, fit positive relations `12/12`, negative
+relations `20/20`, and supported copies `6/6`; sealed-family transfer was only
+`5/12`, `14/20`, and `0/6`. Candidate-array order equivariance passed, while
+the matched same-source, query-swap, duplicate-agreement, and distinct-value
+conflict controls failed. It stopped before Rust parity, the sole 512-step fit,
+development, product reveal, or final-head emission. This failure does not
+revise the established attention or generation results. See the
+[#954 campaign record](r4_grounded_correctness_954.md) and
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json).
 
 The #1017 export remains the current working 7.15M coherent-generation
 prototype. `r4 generate --prompt "..."` defaults to
@@ -132,8 +146,12 @@ and `f32`/multiply/alloc/source-weight backed; it is not source-free,
 table-native, multiply-free, transformerless, browser-WASM, release, or
 frontier-model evidence.
 Intrinsic/readout alternatives, multi-resonance softmax replacement, full-model
-recurrent lowering, and exact H4/Q29/integer-table deployment are parked; #954
-remains blocked. Validation,
+recurrent lowering, and exact H4/Q29/integer-table deployment are parked. #954
+remains open: its next proposed mechanism trains relation supervision into the
+representation through the existing R4/Spin attention path while retaining the
+exact-copy and typed non-answer Rust seam. #955 remains blocked on a positive
+correctness result, and #954's final source-free terminal remains blocked behind
+#973. Validation,
 test, and inference remain strictly causal and cannot fit on their future
 tokens. Compiler-side floating point, matrix operations, and softmax are allowed
 to prove the representation before exact quantized/table lowering. No source-free
@@ -155,14 +173,19 @@ localization terminal `REJECT_TANGENT_READOUT_SELECT_SCORE_PREFLIGHT`; D3
 #1017 continuation complete at `149,995,520` cumulative tokens with enabled
 Rust parity and all mechanical gates `PASS`, sealed NLL `FAIL`
 (`1.5727521962806827`), prompt retention `PASS` (`5/5`), and normalized replay
-`PASS` (`5/5`); overall NLL-only negative;
+`PASS` (`5/5`); overall NLL-only negative; #954 C1-SB2
+`FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP` with fit positive/negative/copy
+`12/12`, `20/20`, `6/6`, sealed `5/12`, `14/20`, `0/6`, Rust parity/full
+fit/development/product `NOT_RUN`, and no final head;
 resonance replacement `NOT_RUN` and parked; full-model recurrent and
-exact lowering parked; #954 blocked. See
+exact lowering parked. See
 [`helm_d_r4_softmax_decoder_973.md`](helm_d_r4_softmax_decoder_973.md) and
 [`helm_d_learned_manifold_r4_construction_973.md`](helm_d_learned_manifold_r4_construction_973.md),
 then [`r4_softmax_trace_student_973.md`](r4_softmax_trace_student_973.md) and
 [`r4_softmax_trace_observability_1012.md`](r4_softmax_trace_observability_1012.md),
-followed by [`r4_softmax_quality_capacity_continuation_1017.md`](r4_softmax_quality_capacity_continuation_1017.md).
+followed by [`r4_softmax_quality_capacity_continuation_1017.md`](r4_softmax_quality_capacity_continuation_1017.md),
+[`r4_grounded_correctness_954.md`](r4_grounded_correctness_954.md), and
+[`r4_source_relation_head_954_raw.json`](r4_source_relation_head_954_raw.json).
 
 ## Current route-native target lifecycle
 
@@ -205,8 +228,12 @@ canonical text/corpus
     -> continue unchanged 7.15M model to 149,995,520 tokens [#1017; NLL-ONLY FAIL, RETENTION/PARITY/REPLAY PASS]
     -> #1019 frozen 12-layer, 13,130,784-parameter campaign over the unchanged mechanism [MODEL SUBGATES PASS; MPS TIME UNAVAILABLE; FULL RUN NOT_RUN]
     -> intrinsic/readout alternatives, paired-E8, resonance replacement, full-model recurrent lowering, and exact deployment parked
-    -> correctness + typed abstention (#954)
-    -> bounded reasoning (#955)
+    -> source-backed grounded SFT [#954 C1-SB0; PRODUCT TRANSFER FAIL]
+    -> cosine source-span pointer [#954 C1-SB1; DEVELOPMENT FAIL, NO FINAL HEAD]
+    -> terminal-residual relation head [#954 C1-SB2; MATCHED-TRANSFER PREFLIGHT FAIL, NO FINAL HEAD]
+    -> train relation supervision through existing R4/Spin attention while retaining exact-copy + typed nonanswer seam [#954; PROPOSED]
+    -> final source-free correctness terminal [#954; BLOCKED BEHIND #973]
+    -> bounded reasoning [#955; BLOCKED ON POSITIVE CORRECTNESS]
     -> durable isolated CLI/HTTP chat + persisted hive memory (#962)
     -> measured cost, formal/serving closure, and release (#963-#965)
 ```
@@ -1551,8 +1578,10 @@ D3 on construction covariance, with diagnostic curved NLL worse than donor and
   also passes the frozen eight-token CLI-parity canary without changing the
   default engine. Dashboard wiring/readiness and static/WASM-isolation checks
   pass, but hosted Pages remains static/offline without a functioning chat
-  backend/artifact lowering. #973 remains open and correctness (#954), reasoning
-  (#955), and durable chat/memory integration (#962) remain blocked. The Q16
+  backend/artifact lowering. #973 and source-backed correctness work in #954
+  remain open; #954's final source-free terminal remains blocked behind #973,
+  and reasoning (#955) remains blocked on a positive correctness result. Durable
+  chat/memory integration (#962) remains downstream. The Q16
   suffix trace student is complete with bounded distillation but looping output.
   Its recurrent `R4SoftmaxTraceStateStudentV1` successor failed promotion with
   no decision change, no material geometry-control effect, and the same loop.
@@ -1572,10 +1601,16 @@ D3 on construction covariance, with diagnostic curved NLL worse than donor and
   `20.66 h` safety projection exceeded `8 h`; memory passed at `21.03%`. That
   terminal applies only to the frozen offline implementation. Full training,
   final parity, reveal, generation, and replay remain `NOT_RUN`. Its fused-
-  AdamW/deferred-logging fast path was slower, so #1019 is optional/paused and
-  the active next step is the #1017 `r4 generate` product path. CUDA and
-  external GPU execution are out of scope. Further exposure and
-  LR tuning of the 7.15M checkpoint are prohibited.
+  AdamW/deferred-logging fast path was slower, so #1019 is optional/paused.
+  #954 C1-SB0 then failed frozen product transfer `1/3`; C1-SB1 failed all four
+  development gates; and C1-SB2 fit positive/negative/copy relations at
+  `12/12`, `20/20`, and `6/6` but transferred only `5/12`, `14/20`, and `0/6`.
+  Only candidate-array order equivariance passed. C1-SB2 stopped before Rust
+  parity, its 512-step fit, development, product, or final-head emission. The
+  active proposed #954 step is to train relation supervision into the existing
+  R4/Spin attention representation while preserving the exact-copy and typed
+  non-answer Rust seam. CUDA and external GPU execution are out of scope.
+  Further exposure and LR tuning of the 7.15M checkpoint are prohibited.
   Resonance substitutes, unrelated optimization, and release work
   remain parked. Lowering does not otherwise reactivate automatically on a
   generation positive.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -155,11 +155,20 @@ assumptions, or objectives rather than measured results.
 > abstain `89.0625%`, conflict `91.40625%`, and supported pointer `94.53125%`.
 > It stopped `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`; no final pointer
 > artifact was emitted, and product probes plus browser/HTTP wiring were
-> `NOT_RUN`. Do not tune or retry that revealed cosine head. The proposed next
-> #954 mechanism is a source-relative learned relation/entailment head
-> preserving exact R4/Spin state capture and source-copy semantics; it must be
-> independently frozen and no successor run or product wiring is active. CUDA and
-> external GPU execution are out of scope. See
+> `NOT_RUN`. Do not tune or retry that revealed cosine head.
+> `R4SourceRelativeRelationHeadV1` then stopped at its independently frozen
+> matched-transfer preflight. Fit-family positive relations, negative relations,
+> and supported copies were exact at `12/12`, `20/20`, and `6/6`; sealed-family
+> transfer fell to `5/12`, `14/20`, and `0/6`. Only candidate-array order
+> equivariance passed; the matched same-source, query-swap, duplicate-agreement,
+> and distinct-value conflict controls failed. The run stopped before Rust
+> parity, the sole 512-step fit, development evaluation, product reveal, or a
+> final head. Do not tune or retry that terminal-residual probe. #954 remains
+> open, but its next proposed mechanism must train relation supervision into the
+> representation through the existing R4/Spin attention path while preserving
+> the exact-copy and typed non-answer Rust seam. #955 remains blocked on a
+> positive correctness result, and #954's final source-free terminal remains
+> blocked behind #973. CUDA and external GPU execution are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
@@ -172,7 +181,9 @@ assumptions, or objectives rather than measured results.
 > [state-student record](r4_softmax_trace_state_student_1011.md),
 > [#1012 observability record](r4_softmax_trace_observability_1012.md), and
 > [#1014 end-to-end record](r4_softmax_end_to_end_attention_1014.md), then the
-> [#1017 continuation record](r4_softmax_quality_capacity_continuation_1017.md).
+> [#1017 continuation record](r4_softmax_quality_capacity_continuation_1017.md),
+> the [#954 campaign record](r4_grounded_correctness_954.md), and the
+> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json).
 >
 > **Measured evidence status:** HELM-D pinned-source provenance `PASS`;
 > ordinary-donor reproduction `PASS`; transported-R4 parity, destructive
@@ -205,6 +216,10 @@ assumptions, or objectives rather than measured results.
 > enabled Rust parity `PASS`, all-layer causal/R4/external audits `PASS`, sealed
 > NLL `FAIL` (`1.5727521962806827 > 1.50`), prompt retention `PASS` (`5/5`), and
 > normalized seeded replay `PASS` (`5/5`); overall NLL-only negative;
+> #954 C1-SB2 `FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP`, with fit
+> positive/negative/copy `12/12`, `20/20`, `6/6`, sealed `5/12`, `14/20`,
+> `0/6`, only candidate-order control passing, Rust parity/full
+> fit/development/product `NOT_RUN`, and no final head;
 > D3 `NOT_RUN`; multi-resonance replacement `NOT_RUN` and parked; whole-decoder
 > recurrent factorization/lowering `NOT_RUN` and parked. See the
 > [`HELM-D-R4` record](helm_d_r4_softmax_decoder_973.md) and the
@@ -569,15 +584,22 @@ assumptions, or objectives rather than measured results.
 > closed without a full run. #954's first fixed grounding SFT subsequently
 > failed its frozen Rust population `1/3`. Its cosine source-span pointer passed
 > preflight and cross-runtime parity but failed its four development gates
-> before a final artifact or product reveal. The proposed next mechanism is a
-> source-relative learned relation/entailment head that must be independently
-> frozen; no successor run is active. CUDA and external
-> GPU execution are out of scope.
+> before a final artifact or product reveal. Its independently frozen
+> `R4SourceRelativeRelationHeadV1` successor fit positive/negative/copy relations
+> at `12/12`, `20/20`, and `6/6`, but transferred only `5/12`, `14/20`, and
+> `0/6`; only candidate-array order equivariance passed, while the matched
+> same-source, query-swap, duplicate-agreement, and conflict controls failed.
+> It stopped before Rust parity, the sole 512-step fit, development, product, or
+> final-head emission. #954 remains open. The next proposed mechanism trains
+> relation supervision into the representation through existing R4/Spin
+> attention while retaining the exact-copy and typed non-answer Rust seam. CUDA
+> and external GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
 > exact deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
-> terminal remains blocked behind #973; no source-relative relation/entailment
-> successor run is active.
+> terminal remains blocked behind #973, and #955 remains blocked on a positive
+> correctness result. See the [#954 campaign record](r4_grounded_correctness_954.md)
+> and [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json).
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1103,11 +1125,15 @@ up to the point where a structure predicts at all, and not past it.**
 
 The project's ultimate runtime goal remains source-free recursive geometric
 attention, but load-bearing ordinary causal attention is now established in the
-R4/Spin reference. The immediate goal is #954 grounded correctness: a proposed
-source-relative learned relation/entailment head after both the
-bounded generative SFT and the cosine source-span pointer failed their frozen
-transfer/development gates. It must be independently frozen; no successor run
-or product wiring is active.
+R4/Spin reference. The immediate goal remains open #954 grounded correctness.
+After the bounded generative SFT and cosine source-span pointer failed their
+frozen transfer/development gates, `R4SourceRelativeRelationHeadV1` fit its
+matched construction families but failed independent lexical transfer at its
+cheap preflight: positive `5/12`, negative `14/20`, and supported copy `0/6`.
+The next proposed mechanism must train relation supervision into the
+representation through the existing R4/Spin attention path while retaining the
+exact-copy and typed non-answer Rust seam. #955 remains blocked, and #954's
+final source-free terminal remains behind #973.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
 reusable summaries erased earlier causal order, terminating as
@@ -1175,10 +1201,18 @@ Python/Rust parity, but its sole 256-step fit reached answer `89/128`, abstain
 the frozen `>=95%` gates. It stopped
 `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP` without a final head, so the
 reserved product probes and browser/HTTP wiring were `NOT_RUN`. Do not tune or
-retry the revealed cosine head. The proposed next mechanism is a source-relative
-learned relation/entailment head preserving the exact R4/Spin state capture and
-deterministic source-copy seams; it must be independently frozen, and no
-successor run is active.
+retry the revealed cosine head. `R4SourceRelativeRelationHeadV1` then fit all
+required construction relations (`12/12` positive, `20/20` negative, `6/6`
+copy) but failed sealed lexical transfer (`5/12`, `14/20`, `0/6`). Candidate
+order was the only passing shortcut control; same-source, query-swap,
+duplicate-agreement, and conflict controls failed. It stopped before Rust
+parity, its sole 512-step full fit, development, product, and final-head
+emission. Do not tune or retry it. The next proposed #954 mechanism trains
+relation supervision into the representation through existing R4/Spin
+attention, retaining deterministic exact copy and typed non-answer output.
+#954 remains open; #955 remains blocked, and the final source-free #954 terminal
+remains behind #973. See the [campaign record](r4_grounded_correctness_954.md)
+and [compact aggregate](r4_source_relation_head_954_raw.json).
 CUDA and external GPU execution remain out of scope. Fiber-preserving
 multi-resonance replacement, whole-decoder recurrent factorization, capacity
 expansion, and final source-free requalification are parked. Dependable broad
@@ -1790,14 +1824,20 @@ was slower, and #1019 closed without a full run. #954's first source-backed
 grounding SFT subsequently completed but failed its frozen product transfer
 population `1/3` through universal `ABSTAIN`. Its cosine source-span pointer
 then passed preflight/parity but failed the frozen development gate before a
-final artifact or product reveal. The proposed next mechanism is a
-source-relative learned relation/entailment head that must be independently
-frozen; no successor run is active.
+final artifact or product reveal. `R4SourceRelativeRelationHeadV1` next fit the
+12-case construction families exactly but failed its matched-transfer
+preflight: positive `5/12`, negative `14/20`, and copy `0/6`, with only
+candidate-order control passing. Rust parity, the 512-step full fit,
+development, product, and final-head emission were `NOT_RUN`.
 CUDA and external GPU execution are out of scope. Intrinsic/readout alternatives,
 multi-resonance replacement, whole-decoder recurrent factorization, and final
-requalification are parked. D3 remains `NOT_RUN`; #954's final source-free
-terminal remains blocked; no source-relative relation/entailment successor run
-is active.
+requalification are parked. D3 remains `NOT_RUN`; #954 remains open, with its
+next proposed mechanism training relation supervision into the existing
+R4/Spin attention representation while preserving exact-copy and typed
+non-answer Rust behavior. Its final source-free terminal remains blocked behind
+#973, and #955 remains blocked on a positive correctness result. See the
+[#954 campaign record](r4_grounded_correctness_954.md) and
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json).
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/r4_grounded_correctness_954.md
+++ b/docs/r4_grounded_correctness_954.md
@@ -1,6 +1,6 @@
 # Source-backed grounded answer campaigns (#954)
 
-Status: **C1-SB1 DEVELOPMENT GATE STOP / NO QUALIFIED ANSWER ARTIFACT**
+Status: **C1-SB2 MATCHED-TRANSFER PREFLIGHT STOP / NO QUALIFIED ANSWER ARTIFACT**
 Parent programme: #820
 Working model: #1017 six-layer R4/Spin causal-softmax checkpoint
 Final source-free correctness terminal: still blocked by parked #973
@@ -132,3 +132,73 @@ or product wiring is active. #1017 remains the working coherent-generation
 prototype, and ordinary causal attention remains established at its existing
 claim scope. The compact bound aggregate is
 [`r4_source_span_pointer_954_raw.json`](r4_source_span_pointer_954_raw.json).
+
+## C1-SB2 source-relative relation-head result — 2026-08-31
+
+`R4SourceRelativeRelationHeadV1` replaced subject/sentence cosine similarity
+with one question-conditioned representation per candidate:
+
+```text
+Evidence:
+<exact source sentence>
+Question:
+Where is the <subject>?
+```
+
+There is no terminal newline. The immutable #1017 executor retains the final
+width-288 normalized residual at the question-mark token after all six coherent
+R4/Spin causal-softmax layers. A fixed `288 -> 32 ReLU -> 1` probe (9,281
+parameters) assigns one relation logit. Only `logit > 0` authorizes a candidate;
+zero is negative. Exact duplicate sentence text collapses before the decision:
+zero unique positives abstains, one copies an original occurrence, and two or
+more distinct positives report contradiction.
+
+The new population removed the shortcut found in C1-SB1. It contains 3,360
+construction and 420 development records across answer/abstain/conflict and
+source widths 2 through 8. Construction and development subjects and exact
+sentences are disjoint. Raw queried-subject occurrence count is ambiguous in
+both splits. The 420 reversed-source and 335 same-source query-swap controls are
+also bound, while four product records were committed before fitting and never
+feature-extracted, scored, or evaluated by Python.
+
+Before any full-population extraction or fit, the frozen cheap gate trained on
+12 motifs from two lexical families and evaluated 12 homologous motifs from two
+unseen families. The 256-step MPS probe reduced fit loss from
+`0.7386124730110168` to `0.14383068680763245` and fit every required relation:
+
+| Preflight metric | Fit | Sealed lexical transfer | Required |
+| --- | ---: | ---: | ---: |
+| answer decisions | `6/6` | `0/6` | exact |
+| abstain decisions | `4/4` | `3/4` | exact |
+| conflict decisions | `2/2` | `1/2` | exact |
+| positive-relation recall | `12/12` | `5/12` | exact |
+| negative-relation specificity | `20/20` | `14/20` | exact |
+| supported copied span | `6/6` | `0/6` | exact |
+
+Candidate-array order equivariance passed, but the matched same-source,
+query-swap, duplicate-agreement, and distinct-value conflict controls did not.
+The terminal is **`FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP`**. Result CID:
+`blake3:ce3f06fd4962ac72127bb7dc0ca4123f89478047acd302481704d1f1b3f4ebaf`;
+manifest CID:
+`blake3:14d04e0a6fe4ffd65c3fe1d63ede3425262c3de8351733021d5f7dbd0aa3c493`.
+
+The gate did its job in about 20 seconds: it showed exact fit-family
+memorization without independent lexical transfer. Python/Rust relation-logit
+parity, the sole 512-step full fit, development evaluation, final head emission,
+and all four product probes are `NOT_RUN`. No C1-SB2 head is qualified for the
+default `r4 answer` surface.
+
+Do not tune or retry this frozen residual probe and do not return to attention,
+capacity, resonance, backend, or corpus-volume campaigns for this failure.
+Ordinary causal attention and coherent bounded generation remain established at
+their prior scopes. The missing capability is now localized more sharply:
+source-relative entailment is not a lexically transferable feature of the
+frozen #1017 terminal residual under this probe. The next proposed mechanism
+must train relation supervision into the representation itself—through the
+existing R4/Spin attention path—while retaining the exact-copy and typed
+non-answer Rust boundary. It must be frozen independently before execution.
+
+The compact bound aggregate is
+[`r4_source_relation_head_954_raw.json`](r4_source_relation_head_954_raw.json).
+The final source-free #954 terminal remains separately blocked by #973, and
+#955 reasoning remains downstream of a positive correctness result.

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -74,8 +74,22 @@
   combined fused AdamW with deferred logging and measured `4.485223 s/step`,
   slower than the signed `3.491307 s/step`; `fused=True` was removed
   immediately. This is a bounded fast-path negative, not a model result. #1019
-  tuning/full-run work stops and remains optional/paused; the active next step
-  is the working #1017 `r4 generate` product path. UOR's deployed
+  tuning/full-run work stops and remains optional/paused; #1017 remains the
+  working generation base. #954's first grounded SFT failed product transfer
+  `1/3`, and its cosine source-span pointer stopped before product after missing
+  all four frozen development gates. The independently frozen
+  `R4SourceRelativeRelationHeadV1` successor then fit positive, negative, and
+  copy relations at `12/12`, `20/20`, and `6/6`, but transferred only `5/12`,
+  `14/20`, and `0/6` to sealed lexical families. Candidate-array order was the
+  only passing control; matched same-source, query-swap, duplicate-agreement,
+  and distinct-value conflict controls failed. It stopped before Rust parity,
+  the sole 512-step fit, development, product, or final-head emission. This
+  negative does not revise the established attention or generation results.
+  #954 remains open. Its next proposed mechanism trains relation supervision
+  into the representation through the existing R4/Spin attention path while
+  retaining the exact-copy and typed non-answer Rust seam. #955 remains
+  blocked, and #954's final source-free terminal remains blocked behind #973.
+  UOR's deployed
   architecture/runtime remains CPU-native;
   Apple Accelerate/BLAS and MPS are local offline accelerators only; CUDA and
   external GPU execution are out of scope. The MPS stop is not a
@@ -85,8 +99,8 @@
   while proving a replacement mechanism; the deployed destination remains
   exact, integer/table-native, and source-free.
   Intrinsic/readout alternatives, resonance-based softmax replacement,
-  full-model recurrent lowering, and exact deployment are parked. D3 remains `NOT_RUN`; #954 remains
-  blocked. No tag, release, hosted promotion, or static-WASM claim is
+  full-model recurrent lowering, and exact deployment are parked. D3 remains
+  `NOT_RUN`. No tag, release, hosted promotion, or static-WASM claim is
   authorized. See the
   [generation record](r4_softmax_reference_generation_973.md) and
   [compact aggregate](r4_softmax_reference_generation_attempt_01_result_973.json),
@@ -97,7 +111,9 @@
   by the [#1014 end-to-end result](r4_softmax_end_to_end_attention_1014.md) and
   [#1017 continuation result](r4_softmax_quality_capacity_continuation_1017.md),
   then the [#1019 frozen contract](r4_softmax_parameter_capacity_1019.md) and
-  [observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json).
+  [observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json),
+  followed by the [#954 campaign record](r4_grounded_correctness_954.md) and
+  [C1-SB2 aggregate](r4_source_relation_head_954_raw.json).
   The intermediate
   [Geometric Causal Decoder Roadmap](geometric_causal_decoder_plan.md) records
   the superseded #948-#958 sequence.

--- a/docs/r4_source_relation_head_954_raw.json
+++ b/docs/r4_source_relation_head_954_raw.json
@@ -1,0 +1,82 @@
+{
+  "schema": "uor-r4.source-relative-relation-head-aggregate/1",
+  "issue": 954,
+  "policy": "R4SourceRelativeRelationHeadV1",
+  "observed_at": "2026-08-31",
+  "terminal": "FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP",
+  "claim_scope": "one frozen 288-to-32-ReLU-to-1 relation probe over immutable #1017 final question-token R4/Spin causal-softmax states",
+  "checkpoint": {
+    "model_weights_cid": "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d",
+    "tokenizer_cid": "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc"
+  },
+  "population": {
+    "construction_records": 3360,
+    "development_records": 420,
+    "development_reversal_controls": 420,
+    "development_query_swap_controls": 335,
+    "preflight_fit_records": 12,
+    "preflight_sealed_records": 12,
+    "product_probe_commitments": 4,
+    "dataset_cid": "blake3:e578c45c25c955d473de3dc1b8645470f4c8b73c24ad4fc488ae1afe710c2cbc",
+    "dataset_manifest_cid": "blake3:4840c70e57ba2b28e620a853f015e5ae594a67918f58fde72e340e567cc3d71c",
+    "split_policy_cid": "blake3:03a9453e92ebde3ccd17f1d6e3f246f88e64cabb8a73552bfd7aea839066a5da",
+    "generator_contract_cid": "blake3:4ab75abee360a11a9fc3eb4c8f7251c301d989d6997c1448ca2a5666a962bc1f",
+    "shortcut_census_cid": "blake3:b6a66ffc2cefafec84ef58815c9579d960841244cdfc1097d5623e45a5b1353d",
+    "preflight_cid": "blake3:74b38e9f3e4b56a1b0ddd45b6849fb2981c3ed645fec475e56b64af8f5fe92ab",
+    "product_probes_cid": "blake3:e956f0e3fc603944eebdcd080ef09cf6c73cd65ebb72757664e4c6274e9ed2d2"
+  },
+  "run_contract_cid": "blake3:56df08813abfc75b3a89f67cce85a1b23eeff1ddac5250b54b255cbac108e151",
+  "optimization": {
+    "seed": 9542,
+    "optimizer": "AdamW",
+    "optimizer_steps": 256,
+    "batch_size": 12,
+    "initial_relation_loss": 0.7386124730110168,
+    "final_relation_loss": 0.14383068680763245
+  },
+  "fit": {
+    "mean_record_balanced_relation_loss": 0.14213033020496368,
+    "answer": {"correct": 6, "total": 6, "accuracy": 1.0},
+    "abstain": {"correct": 4, "total": 4, "accuracy": 1.0},
+    "conflict": {"correct": 2, "total": 2, "accuracy": 1.0},
+    "positive_relation_recall": {"correct": 12, "total": 12, "accuracy": 1.0},
+    "negative_relation_specificity": {"correct": 20, "total": 20, "accuracy": 1.0},
+    "supported_copied_span": {"correct": 6, "total": 6, "accuracy": 1.0}
+  },
+  "sealed_transfer": {
+    "mean_record_balanced_relation_loss": 1.0724267959594727,
+    "answer": {"correct": 0, "total": 6, "accuracy": 0.0},
+    "abstain": {"correct": 3, "total": 4, "accuracy": 0.75},
+    "conflict": {"correct": 1, "total": 2, "accuracy": 0.5},
+    "positive_relation_recall": {"correct": 5, "total": 12, "accuracy": 0.4166666666666667},
+    "negative_relation_specificity": {"correct": 14, "total": 20, "accuracy": 0.7},
+    "supported_copied_span": {"correct": 0, "total": 6, "accuracy": 0.0}
+  },
+  "controls": {
+    "candidate_array_order_equivariant": true,
+    "same_source_matched_pairs_exact": false,
+    "query_swap_sensitive": false,
+    "duplicate_agreement": false,
+    "different_value_conflict": false,
+    "passed": false
+  },
+  "preflight_result_cid": "blake3:ce3f06fd4962ac72127bb7dc0ca4123f89478047acd302481704d1f1b3f4ebaf",
+  "preflight_manifest_cid": "blake3:14d04e0a6fe4ffd65c3fe1d63ede3425262c3de8351733021d5f7dbd0aa3c493",
+  "preflight_tree_cid": "blake3:4291d713ab9d31e366575b157e8f7f5371e704db95fc933896015586a26ec5dc",
+  "stage_status": {
+    "zero_training_shortcut_census": "PASS",
+    "matched_transfer_preflight": "FAIL",
+    "python_rust_relation_parity": "NOT_RUN",
+    "sole_512_step_fit": "NOT_RUN",
+    "development_gate": "NOT_RUN",
+    "final_relation_head_artifact": "NOT_EMITTED",
+    "product_probe_reveal": "NOT_RUN",
+    "browser_or_http_wiring": "NOT_RUN"
+  },
+  "decision": "The frozen probe memorized both fit lexical families but did not transfer source-relative locative relations to either sealed family. Do not retry or tune this probe. Preserve the exact-copy Rust seam and move relation supervision into the representation rather than adding another frozen residual readout.",
+  "nonclaims": [
+    "This result does not revoke the established ordinary causal attention result.",
+    "This result does not test the independently blocked final source-free #954 terminal.",
+    "This result does not establish or refute general R4 geometry, reasoning, transformerlessness, exact lowering, or product readiness."
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod r4_softmax_trace_observability_experiment;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4_softmax_trace_state_experiment;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod r4_source_relation_head;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod r4_source_span_pointer;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod r4g1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use uor_r4_wasm_router::tless_uor;
     name = "r4",
     version,
     about,
-    long_about = "Run the working R4/Spin causal-attention generator, exercise the fail-closed source-span-pointer research surface, or inspect the preserved geometric research tools.\n\n`generate` uses the coherent #1017 reference. `answer` accepts a #954 pointer artifact over independently encoded #1017 R4/Spin states and serves only an exact source sentence or a typed non-answer; the frozen C1-SB1 run failed its development gate and emitted no qualified final head. Both paths remain source-backed floating-point/softmax references, not the final source-free transformerless runtime. Preserved compiler and certification commands remain available through `r4 research-tools`."
+    long_about = "Run the working R4/Spin causal-attention generator, exercise the fail-closed grounded-answer research surface, or inspect the preserved geometric research tools.\n\n`generate` uses the coherent #1017 reference. `answer` accepts either the historical #954 cosine-pointer schema or the source-relative relation-head schema over independently encoded #1017 R4/Spin states and serves only an exact source sentence or a typed non-answer. C1-SB1 failed development and C1-SB2 failed matched lexical transfer; neither emitted a qualified final head. Both paths remain source-backed floating-point/softmax references, not the final source-free transformerless runtime. Preserved compiler and certification commands remain available through `r4 research-tools`."
 )]
 struct Cli {
     /// Increase log verbosity (-v info, -vv debug, -vvv trace).
@@ -115,7 +115,7 @@ enum Command {
     /// Generate from the local learned R4/Spin model through causal softmax.
     #[command(visible_alias = "generate")]
     R4SoftmaxLocalGenerate(R4SoftmaxLocalGenerateArgs),
-    /// Exercise a #954 source-span pointer; no qualified final head exists yet.
+    /// Select an exact source answer with the #954 source-relative relation head.
     Answer(GroundedAnswerArgs),
     /// Qualify one frozen #1014, #1017, or #1019 local causal-softmax campaign.
     R4SoftmaxLocalQualify(R4SoftmaxLocalQualifyArgs),
@@ -774,13 +774,13 @@ struct R4SoftmaxLocalGenerateArgs {
 
 #[derive(Args, Debug)]
 struct GroundedAnswerArgs {
-    /// Frozen local #1017 checkpoint directory used to encode pointer states.
+    /// Frozen local #1017 checkpoint directory used to encode relation states.
     #[arg(long, default_value = ".uor-models/research/issue-1017/export")]
     model: PathBuf,
-    /// Research #954 pointer artifact bound to the frozen checkpoint.
+    /// Research #954 relation-head artifact bound to the frozen checkpoint.
     #[arg(
         long,
-        default_value = ".uor-models/research/issue-954/source-span-pointer/source-span-pointer.json"
+        default_value = ".uor-models/research/issue-954/source-relation-head/source-relation-head.json"
     )]
     head: PathBuf,
     /// Exact regular, non-symlink UTF-8 source file used to ground the answer.
@@ -789,7 +789,7 @@ struct GroundedAnswerArgs {
     /// Exact question in the sole admitted form: `Where is the <subject>?`.
     #[arg(long)]
     question: String,
-    /// Optional path for the source binding, pointer scores, and R4 state audit.
+    /// Optional path for the source binding, relation logits, and R4 state audit.
     #[arg(long)]
     json_output: Option<PathBuf>,
 }
@@ -2525,7 +2525,7 @@ const DEFAULT_REFERENCE_CHECKPOINT: &str = "/tmp/ref/out/model.bin";
 const DEFAULT_R4_SOFTMAX_LOCAL_MODEL: &str = ".uor-models/research/issue-1017/export";
 const DEFAULT_GROUNDED_ANSWER_MODEL: &str = ".uor-models/research/issue-1017/export";
 const DEFAULT_GROUNDED_ANSWER_HEAD: &str =
-    ".uor-models/research/issue-954/source-span-pointer/source-span-pointer.json";
+    ".uor-models/research/issue-954/source-relation-head/source-relation-head.json";
 
 fn resolve_r4_softmax_local_model(configured: &Path) -> Result<PathBuf, RunError> {
     let model = if configured == Path::new(DEFAULT_R4_SOFTMAX_LOCAL_MODEL) {
@@ -2559,13 +2559,13 @@ fn resolve_grounded_answer_model(configured: &Path) -> Result<PathBuf, RunError>
 
 fn resolve_grounded_answer_head(configured: &Path) -> Result<PathBuf, RunError> {
     let head = if configured == Path::new(DEFAULT_GROUNDED_ANSWER_HEAD) {
-        model_store_root().join("research/issue-954/source-span-pointer/source-span-pointer.json")
+        model_store_root().join("research/issue-954/source-relation-head/source-relation-head.json")
     } else {
         configured.to_path_buf()
     };
     if !head.is_file() {
         return Err(RunError::Command(format!(
-            "no #954 source-span pointer artifact found at {}; the bounded run emitted no qualified final head, so pass --head only for an explicit research artifact",
+            "no qualified #954 C1-SB2 source-relative relation head found at {}; C1-SB2 stopped before final-head emission, so pass --head only to replay an explicit research artifact",
             head.display()
         )));
     }

--- a/src/r4_grounded_answer.rs
+++ b/src/r4_grounded_answer.rs
@@ -1,10 +1,12 @@
 //! Fail-closed exact source-span answers selected from #1017 R4/Spin states.
 //!
 //! This surface does not ask the language-model decoder to invent an answer.
-//! It encodes the requested subject and each admitted source sentence through
-//! the established six-layer coherent R4/Spin causal-softmax executor, applies
-//! one learned pointer head, and either copies one original UTF-8 byte span or
-//! returns a typed abstention/conflict terminal.
+//! The current policy encodes every admitted source sentence relative to the
+//! exact question through the established six-layer coherent R4/Spin
+//! causal-softmax executor, applies one learned relation head, and either copies
+//! one original UTF-8 byte span or returns a typed abstention/conflict terminal.
+//! The failed historical cosine pointer remains readable only for replay of its
+//! already-recorded evidence.
 
 use std::fmt;
 use std::fs::{File, OpenOptions};
@@ -20,12 +22,20 @@ use crate::r4_softmax_local_generation::{
     R4SoftmaxLocalStateEncodingConfig, R4SoftmaxLocalStateSequenceAudit, SourceReadAudit,
 };
 use crate::r4_softmax_reference_generation::ModelShape;
+use crate::r4_source_relation_head::{
+    evaluate_source_relation_head, load_source_relation_head, render_relation_input,
+    SourceRelationCandidate, SourceRelationHeadBinding, SourceRelationHeadDecision,
+    SourceRelationHeadError, SourceRelationHeadEvaluation, RELATION_HEAD_ARTIFACT_SCHEMA,
+    RELATION_HEAD_POLICY, RELATION_INPUT_POLICY,
+};
 use crate::r4_source_span_pointer::{
     evaluate_source_span_pointer, load_source_span_pointer, SourceSpanPointerBinding,
-    SourceSpanPointerDecision, SourceSpanPointerError, SourceSpanPointerEvaluation, POINTER_POLICY,
+    SourceSpanPointerDecision, SourceSpanPointerError, SourceSpanPointerEvaluation,
+    POINTER_ARTIFACT_SCHEMA, POINTER_POLICY,
 };
 
-pub const REPORT_SCHEMA: &str = "uor-r4.grounded-answer/2";
+pub const POINTER_REPORT_SCHEMA: &str = "uor-r4.grounded-answer/2";
+pub const RELATION_REPORT_SCHEMA: &str = "uor-r4.grounded-answer/3";
 pub const MAX_SOURCE_BYTES: usize = 4 * 1024;
 pub const MAX_QUESTION_BYTES: usize = 1024;
 pub const MAX_SOURCE_SPANS: usize = 8;
@@ -63,6 +73,10 @@ pub struct SourceSpanCandidateBinding {
     pub text_cid: String,
     pub state_cid: String,
     pub content_token_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_input_text_cid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_state_cid: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -74,9 +88,14 @@ pub struct GroundedStateEncodingAudit {
     pub hidden_size: usize,
     pub checkpoint: LocalCheckpointBinding,
     pub model_shape: ModelShape,
-    pub subject_text_cid: String,
-    pub subject_state_cid: String,
-    pub subject_content_token_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_text_cid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_state_cid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_content_token_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_input_policy: Option<String>,
     pub sequence_audits: Vec<R4SoftmaxLocalStateSequenceAudit>,
     pub source_read_audit: SourceReadAudit,
     pub execution: TeacherExecutionSnapshot,
@@ -98,16 +117,27 @@ pub struct GroundedPointerEvaluation {
     pub selected_span_index: Option<usize>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GroundedRelationEvaluation {
+    pub candidate_logits: Vec<f32>,
+    pub positive_candidate_indices: Vec<usize>,
+    pub positive_unique_span_count: usize,
+    pub decision: String,
+    pub selected_span_index: Option<usize>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GroundedAbstentionReason {
     PointerAbstained,
+    RelationNoSupport,
 }
 
 impl GroundedAbstentionReason {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::PointerAbstained => "pointer_abstained",
+            Self::RelationNoSupport => "relation_no_support",
         }
     }
 }
@@ -141,6 +171,21 @@ struct GroundedDecisionIdentity<'a> {
 }
 
 #[derive(Serialize)]
+struct GroundedRelationDecisionIdentity<'a> {
+    schema: &'static str,
+    relation_policy: &'static str,
+    relation_input_policy: &'static str,
+    source_cid: &'a str,
+    source_byte_length: usize,
+    question: &'a str,
+    relation_artifact_cid: &'a str,
+    state_encoding_audit_cid: &'a str,
+    candidate_spans: &'a [SourceSpanCandidateBinding],
+    relation_evaluation: &'a GroundedRelationEvaluation,
+    outcome: &'a GroundedAnswerOutcome,
+}
+
+#[derive(Serialize)]
 pub struct GroundedAnswerReport {
     pub schema: String,
     pub decision_cid: String,
@@ -149,8 +194,14 @@ pub struct GroundedAnswerReport {
     pub question: String,
     pub subject: String,
     pub candidate_spans: Vec<SourceSpanCandidateBinding>,
-    pub pointer: SourceSpanPointerBinding,
-    pub pointer_evaluation: GroundedPointerEvaluation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pointer: Option<SourceSpanPointerBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pointer_evaluation: Option<GroundedPointerEvaluation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation: Option<SourceRelationHeadBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_evaluation: Option<GroundedRelationEvaluation>,
     /// Compact audit only. Raw width-288 state vectors are deliberately not
     /// repeated in the public report, but their content CIDs remain bound.
     pub state_encoding: GroundedStateEncodingAudit,
@@ -164,6 +215,7 @@ pub enum GroundedAnswerError {
     InvalidSource(String),
     StateEncoding(R4SoftmaxLocalGenerationError),
     Pointer(SourceSpanPointerError),
+    Relation(SourceRelationHeadError),
     Audit(String),
     Io(io::Error),
 }
@@ -175,6 +227,7 @@ impl fmt::Display for GroundedAnswerError {
             Self::InvalidSource(reason) => write!(formatter, "invalid grounding source: {reason}"),
             Self::StateEncoding(error) => error.fmt(formatter),
             Self::Pointer(error) => error.fmt(formatter),
+            Self::Relation(error) => error.fmt(formatter),
             Self::Audit(reason) => write!(formatter, "grounded answer audit failed: {reason}"),
             Self::Io(error) => error.fmt(formatter),
         }
@@ -195,6 +248,12 @@ impl From<SourceSpanPointerError> for GroundedAnswerError {
     }
 }
 
+impl From<SourceRelationHeadError> for GroundedAnswerError {
+    fn from(error: SourceRelationHeadError) -> Self {
+        Self::Relation(error)
+    }
+}
+
 impl From<io::Error> for GroundedAnswerError {
     fn from(error: io::Error) -> Self {
         Self::Io(error)
@@ -202,6 +261,34 @@ impl From<io::Error> for GroundedAnswerError {
 }
 
 pub fn run_grounded_answer(
+    config: &GroundedAnswerConfig,
+) -> Result<GroundedAnswerReport, GroundedAnswerError> {
+    validate_request(config)?;
+    let head_bytes = std::fs::read(&config.head).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot read answer head {}: {error}",
+            config.head.display()
+        ))
+    })?;
+    let head_value: serde_json::Value = serde_json::from_slice(&head_bytes).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot decode answer head {}: {error}",
+            config.head.display()
+        ))
+    })?;
+    match head_value.get("schema").and_then(serde_json::Value::as_str) {
+        Some(RELATION_HEAD_ARTIFACT_SCHEMA) => run_relation_grounded_answer(config),
+        Some(POINTER_ARTIFACT_SCHEMA) => run_pointer_grounded_answer(config),
+        Some(schema) => Err(GroundedAnswerError::InvalidRequest(format!(
+            "unsupported answer-head schema {schema:?}"
+        ))),
+        None => Err(GroundedAnswerError::InvalidRequest(
+            "answer head has no string schema".to_owned(),
+        )),
+    }
+}
+
+fn run_pointer_grounded_answer(
     config: &GroundedAnswerConfig,
 ) -> Result<GroundedAnswerReport, GroundedAnswerError> {
     validate_request(config)?;
@@ -272,6 +359,8 @@ pub fn run_grounded_answer(
                 text_cid: sequence.text_cid.clone(),
                 state_cid: sequence.audit.state_cid.clone(),
                 content_token_count: sequence.audit.content_token_count,
+                relation_input_text_cid: None,
+                terminal_state_cid: None,
             })
         })
         .collect::<Result<Vec<_>, GroundedAnswerError>>()?;
@@ -337,15 +426,16 @@ pub fn run_grounded_answer(
         hidden_size: encoded.model_shape.dimension,
         checkpoint: encoded.checkpoint,
         model_shape: encoded.model_shape,
-        subject_text_cid: encoded.sequences[0].text_cid.clone(),
-        subject_state_cid: encoded.sequences[0].audit.state_cid.clone(),
-        subject_content_token_count: encoded.sequences[0].audit.content_token_count,
+        subject_text_cid: Some(encoded.sequences[0].text_cid.clone()),
+        subject_state_cid: Some(encoded.sequences[0].audit.state_cid.clone()),
+        subject_content_token_count: Some(encoded.sequences[0].audit.content_token_count),
+        relation_input_policy: None,
         sequence_audits,
         source_read_audit: encoded.source_read_audit,
         execution: encoded.execution,
     };
     let decision_cid = cid_serializable(&GroundedDecisionIdentity {
-        schema: REPORT_SCHEMA,
+        schema: POINTER_REPORT_SCHEMA,
         pointer_policy: POINTER_POLICY,
         source_cid: &source.source_cid,
         source_byte_length: source.byte_length,
@@ -359,15 +449,17 @@ pub fn run_grounded_answer(
     })?;
 
     Ok(GroundedAnswerReport {
-        schema: REPORT_SCHEMA.to_owned(),
+        schema: POINTER_REPORT_SCHEMA.to_owned(),
         decision_cid,
         claim_scope: "one learned source-span pointer over frozen #1017 all-layer coherent R4/Spin causal-softmax states; output is an exact original source sentence or a typed non-answer".to_owned(),
         source,
         question: config.question.clone(),
         subject,
         candidate_spans,
-        pointer: pointer.binding,
-        pointer_evaluation,
+        pointer: Some(pointer.binding),
+        pointer_evaluation: Some(pointer_evaluation),
+        relation: None,
+        relation_evaluation: None,
         state_encoding,
         outcome,
         nonclaims: vec![
@@ -376,6 +468,258 @@ pub fn run_grounded_answer(
             "This result does not establish the final source-free exact geometric runtime or a browser product surface.".to_owned(),
         ],
     })
+}
+
+fn run_relation_grounded_answer(
+    config: &GroundedAnswerConfig,
+) -> Result<GroundedAnswerReport, GroundedAnswerError> {
+    let source_before = read_source_file(&config.source_file)?;
+    let source_text = std::str::from_utf8(&source_before).map_err(|error| {
+        GroundedAnswerError::InvalidSource(format!(
+            "{} is not exact UTF-8: {error}",
+            config.source_file.display()
+        ))
+    })?;
+    let head_before = std::fs::read(&config.head).map_err(|error| {
+        GroundedAnswerError::InvalidRequest(format!(
+            "cannot read source-relative relation head {}: {error}",
+            config.head.display()
+        ))
+    })?;
+    let subject = parse_subject(&config.question)?;
+    let sentence_spans = split_sentence_spans(source_text)?;
+    if sentence_spans.len() < 2 {
+        return Err(GroundedAnswerError::InvalidSource(
+            "source-relative relation selection requires 2..=8 sentence spans".to_owned(),
+        ));
+    }
+
+    let sequences = sentence_spans
+        .iter()
+        .map(|(_, text)| render_relation_input(text, &config.question))
+        .collect::<Vec<_>>();
+    let encoded = encode_r4_softmax_local_states(&R4SoftmaxLocalStateEncodingConfig {
+        model: config.model.clone(),
+        sequences,
+        workers: config.workers,
+    })?;
+    if encoded.sequences.len() != sentence_spans.len() {
+        return Err(GroundedAnswerError::Audit(
+            "relation state encoder returned the wrong independent-sequence count".to_owned(),
+        ));
+    }
+
+    let relation = load_source_relation_head(
+        &config.head,
+        &encoded.checkpoint.weights_cid,
+        &encoded.checkpoint.tokenizer_cid,
+    )?;
+    if relation.artifact.hidden_size != encoded.model_shape.dimension {
+        return Err(GroundedAnswerError::Audit(format!(
+            "relation-head width {} differs from model width {}",
+            relation.artifact.hidden_size, encoded.model_shape.dimension
+        )));
+    }
+
+    let terminal_states = encoded
+        .sequences
+        .iter()
+        .enumerate()
+        .map(|(candidate_index, sequence)| {
+            sequence
+                .final_normalized_residuals
+                .last()
+                .map(Vec::as_slice)
+                .ok_or_else(|| {
+                    GroundedAnswerError::Audit(format!(
+                        "candidate {candidate_index} relation input emitted no terminal state"
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>, GroundedAnswerError>>()?;
+    let relation_candidates = sentence_spans
+        .iter()
+        .zip(&terminal_states)
+        .map(|((source_span, text), state)| SourceRelationCandidate {
+            span_text: text,
+            byte_start: source_span.byte_start,
+            final_relation_state: state,
+        })
+        .collect::<Vec<_>>();
+    let internal_evaluation =
+        evaluate_source_relation_head(&relation.artifact, &relation_candidates)?;
+    let relation_evaluation = public_relation_evaluation(
+        &internal_evaluation,
+        &sentence_spans,
+        relation.artifact.threshold,
+    );
+
+    let candidate_spans = sentence_spans
+        .iter()
+        .zip(&encoded.sequences)
+        .zip(&terminal_states)
+        .enumerate()
+        .map(
+            |(candidate_index, (((source_span, text), sequence), terminal_state))| {
+                let relation_input = render_relation_input(text, &config.question);
+                let relation_input_text_cid = raw_cid(relation_input.as_bytes());
+                if sequence.text_cid != relation_input_text_cid {
+                    return Err(GroundedAnswerError::Audit(format!(
+                        "candidate {candidate_index} state text CID does not match the exact relation input"
+                    )));
+                }
+                Ok(SourceSpanCandidateBinding {
+                    candidate_index,
+                    source_span: *source_span,
+                    text_cid: raw_cid(text.as_bytes()),
+                    state_cid: sequence.audit.state_cid.clone(),
+                    content_token_count: sequence.audit.content_token_count,
+                    relation_input_text_cid: Some(relation_input_text_cid),
+                    terminal_state_cid: Some(cid_serializable(terminal_state)?),
+                })
+            },
+        )
+        .collect::<Result<Vec<_>, GroundedAnswerError>>()?;
+
+    let outcome = match internal_evaluation.decision {
+        SourceRelationHeadDecision::Answer { candidate_index } => {
+            let candidate = sentence_spans.get(candidate_index).ok_or_else(|| {
+                GroundedAnswerError::Audit(
+                    "relation head selected an absent source span".to_owned(),
+                )
+            })?;
+            GroundedAnswerOutcome::Answered {
+                answer: candidate.1.to_owned(),
+                source_span: candidate.0,
+            }
+        }
+        SourceRelationHeadDecision::Abstain => GroundedAnswerOutcome::Abstained {
+            reason: GroundedAbstentionReason::RelationNoSupport,
+        },
+        SourceRelationHeadDecision::Contradiction => GroundedAnswerOutcome::Contradiction,
+    };
+
+    let source_after = read_source_file(&config.source_file)?;
+    let source_cid = raw_cid(&source_before);
+    if source_before != source_after {
+        return Err(GroundedAnswerError::Audit(format!(
+            "source {} changed during selection (before {}, after {})",
+            config.source_file.display(),
+            source_cid,
+            raw_cid(&source_after)
+        )));
+    }
+    let head_after = std::fs::read(&config.head).map_err(|error| {
+        GroundedAnswerError::Audit(format!(
+            "cannot rescan source-relative relation head {}: {error}",
+            config.head.display()
+        ))
+    })?;
+    if head_before != head_after {
+        return Err(GroundedAnswerError::Audit(format!(
+            "source-relative relation head {} changed during selection",
+            config.head.display()
+        )));
+    }
+
+    let source = GroundingSourceBinding {
+        path: config.source_file.display().to_string(),
+        source_cid,
+        byte_length: source_before.len(),
+        regular_non_symlink: true,
+        utf8: true,
+        reads: 2,
+        unchanged_after_run: true,
+    };
+    let sequence_audits = encoded
+        .sequences
+        .iter()
+        .map(|sequence| sequence.audit.clone())
+        .collect::<Vec<_>>();
+    let state_encoding = GroundedStateEncodingAudit {
+        schema: encoded.schema,
+        audit_cid: encoded.audit_cid,
+        model_weights_cid: encoded.checkpoint.weights_cid.clone(),
+        tokenizer_cid: encoded.checkpoint.tokenizer_cid.clone(),
+        hidden_size: encoded.model_shape.dimension,
+        checkpoint: encoded.checkpoint,
+        model_shape: encoded.model_shape,
+        subject_text_cid: None,
+        subject_state_cid: None,
+        subject_content_token_count: None,
+        relation_input_policy: Some(RELATION_INPUT_POLICY.to_owned()),
+        sequence_audits,
+        source_read_audit: encoded.source_read_audit,
+        execution: encoded.execution,
+    };
+    let decision_cid = cid_serializable(&GroundedRelationDecisionIdentity {
+        schema: RELATION_REPORT_SCHEMA,
+        relation_policy: RELATION_HEAD_POLICY,
+        relation_input_policy: RELATION_INPUT_POLICY,
+        source_cid: &source.source_cid,
+        source_byte_length: source.byte_length,
+        question: &config.question,
+        relation_artifact_cid: &relation.binding.artifact_cid,
+        state_encoding_audit_cid: &state_encoding.audit_cid,
+        candidate_spans: &candidate_spans,
+        relation_evaluation: &relation_evaluation,
+        outcome: &outcome,
+    })?;
+
+    Ok(GroundedAnswerReport {
+        schema: RELATION_REPORT_SCHEMA.to_owned(),
+        decision_cid,
+        claim_scope: "one learned source-relative relation head over frozen #1017 all-layer coherent R4/Spin causal-softmax states; output is an exact original source sentence or a typed non-answer".to_owned(),
+        source,
+        question: config.question.clone(),
+        subject,
+        candidate_spans,
+        pointer: None,
+        pointer_evaluation: None,
+        relation: Some(relation.binding),
+        relation_evaluation: Some(relation_evaluation),
+        state_encoding,
+        outcome,
+        nonclaims: vec![
+            "This bounded source-relative result does not establish open-domain question answering, reasoning, or general semantic entailment.".to_owned(),
+            "The learned head and #1017 executor remain source-backed, floating-point, multiplication-using, and ordinary-softmax based.".to_owned(),
+            "This result does not establish the final source-free exact geometric runtime or a browser product surface.".to_owned(),
+        ],
+    })
+}
+
+fn public_relation_evaluation(
+    evaluation: &SourceRelationHeadEvaluation,
+    sentence_spans: &[(SourceSpan, &str)],
+    threshold: f32,
+) -> GroundedRelationEvaluation {
+    let positive_candidate_indices = evaluation
+        .candidate_logits
+        .iter()
+        .enumerate()
+        .filter_map(|(candidate_index, &logit)| (logit > threshold).then_some(candidate_index))
+        .collect::<Vec<_>>();
+    let mut unique_positive_texts = Vec::<&str>::new();
+    for &candidate_index in &positive_candidate_indices {
+        let text = sentence_spans[candidate_index].1;
+        if !unique_positive_texts.contains(&text) {
+            unique_positive_texts.push(text);
+        }
+    }
+    let (decision, selected_span_index) = match evaluation.decision {
+        SourceRelationHeadDecision::Answer { candidate_index } => {
+            ("answer".to_owned(), Some(candidate_index))
+        }
+        SourceRelationHeadDecision::Abstain => ("abstain".to_owned(), None),
+        SourceRelationHeadDecision::Contradiction => ("conflict".to_owned(), None),
+    };
+    GroundedRelationEvaluation {
+        candidate_logits: evaluation.candidate_logits.clone(),
+        positive_candidate_indices,
+        positive_unique_span_count: unique_positive_texts.len(),
+        decision,
+        selected_span_index,
+    }
 }
 
 fn public_pointer_evaluation(

--- a/src/r4_source_relation_head.rs
+++ b/src/r4_source_relation_head.rs
@@ -1,0 +1,967 @@
+//! Learned, fail-closed source-relative relation decisions over #1017 states.
+//!
+//! Each candidate is represented by the final normalized residual from the exact
+//! relation input rendered by [`render_relation_input`]. The head scores those
+//! width-288 states, collapses exact duplicate span text, and either selects one
+//! original occurrence or returns an explicit non-answer terminal.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+pub const RELATION_HEAD_ARTIFACT_SCHEMA: &str = "uor-r4.source-relative-relation-head/1";
+pub const RELATION_HEAD_POLICY: &str = "R4SourceRelativeRelationHeadV1";
+pub const RELATION_INPUT_POLICY: &str = "Evidence:\n<span>\nQuestion:\n<question>";
+pub const RELATION_STATE_WIDTH: usize = 288;
+pub const RELATION_HIDDEN_WIDTH: usize = 32;
+pub const MAXIMUM_SOURCE_SPANS: usize = 8;
+pub const EXPECTED_MODEL_WEIGHTS_CID: &str =
+    "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d";
+pub const EXPECTED_TOKENIZER_CID: &str =
+    "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc";
+
+const FIRST_LAYER_WEIGHT_COUNT: usize = RELATION_HIDDEN_WIDTH * RELATION_STATE_WIDTH;
+
+/// Render the sole relation input admitted by this head.
+pub fn render_relation_input(span_text: &str, question: &str) -> String {
+    format!("Evidence:\n{span_text}\nQuestion:\n{question}")
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceRelationHeadArtifact {
+    pub schema: String,
+    pub policy: String,
+    pub issue: u32,
+    pub model_weights_cid: String,
+    pub tokenizer_cid: String,
+    pub hidden_size: usize,
+    pub hidden_width: usize,
+    /// Row-major `[hidden_width, hidden_size]` dense affine weights.
+    pub first_layer_weights: Vec<f32>,
+    pub first_layer_biases: Vec<f32>,
+    pub output_weights: Vec<f32>,
+    pub output_bias: f32,
+    pub threshold: f32,
+    pub maximum_source_spans: usize,
+    pub relation_input_policy: String,
+    pub dataset_cid: String,
+    pub split_policy_cid: String,
+    pub run_contract_cid: String,
+    pub training_result_cid: String,
+    pub preflight: serde_json::Value,
+    pub development_metrics: serde_json::Value,
+    pub product_probe_commitments: Vec<String>,
+    pub artifact_cid: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRelationHeadBinding {
+    pub path: String,
+    pub artifact_cid: String,
+    pub policy: String,
+    pub model_weights_cid: String,
+    pub tokenizer_cid: String,
+    pub dataset_cid: String,
+    pub split_policy_cid: String,
+    pub run_contract_cid: String,
+    pub training_result_cid: String,
+}
+
+pub struct LoadedSourceRelationHead {
+    pub artifact: SourceRelationHeadArtifact,
+    pub binding: SourceRelationHeadBinding,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SourceRelationCandidate<'a> {
+    pub span_text: &'a str,
+    pub byte_start: usize,
+    pub final_relation_state: &'a [f32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRelationHeadDecision {
+    Answer { candidate_index: usize },
+    Abstain,
+    Contradiction,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SourceRelationHeadEvaluation {
+    pub candidate_logits: Vec<f32>,
+    pub decision: SourceRelationHeadDecision,
+}
+
+#[derive(Debug)]
+pub enum SourceRelationHeadError {
+    InvalidArtifact(String),
+    InvalidInput(String),
+    Io(std::io::Error),
+}
+
+impl fmt::Display for SourceRelationHeadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidArtifact(reason) => {
+                write!(formatter, "invalid source-relative relation head: {reason}")
+            }
+            Self::InvalidInput(reason) => {
+                write!(
+                    formatter,
+                    "invalid source-relative relation input: {reason}"
+                )
+            }
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SourceRelationHeadError {}
+
+impl From<std::io::Error> for SourceRelationHeadError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// Load one canonical, self-addressed head bound to the exact #1017 checkpoint.
+pub fn load_source_relation_head(
+    path: &Path,
+    loaded_model_weights_cid: &str,
+    loaded_tokenizer_cid: &str,
+) -> Result<LoadedSourceRelationHead, SourceRelationHeadError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(SourceRelationHeadError::InvalidArtifact(format!(
+            "{} is not a regular non-symlink file",
+            path.display()
+        )));
+    }
+    let bytes = std::fs::read(path)?;
+    let artifact =
+        decode_artifact_bytes(&bytes, path, loaded_model_weights_cid, loaded_tokenizer_cid)?;
+    let binding = SourceRelationHeadBinding {
+        path: PathBuf::from(path).display().to_string(),
+        artifact_cid: artifact.artifact_cid.clone(),
+        policy: artifact.policy.clone(),
+        model_weights_cid: artifact.model_weights_cid.clone(),
+        tokenizer_cid: artifact.tokenizer_cid.clone(),
+        dataset_cid: artifact.dataset_cid.clone(),
+        split_policy_cid: artifact.split_policy_cid.clone(),
+        run_contract_cid: artifact.run_contract_cid.clone(),
+        training_result_cid: artifact.training_result_cid.clone(),
+    };
+    Ok(LoadedSourceRelationHead { artifact, binding })
+}
+
+/// Score all candidates and apply the fixed duplicate-aware safety decision.
+pub fn evaluate_source_relation_head(
+    artifact: &SourceRelationHeadArtifact,
+    candidates: &[SourceRelationCandidate<'_>],
+) -> Result<SourceRelationHeadEvaluation, SourceRelationHeadError> {
+    validate_artifact(artifact, EXPECTED_MODEL_WEIGHTS_CID, EXPECTED_TOKENIZER_CID)?;
+    if !(2..=MAXIMUM_SOURCE_SPANS).contains(&candidates.len()) {
+        return Err(SourceRelationHeadError::InvalidInput(format!(
+            "candidate span count must be in 2..={MAXIMUM_SOURCE_SPANS}, observed {}",
+            candidates.len()
+        )));
+    }
+
+    let mut candidate_logits = Vec::with_capacity(candidates.len());
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        if candidate.span_text.is_empty() {
+            return Err(SourceRelationHeadError::InvalidInput(format!(
+                "candidate {candidate_index} has empty exact span text"
+            )));
+        }
+        if candidate.final_relation_state.len() != RELATION_STATE_WIDTH
+            || candidate
+                .final_relation_state
+                .iter()
+                .any(|value| !value.is_finite())
+        {
+            return Err(SourceRelationHeadError::InvalidInput(format!(
+                "candidate {candidate_index} state is not {RELATION_STATE_WIDTH} finite lanes"
+            )));
+        }
+        candidate_logits.push(score_candidate(artifact, candidate.final_relation_state)?);
+    }
+
+    // One representative is retained for every exact positive span string. Its
+    // occurrence is the highest-logit candidate, then earliest byte, then index.
+    let mut positive_representatives = Vec::<usize>::new();
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        if candidate_logits[candidate_index] <= artifact.threshold {
+            continue;
+        }
+        if let Some(slot) = positive_representatives
+            .iter()
+            .position(|&representative| candidates[representative].span_text == candidate.span_text)
+        {
+            let prior = positive_representatives[slot];
+            if occurrence_is_better(candidate_index, prior, candidates, &candidate_logits) {
+                positive_representatives[slot] = candidate_index;
+            }
+        } else {
+            positive_representatives.push(candidate_index);
+        }
+    }
+
+    let decision = match positive_representatives.as_slice() {
+        [] => SourceRelationHeadDecision::Abstain,
+        [candidate_index] => SourceRelationHeadDecision::Answer {
+            candidate_index: *candidate_index,
+        },
+        [_, _, ..] => SourceRelationHeadDecision::Contradiction,
+    };
+    Ok(SourceRelationHeadEvaluation {
+        candidate_logits,
+        decision,
+    })
+}
+
+fn score_candidate(
+    artifact: &SourceRelationHeadArtifact,
+    state: &[f32],
+) -> Result<f32, SourceRelationHeadError> {
+    let mut hidden = [0.0_f32; RELATION_HIDDEN_WIDTH];
+    for (row, hidden_value) in hidden.iter_mut().enumerate() {
+        let row_start = row * RELATION_STATE_WIDTH;
+        let weights = &artifact.first_layer_weights[row_start..row_start + RELATION_STATE_WIDTH];
+        let mut value = artifact.first_layer_biases[row];
+        for (&weight, &state_value) in weights.iter().zip(state) {
+            value += weight * state_value;
+        }
+        if !value.is_finite() {
+            return Err(SourceRelationHeadError::InvalidInput(format!(
+                "hidden relation lane {row} overflowed or became nonfinite"
+            )));
+        }
+        *hidden_value = value.max(0.0);
+    }
+
+    let mut logit = artifact.output_bias;
+    for (&weight, hidden_value) in artifact.output_weights.iter().zip(hidden) {
+        logit += weight * hidden_value;
+    }
+    if !logit.is_finite() {
+        return Err(SourceRelationHeadError::InvalidInput(
+            "relation logit overflowed or became nonfinite".to_owned(),
+        ));
+    }
+    Ok(logit)
+}
+
+fn occurrence_is_better(
+    candidate_index: usize,
+    prior_index: usize,
+    candidates: &[SourceRelationCandidate<'_>],
+    logits: &[f32],
+) -> bool {
+    match logits[candidate_index].total_cmp(&logits[prior_index]) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => {
+            candidates[candidate_index].byte_start < candidates[prior_index].byte_start
+                || (candidates[candidate_index].byte_start == candidates[prior_index].byte_start
+                    && candidate_index < prior_index)
+        }
+    }
+}
+
+fn decode_artifact_bytes(
+    bytes: &[u8],
+    path: &Path,
+    loaded_model_weights_cid: &str,
+    loaded_tokenizer_cid: &str,
+) -> Result<SourceRelationHeadArtifact, SourceRelationHeadError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
+        SourceRelationHeadError::InvalidArtifact(format!("{} is not JSON: {error}", path.display()))
+    })?;
+    verify_canonical_json_layout(bytes).map_err(|reason| {
+        SourceRelationHeadError::InvalidArtifact(format!(
+            "{} is not canonical JSON: {reason}",
+            path.display()
+        ))
+    })?;
+    let embedded_cid = value
+        .as_object()
+        .ok_or_else(|| {
+            SourceRelationHeadError::InvalidArtifact(
+                "artifact root is not a JSON object".to_owned(),
+            )
+        })?
+        .get("artifact_cid")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            SourceRelationHeadError::InvalidArtifact(
+                "artifact_cid is absent or is not a string".to_owned(),
+            )
+        })?;
+    verify_self_cid(bytes, embedded_cid)?;
+    let artifact: SourceRelationHeadArtifact = serde_json::from_value(value).map_err(|error| {
+        SourceRelationHeadError::InvalidArtifact(format!("artifact fields are invalid: {error}"))
+    })?;
+    validate_artifact(&artifact, loaded_model_weights_cid, loaded_tokenizer_cid)?;
+    Ok(artifact)
+}
+
+fn verify_self_cid(bytes: &[u8], embedded_cid: &str) -> Result<(), SourceRelationHeadError> {
+    if !is_blake3_cid(embedded_cid) {
+        return Err(SourceRelationHeadError::InvalidArtifact(
+            "artifact_cid is not a lowercase BLAKE3 CID".to_owned(),
+        ));
+    }
+    // `artifact_cid` sorts before every other admitted top-level field. Remove
+    // that exact first member while retaining every producer-supplied numeric
+    // lexeme; Python and Rust use different valid exponent spellings for some
+    // finite floats, but the self-CID must bind the producer's exact bytes.
+    let prefix = format!("{{\"artifact_cid\":\"{embedded_cid}\",");
+    if !bytes.starts_with(prefix.as_bytes()) {
+        return Err(SourceRelationHeadError::InvalidArtifact(
+            "artifact_cid is not the first canonical top-level field".to_owned(),
+        ));
+    }
+    let mut unsigned = Vec::with_capacity(bytes.len() - prefix.len() + 1);
+    unsigned.push(b'{');
+    unsigned.extend_from_slice(&bytes[prefix.len()..]);
+    let observed = raw_cid(&unsigned);
+    if embedded_cid != observed {
+        return Err(SourceRelationHeadError::InvalidArtifact(format!(
+            "artifact_cid does not reproduce: embedded {embedded_cid}, observed {observed}"
+        )));
+    }
+    Ok(())
+}
+
+/// Verify the Python/Rust shared canonical envelope without normalizing number
+/// spellings. Objects are recursively key-sorted, strings use their shortest
+/// JSON escapes, no structural whitespace is allowed, and exactly one terminal
+/// newline is required. The full JSON parser separately enforces number syntax.
+fn verify_canonical_json_layout(bytes: &[u8]) -> Result<(), String> {
+    let body = bytes
+        .strip_suffix(b"\n")
+        .ok_or_else(|| "one terminal newline is required".to_owned())?;
+    if body.is_empty() || body.ends_with(b"\n") {
+        return Err("exactly one terminal newline is required".to_owned());
+    }
+    let mut scanner = CanonicalJsonScanner {
+        bytes: body,
+        position: 0,
+    };
+    scanner.parse_value()?;
+    if scanner.position != body.len() {
+        return Err("trailing bytes follow the canonical JSON value".to_owned());
+    }
+    Ok(())
+}
+
+struct CanonicalJsonScanner<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl CanonicalJsonScanner<'_> {
+    fn parse_value(&mut self) -> Result<(), String> {
+        match self.peek() {
+            Some(b'{') => self.parse_object(),
+            Some(b'[') => self.parse_array(),
+            Some(b'"') => self.parse_string().map(|_| ()),
+            Some(b't') => self.parse_literal(b"true"),
+            Some(b'f') => self.parse_literal(b"false"),
+            Some(b'n') => self.parse_literal(b"null"),
+            Some(b'-' | b'0'..=b'9') => self.parse_number(),
+            Some(byte) => Err(format!(
+                "unexpected structural byte 0x{byte:02x} at {}",
+                self.position
+            )),
+            None => Err("JSON value ended unexpectedly".to_owned()),
+        }
+    }
+
+    fn parse_object(&mut self) -> Result<(), String> {
+        self.expect(b'{')?;
+        if self.consume(b'}') {
+            return Ok(());
+        }
+        let mut previous_key: Option<String> = None;
+        loop {
+            let key = self.parse_string()?;
+            if previous_key
+                .as_ref()
+                .is_some_and(|previous| previous >= &key)
+            {
+                return Err(format!(
+                    "object key {key:?} is duplicate or not strictly sorted"
+                ));
+            }
+            previous_key = Some(key);
+            self.expect(b':')?;
+            self.parse_value()?;
+            if self.consume(b'}') {
+                return Ok(());
+            }
+            self.expect(b',')?;
+        }
+    }
+
+    fn parse_array(&mut self) -> Result<(), String> {
+        self.expect(b'[')?;
+        if self.consume(b']') {
+            return Ok(());
+        }
+        loop {
+            self.parse_value()?;
+            if self.consume(b']') {
+                return Ok(());
+            }
+            self.expect(b',')?;
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, String> {
+        let start = self.position;
+        self.expect(b'"')?;
+        loop {
+            match self.peek() {
+                Some(b'"') => {
+                    self.position += 1;
+                    break;
+                }
+                Some(b'\\') => {
+                    self.position += 1;
+                    let escaped = self
+                        .peek()
+                        .ok_or_else(|| "JSON string ended after an escape prefix".to_owned())?;
+                    self.position += 1;
+                    if escaped == b'u' {
+                        self.position = self
+                            .position
+                            .checked_add(4)
+                            .ok_or_else(|| "JSON string escape position overflowed".to_owned())?;
+                        if self.position > self.bytes.len() {
+                            return Err("JSON unicode escape ended early".to_owned());
+                        }
+                    }
+                }
+                Some(_) => self.position += 1,
+                None => return Err("JSON string is unterminated".to_owned()),
+            }
+        }
+        let token = &self.bytes[start..self.position];
+        let decoded: String = serde_json::from_slice(token)
+            .map_err(|error| format!("JSON string is invalid: {error}"))?;
+        let canonical = serde_json::to_vec(&decoded)
+            .map_err(|error| format!("JSON string cannot be canonicalized: {error}"))?;
+        if canonical != token {
+            return Err("JSON string does not use canonical escaping".to_owned());
+        }
+        Ok(decoded)
+    }
+
+    fn parse_literal(&mut self, literal: &[u8]) -> Result<(), String> {
+        if self.bytes.get(self.position..self.position + literal.len()) != Some(literal) {
+            return Err(format!("invalid JSON literal at byte {}", self.position));
+        }
+        self.position += literal.len();
+        Ok(())
+    }
+
+    fn parse_number(&mut self) -> Result<(), String> {
+        let start = self.position;
+        while self
+            .peek()
+            .is_some_and(|byte| !matches!(byte, b',' | b']' | b'}'))
+        {
+            self.position += 1;
+        }
+        let token = &self.bytes[start..self.position];
+        if token.iter().any(u8::is_ascii_whitespace) {
+            return Err("JSON number contains structural whitespace".to_owned());
+        }
+        serde_json::from_slice::<serde_json::Number>(token)
+            .map_err(|error| format!("JSON number is invalid: {error}"))?;
+        Ok(())
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.position).copied()
+    }
+
+    fn consume(&mut self, expected: u8) -> bool {
+        if self.peek() == Some(expected) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, expected: u8) -> Result<(), String> {
+        if self.consume(expected) {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected structural byte {:?} at {}",
+                char::from(expected),
+                self.position
+            ))
+        }
+    }
+}
+
+fn validate_artifact(
+    artifact: &SourceRelationHeadArtifact,
+    loaded_model_weights_cid: &str,
+    loaded_tokenizer_cid: &str,
+) -> Result<(), SourceRelationHeadError> {
+    let invalid = |reason: &str| SourceRelationHeadError::InvalidArtifact(reason.to_owned());
+    if artifact.schema != RELATION_HEAD_ARTIFACT_SCHEMA
+        || artifact.policy != RELATION_HEAD_POLICY
+        || artifact.issue != 954
+    {
+        return Err(invalid("schema, policy, or issue does not match C1-SB2"));
+    }
+    if loaded_model_weights_cid != EXPECTED_MODEL_WEIGHTS_CID
+        || loaded_tokenizer_cid != EXPECTED_TOKENIZER_CID
+        || artifact.model_weights_cid != EXPECTED_MODEL_WEIGHTS_CID
+        || artifact.tokenizer_cid != EXPECTED_TOKENIZER_CID
+    {
+        return Err(invalid(
+            "head and loaded checkpoint must match the immutable #1017 weights/tokenizer",
+        ));
+    }
+    if artifact.hidden_size != RELATION_STATE_WIDTH
+        || artifact.hidden_width != RELATION_HIDDEN_WIDTH
+    {
+        return Err(invalid(
+            "relation head width differs from the frozen 288x32 shape",
+        ));
+    }
+    if artifact.first_layer_weights.len() != FIRST_LAYER_WEIGHT_COUNT
+        || artifact.first_layer_biases.len() != RELATION_HIDDEN_WIDTH
+        || artifact.output_weights.len() != RELATION_HIDDEN_WIDTH
+    {
+        return Err(invalid(
+            "relation head tensors differ from row-major 32x288, 32, and 32",
+        ));
+    }
+    if artifact
+        .first_layer_weights
+        .iter()
+        .chain(&artifact.first_layer_biases)
+        .chain(&artifact.output_weights)
+        .any(|value| !value.is_finite())
+        || !artifact.output_bias.is_finite()
+    {
+        return Err(invalid("relation head parameters must all be finite"));
+    }
+    if artifact.threshold.to_bits() != 0.0_f32.to_bits() {
+        return Err(invalid("relation threshold must be exact positive 0.0"));
+    }
+    if artifact.maximum_source_spans != MAXIMUM_SOURCE_SPANS
+        || artifact.relation_input_policy != RELATION_INPUT_POLICY
+    {
+        return Err(invalid(
+            "maximum span count or exact relation input policy differs",
+        ));
+    }
+    if artifact.product_probe_commitments.len() != 4
+        || artifact
+            .product_probe_commitments
+            .iter()
+            .any(|cid| !is_blake3_cid(cid))
+        || artifact
+            .product_probe_commitments
+            .iter()
+            .enumerate()
+            .any(|(index, cid)| artifact.product_probe_commitments[..index].contains(cid))
+    {
+        return Err(invalid(
+            "exactly four distinct valid product-probe commitments are required",
+        ));
+    }
+    for (label, cid) in [
+        ("artifact", artifact.artifact_cid.as_str()),
+        ("model weights", artifact.model_weights_cid.as_str()),
+        ("tokenizer", artifact.tokenizer_cid.as_str()),
+        ("dataset", artifact.dataset_cid.as_str()),
+        ("split policy", artifact.split_policy_cid.as_str()),
+        ("run contract", artifact.run_contract_cid.as_str()),
+        ("training result", artifact.training_result_cid.as_str()),
+    ] {
+        if !is_blake3_cid(cid) {
+            return Err(invalid(&format!("{label} CID is invalid")));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn canonical_json_bytes(value: &serde_json::Value) -> Result<Vec<u8>, SourceRelationHeadError> {
+    let mut bytes = serde_json::to_vec(value).map_err(|error| {
+        SourceRelationHeadError::InvalidArtifact(format!(
+            "artifact cannot be encoded as canonical JSON: {error}"
+        ))
+    })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn raw_cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn is_blake3_cid(value: &str) -> bool {
+    value.len() == 71
+        && value.strip_prefix("blake3:").is_some_and(|hex| {
+            hex.bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cid(label: &str) -> String {
+        raw_cid(label.as_bytes())
+    }
+
+    fn valid_artifact() -> SourceRelationHeadArtifact {
+        let mut first_layer_weights = vec![0.0; FIRST_LAYER_WEIGHT_COUNT];
+        first_layer_weights[0] = 1.0;
+        let mut output_weights = vec![0.0; RELATION_HIDDEN_WIDTH];
+        output_weights[0] = 1.0;
+        SourceRelationHeadArtifact {
+            schema: RELATION_HEAD_ARTIFACT_SCHEMA.to_owned(),
+            policy: RELATION_HEAD_POLICY.to_owned(),
+            issue: 954,
+            model_weights_cid: EXPECTED_MODEL_WEIGHTS_CID.to_owned(),
+            tokenizer_cid: EXPECTED_TOKENIZER_CID.to_owned(),
+            hidden_size: RELATION_STATE_WIDTH,
+            hidden_width: RELATION_HIDDEN_WIDTH,
+            first_layer_weights,
+            first_layer_biases: vec![0.0; RELATION_HIDDEN_WIDTH],
+            output_weights,
+            output_bias: -0.5,
+            threshold: 0.0,
+            maximum_source_spans: MAXIMUM_SOURCE_SPANS,
+            relation_input_policy: RELATION_INPUT_POLICY.to_owned(),
+            dataset_cid: test_cid("dataset"),
+            split_policy_cid: test_cid("split"),
+            run_contract_cid: test_cid("run"),
+            training_result_cid: test_cid("result"),
+            preflight: serde_json::json!({"status": "PASS"}),
+            development_metrics: serde_json::json!({"status": "PASS"}),
+            product_probe_commitments: (0..4)
+                .map(|index| test_cid(&format!("probe-{index}")))
+                .collect(),
+            artifact_cid: test_cid("artifact-placeholder"),
+        }
+    }
+
+    fn state(first_lane: f32) -> Vec<f32> {
+        let mut state = vec![0.0; RELATION_STATE_WIDTH];
+        state[0] = first_lane;
+        state
+    }
+
+    fn signed_value(mut value: serde_json::Value) -> Vec<u8> {
+        let object = value.as_object_mut().expect("artifact object");
+        object.remove("artifact_cid");
+        let artifact_cid = raw_cid(&canonical_json_bytes(&value).expect("unsigned JSON"));
+        value.as_object_mut().expect("artifact object").insert(
+            "artifact_cid".to_owned(),
+            serde_json::Value::String(artifact_cid),
+        );
+        canonical_json_bytes(&value).expect("signed JSON")
+    }
+
+    fn signed_artifact(artifact: &SourceRelationHeadArtifact) -> Vec<u8> {
+        signed_value(serde_json::to_value(artifact).expect("artifact value"))
+    }
+
+    #[test]
+    fn relation_input_policy_ends_on_the_question_without_a_trailing_newline() {
+        assert_eq!(
+            render_relation_input(
+                "The opal astrolabe is beneath the maple stair.",
+                "Where is the opal astrolabe?"
+            ),
+            "Evidence:\nThe opal astrolabe is beneath the maple stair.\nQuestion:\nWhere is the opal astrolabe?"
+        );
+        assert_eq!(
+            RELATION_INPUT_POLICY,
+            "Evidence:\n<span>\nQuestion:\n<question>"
+        );
+    }
+
+    #[test]
+    fn dense_relu_affine_logits_use_row_major_weights() {
+        let artifact = valid_artifact();
+        let positive = state(2.0);
+        let zero = state(0.5);
+        let candidates = [
+            SourceRelationCandidate {
+                span_text: "positive.",
+                byte_start: 0,
+                final_relation_state: &positive,
+            },
+            SourceRelationCandidate {
+                span_text: "zero.",
+                byte_start: 10,
+                final_relation_state: &zero,
+            },
+        ];
+        let evaluation =
+            evaluate_source_relation_head(&artifact, &candidates).expect("valid evaluation");
+        assert_eq!(evaluation.candidate_logits, vec![1.5, 0.0]);
+        assert_eq!(
+            evaluation.decision,
+            SourceRelationHeadDecision::Answer { candidate_index: 0 }
+        );
+    }
+
+    #[test]
+    fn exact_duplicates_count_once_and_choose_best_then_earliest_occurrence() {
+        let artifact = valid_artifact();
+        let one = state(1.0);
+        let two = state(2.0);
+        let negative = state(0.0);
+        let candidates = [
+            SourceRelationCandidate {
+                span_text: "The jade sextant is inside the linen drawer.",
+                byte_start: 40,
+                final_relation_state: &one,
+            },
+            SourceRelationCandidate {
+                span_text: "The jade sextant is inside the linen drawer.",
+                byte_start: 5,
+                final_relation_state: &two,
+            },
+            SourceRelationCandidate {
+                span_text: "The jade sextant was calibrated yesterday.",
+                byte_start: 90,
+                final_relation_state: &negative,
+            },
+        ];
+        let evaluation =
+            evaluate_source_relation_head(&artifact, &candidates).expect("deduplicated answer");
+        assert_eq!(
+            evaluation.decision,
+            SourceRelationHeadDecision::Answer { candidate_index: 1 }
+        );
+
+        let tied = [
+            SourceRelationCandidate {
+                span_text: "duplicate.",
+                byte_start: 20,
+                final_relation_state: &one,
+            },
+            SourceRelationCandidate {
+                span_text: "duplicate.",
+                byte_start: 5,
+                final_relation_state: &one,
+            },
+        ];
+        let evaluation =
+            evaluate_source_relation_head(&artifact, &tied).expect("earliest duplicate");
+        assert_eq!(
+            evaluation.decision,
+            SourceRelationHeadDecision::Answer { candidate_index: 1 }
+        );
+    }
+
+    #[test]
+    fn zero_never_authorizes_text_and_distinct_positives_conflict() {
+        let artifact = valid_artifact();
+        let zero = state(0.5);
+        let negative = state(0.0);
+        let abstaining = [
+            SourceRelationCandidate {
+                span_text: "zero.",
+                byte_start: 0,
+                final_relation_state: &zero,
+            },
+            SourceRelationCandidate {
+                span_text: "negative.",
+                byte_start: 10,
+                final_relation_state: &negative,
+            },
+        ];
+        let evaluation =
+            evaluate_source_relation_head(&artifact, &abstaining).expect("safe abstention");
+        assert_eq!(evaluation.candidate_logits, vec![0.0, -0.5]);
+        assert_eq!(evaluation.decision, SourceRelationHeadDecision::Abstain);
+
+        let one = state(1.0);
+        let two = state(2.0);
+        let conflicting = [
+            SourceRelationCandidate {
+                span_text: "first location.",
+                byte_start: 0,
+                final_relation_state: &one,
+            },
+            SourceRelationCandidate {
+                span_text: "second location.",
+                byte_start: 20,
+                final_relation_state: &two,
+            },
+        ];
+        let evaluation =
+            evaluate_source_relation_head(&artifact, &conflicting).expect("safe conflict");
+        assert_eq!(
+            evaluation.decision,
+            SourceRelationHeadDecision::Contradiction
+        );
+    }
+
+    #[test]
+    fn malformed_states_and_unsafe_candidate_counts_fail_closed() {
+        let artifact = valid_artifact();
+        let short = vec![0.0; RELATION_STATE_WIDTH - 1];
+        let valid = state(0.0);
+        let candidates = [
+            SourceRelationCandidate {
+                span_text: "short.",
+                byte_start: 0,
+                final_relation_state: &short,
+            },
+            SourceRelationCandidate {
+                span_text: "valid.",
+                byte_start: 10,
+                final_relation_state: &valid,
+            },
+        ];
+        assert!(matches!(
+            evaluate_source_relation_head(&artifact, &candidates),
+            Err(SourceRelationHeadError::InvalidInput(_))
+        ));
+
+        let singleton = [SourceRelationCandidate {
+            span_text: "single.",
+            byte_start: 0,
+            final_relation_state: &valid,
+        }];
+        assert!(matches!(
+            evaluate_source_relation_head(&artifact, &singleton),
+            Err(SourceRelationHeadError::InvalidInput(_))
+        ));
+
+        let mut nonfinite = state(0.0);
+        nonfinite[17] = f32::NAN;
+        let candidates = [
+            SourceRelationCandidate {
+                span_text: "nonfinite.",
+                byte_start: 0,
+                final_relation_state: &nonfinite,
+            },
+            SourceRelationCandidate {
+                span_text: "valid.",
+                byte_start: 10,
+                final_relation_state: &valid,
+            },
+        ];
+        assert!(matches!(
+            evaluate_source_relation_head(&artifact, &candidates),
+            Err(SourceRelationHeadError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn artifact_shape_threshold_and_checkpoint_bindings_fail_closed() {
+        let mut artifact = valid_artifact();
+        artifact.first_layer_weights.pop();
+        assert!(validate_artifact(
+            &artifact,
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID
+        )
+        .is_err());
+
+        let mut artifact = valid_artifact();
+        artifact.threshold = -0.0;
+        assert!(validate_artifact(
+            &artifact,
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID
+        )
+        .is_err());
+
+        let artifact = valid_artifact();
+        assert!(validate_artifact(
+            &artifact,
+            &test_cid("different weights"),
+            EXPECTED_TOKENIZER_CID
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn canonical_self_cid_loader_rejects_reformatting_tampering_and_unknown_fields() {
+        let artifact = valid_artifact();
+        let bytes = signed_artifact(&artifact);
+        let decoded = decode_artifact_bytes(
+            &bytes,
+            Path::new("fixture.json"),
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID,
+        )
+        .expect("canonical artifact");
+        assert_eq!(decoded.policy, RELATION_HEAD_POLICY);
+
+        let mut pretty = serde_json::to_vec_pretty(
+            &serde_json::from_slice::<serde_json::Value>(&bytes).expect("fixture value"),
+        )
+        .expect("pretty JSON");
+        pretty.push(b'\n');
+        assert!(decode_artifact_bytes(
+            &pretty,
+            Path::new("pretty.json"),
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID,
+        )
+        .is_err());
+
+        let mut tampered: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("fixture value");
+        tampered["output_bias"] = serde_json::json!(-0.25);
+        let tampered = canonical_json_bytes(&tampered).expect("tampered JSON");
+        assert!(decode_artifact_bytes(
+            &tampered,
+            Path::new("tampered.json"),
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID,
+        )
+        .is_err());
+
+        let mut unknown: serde_json::Value =
+            serde_json::to_value(valid_artifact()).expect("artifact value");
+        unknown
+            .as_object_mut()
+            .expect("artifact object")
+            .insert("unexpected".to_owned(), serde_json::json!(true));
+        let unknown = signed_value(unknown);
+        assert!(decode_artifact_bytes(
+            &unknown,
+            Path::new("unknown.json"),
+            EXPECTED_MODEL_WEIGHTS_CID,
+            EXPECTED_TOKENIZER_CID,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn canonical_layout_accepts_python_exponents_but_rejects_spacing_and_key_reordering() {
+        verify_canonical_json_layout(b"{\"a\":1e-07,\"b\":3.2000000000000005e-05}\n")
+            .expect("Python number spellings remain bound as raw bytes");
+        assert!(verify_canonical_json_layout(b"{\"a\": 1}\n").is_err());
+        assert!(verify_canonical_json_layout(b"{\"a\":1 ,\"b\":2}\n").is_err());
+        assert!(verify_canonical_json_layout(b"{\"b\":1,\"a\":2}\n").is_err());
+        assert!(verify_canonical_json_layout(b"{\"a\":1}\n\n").is_err());
+    }
+}

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -5,7 +5,8 @@ This package contains the bounded offline training paths authorized by issues
 [#1017](https://github.com/UOR-Foundation/uor-r4/issues/1017), plus the frozen,
 preflight-recorded [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
 parameter-capacity campaign, and the bounded [#954](https://github.com/UOR-Foundation/uor-r4/issues/954)
-grounding fine-tune plus its frozen source-span-pointer successor. They train
+grounding fine-tune, frozen source-span-pointer successor, and independently
+frozen source-relative relation-head successor. They train
 and continue ordinary causal-softmax
 Llama-family models, export them in the existing Rust loaders' Hugging Face
 format, and freeze evidence before each sealed test is opened. They contain no
@@ -52,9 +53,12 @@ MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
 deferred logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
 fast-path negative, not a model result. #1019 closed without a full run. #954's
-grounding fine-tune and positive-diagonal cosine pointer have also completed as
-bounded negatives. The next #954 mechanism must be frozen independently before
-use; it is not a retry of either revealed run. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+grounding fine-tune, positive-diagonal cosine pointer, and source-relative
+relation probe have also completed as bounded negatives. The relation probe fit
+both construction lexical families exactly but failed its independent
+12-record transfer gate, so no full fit or product reveal ran. The next #954
+mechanism must train relation supervision into the representation and be frozen
+independently; it is not a retry of any revealed readout. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
 and MPS are local offline accelerators only; CUDA and external GPU execution
 are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
@@ -131,10 +135,34 @@ answer classification was `89/128` (`69.53125%`), abstention `114/128`
 Terminal: `FAIL_SOURCE_SPAN_POINTER_DEVELOPMENT_GATE_STOP`. No final pointer
 artifact was emitted, and all three committed product probes remain `NOT_RUN`.
 Do not rerun, tune, or use the preflight head as a product head. The retained
-state-capture and parity seams may support a future independently frozen
-source-relative relation/entailment head that preserves exact copy semantics.
+state-capture and parity seams subsequently supported the independently frozen
+C1-SB2 source-relative relation probe below.
 See the [#954 record](../../docs/r4_grounded_correctness_954.md) and
 [structured C1-SB1 result](../../docs/r4_source_span_pointer_954_raw.json).
+
+## C1-SB2 source-relative relation-head result
+
+`train-source-relation-head` implemented
+`R4SourceRelativeRelationHeadV1`. Each exact sentence is encoded together with
+the exact question, ending at the question-mark token. The immutable #1017
+executor supplies that final width-288 normalized R4/Spin state to a fixed
+`288 -> 32 ReLU -> 1` probe. Strict positive logits identify supporting
+relations; exact duplicate text collapses before deterministic exact-copy,
+abstain, or contradiction selection.
+
+The zero-training census passed over 3,360 construction and 420 lexically
+disjoint development records. The mandatory cheap gate then fit all 12 records
+from two construction families exactly but failed all six answer decisions in
+the two unseen families. Sealed answer, abstain, and conflict decisions were
+`0/6`, `3/4`, and `1/2`; positive recall was `5/12`, negative specificity
+`14/20`, and copied-span accuracy `0/6`. Terminal:
+`FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP`.
+
+No Python/Rust parity report, 512-step full fit, final head, development result,
+or product evaluation exists. Do not rerun or tune the frozen probe. The
+preserved trainer/runtime seam is for replay and for a future independently
+frozen mechanism that trains relation semantics into the representation. See
+the [structured C1-SB2 result](../../docs/r4_source_relation_head_954_raw.json).
 
 ## Isolated environment
 
@@ -158,7 +186,8 @@ instead used its own eight-hour backend-admission gate. MPS stopped
 `21.03%`. That result applies only to the frozen offline implementation. The
 subsequent fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
 signed `3.491307 s/step`), so #1019 closed without a full run. #954's grounding
-fine-tune and source-span pointer also closed negative; neither is rerun.
+fine-tune, source-span pointer, and source-relative relation probe also closed
+negative; none is rerun.
 CUDA and external GPU execution are out of scope.
 
 ## One-way campaign
@@ -268,7 +297,7 @@ Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
 terminal applies only to the frozen offline implementation. Full training,
 final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
 fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-`3.491307 s/step`), so #1019 closed without a full run. #954's two bounded
+`3.491307 s/step`), so #1019 closed without a full run. #954's three bounded
 source-grounding mechanisms subsequently closed negative. CUDA and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -43,9 +43,11 @@ from .paths import (
     default_grounding_predecessor_root,
     default_grounding_root,
     default_research_root,
+    default_source_relation_head_root,
     default_source_span_pointer_root,
 )
 from .provenance import verify_bound_manifest
+from .source_relation_head import train_source_relation_head
 from .source_span_pointer import train_source_span_pointer
 from .train import TrainConfig, reveal_sealed_test, run_overfit_smoke, train_main
 
@@ -68,7 +70,7 @@ def parser() -> argparse.ArgumentParser:
         type=_root,
         help=(
             "untracked data/checkpoint root (defaults to issue-1014, issue-1017, "
-            "issue-1019, or issue-954/source-span-pointer according to the selected "
+            "issue-1019, or the selected issue-954 grounding mechanism according to the "
             "lifecycle)"
         ),
     )
@@ -253,6 +255,29 @@ def parser() -> argparse.ArgumentParser:
             "preflight head/source; required only on the second invocation"
         ),
     )
+    relation = subcommands.add_parser(
+        "train-source-relation-head",
+        help=(
+            "run the C1-SB2 matched-transfer gate, admit three Rust parity "
+            "reports, and only then perform its sole 512-step relation-head fit"
+        ),
+    )
+    relation.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
+    relation.add_argument(
+        "--rust-score-parity",
+        type=_root,
+        nargs=3,
+        metavar=("ANSWER_JSON", "ABSTAIN_JSON", "CONFLICT_JSON"),
+        help=(
+            "three uor-r4.grounded-answer/3 reports emitted from the preflight "
+            "head; required only on the second invocation"
+        ),
+    )
     return command
 
 
@@ -281,6 +306,7 @@ def main() -> None:
     }
     grounding_commands = {"finetune-grounding"}
     pointer_commands = {"train-source-span-pointer"}
+    relation_commands = {"train-source-relation-head"}
     if arguments.root:
         root = arguments.root
     elif arguments.command in capacity_commands:
@@ -291,6 +317,8 @@ def main() -> None:
         root = default_grounding_root()
     elif arguments.command in pointer_commands:
         root = default_source_span_pointer_root()
+    elif arguments.command in relation_commands:
+        root = default_source_relation_head_root()
     else:
         root = default_research_root()
     if arguments.command == "download":
@@ -411,6 +439,15 @@ def main() -> None:
     if arguments.command == "train-source-span-pointer":
         _print_result(
             train_source_span_pointer(
+                root,
+                predecessor=arguments.predecessor,
+                rust_score_parity=arguments.rust_score_parity,
+            )
+        )
+        return
+    if arguments.command == "train-source-relation-head":
+        _print_result(
+            train_source_relation_head(
                 root,
                 predecessor=arguments.predecessor,
                 rust_score_parity=arguments.rust_score_parity,

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
@@ -46,3 +46,7 @@ def default_grounding_root() -> Path:
 
 def default_source_span_pointer_root() -> Path:
     return model_store_root() / "research" / "issue-954" / "source-span-pointer"
+
+
+def default_source_relation_head_root() -> Path:
+    return model_store_root() / "research" / "issue-954" / "source-relation-head"

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_data.py
@@ -1,0 +1,1176 @@
+"""Frozen C1-SB2 source-relative relation population and sealed probes.
+
+This module contains data and labels only.  It never loads the #1017 model,
+extracts states, fits a head, or evaluates a reserved product record.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from functools import lru_cache
+from typing import Any, Iterable, Sequence
+
+from .provenance import canonical_json_bytes, cid_bytes
+
+
+ISSUE = 954
+POLICY = "R4SourceRelativeRelationHeadV1"
+RELATION_RECORD_SCHEMA = "uor-r4.source-relative-relation-record/1"
+RELATION_DATASET_SCHEMA = "uor-r4.source-relative-relation-dataset/1"
+RELATION_SPLIT_POLICY_SCHEMA = "uor-r4.source-relative-relation-split/1"
+RELATION_PREFLIGHT_SCHEMA = "uor-r4.source-relative-relation-preflight/1"
+RELATION_PRODUCT_PROBES_SCHEMA = "uor-r4.source-relative-relation-product-probes/1"
+RELATION_SHORTCUT_CENSUS_SCHEMA = "uor-r4.source-relative-relation-shortcut-census/1"
+RELATION_INPUT_POLICY = (
+    "exact UTF-8 `Evidence:\\n<span>\\nQuestion:\\n<question>` with no terminal "
+    "newline; evidence precedes the question and the retained final state is the "
+    "question mark"
+)
+QUESTION_POLICY = "Where is the <subject>?"
+SENTENCE_POLICY = "exact .!? terminated UTF-8 byte spans"
+SOURCE_WIDTHS = tuple(range(2, 9))
+OUTCOMES = ("answer", "abstain", "conflict")
+ABSTAIN = "ABSTAIN"
+CONTRADICTION = "CONTRADICTION"
+CONSTRUCTION_PER_CELL = 160
+DEVELOPMENT_PER_CELL = 20
+
+
+CONSTRUCTION_BANK = {
+    "name": "c1-sb2-construction",
+    "subjects": (
+        "azure compass",
+        "bronze lantern",
+        "ceramic falcon",
+        "crimson ledger",
+        "ivory kettle",
+        "silver spindle",
+        "violet banner",
+        "marble flute",
+        "canvas satchel",
+        "walnut puzzle",
+        "teal goblet",
+        "linen drum",
+        "pewter crown",
+        "glass acorn",
+        "ochre telescope",
+        "indigo whistle",
+        "scarlet thimble",
+        "granite token",
+        "willow map",
+        "copper kite",
+        "porcelain key",
+        "umber book",
+        "golden shell",
+        "saffron bell",
+    ),
+    "locations": (
+        "inside the willow cupboard",
+        "beneath the granite arch",
+        "beside the mossy fountain",
+        "above the pantry window",
+        "behind the cotton screen",
+        "near the glass pavilion",
+        "within the stone alcove",
+        "under the copper awning",
+        "inside the wicker hamper",
+        "beneath the oak balcony",
+        "beside the quiet canal",
+        "above the cedar desk",
+        "behind the garden trellis",
+        "near the slate bridge",
+        "within the paper chest",
+        "under the narrow shelf",
+        "inside the clay pantry",
+        "beneath the round table",
+        "beside the apple gate",
+        "above the river bench",
+        "behind the blue tapestry",
+        "near the iron brazier",
+        "within the birch closet",
+        "under the vaulted passage",
+    ),
+    "nonlocatives": (
+        "was inventoried at noon",
+        "was cleaned after supper",
+        "was photographed on Tuesday",
+        "was repaired by the curator",
+        "was weighed before breakfast",
+        "was catalogued last winter",
+        "was wrapped for transport",
+        "was inspected during rehearsal",
+        "was painted by an apprentice",
+        "was displayed during the festival",
+        "was counted twice yesterday",
+        "was labeled for the archive",
+    ),
+}
+
+DEVELOPMENT_BANK = {
+    "name": "c1-sb2-development",
+    "subjects": (
+        "coral abacus",
+        "jade pendulum",
+        "navy brooch",
+        "quartz horn",
+        "russet helmet",
+        "pearl tablet",
+        "magenta shuttle",
+        "obsidian wheel",
+        "alabaster flute",
+        "emerald stencil",
+        "vermilion cup",
+        "charcoal prism",
+    ),
+    "locations": (
+        "inside the aspen locker",
+        "beneath the tiled landing",
+        "beside the fern courtyard",
+        "above the brass railing",
+        "behind the wool curtain",
+        "near the marble kiosk",
+        "within the elm cabinet",
+        "under the painted canopy",
+        "inside the reed basket",
+        "beneath the limestone porch",
+        "beside the silver cistern",
+        "above the orchard wall",
+    ),
+    "nonlocatives": (
+        "was audited at dusk",
+        "was rinsed after the concert",
+        "was sketched on Thursday",
+        "was mended by the watchmaker",
+        "was measured before lunch",
+        "was indexed last spring",
+        "was packed for exhibition",
+        "was examined during intermission",
+    ),
+}
+
+PREFLIGHT_FAMILIES = (
+    {
+        "name": "fit-quartz",
+        "subject": "quartz chronometer",
+        "distractor": "umber weather vane",
+        "absent": "carmine sextant",
+        "location_a": "inside the alder case",
+        "location_b": "beside the basalt pillar",
+        "nonlocative": "was serviced before the recital",
+    },
+    {
+        "name": "fit-celadon",
+        "subject": "celadon armillary",
+        "distractor": "silver plumb bob",
+        "absent": "indigo quadrant",
+        "location_a": "beneath the ash gallery",
+        "location_b": "near the brick colonnade",
+        "nonlocative": "was engraved after the lecture",
+    },
+    {
+        "name": "sealed-amber",
+        "subject": "amber orrery",
+        "distractor": "violet survey chain",
+        "absent": "pearl inclinometer",
+        "location_a": "within the beech hutch",
+        "location_b": "under the chalk portico",
+        "nonlocative": "was calibrated before the banquet",
+    },
+    {
+        "name": "sealed-onyx",
+        "subject": "onyx transit scope",
+        "distractor": "scarlet level vial",
+        "absent": "cerulean planimeter",
+        "location_a": "behind the fir partition",
+        "location_b": "above the sandstone landing",
+        "nonlocative": "was documented after the procession",
+    },
+)
+
+PRODUCT_OBJECTS = (
+    "opal astrolabe",
+    "brass sundial",
+    "silk atlas",
+    "jade sextant",
+)
+PRODUCT_LOCATIONS = (
+    "beside the north alcove",
+    "beneath the maple stair",
+    "inside the cedar cabinet",
+    "inside the linen drawer",
+)
+PRODUCT_NONLOCATIVES = (
+    "was polished before sunrise",
+    "was restored yesterday",
+    "was calibrated yesterday",
+)
+
+
+def parse_subject(question: str) -> str:
+    """Parse the sole admitted C1-SB2 question without loading trainer code."""
+    prefix = "Where is the "
+    if not question.startswith(prefix) or not question.endswith("?"):
+        raise ValueError(f"question does not match {QUESTION_POLICY!r}")
+    subject = question[len(prefix) : -1]
+    if (
+        not subject
+        or subject != subject.strip()
+        or "?" in subject
+        or "\n" in subject
+        or "\r" in subject
+    ):
+        raise ValueError(f"question does not match {QUESTION_POLICY!r}")
+    return subject
+
+
+def split_sentence_spans(source: str) -> list[dict[str, Any]]:
+    """Split exact UTF-8 bytes on the admitted ASCII terminators."""
+    if not source:
+        raise ValueError("source is empty")
+    encoded = source.encode("utf-8")
+    spans: list[dict[str, Any]] = []
+    byte_offset = 0
+    byte_start: int | None = None
+    for character in source:
+        width = len(character.encode("utf-8"))
+        if byte_start is None:
+            if character.isspace():
+                byte_offset += width
+                continue
+            byte_start = byte_offset
+        byte_offset += width
+        if character not in ".!?":
+            continue
+        raw = encoded[byte_start:byte_offset]
+        text = raw.decode("utf-8")
+        if not text[:-1].strip():
+            raise ValueError("source contains an empty punctuation-only sentence")
+        spans.append({"byte_start": byte_start, "byte_end": byte_offset, "text": text})
+        if len(spans) > max(SOURCE_WIDTHS):
+            raise ValueError("source exceeds the admitted sentence count")
+        byte_start = None
+    if byte_start is not None:
+        raise ValueError("source has a non-whitespace suffix without .!? termination")
+    return spans
+
+
+def render_relation_input(span: str, question: str) -> str:
+    """Render the exact evidence-first input ending at the question mark."""
+    if not span or span != span.strip() or span[-1] not in ".!?":
+        raise ValueError("relation evidence must be one trimmed terminated span")
+    parse_subject(question)
+    return f"Evidence:\n{span}\nQuestion:\n{question}"
+
+
+def _canonical_with_cid(value: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _question(subject: str) -> str:
+    return f"Where is the {subject}?"
+
+
+def _locative(subject: str, location: str) -> str:
+    return f"The {subject} is {location}."
+
+
+def _nonlocative(subject: str, phrase: str) -> str:
+    return f"The {subject} {phrase}."
+
+
+def _negated(subject: str, location: str) -> str:
+    return f"The {subject} is not {location}."
+
+
+def _entry(text: str, relation_label: int, role: str) -> dict[str, Any]:
+    if relation_label not in (0, 1):
+        raise ValueError("relation label must be binary")
+    return {"text": text, "relation_label": relation_label, "role": role}
+
+
+def _arrange(
+    width: int,
+    fixed: dict[int, dict[str, Any]],
+    remaining: Sequence[dict[str, Any]],
+    *,
+    offset: int,
+) -> list[dict[str, Any]]:
+    if width not in SOURCE_WIDTHS or len(fixed) + len(remaining) != width:
+        raise ValueError("candidate arrangement does not match the admitted width")
+    ordered: list[dict[str, Any] | None] = [None] * width
+    for index, value in fixed.items():
+        if not 0 <= index < width or ordered[index] is not None:
+            raise ValueError("candidate arrangement has a duplicate or invalid position")
+        ordered[index] = value
+    available = [index for index in range(width) if ordered[index] is None]
+    if available:
+        shift = offset % len(available)
+        available = available[shift:] + available[:shift]
+    for index, value in zip(available, remaining):
+        ordered[index] = value
+    if any(value is None for value in ordered):
+        raise RuntimeError("candidate arrangement left an empty position")
+    return [value for value in ordered if value is not None]
+
+
+@lru_cache(maxsize=None)
+def _balanced_pair_schedule(width: int) -> tuple[tuple[int, int], ...]:
+    """Round-robin every unordered pair while balancing every prefix by position."""
+    players: list[int | None] = list(range(width))
+    if width % 2:
+        players.append(None)
+    rounds = len(players) - 1
+    schedule: list[tuple[int, int]] = []
+    for _ in range(rounds):
+        round_pairs: list[tuple[int, int]] = []
+        for index in range(len(players) // 2):
+            left = players[index]
+            right = players[-1 - index]
+            if left is None or right is None:
+                continue
+            round_pairs.append(tuple(sorted((left, right))))
+        schedule.extend(sorted(round_pairs))
+        players = [players[0], players[-1], *players[1:-1]]
+    expected = width * (width - 1) // 2
+    if len(schedule) != expected or len(set(schedule)) != expected:
+        raise RuntimeError("round-robin position schedule did not cover each pair once")
+    return tuple(schedule)
+
+
+def _pair(width: int, ordinal: int) -> tuple[int, int]:
+    pairs = _balanced_pair_schedule(width)
+    return pairs[ordinal % len(pairs)]
+
+
+@lru_cache(maxsize=None)
+def _answer_layout(
+    width: int, records_per_cell: int
+) -> tuple[tuple[int, ...], tuple[tuple[int, int], ...]]:
+    """Balance singleton and duplicate positive incidence as one answer cell."""
+    if records_per_cell % 2:
+        raise ValueError("answer cell size must alternate evenly between its two motifs")
+    motif_count = records_per_cell // 2
+    duplicate_pairs = tuple(_pair(width, index) for index in range(motif_count))
+    position_counts = Counter(
+        position for pair in duplicate_pairs for position in pair
+    )
+    singleton_positions: list[int] = []
+    for index in range(motif_count):
+        position = min(
+            range(width),
+            key=lambda candidate: (
+                position_counts[candidate],
+                (candidate - index) % width,
+            ),
+        )
+        singleton_positions.append(position)
+        position_counts[position] += 1
+    if max(position_counts.values()) - min(position_counts.values()) > 1:
+        raise RuntimeError("answer position schedule is not balanced")
+    return tuple(singleton_positions), duplicate_pairs
+
+
+def _other_subjects(
+    bank: dict[str, Any], subject: str, *, ordinal: int, count: int
+) -> list[str]:
+    subjects = tuple(str(value) for value in bank["subjects"])
+    chosen: list[str] = []
+    cursor = (ordinal * 5 + 3) % len(subjects)
+    while len(chosen) < count:
+        candidate = subjects[cursor % len(subjects)]
+        cursor += 7
+        if candidate == subject or candidate in chosen:
+            continue
+        chosen.append(candidate)
+    return chosen
+
+
+def _filler_entries(
+    bank: dict[str, Any],
+    subject: str,
+    *,
+    ordinal: int,
+    width: int,
+    count: int,
+) -> list[dict[str, Any]]:
+    others = _other_subjects(bank, subject, ordinal=ordinal + width, count=count)
+    locations = tuple(str(value) for value in bank["locations"])
+    return [
+        _entry(
+            _locative(other, locations[(ordinal * 7 + lane * 5 + width) % len(locations)]),
+            0,
+            "swap-locative" if lane == 0 else "locative-distractor",
+        )
+        for lane, other in enumerate(others)
+    ]
+
+
+def _make_record(
+    *,
+    population: str,
+    motif: str,
+    outcome: str,
+    subject: str,
+    entries: Sequence[dict[str, Any]],
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if outcome not in OUTCOMES or len(entries) not in SOURCE_WIDTHS:
+        raise ValueError("relation record outcome or source width is invalid")
+    question = _question(subject)
+    if parse_subject(question) != subject:
+        raise RuntimeError("relation question did not reproduce its subject")
+    source = " ".join(str(entry["text"]) for entry in entries)
+    parsed = split_sentence_spans(source)
+    if len(parsed) != len(entries):
+        raise RuntimeError("relation source did not reproduce its candidate count")
+
+    sentence_spans: list[dict[str, Any]] = []
+    for index, (span, entry) in enumerate(zip(parsed, entries)):
+        text = str(entry["text"])
+        if span["text"] != text:
+            raise RuntimeError("relation source span text changed during parsing")
+        text_cid = cid_bytes(text.encode("utf-8"))
+        relation_input = render_relation_input(text, question)
+        sentence_spans.append(
+            {
+                "candidate_index": index,
+                "byte_start": int(span["byte_start"]),
+                "byte_end": int(span["byte_end"]),
+                "text": text,
+                "text_cid": text_cid,
+                "role": str(entry["role"]),
+                "relation_label": int(entry["relation_label"]),
+                "relation_group_cid": text_cid,
+                "relation_input": relation_input,
+                "relation_input_cid": cid_bytes(relation_input.encode("utf-8")),
+            }
+        )
+
+    positive = [
+        int(span["candidate_index"])
+        for span in sentence_spans
+        if int(span["relation_label"]) == 1
+    ]
+    positive_groups = sorted(
+        {str(sentence_spans[index]["relation_group_cid"]) for index in positive}
+    )
+    derived = (
+        "abstain"
+        if not positive_groups
+        else "answer"
+        if len(positive_groups) == 1
+        else "conflict"
+    )
+    if derived != outcome:
+        raise ValueError(
+            f"relation labels derive {derived}, not the declared outcome {outcome}"
+        )
+    target_span_index: int | None = None
+    answer = ABSTAIN if outcome == "abstain" else CONTRADICTION
+    if outcome == "answer":
+        target_span_index = min(positive)
+        answer = str(sentence_spans[target_span_index]["text"])
+    duplicate_agreement = outcome == "answer" and len(positive) > 1
+    if duplicate_agreement and len(
+        {sentence_spans[index]["text"] for index in positive}
+    ) != 1:
+        raise ValueError("answer agreement must consist of exact duplicate spans")
+    if outcome == "conflict" and len(positive_groups) != 2:
+        raise ValueError("conflict must contain exactly two distinct positive relations")
+
+    value: dict[str, Any] = {
+        "schema": RELATION_RECORD_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "population": population,
+        "motif": motif,
+        "target_outcome": outcome,
+        "source_width": len(sentence_spans),
+        "source": source,
+        "source_cid": cid_bytes(source.encode("utf-8")),
+        "question": question,
+        "question_cid": cid_bytes(question.encode("utf-8")),
+        "subject": subject,
+        "sentence_spans": sentence_spans,
+        "positive_span_indices": positive,
+        "positive_relation_group_cids": positive_groups,
+        "raw_subject_occurrence_count": sum(
+            str(span["text"]).count(subject) for span in sentence_spans
+        ),
+        "target_span_index": target_span_index,
+        "answer": answer,
+        "duplicate_agreement": duplicate_agreement,
+    }
+    if extra:
+        overlap = set(value).intersection(extra)
+        if overlap:
+            raise ValueError(f"extra relation fields collide: {sorted(overlap)}")
+        value.update(extra)
+    return _canonical_with_cid(value, "record_cid")
+
+
+def _cell_record(
+    bank: dict[str, Any],
+    *,
+    population: str,
+    outcome: str,
+    width: int,
+    ordinal: int,
+) -> dict[str, Any]:
+    subjects = tuple(str(value) for value in bank["subjects"])
+    locations = tuple(str(value) for value in bank["locations"])
+    nonlocatives = tuple(str(value) for value in bank["nonlocatives"])
+    subject = subjects[ordinal % len(subjects)]
+    cycle = ordinal // len(subjects)
+    location_a = locations[(cycle + width * 3 + OUTCOMES.index(outcome)) % len(locations)]
+    location_b = locations[
+        (cycle + width * 3 + OUTCOMES.index(outcome) + 1 + ordinal % 11)
+        % len(locations)
+    ]
+    if location_b == location_a:
+        location_b = locations[(locations.index(location_a) + 1) % len(locations)]
+    nonlocative = nonlocatives[(ordinal * 7 + width) % len(nonlocatives)]
+    negated_location = locations[(ordinal * 11 + width + 5) % len(locations)]
+
+    fixed: dict[int, dict[str, Any]] = {}
+    remaining: list[dict[str, Any]] = []
+    motif: str
+    if outcome == "answer":
+        duplicate = ordinal % 2 == 1
+        records_per_cell = (
+            CONSTRUCTION_PER_CELL
+            if population == "construction"
+            else DEVELOPMENT_PER_CELL
+        )
+        singleton_positions, duplicate_pairs = _answer_layout(width, records_per_cell)
+        if duplicate:
+            motif = "duplicate-agreement"
+            duplicate_fact = _entry(_locative(subject, location_a), 1, "agreement")
+            first, second = duplicate_pairs[ordinal // 2]
+            fixed[first] = duplicate_fact
+            fixed[second] = dict(duplicate_fact)
+            add_negative = width >= 3 and (ordinal // 2) % 2 == 1
+            if add_negative:
+                remaining.append(
+                    _entry(_nonlocative(subject, nonlocative), 0, "same-subject-nonlocative")
+                )
+        else:
+            motif = "singleton"
+            target = singleton_positions[ordinal // 2]
+            fixed[target] = _entry(_locative(subject, location_a), 1, "singleton-answer")
+            remaining.append(
+                _entry(_nonlocative(subject, nonlocative), 0, "same-subject-nonlocative")
+            )
+    elif outcome == "conflict":
+        motif = "distinct-location-conflict"
+        first, second = _pair(width, ordinal)
+        fixed[first] = _entry(_locative(subject, location_a), 1, "conflict-location-a")
+        fixed[second] = _entry(_locative(subject, location_b), 1, "conflict-location-b")
+        if width >= 3 and ordinal % 2 == 1:
+            remaining.append(
+                _entry(_nonlocative(subject, nonlocative), 0, "same-subject-nonlocative")
+            )
+    else:
+        motif = "same-subject-nonanswer"
+        remaining.extend(
+            (
+                _entry(_nonlocative(subject, nonlocative), 0, "same-subject-nonlocative"),
+                _entry(_negated(subject, negated_location), 0, "same-subject-negated"),
+            )
+        )
+        if width >= 3 and ordinal % 2 == 1:
+            second_phrase = nonlocatives[(ordinal * 7 + width + 1) % len(nonlocatives)]
+            remaining.append(
+                _entry(
+                    _nonlocative(subject, second_phrase),
+                    0,
+                    "same-subject-nonlocative-second",
+                )
+            )
+
+    filler_count = width - len(fixed) - len(remaining)
+    if filler_count < 0:
+        raise RuntimeError("relation cell overfilled its source width")
+    remaining.extend(
+        _filler_entries(
+            bank,
+            subject,
+            ordinal=ordinal,
+            width=width,
+            count=filler_count,
+        )
+    )
+    entries = _arrange(width, fixed, remaining, offset=ordinal + width)
+    swap_indices = [
+        index for index, entry in enumerate(entries) if entry["role"] == "swap-locative"
+    ]
+    extra: dict[str, Any] = {
+        "cell_ordinal": ordinal,
+        "lexical_bank": str(bank["name"]),
+    }
+    if swap_indices:
+        swap_index = swap_indices[0]
+        swap_subject = str(entries[swap_index]["text"])[4:].split(" is ", 1)[0]
+        extra.update(
+            {
+                "query_swap_subject": swap_subject,
+                "query_swap_target_span_index": swap_index,
+            }
+        )
+    return _make_record(
+        population=population,
+        motif=motif,
+        outcome=outcome,
+        subject=subject,
+        entries=entries,
+        extra=extra,
+    )
+
+
+def _reversal_control(record: dict[str, Any]) -> dict[str, Any]:
+    original = list(record["sentence_spans"])
+    entries = [
+        _entry(str(span["text"]), int(span["relation_label"]), str(span["role"]))
+        for span in reversed(original)
+    ]
+    return _make_record(
+        population="development-control",
+        motif="reverse-candidate-order",
+        outcome=str(record["target_outcome"]),
+        subject=str(record["subject"]),
+        entries=entries,
+        extra={
+            "control_kind": "order-reversal",
+            "base_record_cid": str(record["record_cid"]),
+            "candidate_original_indices": list(reversed(range(len(original)))),
+        },
+    )
+
+
+def _query_swap_control(record: dict[str, Any]) -> dict[str, Any] | None:
+    swap_subject = record.get("query_swap_subject")
+    swap_index = record.get("query_swap_target_span_index")
+    if not isinstance(swap_subject, str) or not isinstance(swap_index, int):
+        return None
+    entries = [
+        _entry(
+            str(span["text"]),
+            int(int(span["candidate_index"]) == swap_index),
+            str(span["role"]),
+        )
+        for span in record["sentence_spans"]
+    ]
+    return _make_record(
+        population="development-control",
+        motif="same-source-query-swap",
+        outcome="answer",
+        subject=swap_subject,
+        entries=entries,
+        extra={
+            "control_kind": "query-swap",
+            "base_record_cid": str(record["record_cid"]),
+            "base_subject": str(record["subject"]),
+            "expected_original_span_index": swap_index,
+        },
+    )
+
+
+def _preflight_family_records(
+    family: dict[str, str], *, population: str, family_index: int
+) -> list[dict[str, Any]]:
+    subject = family["subject"]
+    distractor = family["distractor"]
+    absent = family["absent"]
+    location_a = family["location_a"]
+    location_b = family["location_b"]
+    nonlocative = family["nonlocative"]
+    locative = _locative(subject, location_a)
+    distractor_locative = _locative(distractor, location_b)
+    subject_nonlocative = _nonlocative(subject, nonlocative)
+
+    matched_source = [
+        _entry(locative, 0, "matched-primary-locative"),
+        _entry(distractor_locative, 0, "matched-distractor-locative"),
+        _entry(subject_nonlocative, 0, "matched-primary-nonlocative"),
+    ]
+    shift = family_index % len(matched_source)
+    matched_source = matched_source[shift:] + matched_source[:shift]
+    absent_record = _make_record(
+        population=population,
+        motif="same-source-absent-query",
+        outcome="abstain",
+        subject=absent,
+        entries=matched_source,
+        extra={"lexical_family": family["name"]},
+    )
+    present_entries = [
+        _entry(
+            str(entry["text"]),
+            int(str(entry["text"]) == locative),
+            str(entry["role"]),
+        )
+        for entry in matched_source
+    ]
+    present_record = _make_record(
+        population=population,
+        motif="same-source-present-locative-query",
+        outcome="answer",
+        subject=subject,
+        entries=present_entries,
+        extra={"lexical_family": family["name"]},
+    )
+
+    nonlocative_source = [
+        _entry(subject_nonlocative, 0, "matched-primary-nonlocative"),
+        _entry(distractor_locative, 0, "matched-distractor-locative"),
+    ]
+    if family_index % 2:
+        nonlocative_source.reverse()
+    nonlocative_record = _make_record(
+        population=population,
+        motif="queried-subject-nonlocative-only",
+        outcome="abstain",
+        subject=subject,
+        entries=nonlocative_source,
+        extra={"lexical_family": family["name"]},
+    )
+    distractor_entries = [
+        _entry(
+            str(entry["text"]),
+            int(str(entry["text"]) == distractor_locative),
+            str(entry["role"]),
+        )
+        for entry in nonlocative_source
+    ]
+    distractor_record = _make_record(
+        population=population,
+        motif="query-locative-distractor-subject",
+        outcome="answer",
+        subject=distractor,
+        entries=distractor_entries,
+        extra={"lexical_family": family["name"]},
+    )
+
+    duplicate_entries = [
+        _entry(locative, 1, "agreement"),
+        _entry(locative, 1, "agreement"),
+        _entry(subject_nonlocative, 0, "same-subject-nonlocative"),
+    ]
+    duplicate_shift = (family_index + 1) % len(duplicate_entries)
+    duplicate_entries = duplicate_entries[duplicate_shift:] + duplicate_entries[:duplicate_shift]
+    duplicate_record = _make_record(
+        population=population,
+        motif="exact-duplicate-agreement",
+        outcome="answer",
+        subject=subject,
+        entries=duplicate_entries,
+        extra={"lexical_family": family["name"]},
+    )
+    conflict_entries = [
+        _entry(locative, 1, "conflict-location-a"),
+        _entry(_locative(subject, location_b), 1, "conflict-location-b"),
+        _entry(subject_nonlocative, 0, "same-subject-nonlocative"),
+    ]
+    conflict_shift = (family_index + 2) % len(conflict_entries)
+    conflict_entries = conflict_entries[conflict_shift:] + conflict_entries[:conflict_shift]
+    conflict_record = _make_record(
+        population=population,
+        motif="distinct-location-conflict",
+        outcome="conflict",
+        subject=subject,
+        entries=conflict_entries,
+        extra={"lexical_family": family["name"]},
+    )
+    return [
+        absent_record,
+        present_record,
+        nonlocative_record,
+        distractor_record,
+        duplicate_record,
+        conflict_record,
+    ]
+
+
+def build_relation_preflight() -> dict[str, Any]:
+    """Build the frozen 12-fit/12-sealed matched-transfer preflight."""
+    fit: list[dict[str, Any]] = []
+    sealed: list[dict[str, Any]] = []
+    matched_pairs: list[dict[str, Any]] = []
+    for family_index, family in enumerate(PREFLIGHT_FAMILIES):
+        target = fit if family_index < 2 else sealed
+        population = "preflight-fit" if family_index < 2 else "preflight-sealed"
+        records = _preflight_family_records(
+            family, population=population, family_index=family_index
+        )
+        target.extend(records)
+        matched_pairs.extend(
+            (
+                {
+                    "lexical_family": family["name"],
+                    "kind": "absent-to-present",
+                    "left_record_cid": records[0]["record_cid"],
+                    "right_record_cid": records[1]["record_cid"],
+                    "same_source": records[0]["source_cid"] == records[1]["source_cid"],
+                },
+                {
+                    "lexical_family": family["name"],
+                    "kind": "nonlocative-to-locative-distractor",
+                    "left_record_cid": records[2]["record_cid"],
+                    "right_record_cid": records[3]["record_cid"],
+                    "same_source": records[2]["source_cid"] == records[3]["source_cid"],
+                },
+            )
+        )
+    value: dict[str, Any] = {
+        "schema": RELATION_PREFLIGHT_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "selection": (
+            "four disjoint lexical families; fit the first two families' six matched "
+            "motifs and evaluate the final two families without fitting"
+        ),
+        "counts": {"fit": len(fit), "sealed": len(sealed), "matched_pairs": len(matched_pairs)},
+        "fit_family_names": [family["name"] for family in PREFLIGHT_FAMILIES[:2]],
+        "sealed_family_names": [family["name"] for family in PREFLIGHT_FAMILIES[2:]],
+        "fit": fit,
+        "sealed": sealed,
+        "matched_pairs": matched_pairs,
+    }
+    return _canonical_with_cid(value, "preflight_cid")
+
+
+def _product_record(
+    *,
+    probe: str,
+    outcome: str,
+    subject: str,
+    entries: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    return _make_record(
+        population="product",
+        motif=probe,
+        outcome=outcome,
+        subject=subject,
+        entries=entries,
+        extra={"probe": probe},
+    )
+
+
+def product_probes() -> dict[str, Any]:
+    """Return four committed records; Python feature and fit code must not open them."""
+    opal_nonlocative = "The opal astrolabe was polished before sunrise."
+    brass_locative = "The brass sundial is beside the north alcove."
+    opal_maple = "The opal astrolabe is beneath the maple stair."
+    silk_nonlocative = "The silk atlas was restored yesterday."
+    silk_negated = "The silk atlas is not beneath the maple stair."
+    opal_cedar = "The opal astrolabe is inside the cedar cabinet."
+    jade_linen = "The jade sextant is inside the linen drawer."
+    jade_nonlocative = "The jade sextant was calibrated yesterday."
+    records = [
+        _product_record(
+            probe="opal-astrolabe-supported",
+            outcome="answer",
+            subject="opal astrolabe",
+            entries=(
+                _entry(opal_nonlocative, 0, "same-subject-nonlocative"),
+                _entry(brass_locative, 0, "locative-distractor"),
+                _entry(opal_maple, 1, "singleton-answer"),
+            ),
+        ),
+        _product_record(
+            probe="silk-atlas-abstain",
+            outcome="abstain",
+            subject="silk atlas",
+            entries=(
+                _entry(silk_nonlocative, 0, "same-subject-nonlocative"),
+                _entry(silk_negated, 0, "same-subject-negated"),
+                _entry(brass_locative, 0, "locative-distractor"),
+            ),
+        ),
+        _product_record(
+            probe="opal-astrolabe-conflict",
+            outcome="conflict",
+            subject="opal astrolabe",
+            entries=(
+                _entry(opal_maple, 1, "conflict-location-a"),
+                _entry(opal_cedar, 1, "conflict-location-b"),
+                _entry(opal_nonlocative, 0, "same-subject-nonlocative"),
+            ),
+        ),
+        _product_record(
+            probe="jade-sextant-duplicate-agreement",
+            outcome="answer",
+            subject="jade sextant",
+            entries=(
+                _entry(jade_linen, 1, "agreement"),
+                _entry(jade_linen, 1, "agreement"),
+                _entry(jade_nonlocative, 0, "same-subject-nonlocative"),
+            ),
+        ),
+    ]
+    value: dict[str, Any] = {
+        "schema": RELATION_PRODUCT_PROBES_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "access_policy": (
+            "commit canonical record CIDs before feature extraction; exclude product text "
+            "from Python feature extraction, preflight, fitting, and development evaluation"
+        ),
+        "records": records,
+    }
+    return _canonical_with_cid(value, "product_probes_cid")
+
+
+def _sentence_inventory(records: Iterable[dict[str, Any]]) -> set[str]:
+    return {
+        str(span["text"])
+        for record in records
+        for span in record["sentence_spans"]
+    }
+
+
+def _subject_inventory(records: Iterable[dict[str, Any]]) -> set[str]:
+    return {str(record["subject"]) for record in records}
+
+
+def _count_outcomes(records: Iterable[dict[str, Any]]) -> dict[int, Counter[str]]:
+    cells: dict[int, Counter[str]] = defaultdict(Counter)
+    for record in records:
+        cells[int(record["raw_subject_occurrence_count"])][
+            str(record["target_outcome"])
+        ] += 1
+    return dict(cells)
+
+
+def shortcut_census(
+    construction: Sequence[dict[str, Any]],
+    development: Sequence[dict[str, Any]],
+    products: dict[str, Any],
+) -> dict[str, Any]:
+    """Prove before training that raw mention count and lexical overlap are shortcuts."""
+    construction_cells = _count_outcomes(construction)
+    development_cells = _count_outcomes(development)
+
+    def summarize(cells: dict[int, Counter[str]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "raw_subject_occurrences": count,
+                "outcome_counts": {name: cells[count][name] for name in OUTCOMES},
+                "outcomes_present": [name for name in OUTCOMES if cells[count][name]],
+            }
+            for count in sorted(cells)
+        ]
+
+    construction_subjects = _subject_inventory(construction)
+    development_subjects = _subject_inventory(development)
+    product_records = list(products["records"])
+    product_subjects = _subject_inventory(product_records)
+    construction_sentences = _sentence_inventory(construction)
+    development_sentences = _sentence_inventory(development)
+    product_sentences = _sentence_inventory(product_records)
+    count_is_ambiguous = all(
+        len([name for name in OUTCOMES if counter[name]]) >= 2
+        for cells in (construction_cells, development_cells)
+        for counter in cells.values()
+    )
+    subject_disjoint = not (
+        construction_subjects & development_subjects
+        or construction_subjects & product_subjects
+        or development_subjects & product_subjects
+    )
+    sentence_disjoint = not (
+        construction_sentences & development_sentences
+        or construction_sentences & product_sentences
+        or development_sentences & product_sentences
+    )
+    value: dict[str, Any] = {
+        "schema": RELATION_SHORTCUT_CENSUS_SCHEMA,
+        "policy": POLICY,
+        "raw_subject_occurrence_definition": (
+            "sum exact queried-subject substring occurrences across admitted sentence spans; "
+            "relation labels and locative parsing are not consulted"
+        ),
+        "construction_count_cells": summarize(construction_cells),
+        "development_count_cells": summarize(development_cells),
+        "count_only_label_lookup_is_perfect": not count_is_ambiguous,
+        "construction_development_subjects_disjoint": not (
+            construction_subjects & development_subjects
+        ),
+        "construction_development_sentences_disjoint": not (
+            construction_sentences & development_sentences
+        ),
+        "construction_development_product_subjects_disjoint": subject_disjoint,
+        "construction_development_product_sentences_disjoint": sentence_disjoint,
+        "passed": count_is_ambiguous and subject_disjoint and sentence_disjoint,
+    }
+    if not value["passed"]:
+        raise RuntimeError("C1-SB2 zero-training shortcut census failed")
+    return _canonical_with_cid(value, "census_cid")
+
+
+def _bank_contract(bank: dict[str, Any]) -> dict[str, Any]:
+    value = {
+        "name": str(bank["name"]),
+        "subjects": list(bank["subjects"]),
+        "locations": list(bank["locations"]),
+        "nonlocatives": list(bank["nonlocatives"]),
+    }
+    return _canonical_with_cid(value, "bank_cid")
+
+
+def _assert_lexical_banks_disjoint() -> None:
+    construction = {
+        *CONSTRUCTION_BANK["subjects"],
+        *CONSTRUCTION_BANK["locations"],
+        *CONSTRUCTION_BANK["nonlocatives"],
+    }
+    development = {
+        *DEVELOPMENT_BANK["subjects"],
+        *DEVELOPMENT_BANK["locations"],
+        *DEVELOPMENT_BANK["nonlocatives"],
+    }
+    product = {*PRODUCT_OBJECTS, *PRODUCT_LOCATIONS, *PRODUCT_NONLOCATIVES}
+    preflight = {
+        value
+        for family in PREFLIGHT_FAMILIES
+        for key, value in family.items()
+        if key != "name"
+    }
+    if (
+        construction & development
+        or construction & product
+        or development & product
+        or preflight & construction
+        or preflight & development
+        or preflight & product
+    ):
+        raise RuntimeError("C1-SB2 lexical banks overlap")
+
+
+def build_source_relation_population() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build the full frozen dataset, matched preflight, and sealed product file."""
+    _assert_lexical_banks_disjoint()
+    construction = [
+        _cell_record(
+            CONSTRUCTION_BANK,
+            population="construction",
+            outcome=outcome,
+            width=width,
+            ordinal=ordinal,
+        )
+        for outcome in OUTCOMES
+        for width in SOURCE_WIDTHS
+        for ordinal in range(CONSTRUCTION_PER_CELL)
+    ]
+    development = [
+        _cell_record(
+            DEVELOPMENT_BANK,
+            population="development",
+            outcome=outcome,
+            width=width,
+            ordinal=ordinal,
+        )
+        for outcome in OUTCOMES
+        for width in SOURCE_WIDTHS
+        for ordinal in range(DEVELOPMENT_PER_CELL)
+    ]
+    if len(construction) != 3_360 or len(development) != 420:
+        raise RuntimeError("C1-SB2 population count drifted")
+    for label, records in (("construction", construction), ("development", development)):
+        if len({record["record_cid"] for record in records}) != len(records):
+            raise RuntimeError(f"C1-SB2 {label} records collide")
+
+    preflight = build_relation_preflight()
+    products = product_probes()
+    reversal_controls = [_reversal_control(record) for record in development]
+    query_swap_controls = [
+        control
+        for record in development
+        if (control := _query_swap_control(record)) is not None
+    ]
+    census = shortcut_census(construction, development, products)
+    construction_bank = _bank_contract(CONSTRUCTION_BANK)
+    development_bank = _bank_contract(DEVELOPMENT_BANK)
+    generator_contract = _canonical_with_cid(
+        {
+            "schema": "uor-r4.source-relative-relation-generator/1",
+            "policy": POLICY,
+            "seed": 9_542,
+            "source_widths": list(SOURCE_WIDTHS),
+            "outcomes": list(OUTCOMES),
+            "construction_per_cell": CONSTRUCTION_PER_CELL,
+            "development_per_cell": DEVELOPMENT_PER_CELL,
+            "answer_policy": "alternate singleton and exact-duplicate agreement",
+            "abstain_policy": "zero positive locative relations with same-subject nonanswers",
+            "conflict_policy": "two positive assertions at distinct locations",
+            "position_policy": (
+                "cycle singleton positions and unordered duplicate/conflict position pairs"
+            ),
+            "relation_input_policy": RELATION_INPUT_POLICY,
+        },
+        "generator_contract_cid",
+    )
+    split_policy = _canonical_with_cid(
+        {
+            "schema": RELATION_SPLIT_POLICY_SCHEMA,
+            "selection": (
+                "independent construction/development lexical banks; enumerate outcomes, "
+                "widths 2..8, and fixed per-cell ordinals without shuffling"
+            ),
+            "construction_bank_cid": construction_bank["bank_cid"],
+            "development_bank_cid": development_bank["bank_cid"],
+            "construction_records": len(construction),
+            "development_records": len(development),
+            "product_records": len(products["records"]),
+            "preflight_policy": "12 fit records and 12 sealed-transfer records",
+            "product_policy": (
+                "four canonical product commitments excluded from every Python data access"
+            ),
+        },
+        "split_policy_cid",
+    )
+    dataset_value: dict[str, Any] = {
+        "schema": RELATION_DATASET_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "question_policy": QUESTION_POLICY,
+        "sentence_policy": SENTENCE_POLICY,
+        "relation_input_policy": RELATION_INPUT_POLICY,
+        "counts": {
+            "construction": len(construction),
+            "development": len(development),
+            "development_reversal_controls": len(reversal_controls),
+            "development_query_swap_controls": len(query_swap_controls),
+            "preflight_fit": len(preflight["fit"]),
+            "preflight_sealed": len(preflight["sealed"]),
+            "product_probe_commitments": len(products["records"]),
+        },
+        "construction_bank": construction_bank,
+        "development_bank": development_bank,
+        "generator_contract": generator_contract,
+        "generator_contract_cid": generator_contract["generator_contract_cid"],
+        "split_policy": split_policy,
+        "split_policy_cid": split_policy["split_policy_cid"],
+        "shortcut_census": census,
+        "preflight_cid": preflight["preflight_cid"],
+        "preflight_fit_commitments": [record["record_cid"] for record in preflight["fit"]],
+        "preflight_sealed_commitments": [
+            record["record_cid"] for record in preflight["sealed"]
+        ],
+        "product_probes_cid": products["product_probes_cid"],
+        "product_probe_commitments": [
+            record["record_cid"] for record in products["records"]
+        ],
+        "construction": construction,
+        "development": development,
+        "development_controls": {
+            "reversal": reversal_controls,
+            "query_swap": query_swap_controls,
+        },
+    }
+    dataset = _canonical_with_cid(dataset_value, "dataset_cid")
+    return dataset, preflight, products

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_head.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_head.py
@@ -1,0 +1,1840 @@
+"""Offline C1-SB2 source-relative relation-head qualification.
+
+The module deliberately keeps the failed C1-SB1 cosine pointer immutable.  It
+extracts one final #1017 residual for each exact evidence/question pair, fits
+the frozen 288 -> 32 -> 1 probe, and emits a head only after every predeclared
+gate has passed.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import struct
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import torch
+from blake3 import blake3
+from safetensors.torch import load_file, save_file
+from tokenizers import Tokenizer
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from .constants import BOS_TOKEN_ID, EOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .model import R4SoftmaxForCausalLM
+from .provenance import (
+    atomic_write,
+    atomic_write_json,
+    canonical_json_bytes,
+    cid_bytes,
+    cid_file,
+    trainer_implementation_contract,
+    verify_bound_manifest,
+    write_bound_manifest,
+)
+from .source_relation_data import (
+    OUTCOMES,
+    POLICY as DATA_POLICY,
+    QUESTION_POLICY,
+    RELATION_INPUT_POLICY,
+    SENTENCE_POLICY,
+    SOURCE_WIDTHS,
+    build_relation_preflight,
+    build_source_relation_population,
+    product_probes,
+    render_relation_input,
+    shortcut_census,
+)
+from .train import require_mps
+
+
+ISSUE = 954
+POLICY = "R4SourceRelativeRelationHeadV1"
+HEAD_SCHEMA = "uor-r4.source-relative-relation-head/1"
+DATASET_MANIFEST_SCHEMA = "uor-r4.source-relative-relation-dataset-manifest/1"
+FEATURE_INDEX_SCHEMA = "uor-r4.source-relative-relation-feature-index/1"
+FEATURE_MANIFEST_SCHEMA = "uor-r4.source-relative-relation-feature-manifest/1"
+RUN_SCHEMA = "uor-r4.source-relative-relation-run/1"
+PREFLIGHT_RESULT_SCHEMA = "uor-r4.source-relative-relation-preflight-result/1"
+PYTHON_SCORE_FIXTURE_SCHEMA = "uor-r4.source-relative-relation-python-score-fixture/1"
+PARITY_ADMISSION_SCHEMA = "uor-r4.source-relative-relation-parity-admission/1"
+TRAINING_RESULT_SCHEMA = "uor-r4.source-relative-relation-training-result/1"
+FINAL_MANIFEST_SCHEMA = "uor-r4.source-relative-relation-final-manifest/1"
+RUST_GROUNDED_REPORT_SCHEMA = "uor-r4.grounded-answer/3"
+EXPECTED_WEIGHTS_CID = (
+    "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d"
+)
+EXPECTED_TOKENIZER_CID = (
+    "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc"
+)
+RELATION_HIDDEN_SIZE = 32
+TRAINABLE_PARAMETER_COUNT = 9_281
+PARITY_MAX_ABSOLUTE_TOLERANCE = 0.01
+RELATION_INPUT_TEMPLATE = "Evidence:\n<span>\nQuestion:\n<question>"
+OUTCOME_TO_ID = {name: index for index, name in enumerate(OUTCOMES)}
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRelationHeadConfig:
+    """The sole no-sweep C1-SB2 work contract."""
+
+    seed: int = 9_542
+    feature_batch_size: int = 128
+    preflight_optimizer_steps: int = 256
+    optimizer_steps: int = 512
+    batch_size: int = 126
+    learning_rate: float = 0.003
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    adam_epsilon: float = 1e-8
+    progress_interval: int = 16
+    required_per_class_accuracy: float = 0.95
+    required_positive_relation_recall: float = 0.95
+    required_negative_relation_specificity: float = 0.95
+    required_pointer_accuracy: float = 0.95
+    required_query_swap_relocation: float = 0.95
+
+    def validate(self) -> None:
+        if self != SourceRelationHeadConfig():
+            raise ValueError("C1-SB2 exposes one frozen relation-head fit, not a sweep")
+        if self.seed != 9_542 or self.optimizer_steps != 512 or self.batch_size != 126:
+            raise AssertionError("C1-SB2 optimizer contract drifted")
+        if self.batch_size % (len(OUTCOMES) * len(SOURCE_WIDTHS)) != 0:
+            raise AssertionError("C1-SB2 batch does not balance all outcome/width cells")
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RelationBatch:
+    states: Tensor
+    candidate_mask: Tensor
+    relation_labels: Tensor
+    outcomes: Tensor
+    target_spans: Tensor
+
+
+class R4SourceRelationHead(nn.Module):
+    """The frozen 288 -> 32 ReLU -> 1 source-relative relation probe."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input = nn.Linear(FROZEN_MODEL_CONFIG.hidden_size, RELATION_HIDDEN_SIZE)
+        self.output = nn.Linear(RELATION_HIDDEN_SIZE, 1)
+        nn.init.xavier_uniform_(self.input.weight)
+        nn.init.zeros_(self.input.bias)
+        nn.init.xavier_uniform_(self.output.weight)
+        nn.init.zeros_(self.output.bias)
+        parameter_count = sum(parameter.numel() for parameter in self.parameters())
+        if parameter_count != TRAINABLE_PARAMETER_COUNT:
+            raise AssertionError(
+                f"relation head has {parameter_count} parameters, expected "
+                f"{TRAINABLE_PARAMETER_COUNT}"
+            )
+
+    def forward(self, states: Tensor) -> Tensor:
+        return self.output(F.relu(self.input(states.float()))).squeeze(-1)
+
+
+def relation_loss(model: R4SourceRelationHead, batch: RelationBatch) -> Tensor:
+    logits = model(batch.states)
+    per_candidate = F.binary_cross_entropy_with_logits(
+        logits, batch.relation_labels, reduction="none"
+    )
+    masked = per_candidate * batch.candidate_mask.to(dtype=per_candidate.dtype)
+    per_record = masked.sum(dim=-1) / batch.candidate_mask.sum(dim=-1).clamp_min(1).float()
+    return per_record.mean()
+
+
+def _canonical_with_cid(value: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _write_or_verify_json(path: Path, value: dict[str, Any]) -> None:
+    encoded = canonical_json_bytes(value)
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ValueError(f"existing C1-SB2 artifact differs: {path}")
+        return
+    atomic_write(path, encoded)
+
+
+def _validated_predecessor(predecessor: Path) -> dict[str, Any]:
+    manifest = verify_bound_manifest(
+        predecessor / "export-manifest.json", artifact_root=predecessor
+    )
+    if manifest.get("model_contract") != FROZEN_MODEL_CONFIG.as_contract():
+        raise ValueError("relation predecessor is not the immutable six-layer #1017 model")
+    if manifest.get("weights_cid") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("relation predecessor weights are not the frozen #1017 weights")
+    if manifest.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("relation predecessor tokenizer is not the frozen #1017 tokenizer")
+    if cid_file(predecessor / "model.safetensors") != EXPECTED_WEIGHTS_CID:
+        raise ValueError("#1017 model file CID does not reproduce")
+    if cid_file(predecessor / "tokenizer.json") != EXPECTED_TOKENIZER_CID:
+        raise ValueError("#1017 tokenizer file CID does not reproduce")
+    return manifest
+
+
+def _progress(
+    phase: str,
+    *,
+    completed: int,
+    total: int,
+    started: float,
+    loss: float | None = None,
+) -> None:
+    elapsed = max(0.0, time.monotonic() - started)
+    rate = elapsed / completed if completed else 0.0
+    eta = rate * max(0, total - completed)
+    suffix = "" if loss is None else f" loss={loss:.6f}"
+    print(
+        f"relation_phase={phase} completed={completed}/{total}{suffix} "
+        f"elapsed_seconds={elapsed:.1f} eta_seconds={eta:.1f}",
+        flush=True,
+    )
+
+
+def _relation_inputs(records: Sequence[dict[str, Any]]) -> list[str]:
+    values: dict[str, str] = {}
+    for record in records:
+        question = str(record["question"])
+        for span in record["sentence_spans"]:
+            text = str(span["text"])
+            relation_input = str(span["relation_input"])
+            expected = render_relation_input(text, question)
+            if relation_input != expected:
+                raise ValueError("relation input differs from the frozen renderer")
+            if relation_input.endswith("\n") or not relation_input.endswith(question):
+                raise ValueError("relation input does not end at the exact question mark")
+            relation_input_cid = cid_bytes(relation_input.encode("utf-8"))
+            if span.get("relation_input_cid") != relation_input_cid:
+                raise ValueError("relation input CID does not reproduce")
+            prior = values.setdefault(relation_input_cid, relation_input)
+            if prior != relation_input:
+                raise RuntimeError("BLAKE3 collision in relation-input inventory")
+    return [values[key] for key in sorted(values)]
+
+
+@torch.no_grad()
+def _extract_features(
+    feature_root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: dict[str, Any],
+    records: Sequence[dict[str, Any]],
+    population_cids: dict[str, str],
+    config: SourceRelationHeadConfig,
+) -> dict[str, Any]:
+    manifest_path = feature_root / "feature-manifest.json"
+    if manifest_path.exists():
+        manifest = verify_bound_manifest(manifest_path, artifact_root=feature_root)
+        expected = {
+            **population_cids,
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        }
+        if any(manifest.get(key) != value for key, value in expected.items()):
+            raise ValueError("existing relation feature manifest binds different inputs")
+        return manifest
+
+    device = require_mps(config.seed)
+    tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+    texts = _relation_inputs(records)
+    encoded: list[list[int]] = []
+    for text in texts:
+        token_ids = tokenizer.encode(text, add_special_tokens=False).ids
+        if not token_ids:
+            raise ValueError("relation input encoded to zero tokens")
+        if len(token_ids) + 1 > FROZEN_MODEL_CONFIG.max_position_embeddings:
+            raise ValueError("relation input exceeds the frozen #1017 context")
+        if tokenizer.decode([token_ids[-1]], skip_special_tokens=False) != "?":
+            raise ValueError("relation input does not end in a standalone question-mark token")
+        encoded.append(token_ids)
+
+    states = torch.zeros(
+        (len(texts), FROZEN_MODEL_CONFIG.hidden_size), dtype=torch.float32
+    )
+    model = R4SoftmaxForCausalLM()
+    model.load_state_dict(
+        load_file(str(predecessor / "model.safetensors"), device="cpu"), strict=True
+    )
+    model.requires_grad_(False)
+    model.eval()
+    model = model.to(device)
+    started = time.monotonic()
+    batches = math.ceil(len(texts) / config.feature_batch_size)
+    for batch_index, base in enumerate(
+        range(0, len(texts), config.feature_batch_size), start=1
+    ):
+        batch_token_ids = encoded[base : base + config.feature_batch_size]
+        width = 1 + max(map(len, batch_token_ids))
+        inputs = torch.full(
+            (len(batch_token_ids), width),
+            EOS_TOKEN_ID,
+            dtype=torch.long,
+            device=device,
+        )
+        for lane, token_ids in enumerate(batch_token_ids):
+            inputs[lane, 0] = BOS_TOKEN_ID
+            inputs[lane, 1 : 1 + len(token_ids)] = torch.tensor(
+                token_ids, dtype=torch.long, device=device
+            )
+        hidden = model.model(inputs).float().cpu()
+        for lane, token_ids in enumerate(batch_token_ids):
+            final_state = hidden[lane, len(token_ids)]
+            if final_state.shape != (FROZEN_MODEL_CONFIG.hidden_size,):
+                raise RuntimeError("#1017 final relation-state shape differs")
+            if not bool(torch.isfinite(final_state).all()):
+                raise RuntimeError("#1017 final relation state is nonfinite")
+            if float(torch.linalg.vector_norm(final_state)) <= 0.0:
+                raise RuntimeError("#1017 final relation state is zero")
+            states[base + lane] = final_state
+        _progress(
+            "feature-extraction",
+            completed=batch_index,
+            total=batches,
+            started=started,
+        )
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    del model
+    if hasattr(torch, "mps"):
+        torch.mps.empty_cache()
+
+    entries = [
+        {
+            "row": row,
+            "relation_input_cid": cid_bytes(text.encode("utf-8")),
+            "token_ids": encoded[row],
+            "content_token_count": len(encoded[row]),
+        }
+        for row, text in enumerate(texts)
+    ]
+    index = {
+        "schema": FEATURE_INDEX_SCHEMA,
+        "policy": POLICY,
+        "model_weights_cid": EXPECTED_WEIGHTS_CID,
+        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "state_definition": (
+            "one final RMS-normalized residual at the exact question-mark token after "
+            "all six immutable #1017 R4/Spin causal-softmax layers; each exact "
+            "Evidence/span/Question input encoded independently"
+        ),
+        "relation_input_policy": RELATION_INPUT_TEMPLATE,
+        "relation_input_policy_description": RELATION_INPUT_POLICY,
+        "hidden_size": FROZEN_MODEL_CONFIG.hidden_size,
+        "entries": entries,
+    }
+    feature_root.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(feature_root / "feature-index.json", index)
+    state_path = feature_root / "states.safetensors"
+    temporary = feature_root / ".states.safetensors.part"
+    save_file(
+        {"states": states.contiguous()},
+        str(temporary),
+        metadata={
+            "schema": FEATURE_INDEX_SCHEMA,
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        },
+    )
+    os.replace(temporary, state_path)
+    return write_bound_manifest(
+        manifest_path,
+        {
+            "schema": FEATURE_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            **population_cids,
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "relation_input_count": len(texts),
+        },
+        artifact_root=feature_root,
+        relative_paths=["feature-index.json", "states.safetensors"],
+    )
+
+
+class FrozenRelationFeatureStore:
+    """Read-only final-state table keyed by exact relation-input CID."""
+
+    def __init__(self, root: Path) -> None:
+        verify_bound_manifest(root / "feature-manifest.json", artifact_root=root)
+        index = json.loads((root / "feature-index.json").read_text(encoding="utf-8"))
+        if index.get("schema") != FEATURE_INDEX_SCHEMA:
+            raise ValueError("relation feature index schema differs")
+        if (
+            index.get("policy") != POLICY
+            or index.get("model_weights_cid") != EXPECTED_WEIGHTS_CID
+            or index.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID
+            or int(index.get("hidden_size", -1)) != FROZEN_MODEL_CONFIG.hidden_size
+            or index.get("relation_input_policy") != RELATION_INPUT_TEMPLATE
+        ):
+            raise ValueError("relation feature index binding differs")
+        tensors = load_file(str(root / "states.safetensors"), device="cpu")
+        self.states = tensors["states"].float().contiguous()
+        self.rows: dict[str, int] = {}
+        for entry in index["entries"]:
+            row = int(entry["row"])
+            relation_input_cid = str(entry["relation_input_cid"])
+            if relation_input_cid in self.rows:
+                raise ValueError("duplicate relation-input feature CID")
+            self.rows[relation_input_cid] = row
+        if self.states.shape != (
+            len(self.rows),
+            FROZEN_MODEL_CONFIG.hidden_size,
+        ):
+            raise ValueError("relation state tensor shape differs")
+        if not bool(torch.isfinite(self.states).all()) or not bool(
+            (torch.linalg.vector_norm(self.states, dim=-1) > 0).all()
+        ):
+            raise ValueError("relation feature states are invalid")
+
+    def get(self, relation_input: str, expected_cid: str) -> Tensor:
+        observed_cid = cid_bytes(relation_input.encode("utf-8"))
+        if observed_cid != expected_cid:
+            raise ValueError("relation input does not reproduce its record CID")
+        try:
+            row = self.rows[observed_cid]
+        except KeyError as error:
+            raise KeyError("relation input is absent from frozen feature store") from error
+        return self.states[row]
+
+
+class RelationDataset:
+    """Frozen relation records assembled into record-balanced padded batches."""
+
+    def __init__(
+        self,
+        records: Sequence[dict[str, Any]],
+        features: FrozenRelationFeatureStore,
+    ) -> None:
+        self.records = list(records)
+        if not self.records:
+            raise ValueError("source-relative relation dataset is empty")
+        self.features = features
+        self.cell_indices: dict[tuple[str, int], list[int]] = {
+            (outcome, width): [] for outcome in OUTCOMES for width in SOURCE_WIDTHS
+        }
+        for index, record in enumerate(self.records):
+            outcome = str(record["target_outcome"])
+            width = int(record["source_width"])
+            cell = (outcome, width)
+            if cell not in self.cell_indices:
+                raise ValueError(f"unknown relation outcome/width cell: {cell}")
+            spans = record["sentence_spans"]
+            if len(spans) != width:
+                raise ValueError("relation source_width differs from candidate count")
+            self.cell_indices[cell].append(index)
+
+    def require_all_cells(self) -> None:
+        missing = [cell for cell, indices in self.cell_indices.items() if not indices]
+        if missing:
+            raise ValueError(f"relation dataset has empty outcome/width cells: {missing}")
+
+    def deterministic_indices(self, *, seed: int, step: int, batch_size: int) -> list[int]:
+        self.require_all_cells()
+        cells = [(outcome, width) for outcome in OUTCOMES for width in SOURCE_WIDTHS]
+        if batch_size % len(cells) != 0:
+            raise ValueError("relation batch cannot balance all outcome/width cells")
+        selected: list[int] = []
+        for lane in range(batch_size):
+            cell = cells[lane % len(cells)]
+            population = self.cell_indices[cell]
+            material = struct.pack(">QQQ", seed, step, lane)
+            offset = int.from_bytes(blake3(material).digest(), "big") % len(population)
+            selected.append(population[offset])
+        return selected
+
+    def batch(self, indices: Sequence[int], *, device: torch.device) -> RelationBatch:
+        selected = [self.records[index] for index in indices]
+        maximum_candidates = max(len(record["sentence_spans"]) for record in selected)
+        batch_size = len(selected)
+        states = torch.zeros(
+            (batch_size, maximum_candidates, FROZEN_MODEL_CONFIG.hidden_size),
+            dtype=torch.float32,
+        )
+        candidate_mask = torch.zeros(
+            (batch_size, maximum_candidates), dtype=torch.bool
+        )
+        relation_labels = torch.zeros(
+            (batch_size, maximum_candidates), dtype=torch.float32
+        )
+        outcomes = torch.empty(batch_size, dtype=torch.long)
+        target_spans = torch.full((batch_size,), -1, dtype=torch.long)
+        for lane, record in enumerate(selected):
+            for candidate_index, span in enumerate(record["sentence_spans"]):
+                relation_input = str(span["relation_input"])
+                relation_input_cid = str(span["relation_input_cid"])
+                states[lane, candidate_index] = self.features.get(
+                    relation_input, relation_input_cid
+                )
+                candidate_mask[lane, candidate_index] = True
+                relation_label = int(span["relation_label"])
+                if relation_label not in (0, 1):
+                    raise ValueError("relation label is not binary")
+                relation_labels[lane, candidate_index] = float(relation_label)
+            outcome = str(record["target_outcome"])
+            outcomes[lane] = OUTCOME_TO_ID[outcome]
+            target = record.get("target_span_index")
+            if target is not None:
+                if not isinstance(target, int) or not 0 <= target < len(
+                    record["sentence_spans"]
+                ):
+                    raise ValueError("relation target span is outside admitted candidates")
+                target_spans[lane] = target
+        return RelationBatch(
+            states=states.to(device),
+            candidate_mask=candidate_mask.to(device),
+            relation_labels=relation_labels.to(device),
+            outcomes=outcomes.to(device),
+            target_spans=target_spans.to(device),
+        )
+
+
+def _decision_from_logits(
+    record: dict[str, Any], candidate_logits: Sequence[float]
+) -> dict[str, Any]:
+    spans = record["sentence_spans"]
+    if len(candidate_logits) != len(spans):
+        raise ValueError("candidate logit count differs from source spans")
+    if any(not math.isfinite(float(value)) for value in candidate_logits):
+        raise ValueError("relation head produced a nonfinite candidate logit")
+
+    groups: dict[str, list[int]] = {}
+    for index, span in enumerate(spans):
+        group_cid = str(span["relation_group_cid"])
+        groups.setdefault(group_cid, []).append(index)
+    group_logits: list[tuple[str, float, int]] = []
+    for group_cid, indices in groups.items():
+        values = [float(candidate_logits[index]) for index in indices]
+        if any(value != values[0] for value in values[1:]):
+            raise RuntimeError("exact duplicate relation spans received different logits")
+        earliest = min(indices, key=lambda index: int(spans[index]["byte_start"]))
+        group_logits.append((group_cid, values[0], earliest))
+    positive = [group for group in group_logits if group[1] > 0.0]
+    if not positive:
+        decision = "abstain"
+        selected_span_index: int | None = None
+    elif len(positive) >= 2:
+        decision = "conflict"
+        selected_span_index = None
+    else:
+        decision = "answer"
+        selected_span_index = positive[0][2]
+
+    ranked = sorted(
+        range(len(spans)),
+        key=lambda index: (-float(candidate_logits[index]), int(spans[index]["byte_start"])),
+    )
+    return {
+        "candidate_logits": [float(value) for value in candidate_logits],
+        "ranked_candidate_indices": ranked,
+        "positive_relation_group_cids": sorted(group[0] for group in positive),
+        "decision": decision,
+        "selected_span_index": selected_span_index,
+    }
+
+
+@torch.no_grad()
+def score_relation_record(
+    model: R4SourceRelationHead,
+    dataset: RelationDataset,
+    *,
+    record_index: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    model.eval()
+    record = dataset.records[record_index]
+    batch = dataset.batch([record_index], device=device)
+    logits = model(batch.states)[0, : len(record["sentence_spans"])]
+    candidate_logits = [float(value) for value in logits.detach().cpu().float().tolist()]
+    return _decision_from_logits(record, candidate_logits)
+
+
+@torch.no_grad()
+def evaluate_relation_head(
+    model: R4SourceRelationHead,
+    dataset: RelationDataset,
+    *,
+    device: torch.device,
+    batch_size: int,
+    indices: Sequence[int] | None = None,
+    include_records: bool = False,
+) -> dict[str, Any]:
+    model.eval()
+    selected = list(range(len(dataset.records))) if indices is None else list(indices)
+    outcome_correct = {name: 0 for name in OUTCOMES}
+    outcome_total = {name: 0 for name in OUTCOMES}
+    positive_correct = 0
+    positive_total = 0
+    negative_correct = 0
+    negative_total = 0
+    pointer_correct = 0
+    pointer_total = 0
+    loss_sum = 0.0
+    examples = 0
+    evaluations: list[dict[str, Any]] = []
+    for base in range(0, len(selected), batch_size):
+        batch_indices = selected[base : base + batch_size]
+        batch = dataset.batch(batch_indices, device=device)
+        logits = model(batch.states)
+        loss = relation_loss(model, batch)
+        loss_sum += float(loss.detach().cpu()) * len(batch_indices)
+        examples += len(batch_indices)
+        logits_cpu = logits.detach().cpu().float()
+        for lane, record_index in enumerate(batch_indices):
+            record = dataset.records[record_index]
+            width = len(record["sentence_spans"])
+            candidate_logits = [float(value) for value in logits_cpu[lane, :width].tolist()]
+            evaluation = _decision_from_logits(record, candidate_logits)
+            outcome = str(record["target_outcome"])
+            outcome_total[outcome] += 1
+            outcome_correct[outcome] += int(evaluation["decision"] == outcome)
+            for candidate_index, span in enumerate(record["sentence_spans"]):
+                label = int(span["relation_label"])
+                predicted = int(candidate_logits[candidate_index] > 0.0)
+                if label:
+                    positive_total += 1
+                    positive_correct += int(predicted == 1)
+                else:
+                    negative_total += 1
+                    negative_correct += int(predicted == 0)
+            if outcome == "answer":
+                pointer_total += 1
+                pointer_correct += int(
+                    evaluation["selected_span_index"] == record.get("target_span_index")
+                )
+            if include_records:
+                evaluations.append(
+                    {
+                        "record_cid": record["record_cid"],
+                        "source_cid": record["source_cid"],
+                        "question_cid": record["question_cid"],
+                        "target_outcome": outcome,
+                        "target_span_index": record.get("target_span_index"),
+                        **evaluation,
+                    }
+                )
+    if not examples or not positive_total or not negative_total or not pointer_total:
+        raise RuntimeError("relation evaluation population is incomplete")
+    value: dict[str, Any] = {
+        "mean_record_balanced_relation_loss": loss_sum / examples,
+        "outcome": {
+            outcome: {
+                "correct": outcome_correct[outcome],
+                "total": outcome_total[outcome],
+                "accuracy": (
+                    outcome_correct[outcome] / outcome_total[outcome]
+                    if outcome_total[outcome]
+                    else None
+                ),
+            }
+            for outcome in OUTCOMES
+        },
+        "positive_relation_recall": {
+            "correct": positive_correct,
+            "total": positive_total,
+            "accuracy": positive_correct / positive_total,
+        },
+        "negative_relation_specificity": {
+            "correct": negative_correct,
+            "total": negative_total,
+            "accuracy": negative_correct / negative_total,
+        },
+        "supported_copied_span": {
+            "correct": pointer_correct,
+            "total": pointer_total,
+            "accuracy": pointer_correct / pointer_total,
+        },
+    }
+    if include_records:
+        value["records"] = evaluations
+    return value
+
+
+def _fit_head(
+    model: R4SourceRelationHead,
+    dataset: RelationDataset,
+    *,
+    device: torch.device,
+    steps: int,
+    batch_size: int,
+    config: SourceRelationHeadConfig,
+    phase: str,
+    fixed_indices: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    model.train()
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.learning_rate,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_epsilon,
+        weight_decay=0.0,
+    )
+    started = time.monotonic()
+    initial_loss: float | None = None
+    final_loss = math.nan
+    for step in range(1, steps + 1):
+        indices = (
+            list(fixed_indices)
+            if fixed_indices is not None
+            else dataset.deterministic_indices(
+                seed=config.seed, step=step, batch_size=batch_size
+            )
+        )
+        batch = dataset.batch(indices, device=device)
+        optimizer.zero_grad(set_to_none=True)
+        loss = relation_loss(model, batch)
+        loss.backward()
+        optimizer.step()
+        report_step = initial_loss is None or step % config.progress_interval == 0 or step == steps
+        if report_step:
+            final_loss = float(loss.detach().cpu())
+            if not math.isfinite(final_loss):
+                raise RuntimeError("relation-head fit produced a nonfinite loss")
+            if initial_loss is None:
+                initial_loss = final_loss
+        if step % config.progress_interval == 0 or step == steps:
+            _progress(
+                phase,
+                completed=step,
+                total=steps,
+                started=started,
+                loss=final_loss,
+            )
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    return {
+        "optimizer_steps": steps,
+        "batch_size": batch_size,
+        "initial_relation_loss": initial_loss,
+        "final_relation_loss": final_loss,
+        "elapsed_seconds": time.monotonic() - started,
+    }
+
+
+def _finite_list(tensor: Tensor, *, length: int, label: str) -> list[float]:
+    values = [
+        float(value)
+        for value in tensor.detach().to(device="cpu", dtype=torch.float32).reshape(-1).tolist()
+    ]
+    if len(values) != length or any(not math.isfinite(value) for value in values):
+        raise RuntimeError(f"relation head {label} violates its finite shape contract")
+    return values
+
+
+def _head_payload(
+    model: R4SourceRelationHead,
+    *,
+    dataset: dict[str, Any],
+    run_contract_cid: str,
+    training_result_cid: str,
+    preflight: dict[str, Any],
+    development_metrics: dict[str, Any],
+) -> dict[str, Any]:
+    output_bias = float(
+        model.output.bias.detach().to(device="cpu", dtype=torch.float32).item()
+    )
+    if not math.isfinite(output_bias):
+        raise RuntimeError("relation head output bias is nonfinite")
+    commitments = dataset["product_probe_commitments"]
+    if len(commitments) != 4:
+        raise RuntimeError("C1-SB2 requires exactly four product commitments")
+    value: dict[str, Any] = {
+        "schema": HEAD_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "model_weights_cid": EXPECTED_WEIGHTS_CID,
+        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "hidden_size": FROZEN_MODEL_CONFIG.hidden_size,
+        "hidden_width": RELATION_HIDDEN_SIZE,
+        "first_layer_weights": _finite_list(
+            model.input.weight,
+            length=RELATION_HIDDEN_SIZE * FROZEN_MODEL_CONFIG.hidden_size,
+            label="input weights",
+        ),
+        "first_layer_biases": _finite_list(
+            model.input.bias, length=RELATION_HIDDEN_SIZE, label="input bias"
+        ),
+        "output_weights": _finite_list(
+            model.output.weight,
+            length=RELATION_HIDDEN_SIZE,
+            label="output weights",
+        ),
+        "output_bias": output_bias,
+        "threshold": 0.0,
+        "maximum_source_spans": max(SOURCE_WIDTHS),
+        "relation_input_policy": RELATION_INPUT_TEMPLATE,
+        "dataset_cid": dataset["dataset_cid"],
+        "split_policy_cid": dataset["split_policy_cid"],
+        "run_contract_cid": run_contract_cid,
+        "training_result_cid": training_result_cid,
+        "preflight": preflight,
+        "development_metrics": development_metrics,
+        "product_probe_commitments": commitments,
+    }
+    return _canonical_with_cid(value, "artifact_cid")
+
+
+def _all_exact(metrics: dict[str, Any]) -> bool:
+    return (
+        all(
+            metrics["outcome"][outcome]["correct"]
+            == metrics["outcome"][outcome]["total"]
+            for outcome in OUTCOMES
+        )
+        and metrics["positive_relation_recall"]["correct"]
+        == metrics["positive_relation_recall"]["total"]
+        and metrics["negative_relation_specificity"]["correct"]
+        == metrics["negative_relation_specificity"]["total"]
+        and metrics["supported_copied_span"]["correct"]
+        == metrics["supported_copied_span"]["total"]
+    )
+
+
+def _reverse_preflight_records(
+    records: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    reversed_records: list[dict[str, Any]] = []
+    for record in records:
+        original_spans = list(record["sentence_spans"])
+        mapping = list(reversed(range(len(original_spans))))
+        reversed_spans: list[dict[str, Any]] = []
+        for candidate_index, original_index in enumerate(mapping):
+            span = dict(original_spans[original_index])
+            span["candidate_index"] = candidate_index
+            reversed_spans.append(span)
+        target = record.get("target_span_index")
+        reversed_target = None if target is None else mapping.index(int(target))
+        value = dict(record)
+        value.pop("record_cid", None)
+        value.update(
+            {
+                "population": "preflight-order-control",
+                "motif": "exact-candidate-array-reversal",
+                "sentence_spans": reversed_spans,
+                "positive_span_indices": [
+                    index
+                    for index, span in enumerate(reversed_spans)
+                    if int(span["relation_label"]) == 1
+                ],
+                "target_span_index": reversed_target,
+                "control_kind": "order-reversal",
+                "base_record_cid": record["record_cid"],
+                "candidate_original_indices": mapping,
+            }
+        )
+        value["record_cid"] = cid_bytes(canonical_json_bytes(value))
+        reversed_records.append(value)
+    return reversed_records
+
+
+def _preflight_control_checks(
+    preflight: dict[str, Any],
+    fit_metrics: dict[str, Any],
+    sealed_metrics: dict[str, Any],
+    reversed_records: Sequence[dict[str, Any]],
+    reversed_metrics: dict[str, Any],
+) -> dict[str, Any]:
+    evaluations = {
+        str(record["record_cid"]): record
+        for record in [*fit_metrics["records"], *sealed_metrics["records"]]
+    }
+    matched_exact = True
+    query_swap_sensitive = True
+    for pair in preflight["matched_pairs"]:
+        left = evaluations[str(pair["left_record_cid"])]
+        right = evaluations[str(pair["right_record_cid"])]
+        matched_exact &= bool(pair["same_source"])
+        matched_exact &= left["decision"] == left["target_outcome"]
+        matched_exact &= right["decision"] == right["target_outcome"]
+        query_swap_sensitive &= left["decision"] != right["decision"]
+
+    all_records = [*preflight["fit"], *preflight["sealed"]]
+    duplicate_records = [
+        record for record in all_records if record["motif"] == "exact-duplicate-agreement"
+    ]
+    conflict_records = [
+        record for record in all_records if record["motif"] == "distinct-location-conflict"
+    ]
+    duplicate_agreement = all(
+        evaluations[str(record["record_cid"])]["decision"] == "answer"
+        and evaluations[str(record["record_cid"])]["selected_span_index"]
+        == record["target_span_index"]
+        for record in duplicate_records
+    )
+    different_value_conflict = all(
+        evaluations[str(record["record_cid"])]["decision"] == "conflict"
+        and evaluations[str(record["record_cid"])]["selected_span_index"] is None
+        for record in conflict_records
+    )
+    reversed_evaluations = {
+        str(record["record_cid"]): record for record in reversed_metrics["records"]
+    }
+    order_invariance = True
+    for record in reversed_records:
+        original = evaluations[str(record["base_record_cid"])]
+        observed = reversed_evaluations[str(record["record_cid"])]
+        mapping = [int(index) for index in record["candidate_original_indices"]]
+        logits_exact = all(
+            observed["candidate_logits"][new_index]
+            == original["candidate_logits"][old_index]
+            for new_index, old_index in enumerate(mapping)
+        )
+        expected_selected = None
+        if original["selected_span_index"] is not None:
+            expected_selected = mapping.index(int(original["selected_span_index"]))
+        order_invariance &= (
+            logits_exact
+            and observed["decision"] == original["decision"]
+            and observed["selected_span_index"] == expected_selected
+        )
+    value = {
+        "same_source_matched_pairs_exact": matched_exact,
+        "query_swap_sensitive": query_swap_sensitive,
+        "candidate_array_order_equivariant": order_invariance,
+        "duplicate_agreement": duplicate_agreement,
+        "different_value_conflict": different_value_conflict,
+    }
+    value["passed"] = all(value.values())
+    return value
+
+
+def _prepare_contract(
+    root: Path,
+    *,
+    predecessor_manifest: dict[str, Any],
+    config: SourceRelationHeadConfig,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    dataset, preflight, probes = build_source_relation_population()
+    if DATA_POLICY != POLICY or dataset.get("policy") != POLICY:
+        raise ValueError("C1-SB2 data and trainer policies differ")
+    if preflight != build_relation_preflight() or probes != product_probes():
+        raise RuntimeError("C1-SB2 independently rebuilt commitments differ")
+    census = shortcut_census(dataset["construction"], dataset["development"], probes)
+    if census != dataset["shortcut_census"] or not census.get("passed"):
+        raise RuntimeError("C1-SB2 shortcut census did not reproduce before MPS work")
+
+    root.mkdir(parents=True, exist_ok=True)
+    _write_or_verify_json(root / "source-relation-dataset.json", dataset)
+    _write_or_verify_json(root / "source-relation-preflight.json", preflight)
+    _write_or_verify_json(root / "product-probes.json", probes)
+    _write_or_verify_json(root / "shortcut-census.json", census)
+    dataset_manifest_path = root / "source-relation-dataset-manifest.json"
+    if dataset_manifest_path.exists():
+        dataset_manifest = verify_bound_manifest(dataset_manifest_path, artifact_root=root)
+        if (
+            dataset_manifest.get("dataset_cid") != dataset["dataset_cid"]
+            or dataset_manifest.get("preflight_cid") != preflight["preflight_cid"]
+            or dataset_manifest.get("product_probes_cid") != probes["product_probes_cid"]
+        ):
+            raise ValueError("existing C1-SB2 dataset manifest differs")
+    else:
+        dataset_manifest = write_bound_manifest(
+            dataset_manifest_path,
+            {
+                "schema": DATASET_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "dataset_cid": dataset["dataset_cid"],
+                "split_policy_cid": dataset["split_policy_cid"],
+                "generator_contract_cid": dataset["generator_contract_cid"],
+                "preflight_cid": preflight["preflight_cid"],
+                "product_probes_cid": probes["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "shortcut_census_cid": census["census_cid"],
+                "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+                "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            },
+            artifact_root=root,
+            relative_paths=[
+                "source-relation-dataset.json",
+                "source-relation-preflight.json",
+                "product-probes.json",
+                "shortcut-census.json",
+            ],
+        )
+
+    run_contract = _canonical_with_cid(
+        {
+            "schema": RUN_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "predecessor": {
+                "export_manifest_cid": predecessor_manifest["manifest_cid"],
+                "weights_cid": EXPECTED_WEIGHTS_CID,
+                "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                "failed_grounding_sft_weights": "EXCLUDED",
+                "failed_source_span_pointer": "EXCLUDED",
+            },
+            "model": FROZEN_MODEL_CONFIG.as_contract(),
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "generator_contract_cid": dataset["generator_contract_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "product_probes_cid": probes["product_probes_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+            "shortcut_census_cid": census["census_cid"],
+            "state_extraction": (
+                "MPS-only immutable #1017 final normalized residual at the exact final "
+                "question-mark token for each independently encoded evidence/question input"
+            ),
+            "question_policy": QUESTION_POLICY,
+            "sentence_policy": SENTENCE_POLICY,
+            "relation_input_policy": RELATION_INPUT_TEMPLATE,
+            "relation_input_policy_description": RELATION_INPUT_POLICY,
+            "mechanism": (
+                "f32 288-to-32 affine, ReLU, 32-to-1 affine; strict positive logits; "
+                "exact-duplicate relation groups collapsed before answer/abstain/conflict"
+            ),
+            "parameter_count": TRAINABLE_PARAMETER_COUNT,
+            "loss": "record-balanced mean candidate binary cross entropy with logits",
+            "optimization": config.as_contract(),
+            "cheap_gate": {
+                "fit_records": 12,
+                "sealed_transfer_records": 12,
+                "optimizer_steps": config.preflight_optimizer_steps,
+                "required_outcomes_relations_and_pointers": "exact",
+                "required_shortcut_controls": "exact",
+                "python_rust_records": 3,
+                "python_rust_candidate_logit_tolerance": PARITY_MAX_ABSOLUTE_TOLERANCE,
+            },
+            "development_gate": {
+                "minimum_per_class_outcome_accuracy": config.required_per_class_accuracy,
+                "minimum_positive_relation_recall": config.required_positive_relation_recall,
+                "minimum_negative_relation_specificity": (
+                    config.required_negative_relation_specificity
+                ),
+                "minimum_supported_copied_span_accuracy": config.required_pointer_accuracy,
+                "minimum_query_swap_relocation": config.required_query_swap_relocation,
+                "order_equivariance": "exact",
+            },
+            "product_behavior": (
+                "four records committed before training; never feature-extracted, "
+                "scored, or evaluated by Python"
+            ),
+            "implementation": trainer_implementation_contract(),
+        },
+        "run_contract_cid",
+    )
+    _write_or_verify_json(root / "source-relation-run-contract.json", run_contract)
+    return dataset, preflight, probes, census, dataset_manifest, run_contract
+
+
+def _run_preflight(
+    root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: dict[str, Any],
+    dataset: dict[str, Any],
+    preflight: dict[str, Any],
+    dataset_manifest: dict[str, Any],
+    run_contract: dict[str, Any],
+    config: SourceRelationHeadConfig,
+) -> dict[str, Any]:
+    records = [*preflight["fit"], *preflight["sealed"]]
+    feature_manifest = _extract_features(
+        root / "preflight/features",
+        predecessor=predecessor,
+        predecessor_manifest=predecessor_manifest,
+        records=records,
+        population_cids={
+            "preflight_cid": preflight["preflight_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+        },
+        config=config,
+    )
+    device = require_mps(config.seed)
+    features = FrozenRelationFeatureStore(root / "preflight/features")
+    fit_dataset = RelationDataset(preflight["fit"], features)
+    sealed_dataset = RelationDataset(preflight["sealed"], features)
+    torch.manual_seed(config.seed)
+    if hasattr(torch.mps, "manual_seed"):
+        torch.mps.manual_seed(config.seed)
+    model = R4SourceRelationHead().to(device)
+    fit = _fit_head(
+        model,
+        fit_dataset,
+        device=device,
+        steps=config.preflight_optimizer_steps,
+        batch_size=len(fit_dataset.records),
+        config=config,
+        phase="12-fit-matched-transfer",
+        fixed_indices=list(range(len(fit_dataset.records))),
+    )
+    fit_metrics = evaluate_relation_head(
+        model,
+        fit_dataset,
+        device=device,
+        batch_size=len(fit_dataset.records),
+        include_records=True,
+    )
+    sealed_metrics = evaluate_relation_head(
+        model,
+        sealed_dataset,
+        device=device,
+        batch_size=len(sealed_dataset.records),
+        include_records=True,
+    )
+    reversed_records = _reverse_preflight_records(records)
+    reversed_dataset = RelationDataset(reversed_records, features)
+    reversed_metrics = evaluate_relation_head(
+        model,
+        reversed_dataset,
+        device=device,
+        batch_size=len(reversed_dataset.records),
+        include_records=True,
+    )
+    controls = _preflight_control_checks(
+        preflight,
+        fit_metrics,
+        sealed_metrics,
+        reversed_records,
+        reversed_metrics,
+    )
+    passed = _all_exact(fit_metrics) and _all_exact(sealed_metrics) and controls["passed"]
+    deterministic_fit = {key: value for key, value in fit.items() if key != "elapsed_seconds"}
+    result = _canonical_with_cid(
+        {
+            "schema": PREFLIGHT_RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": (
+                "PASS_MATCHED_TRANSFER_AWAIT_RUST_RELATION_PARITY"
+                if passed
+                else "FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP"
+            ),
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "fit_record_cids": [record["record_cid"] for record in preflight["fit"]],
+            "sealed_record_cids": [
+                record["record_cid"] for record in preflight["sealed"]
+            ],
+            "optimization": deterministic_fit,
+            "fit_metrics": fit_metrics,
+            "sealed_transfer_metrics": sealed_metrics,
+            "reversed_order_metrics": reversed_metrics,
+            "shortcut_controls": controls,
+            "passed": passed,
+        },
+        "result_cid",
+    )
+    preflight_root = root / "preflight"
+    atomic_write_json(preflight_root / "preflight-result.json", result)
+    if not passed:
+        manifest = write_bound_manifest(
+            preflight_root / "preflight-manifest.json",
+            {
+                "schema": PREFLIGHT_RESULT_SCHEMA,
+                "terminal": result["terminal"],
+                "run_contract_cid": run_contract["run_contract_cid"],
+                "preflight_result_cid": result["result_cid"],
+            },
+            artifact_root=root,
+            relative_paths=[
+                "source-relation-dataset.json",
+                "source-relation-preflight.json",
+                "product-probes.json",
+                "shortcut-census.json",
+                "source-relation-dataset-manifest.json",
+                "source-relation-run-contract.json",
+                "preflight/features/feature-index.json",
+                "preflight/features/states.safetensors",
+                "preflight/features/feature-manifest.json",
+                "preflight/preflight-result.json",
+            ],
+        )
+        return {
+            "terminal": result["terminal"],
+            "preflight_result_cid": result["result_cid"],
+            "preflight_manifest_cid": manifest["manifest_cid"],
+        }
+
+    embedded_preflight = {
+        "status": "PASS_12_FIT_12_SEALED_MATCHED_TRANSFER",
+        "preflight_result_cid": result["result_cid"],
+        "optimizer_steps": config.preflight_optimizer_steps,
+        "fit_metrics": fit_metrics,
+        "sealed_transfer_metrics": sealed_metrics,
+        "shortcut_controls": controls,
+        "rust_score_parity": "AWAITING",
+    }
+    head = _head_payload(
+        model,
+        dataset=dataset,
+        run_contract_cid=run_contract["run_contract_cid"],
+        training_result_cid=result["result_cid"],
+        preflight=embedded_preflight,
+        development_metrics={"status": "NOT_RUN_BEFORE_SOLE_512_STEP_FIT"},
+    )
+    atomic_write_json(preflight_root / "preflight-head.json", head)
+
+    fixtures: list[dict[str, Any]] = []
+    fixture_paths: list[str] = []
+    for outcome in OUTCOMES:
+        record_index = next(
+            index
+            for index, record in enumerate(sealed_dataset.records)
+            if record["target_outcome"] == outcome
+        )
+        record = sealed_dataset.records[record_index]
+        evaluation = score_relation_record(
+            model, sealed_dataset, record_index=record_index, device=device
+        )
+        if (
+            evaluation["decision"] != record["target_outcome"]
+            or evaluation["selected_span_index"] != record.get("target_span_index")
+        ):
+            raise RuntimeError("passing matched-transfer preflight yielded a bad parity case")
+        source_relative = f"preflight/parity/{outcome}-source.txt"
+        source_path = root / source_relative
+        atomic_write(source_path, str(record["source"]).encode("utf-8"))
+        fixture = _canonical_with_cid(
+            {
+                "schema": PYTHON_SCORE_FIXTURE_SCHEMA,
+                "policy": POLICY,
+                "outcome": outcome,
+                "preflight_artifact_cid": head["artifact_cid"],
+                "record_cid": record["record_cid"],
+                "source_cid": record["source_cid"],
+                "source_path": source_relative,
+                "question": record["question"],
+                "question_cid": record["question_cid"],
+                **evaluation,
+                "maximum_absolute_tolerance": PARITY_MAX_ABSOLUTE_TOLERANCE,
+            },
+            "fixture_cid",
+        )
+        fixture_relative = f"preflight/parity/{outcome}-python-score-fixture.json"
+        atomic_write_json(root / fixture_relative, fixture)
+        fixtures.append(fixture)
+        fixture_paths.extend([source_relative, fixture_relative])
+
+    parity_index = _canonical_with_cid(
+        {
+            "schema": PYTHON_SCORE_FIXTURE_SCHEMA,
+            "policy": POLICY,
+            "preflight_artifact_cid": head["artifact_cid"],
+            "fixtures": [
+                {
+                    "outcome": fixture["outcome"],
+                    "fixture_cid": fixture["fixture_cid"],
+                    "record_cid": fixture["record_cid"],
+                }
+                for fixture in fixtures
+            ],
+        },
+        "index_cid",
+    )
+    atomic_write_json(preflight_root / "parity-index.json", parity_index)
+    manifest = write_bound_manifest(
+        preflight_root / "preflight-manifest.json",
+        {
+            "schema": PREFLIGHT_RESULT_SCHEMA,
+            "terminal": "AWAITING_THREE_RUST_RELATION_PARITY_REPORTS",
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "preflight_result_cid": result["result_cid"],
+            "preflight_artifact_cid": head["artifact_cid"],
+            "parity_index_cid": parity_index["index_cid"],
+        },
+        artifact_root=root,
+        relative_paths=[
+            "source-relation-dataset.json",
+            "source-relation-preflight.json",
+            "product-probes.json",
+            "shortcut-census.json",
+            "source-relation-dataset-manifest.json",
+            "source-relation-run-contract.json",
+            "preflight/features/feature-index.json",
+            "preflight/features/states.safetensors",
+            "preflight/features/feature-manifest.json",
+            "preflight/preflight-result.json",
+            "preflight/preflight-head.json",
+            "preflight/parity-index.json",
+            *fixture_paths,
+        ],
+    )
+    return {
+        "terminal": "AWAITING_THREE_RUST_RELATION_PARITY_REPORTS",
+        "preflight_artifact": str(preflight_root / "preflight-head.json"),
+        "preflight_artifact_cid": head["artifact_cid"],
+        "parity_fixtures": [
+            {
+                "outcome": fixture["outcome"],
+                "source": str(root / fixture["source_path"]),
+                "question": fixture["question"],
+                "fixture": str(
+                    root
+                    / f"preflight/parity/{fixture['outcome']}-python-score-fixture.json"
+                ),
+                "fixture_cid": fixture["fixture_cid"],
+            }
+            for fixture in fixtures
+        ],
+        "preflight_manifest_cid": manifest["manifest_cid"],
+    }
+
+
+def _numeric_logits(value: Any) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("Rust relation candidate_logits must be a nonempty list")
+    logits = [float(item) for item in value]
+    if any(not math.isfinite(item) for item in logits):
+        raise ValueError("Rust relation candidate_logits contain a nonfinite value")
+    return logits
+
+
+def _admit_rust_score_parity(
+    root: Path, report_paths: Sequence[Path]
+) -> dict[str, Any]:
+    if len(report_paths) != len(OUTCOMES):
+        raise ValueError("C1-SB2 requires exactly three Rust parity reports")
+    resolved = [path.expanduser().resolve() for path in report_paths]
+    if len(set(resolved)) != len(resolved) or any(not path.is_file() for path in resolved):
+        raise ValueError("Rust parity paths must be three distinct regular files")
+    head = json.loads((root / "preflight/preflight-head.json").read_text(encoding="utf-8"))
+    fixtures = {
+        outcome: json.loads(
+            (
+                root
+                / f"preflight/parity/{outcome}-python-score-fixture.json"
+            ).read_text(encoding="utf-8")
+        )
+        for outcome in OUTCOMES
+    }
+    reports = [json.loads(path.read_text(encoding="utf-8")) for path in resolved]
+    report_by_outcome: dict[str, dict[str, Any]] = {}
+    admissions: list[dict[str, Any]] = []
+    for report in reports:
+        if report.get("schema") != RUST_GROUNDED_REPORT_SCHEMA:
+            raise ValueError("Rust parity report is not uor-r4.grounded-answer/3")
+        relation = report.get("relation")
+        evaluation = report.get("relation_evaluation")
+        source = report.get("source")
+        state_encoding = report.get("state_encoding")
+        if not isinstance(relation, dict) or not isinstance(evaluation, dict):
+            raise ValueError("Rust parity report omits relation binding/evaluation")
+        if not isinstance(source, dict) or not isinstance(state_encoding, dict):
+            raise ValueError("Rust parity report omits source/state encoding")
+        if relation.get("artifact_cid") != head["artifact_cid"]:
+            raise ValueError("Rust parity loaded a different preflight relation head")
+        if relation.get("policy") != POLICY:
+            raise ValueError("Rust parity loaded a different relation policy")
+        if relation.get("model_weights_cid") != EXPECTED_WEIGHTS_CID:
+            raise ValueError("Rust relation binding names different model weights")
+        if relation.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+            raise ValueError("Rust relation binding names a different tokenizer")
+        checkpoint = state_encoding.get("checkpoint")
+        model_shape = state_encoding.get("model_shape")
+        if not isinstance(checkpoint, dict) or not isinstance(model_shape, dict):
+            raise ValueError("Rust parity state encoding omits checkpoint/model shape")
+        if checkpoint.get("weights_cid") != EXPECTED_WEIGHTS_CID:
+            raise ValueError("Rust parity state encoder loaded different model weights")
+        if checkpoint.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+            raise ValueError("Rust parity state encoder loaded a different tokenizer")
+        if int(model_shape.get("dimension", -1)) != FROZEN_MODEL_CONFIG.hidden_size:
+            raise ValueError("Rust parity state encoder hidden width differs")
+        if state_encoding.get("model_weights_cid") != EXPECTED_WEIGHTS_CID:
+            raise ValueError("Rust parity public state binding names different weights")
+        if state_encoding.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID:
+            raise ValueError("Rust parity public state binding names a different tokenizer")
+        if int(state_encoding.get("hidden_size", -1)) != FROZEN_MODEL_CONFIG.hidden_size:
+            raise ValueError("Rust parity public state binding names a different hidden width")
+
+        matching = [
+            fixture
+            for fixture in fixtures.values()
+            if source.get("source_cid") == fixture["source_cid"]
+            and report.get("question") == fixture["question"]
+        ]
+        if len(matching) != 1:
+            raise ValueError("Rust parity source/question does not identify one fixture")
+        fixture = matching[0]
+        outcome = str(fixture["outcome"])
+        if outcome in report_by_outcome:
+            raise ValueError("Rust parity reports duplicate one outcome")
+        rust_logits = _numeric_logits(evaluation.get("candidate_logits"))
+        python_logits = _numeric_logits(fixture["candidate_logits"])
+        if len(rust_logits) != len(python_logits):
+            raise ValueError("Rust parity candidate count differs")
+        maximum_delta = max(
+            abs(left - right) for left, right in zip(rust_logits, python_logits)
+        )
+        tolerance = float(fixture["maximum_absolute_tolerance"])
+        if tolerance != PARITY_MAX_ABSOLUTE_TOLERANCE or maximum_delta > tolerance:
+            raise ValueError(
+                "Rust relation parity exceeded tolerance: "
+                f"delta={maximum_delta}, limit={tolerance}"
+            )
+        decision = evaluation.get("decision")
+        selected_span = evaluation.get("selected_span_index")
+        if decision not in OUTCOMES:
+            raise ValueError("Rust parity decision is outside answer/abstain/conflict")
+        if selected_span is not None and not isinstance(selected_span, int):
+            raise ValueError("Rust parity selected span is not an integer or null")
+        if decision != fixture["decision"]:
+            raise ValueError("Rust parity decision differs from Python")
+        if selected_span != fixture["selected_span_index"]:
+            raise ValueError("Rust parity selected span differs from Python")
+        report_by_outcome[outcome] = report
+        admissions.append(
+            {
+                "outcome": outcome,
+                "fixture_cid": fixture["fixture_cid"],
+                "record_cid": fixture["record_cid"],
+                "rust_report_cid": cid_bytes(canonical_json_bytes(report)),
+                "maximum_absolute_candidate_logit_delta": maximum_delta,
+                "decision": decision,
+                "selected_span_index": selected_span,
+            }
+        )
+    if set(report_by_outcome) != set(OUTCOMES):
+        raise ValueError("Rust parity reports do not cover all three outcomes")
+
+    copied_paths: list[str] = []
+    for outcome in OUTCOMES:
+        relative = f"preflight/rust-score-parity-{outcome}.json"
+        atomic_write_json(root / relative, report_by_outcome[outcome])
+        copied_paths.append(relative)
+    admission = _canonical_with_cid(
+        {
+            "schema": PARITY_ADMISSION_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": "PASS_THREE_OUTCOME_PYTHON_RUST_RELATION_PARITY",
+            "preflight_artifact_cid": head["artifact_cid"],
+            "maximum_absolute_tolerance": PARITY_MAX_ABSOLUTE_TOLERANCE,
+            "reports": sorted(admissions, key=lambda item: OUTCOMES.index(item["outcome"])),
+        },
+        "admission_cid",
+    )
+    atomic_write_json(root / "preflight/score-parity-admission.json", admission)
+    return {**admission, "copied_paths": copied_paths}
+
+
+def _development_control_metrics(
+    base_metrics: dict[str, Any],
+    reversal_records: Sequence[dict[str, Any]],
+    reversal_metrics: dict[str, Any],
+    query_swap_records: Sequence[dict[str, Any]],
+    query_swap_metrics: dict[str, Any],
+) -> dict[str, Any]:
+    base = {str(item["record_cid"]): item for item in base_metrics["records"]}
+    reversal = {
+        str(item["record_cid"]): item for item in reversal_metrics["records"]
+    }
+    order_correct = 0
+    for record in reversal_records:
+        original = base[str(record["base_record_cid"])]
+        observed = reversal[str(record["record_cid"])]
+        mapping = [int(index) for index in record["candidate_original_indices"]]
+        logits_exact = all(
+            observed["candidate_logits"][new_index]
+            == original["candidate_logits"][old_index]
+            for new_index, old_index in enumerate(mapping)
+        )
+        expected_selected = record.get("target_span_index")
+        order_correct += int(
+            logits_exact
+            and observed["decision"] == original["decision"]
+            and observed["selected_span_index"] == expected_selected
+        )
+
+    swaps = {str(item["record_cid"]): item for item in query_swap_metrics["records"]}
+    relocation_correct = 0
+    for record in query_swap_records:
+        original = base[str(record["base_record_cid"])]
+        observed = swaps[str(record["record_cid"])]
+        base_exact = original["decision"] == original["target_outcome"] and (
+            original["target_outcome"] != "answer"
+            or original["selected_span_index"] == original["target_span_index"]
+        )
+        relocation_correct += int(
+            base_exact
+            and observed["source_cid"] == original["source_cid"]
+            and record["source_cid"] == original["source_cid"]
+            and observed["decision"] == "answer"
+            and observed["selected_span_index"] == record["target_span_index"]
+            and (
+                original["decision"] != "answer"
+                or original["selected_span_index"] != observed["selected_span_index"]
+            )
+        )
+    if not reversal_records or not query_swap_records:
+        raise RuntimeError("C1-SB2 development controls are empty")
+    return {
+        "order_equivariance": {
+            "correct": order_correct,
+            "total": len(reversal_records),
+            "exact": order_correct == len(reversal_records),
+        },
+        "query_swap_relocation": {
+            "correct": relocation_correct,
+            "total": len(query_swap_records),
+            "accuracy": relocation_correct / len(query_swap_records),
+        },
+    }
+
+
+def _development_gate(
+    metrics: dict[str, Any],
+    controls: dict[str, Any],
+    config: SourceRelationHeadConfig,
+) -> bool:
+    return (
+        all(
+            float(metrics["outcome"][outcome]["accuracy"])
+            >= config.required_per_class_accuracy
+            for outcome in OUTCOMES
+        )
+        and float(metrics["positive_relation_recall"]["accuracy"])
+        >= config.required_positive_relation_recall
+        and float(metrics["negative_relation_specificity"]["accuracy"])
+        >= config.required_negative_relation_specificity
+        and float(metrics["supported_copied_span"]["accuracy"])
+        >= config.required_pointer_accuracy
+        and float(controls["query_swap_relocation"]["accuracy"])
+        >= config.required_query_swap_relocation
+        and bool(controls["order_equivariance"]["exact"])
+    )
+
+
+def _run_full_fit(
+    root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: dict[str, Any],
+    dataset: dict[str, Any],
+    probes: dict[str, Any],
+    dataset_manifest: dict[str, Any],
+    run_contract: dict[str, Any],
+    parity_admission: dict[str, Any],
+    config: SourceRelationHeadConfig,
+) -> dict[str, Any]:
+    reversal_records = list(dataset["development_controls"]["reversal"])
+    query_swap_records = list(dataset["development_controls"]["query_swap"])
+    full_records = [
+        *dataset["construction"],
+        *dataset["development"],
+        *reversal_records,
+        *query_swap_records,
+    ]
+    feature_manifest = _extract_features(
+        root / "features",
+        predecessor=predecessor,
+        predecessor_manifest=predecessor_manifest,
+        records=full_records,
+        population_cids={
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+        },
+        config=config,
+    )
+
+    fit_marker = root / "fit-started.json"
+    if fit_marker.exists():
+        raise FileExistsError(
+            "the sole C1-SB2 fit was already started; no rerun or resume is authorized"
+        )
+    atomic_write_json(
+        fit_marker,
+        {
+            "schema": RUN_SCHEMA,
+            "phase": "SOLE_512_STEP_FIT_STARTED",
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "parity_admission_cid": parity_admission["admission_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+        },
+    )
+    device = require_mps(config.seed)
+    features = FrozenRelationFeatureStore(root / "features")
+    construction = RelationDataset(dataset["construction"], features)
+    development = RelationDataset(dataset["development"], features)
+    reversal = RelationDataset(reversal_records, features)
+    query_swap = RelationDataset(query_swap_records, features)
+    construction.require_all_cells()
+    development.require_all_cells()
+    torch.manual_seed(config.seed)
+    if hasattr(torch.mps, "manual_seed"):
+        torch.mps.manual_seed(config.seed)
+    model = R4SourceRelationHead().to(device)
+    fit = _fit_head(
+        model,
+        construction,
+        device=device,
+        steps=config.optimizer_steps,
+        batch_size=config.batch_size,
+        config=config,
+        phase="sole-512-step-fit",
+    )
+    development_raw = evaluate_relation_head(
+        model,
+        development,
+        device=device,
+        batch_size=config.batch_size,
+        include_records=True,
+    )
+    reversal_raw = evaluate_relation_head(
+        model,
+        reversal,
+        device=device,
+        batch_size=config.batch_size,
+        include_records=True,
+    )
+    query_swap_raw = evaluate_relation_head(
+        model,
+        query_swap,
+        device=device,
+        batch_size=config.batch_size,
+        include_records=True,
+    )
+    controls = _development_control_metrics(
+        development_raw,
+        reversal_records,
+        reversal_raw,
+        query_swap_records,
+        query_swap_raw,
+    )
+    development_metrics = {
+        key: value for key, value in development_raw.items() if key != "records"
+    }
+    development_metrics["controls"] = controls
+    passed = _development_gate(development_metrics, controls, config)
+    preflight_result = json.loads(
+        (root / "preflight/preflight-result.json").read_text(encoding="utf-8")
+    )
+    deterministic_fit = {key: value for key, value in fit.items() if key != "elapsed_seconds"}
+    result = _canonical_with_cid(
+        {
+            "schema": TRAINING_RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": (
+                "SOURCE_RELATION_HEAD_FIT_COMPLETE_AWAITING_RUST_PRODUCT_REVEAL"
+                if passed
+                else "FAIL_SOURCE_RELATION_HEAD_DEVELOPMENT_GATE_STOP"
+            ),
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "preflight_result_cid": preflight_result["result_cid"],
+            "rust_score_parity_admission_cid": parity_admission["admission_cid"],
+            "optimization": deterministic_fit,
+            "development_metrics": development_metrics,
+            "development_gate_passed": passed,
+            "product_probe_commitments": dataset["product_probe_commitments"],
+            "product_probe_file_cid": probes["product_probes_cid"],
+            "product_behavior_status": "NOT_RUN",
+        },
+        "result_cid",
+    )
+    atomic_write_json(root / "source-relation-training-result.json", result)
+
+    final_paths = [
+        "source-relation-dataset.json",
+        "source-relation-preflight.json",
+        "product-probes.json",
+        "shortcut-census.json",
+        "source-relation-dataset-manifest.json",
+        "source-relation-run-contract.json",
+        "preflight/features/feature-index.json",
+        "preflight/features/states.safetensors",
+        "preflight/features/feature-manifest.json",
+        "preflight/preflight-result.json",
+        "preflight/preflight-head.json",
+        "preflight/parity-index.json",
+        "preflight/preflight-manifest.json",
+        *[
+            f"preflight/parity/{outcome}-source.txt"
+            for outcome in OUTCOMES
+        ],
+        *[
+            f"preflight/parity/{outcome}-python-score-fixture.json"
+            for outcome in OUTCOMES
+        ],
+        *parity_admission["copied_paths"],
+        "preflight/score-parity-admission.json",
+        "features/feature-index.json",
+        "features/states.safetensors",
+        "features/feature-manifest.json",
+        "fit-started.json",
+        "source-relation-training-result.json",
+    ]
+    head: dict[str, Any] | None = None
+    if passed:
+        embedded_preflight = {
+            "status": "PASS_MATCHED_TRANSFER_AND_THREE_RUST_PARITY_REPORTS",
+            "preflight_result_cid": preflight_result["result_cid"],
+            "rust_score_parity_admission_cid": parity_admission["admission_cid"],
+        }
+        head = _head_payload(
+            model,
+            dataset=dataset,
+            run_contract_cid=run_contract["run_contract_cid"],
+            training_result_cid=result["result_cid"],
+            preflight=embedded_preflight,
+            development_metrics=development_metrics,
+        )
+        atomic_write_json(root / "source-relation-head.json", head)
+        final_paths.append("source-relation-head.json")
+
+    final_manifest = write_bound_manifest(
+        root / "source-relation-final-manifest.json",
+        {
+            "schema": FINAL_MANIFEST_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": result["terminal"],
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "dataset_manifest_cid": dataset_manifest["manifest_cid"],
+            "feature_manifest_cid": feature_manifest["manifest_cid"],
+            "training_result_cid": result["result_cid"],
+            "relation_head_artifact_cid": None if head is None else head["artifact_cid"],
+            "development_gate_passed": passed,
+            "product_behavior_status": "NOT_RUN" if passed else "BLOCKED_BY_DEVELOPMENT",
+        },
+        artifact_root=root,
+        relative_paths=final_paths,
+    )
+    return {
+        "terminal": result["terminal"],
+        "optimizer_steps_completed": config.optimizer_steps,
+        "development_metrics": development_metrics,
+        "relation_head_artifact": None
+        if head is None
+        else str(root / "source-relation-head.json"),
+        "relation_head_artifact_cid": None if head is None else head["artifact_cid"],
+        "training_result_cid": result["result_cid"],
+        "final_manifest_cid": final_manifest["manifest_cid"],
+        "product_behavior_status": "NOT_RUN" if passed else "BLOCKED_BY_DEVELOPMENT",
+    }
+
+
+def train_source_relation_head(
+    root: Path,
+    *,
+    predecessor: Path,
+    rust_score_parity: Sequence[Path] | None = None,
+    config: SourceRelationHeadConfig = SourceRelationHeadConfig(),
+) -> dict[str, Any]:
+    """Advance C1-SB2 without feature-extracting, scoring, or evaluating product probes."""
+    config.validate()
+    root = root.expanduser().resolve()
+    predecessor = predecessor.expanduser().resolve()
+    if (
+        root == predecessor
+        or predecessor in root.parents
+        or root in predecessor.parents
+    ):
+        raise ValueError("relation-head output must be disjoint from immutable #1017")
+    if (root / "source-relation-final-manifest.json").exists():
+        raise FileExistsError("the sole C1-SB2 relation-head fit is already complete")
+
+    predecessor_manifest = _validated_predecessor(predecessor)
+    (
+        dataset,
+        preflight,
+        probes,
+        _census,
+        dataset_manifest,
+        run_contract,
+    ) = _prepare_contract(
+        root,
+        predecessor_manifest=predecessor_manifest,
+        config=config,
+    )
+    preflight_manifest_path = root / "preflight/preflight-manifest.json"
+    if not preflight_manifest_path.exists():
+        result = _run_preflight(
+            root,
+            predecessor=predecessor,
+            predecessor_manifest=predecessor_manifest,
+            dataset=dataset,
+            preflight=preflight,
+            dataset_manifest=dataset_manifest,
+            run_contract=run_contract,
+            config=config,
+        )
+        if rust_score_parity is not None:
+            result["note"] = (
+                "preflight was created in this invocation; run all three emitted Rust "
+                "parity commands and invoke this subcommand again with their reports"
+            )
+        return result
+
+    preflight_manifest = verify_bound_manifest(
+        preflight_manifest_path, artifact_root=root
+    )
+    if preflight_manifest.get("terminal") != "AWAITING_THREE_RUST_RELATION_PARITY_REPORTS":
+        return {
+            "terminal": preflight_manifest.get("terminal", "PREFLIGHT_STOPPED"),
+            "preflight_manifest_cid": preflight_manifest["manifest_cid"],
+        }
+    if rust_score_parity is None:
+        parity_index = json.loads(
+            (root / "preflight/parity-index.json").read_text(encoding="utf-8")
+        )
+        fixtures = []
+        for item in parity_index["fixtures"]:
+            outcome = str(item["outcome"])
+            fixture_path = (
+                root / f"preflight/parity/{outcome}-python-score-fixture.json"
+            )
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+            fixtures.append(
+                {
+                    "outcome": outcome,
+                    "source": str(root / fixture["source_path"]),
+                    "question": fixture["question"],
+                    "fixture": str(fixture_path),
+                    "fixture_cid": fixture["fixture_cid"],
+                }
+            )
+        return {
+            "terminal": "AWAITING_THREE_RUST_RELATION_PARITY_REPORTS",
+            "preflight_artifact": str(root / "preflight/preflight-head.json"),
+            "preflight_artifact_cid": parity_index["preflight_artifact_cid"],
+            "parity_fixtures": fixtures,
+        }
+
+    parity_admission = _admit_rust_score_parity(root, rust_score_parity)
+    return _run_full_fit(
+        root,
+        predecessor=predecessor,
+        predecessor_manifest=predecessor_manifest,
+        dataset=dataset,
+        probes=probes,
+        dataset_manifest=dataset_manifest,
+        run_contract=run_contract,
+        parity_admission=parity_admission,
+        config=config,
+    )

--- a/tools/r4-softmax-trainer/tests/test_source_relation_data.py
+++ b/tools/r4-softmax-trainer/tests/test_source_relation_data.py
@@ -1,0 +1,369 @@
+"""Focused contract tests for the frozen C1-SB2 relation population."""
+
+from __future__ import annotations
+
+from collections import Counter
+import unittest
+
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+from r4_softmax_trainer.source_relation_data import (
+    CONSTRUCTION_BANK,
+    DEVELOPMENT_BANK,
+    OUTCOMES,
+    POLICY,
+    PREFLIGHT_FAMILIES,
+    PRODUCT_LOCATIONS,
+    PRODUCT_NONLOCATIVES,
+    PRODUCT_OBJECTS,
+    RELATION_INPUT_POLICY,
+    RELATION_RECORD_SCHEMA,
+    SOURCE_WIDTHS,
+    build_source_relation_population,
+    render_relation_input,
+)
+
+
+def _reproduce_cid(value: dict[str, object], field: str) -> str:
+    unsigned = dict(value)
+    expected = str(unsigned.pop(field))
+    actual = cid_bytes(canonical_json_bytes(unsigned))
+    if actual != expected:
+        raise AssertionError(f"{field} does not reproduce: {expected} != {actual}")
+    return actual
+
+
+class RelationInputTests(unittest.TestCase):
+    def test_evidence_precedes_question_and_question_mark_is_final(self) -> None:
+        rendered = render_relation_input(
+            "The coral abacus is inside the aspen locker.",
+            "Where is the coral abacus?",
+        )
+        self.assertEqual(
+            rendered,
+            "Evidence:\nThe coral abacus is inside the aspen locker.\n"
+            "Question:\nWhere is the coral abacus?",
+        )
+        self.assertTrue(rendered.endswith("?"))
+        self.assertFalse(rendered.endswith("?\n"))
+        self.assertIn("no terminal newline", RELATION_INPUT_POLICY)
+
+    def test_relation_input_rejects_noncanonical_evidence_or_question(self) -> None:
+        rejected = [
+            ("unterminated", "Where is the coral abacus?"),
+            (" trailing. ", "Where is the coral abacus?"),
+            ("The coral abacus is listed.", "where is the coral abacus?"),
+        ]
+        for span, question in rejected:
+            with self.subTest(span=span, question=question), self.assertRaises(ValueError):
+                render_relation_input(span, question)
+
+
+class SourceRelationPopulationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset, cls.preflight, cls.products = build_source_relation_population()
+
+    def test_exact_balanced_population_counts_and_widths(self) -> None:
+        self.assertEqual(self.dataset["policy"], POLICY)
+        self.assertEqual(self.dataset["counts"]["construction"], 3_360)
+        self.assertEqual(self.dataset["counts"]["development"], 420)
+        self.assertEqual(self.dataset["counts"]["product_probe_commitments"], 4)
+        for population, per_cell in (("construction", 160), ("development", 20)):
+            cells: Counter[tuple[str, int]] = Counter(
+                (record["target_outcome"], record["source_width"])
+                for record in self.dataset[population]
+            )
+            self.assertEqual(
+                cells,
+                Counter(
+                    {
+                        (outcome, width): per_cell
+                        for outcome in OUTCOMES
+                        for width in SOURCE_WIDTHS
+                    }
+                ),
+            )
+
+    def test_relations_require_locative_value_not_raw_subject_count(self) -> None:
+        for population, singleton_count, agreement_count in (
+            ("construction", 80, 80),
+            ("development", 10, 10),
+        ):
+            records = self.dataset[population]
+            for width in SOURCE_WIDTHS:
+                answers = [
+                    record
+                    for record in records
+                    if record["target_outcome"] == "answer"
+                    and record["source_width"] == width
+                ]
+                motifs = Counter(record["motif"] for record in answers)
+                self.assertEqual(
+                    motifs,
+                    {"singleton": singleton_count, "duplicate-agreement": agreement_count},
+                )
+                conflicts = [
+                    record
+                    for record in records
+                    if record["target_outcome"] == "conflict"
+                    and record["source_width"] == width
+                ]
+                self.assertTrue(conflicts)
+                for record in conflicts:
+                    positives = [
+                        record["sentence_spans"][index]["text"]
+                        for index in record["positive_span_indices"]
+                    ]
+                    self.assertEqual(len(positives), 2)
+                    self.assertEqual(len(set(positives)), 2)
+                abstentions = [
+                    record
+                    for record in records
+                    if record["target_outcome"] == "abstain"
+                    and record["source_width"] == width
+                ]
+                self.assertTrue(
+                    all(not record["positive_span_indices"] for record in abstentions)
+                )
+                self.assertTrue(
+                    all(record["raw_subject_occurrence_count"] >= 2 for record in abstentions)
+                )
+                if width >= 3:
+                    for cell in (answers, abstentions, conflicts):
+                        self.assertTrue(
+                            any(
+                                span["role"].startswith("same-subject-")
+                                for candidate in cell
+                                for span in candidate["sentence_spans"]
+                            )
+                        )
+
+            for record in records:
+                if record["motif"] == "singleton":
+                    self.assertEqual(len(record["positive_span_indices"]), 1)
+                    self.assertFalse(record["duplicate_agreement"])
+                elif record["motif"] == "duplicate-agreement":
+                    positives = [
+                        record["sentence_spans"][index]
+                        for index in record["positive_span_indices"]
+                    ]
+                    self.assertEqual(len(positives), 2)
+                    self.assertEqual(positives[0]["text_cid"], positives[1]["text_cid"])
+                    self.assertEqual(
+                        record["target_span_index"], min(record["positive_span_indices"])
+                    )
+
+        census = self.dataset["shortcut_census"]
+        self.assertTrue(census["passed"])
+        self.assertFalse(census["count_only_label_lookup_is_perfect"])
+        for partition in ("construction", "development"):
+            for cell in census[f"{partition}_count_cells"]:
+                self.assertEqual(set(cell["outcomes_present"]), set(OUTCOMES))
+
+    def test_candidate_and_conflict_pair_positions_are_balanced(self) -> None:
+        for population in ("construction", "development"):
+            records = self.dataset[population]
+            for outcome in ("answer", "conflict"):
+                for width in SOURCE_WIDTHS:
+                    cell = [
+                        record
+                        for record in records
+                        if record["target_outcome"] == outcome
+                        and record["source_width"] == width
+                    ]
+                    incidence = Counter(
+                        index for record in cell for index in record["positive_span_indices"]
+                    )
+                    self.assertLessEqual(
+                        max(incidence.values()) - min(incidence.values()), 1
+                    )
+                    if outcome == "conflict":
+                        pair_counts = Counter(
+                            tuple(record["positive_span_indices"]) for record in cell
+                        )
+                        self.assertLessEqual(
+                            max(pair_counts.values()) - min(pair_counts.values()), 1
+                        )
+
+    def test_preflight_is_matched_twelve_fit_twelve_sealed_transfer(self) -> None:
+        self.assertEqual(self.preflight["counts"]["fit"], 12)
+        self.assertEqual(self.preflight["counts"]["sealed"], 12)
+        self.assertEqual(self.preflight["counts"]["matched_pairs"], 8)
+        expected_motifs = {
+            "same-source-absent-query",
+            "same-source-present-locative-query",
+            "queried-subject-nonlocative-only",
+            "query-locative-distractor-subject",
+            "exact-duplicate-agreement",
+            "distinct-location-conflict",
+        }
+        for partition, family_names in (
+            ("fit", self.preflight["fit_family_names"]),
+            ("sealed", self.preflight["sealed_family_names"]),
+        ):
+            records = self.preflight[partition]
+            self.assertEqual(len(family_names), 2)
+            for family_name in family_names:
+                family_records = [
+                    record
+                    for record in records
+                    if record["lexical_family"] == family_name
+                ]
+                self.assertEqual(
+                    {record["motif"] for record in family_records}, expected_motifs
+                )
+                duplicate = next(
+                    record
+                    for record in family_records
+                    if record["motif"] == "exact-duplicate-agreement"
+                )
+                self.assertTrue(duplicate["duplicate_agreement"])
+                conflict = next(
+                    record
+                    for record in family_records
+                    if record["motif"] == "distinct-location-conflict"
+                )
+                self.assertEqual(len(conflict["positive_relation_group_cids"]), 2)
+        self.assertTrue(all(pair["same_source"] for pair in self.preflight["matched_pairs"]))
+        self.assertTrue(
+            set(self.preflight["fit_family_names"]).isdisjoint(
+                self.preflight["sealed_family_names"]
+            )
+        )
+
+    def test_development_controls_preserve_source_or_remap_order(self) -> None:
+        development = {
+            record["record_cid"]: record for record in self.dataset["development"]
+        }
+        reversals = self.dataset["development_controls"]["reversal"]
+        swaps = self.dataset["development_controls"]["query_swap"]
+        self.assertEqual(len(reversals), 420)
+        self.assertGreaterEqual(len(swaps), 300)
+        for control in reversals:
+            base = development[control["base_record_cid"]]
+            self.assertEqual(
+                control["candidate_original_indices"],
+                list(reversed(range(base["source_width"]))),
+            )
+            self.assertEqual(control["target_outcome"], base["target_outcome"])
+            self.assertEqual(
+                [span["text"] for span in control["sentence_spans"]],
+                list(reversed([span["text"] for span in base["sentence_spans"]])),
+            )
+        for control in swaps:
+            base = development[control["base_record_cid"]]
+            self.assertEqual(control["source_cid"], base["source_cid"])
+            self.assertNotEqual(control["subject"], base["subject"])
+            self.assertEqual(control["target_outcome"], "answer")
+            self.assertEqual(
+                control["target_span_index"], control["expected_original_span_index"]
+            )
+            if base["target_outcome"] == "answer":
+                self.assertNotEqual(control["target_span_index"], base["target_span_index"])
+
+    def test_four_product_commitments_are_exact_and_python_disjoint(self) -> None:
+        records = self.products["records"]
+        self.assertEqual(
+            [record["probe"] for record in records],
+            [
+                "opal-astrolabe-supported",
+                "silk-atlas-abstain",
+                "opal-astrolabe-conflict",
+                "jade-sextant-duplicate-agreement",
+            ],
+        )
+        self.assertEqual(
+            [record["target_outcome"] for record in records],
+            ["answer", "abstain", "conflict", "answer"],
+        )
+        self.assertEqual(
+            records[0]["source"],
+            "The opal astrolabe was polished before sunrise. "
+            "The brass sundial is beside the north alcove. "
+            "The opal astrolabe is beneath the maple stair.",
+        )
+        self.assertEqual(records[3]["target_span_index"], 0)
+        self.assertTrue(records[3]["duplicate_agreement"])
+        self.assertEqual(
+            self.dataset["product_probe_commitments"],
+            [record["record_cid"] for record in records],
+        )
+        training_sentences = {
+            span["text"]
+            for record in [
+                *self.dataset["construction"],
+                *self.dataset["development"],
+            ]
+            for span in record["sentence_spans"]
+        }
+        product_sentences = {
+            span["text"] for record in records for span in record["sentence_spans"]
+        }
+        self.assertTrue(training_sentences.isdisjoint(product_sentences))
+
+    def test_lexical_banks_records_and_content_ids_are_disjoint_and_canonical(self) -> None:
+        construction_bank = {
+            *CONSTRUCTION_BANK["subjects"],
+            *CONSTRUCTION_BANK["locations"],
+            *CONSTRUCTION_BANK["nonlocatives"],
+        }
+        development_bank = {
+            *DEVELOPMENT_BANK["subjects"],
+            *DEVELOPMENT_BANK["locations"],
+            *DEVELOPMENT_BANK["nonlocatives"],
+        }
+        product_bank = {*PRODUCT_OBJECTS, *PRODUCT_LOCATIONS, *PRODUCT_NONLOCATIVES}
+        preflight_bank = {
+            value
+            for family in PREFLIGHT_FAMILIES
+            for key, value in family.items()
+            if key != "name"
+        }
+        self.assertTrue(construction_bank.isdisjoint(development_bank))
+        self.assertTrue(construction_bank.isdisjoint(product_bank))
+        self.assertTrue(development_bank.isdisjoint(product_bank))
+        self.assertTrue(
+            preflight_bank.isdisjoint(
+                construction_bank | development_bank | product_bank
+            )
+        )
+        census = self.dataset["shortcut_census"]
+        self.assertTrue(census["construction_development_subjects_disjoint"])
+        self.assertTrue(census["construction_development_sentences_disjoint"])
+        self.assertTrue(census["construction_development_product_subjects_disjoint"])
+        self.assertTrue(census["construction_development_product_sentences_disjoint"])
+
+        all_records = [
+            *self.dataset["construction"],
+            *self.dataset["development"],
+            *self.dataset["development_controls"]["reversal"],
+            *self.dataset["development_controls"]["query_swap"],
+            *self.preflight["fit"],
+            *self.preflight["sealed"],
+            *self.products["records"],
+        ]
+        for record in all_records:
+            self.assertEqual(record["schema"], RELATION_RECORD_SCHEMA)
+            _reproduce_cid(record, "record_cid")
+            for span in record["sentence_spans"]:
+                self.assertEqual(
+                    span["relation_input"],
+                    render_relation_input(span["text"], record["question"]),
+                )
+                self.assertTrue(span["relation_input"].endswith("?"))
+                self.assertEqual(span["relation_group_cid"], span["text_cid"])
+        _reproduce_cid(self.dataset, "dataset_cid")
+        _reproduce_cid(self.preflight, "preflight_cid")
+        _reproduce_cid(self.products, "product_probes_cid")
+
+    def test_rebuild_is_byte_identical(self) -> None:
+        other_dataset, other_preflight, other_products = build_source_relation_population()
+        self.assertEqual(canonical_json_bytes(other_dataset), canonical_json_bytes(self.dataset))
+        self.assertEqual(
+            canonical_json_bytes(other_preflight), canonical_json_bytes(self.preflight)
+        )
+        self.assertEqual(canonical_json_bytes(other_products), canonical_json_bytes(self.products))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_source_relation_head.py
+++ b/tools/r4-softmax-trainer/tests/test_source_relation_head.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+from r4_softmax_trainer.source_relation_data import (
+    build_relation_preflight,
+    build_source_relation_population,
+)
+from r4_softmax_trainer.source_relation_head import (
+    R4SourceRelationHead,
+    _decision_from_logits,
+    _development_control_metrics,
+    _head_payload,
+)
+
+
+def _perfect_evaluation(record: dict[str, object]) -> dict[str, object]:
+    spans = list(record["sentence_spans"])
+    logits = [1.0 if int(span["relation_label"]) else -1.0 for span in spans]
+    return {
+        "record_cid": record["record_cid"],
+        "source_cid": record["source_cid"],
+        "question_cid": record["question_cid"],
+        "target_outcome": record["target_outcome"],
+        "target_span_index": record["target_span_index"],
+        **_decision_from_logits(record, logits),
+    }
+
+
+class SourceRelationHeadTests(unittest.TestCase):
+    def test_strict_positive_duplicate_aware_decisions(self) -> None:
+        preflight = build_relation_preflight()
+        records = [*preflight["fit"], *preflight["sealed"]]
+        by_motif = {record["motif"]: record for record in records}
+
+        absent = by_motif["same-source-absent-query"]
+        absent_result = _decision_from_logits(
+            absent, [0.0] * len(absent["sentence_spans"])
+        )
+        self.assertEqual(absent_result["decision"], "abstain")
+
+        duplicate = by_motif["exact-duplicate-agreement"]
+        duplicate_result = _decision_from_logits(
+            duplicate,
+            [
+                1.0 if int(span["relation_label"]) else -1.0
+                for span in duplicate["sentence_spans"]
+            ],
+        )
+        self.assertEqual(duplicate_result["decision"], "answer")
+        self.assertEqual(
+            duplicate_result["selected_span_index"], duplicate["target_span_index"]
+        )
+
+        conflict = by_motif["distinct-location-conflict"]
+        conflict_result = _decision_from_logits(
+            conflict,
+            [
+                1.0 if int(span["relation_label"]) else -1.0
+                for span in conflict["sentence_spans"]
+            ],
+        )
+        self.assertEqual(conflict_result["decision"], "conflict")
+        self.assertIsNone(conflict_result["selected_span_index"])
+
+    def test_head_payload_matches_the_strict_rust_schema_and_self_cid(self) -> None:
+        torch.manual_seed(9_542)
+        model = R4SourceRelationHead()
+        dataset, _, _ = build_source_relation_population()
+        payload = _head_payload(
+            model,
+            dataset=dataset,
+            run_contract_cid="blake3:" + "1" * 64,
+            training_result_cid="blake3:" + "2" * 64,
+            preflight={"status": "TEST_ONLY"},
+            development_metrics={"status": "TEST_ONLY"},
+        )
+        self.assertEqual(
+            set(payload),
+            {
+                "artifact_cid",
+                "dataset_cid",
+                "development_metrics",
+                "first_layer_biases",
+                "first_layer_weights",
+                "hidden_size",
+                "hidden_width",
+                "issue",
+                "maximum_source_spans",
+                "model_weights_cid",
+                "output_bias",
+                "output_weights",
+                "policy",
+                "preflight",
+                "product_probe_commitments",
+                "relation_input_policy",
+                "run_contract_cid",
+                "schema",
+                "split_policy_cid",
+                "threshold",
+                "tokenizer_cid",
+                "training_result_cid",
+            },
+        )
+        unsigned = dict(payload)
+        embedded = unsigned.pop("artifact_cid")
+        self.assertEqual(embedded, cid_bytes(canonical_json_bytes(unsigned)))
+
+    def test_perfect_reversal_and_all_outcome_query_swaps_are_reachable(self) -> None:
+        dataset, _, _ = build_source_relation_population()
+        development = list(dataset["development"])
+        reversals = list(dataset["development_controls"]["reversal"])
+        swaps = list(dataset["development_controls"]["query_swap"])
+        base_metrics = {"records": [_perfect_evaluation(record) for record in development]}
+        reversal_metrics = {"records": [_perfect_evaluation(record) for record in reversals]}
+        swap_metrics = {"records": [_perfect_evaluation(record) for record in swaps]}
+
+        controls = _development_control_metrics(
+            base_metrics,
+            reversals,
+            reversal_metrics,
+            swaps,
+            swap_metrics,
+        )
+        self.assertTrue(controls["order_equivariance"]["exact"])
+        self.assertEqual(controls["query_swap_relocation"]["accuracy"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Implements the independently frozen C1-SB2 `R4SourceRelativeRelationHeadV1` mechanism and records its decision-bearing negative result.

The new seam:

- encodes each exact source sentence relative to the exact question through the immutable #1017 six-layer R4/Spin causal-softmax executor;
- retains the final question-token width-288 state;
- fits a fixed `288 -> 32 ReLU -> 1` relation probe;
- loads canonical self-addressed artifacts through strict Rust validation; and
- collapses exact duplicate text before fail-closed exact-copy, typed abstention, or typed conflict.

The Python campaign freezes 3,360 construction and 420 lexically disjoint development records, reversal/query-swap controls, four product commitments, and a mandatory 12-fit/12-sealed matched-transfer gate before Rust parity or the sole full fit.

## Observed decision

Terminal: `FAIL_MATCHED_TRANSFER_PREFLIGHT_STOP`.

- Fit: positive `12/12`, negative `20/20`, copied span `6/6`.
- Sealed transfer: positive `5/12`, negative `14/20`, copied span `0/6`.
- Sealed outcomes: answer `0/6`, abstain `3/4`, conflict `1/2`.
- Candidate-array order equivariance passed; same-source, query-swap, duplicate-agreement, and distinct-value conflict controls failed.
- Rust parity, the 512-step full fit, development evaluation, final-head emission, all four product probes, and browser/HTTP wiring are `NOT_RUN`.

No final relation head is qualified. This does not revoke established ordinary causal attention or #1017 bounded coherent generation. The next proposed #954 mechanism must train relation supervision into the representation through the existing R4/Spin attention path while retaining the exact-copy and typed non-answer Rust boundary.

## Focused verification

- 13 source-relation Python contract tests pass.
- 8 strict Rust artifact/scoring/decision tests pass.
- Grounded-answer policy test passes.
- Root library and binary compile pass.
- Targeted root clippy with warnings denied passes.
- CLI and `answer` help render the current boundary.
- Rust formatting, diff whitespace, JSON validity, and claim-wording gate pass.

The broad recurring suite was intentionally not run locally because the frozen preflight already made the scientific decision; the protected merge queue remains the repository-wide integration verdict.

References #954
