### PR TITLE
C1-SB4 joint-candidate margin falsifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,19 @@ relations, 20/20 negatives, and 6/6 supported copies; the independently sealed
 families scored 5/12 positives, 14/20 negatives, and 0/6 copies. Same-source
 matched-pair, query-swap, duplicate-agreement, and distinct-conflict controls
 were false, so the run stopped before Rust parity, the sole 512-step full fit,
-development, and product reveal. No final relation head exists. The next
-proposed #954 mechanism trains relation supervision into the representation
-through the established R4/Spin attention path while retaining exact-source-copy
-and typed-nonanswer semantics. #954's final source-free terminal remains blocked
-behind #973, and #955 remains blocked behind #954. The #1017 `r4 generate` path
-remains the working coherent-generation prototype.
+development, and product reveal. No final relation head exists. C1-SB3 then
+moved supervision into all six attention layers and transferred most relations,
+but missed its exact gate. C1-SB4's independently frozen full-source,
+record-level structured-margin successor also failed: exact records were
+`70/126` fit and `35/63` sealed; positive groups were exact, negative-group
+specificity was `394/478` and `197/239`, and same-source query relocation was
+not exact. It stopped before Rust parity, checkpoint emission, development, or
+the four committed product probes; do not tune or retry it. The next proposal
+is a separately frozen paired-query conditional-binding objective over the same
+source, not another C1-SB4 seed/rank/threshold/schedule run. #954's final
+source-free terminal remains blocked behind #973, and #955 remains blocked
+behind #954. The #1017 `r4 generate` path remains the working
+coherent-generation prototype.
 Prototype iteration uses
 one targeted compile plus one real behavior check; do not run a broad local
 suite or add a permanent gate until the mechanism is useful. The existing
@@ -134,11 +141,13 @@ passed, MPS is `UNAVAILABLE_HARDWARE_BUDGET` for the frozen eight-hour offline
 implementation, and the full campaign remains `NOT_RUN`. The subsequent fused-
 AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so `fused=True` was removed and #1019 is optional/paused.
-The #1017 `r4 generate` path remains the working coherent-generation prototype;
-#954 C1-SB2 is an implemented matched-transfer preflight negative, not an active
-head. Its proposed representation-trained successor keeps the same established
-R4/Spin attention plus exact-copy/typed-nonanswer seam. CUDA and external GPU
-execution are out of scope. This reference remains
+The #1017 `r4 generate` path remains the working coherent-generation prototype.
+#954 C1-SB2, C1-SB3, and C1-SB4 are bounded negatives, not active answer
+artifacts. C1-SB4's full-source structured-margin arm reached only `70/126` fit
+and `35/63` sealed exact records and stopped before Rust/checkpoint/product.
+Its product text remains unopened and it must not be retried. The next proposal
+is paired-query conditional binding under a separate freeze. CUDA and external
+GPU execution are out of scope. This reference remains
 transformer-compatible and `f32`/multiply/alloc/source-weight backed—not
 table-native, multiply-free, or transformerless. It does not establish geometry
 advantage, softmax removal, correctness, reasoning, frontier quality, release
@@ -289,10 +298,12 @@ offline implementation, and full training through replay remains `NOT_RUN`.
 The fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
 optional/paused. The #1017 `r4 generate` path remains the working prototype;
-#954 C1-SB2 is implemented but stopped at its failed matched-transfer preflight,
-before Rust parity/full fit/development/product and without a final head. The
-next proposed mechanism trains relation supervision into the existing R4/Spin
-attention representation while retaining exact-copy/typed-nonanswer behavior.
+#954 C1-SB2 and C1-SB3 are preserved negatives. C1-SB4 then trained the frozen
+full-source structured-margin attention representation but reached only
+`70/126` fit and `35/63` sealed exact records; it stopped before Rust parity,
+checkpoint emission, development, or its unopened products. Do not retry it.
+The next proposal couples multiple questions over the same source so candidate
+sign must change with the queried subject, under a new independent freeze.
 CUDA and external GPU execution are out of scope.
 Intrinsic/readout, resonance, recurrence,
 and lowering are parked. D3 remains `NOT_RUN`; #954's final source-free
@@ -668,11 +679,12 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
   `3.491307 s/step`), so #1019 tuning/full-run work stops and remains
   optional/paused. The #1017 `r4 generate` path remains the working prototype;
-  #954 C1-SB2 is implemented but stopped at its failed matched-transfer
-  preflight before Rust parity/full fit/development/product, with no final head.
-  The next proposed mechanism trains relation supervision into the existing
-  R4/Spin attention representation while retaining exact-copy/typed-nonanswer
-  behavior. CUDA and external GPU execution are out of scope.
+  #954 C1-SB2 and C1-SB3 are preserved negatives. C1-SB4's independently frozen
+  full-source structured-margin attention arm reached only `70/126` fit and
+  `35/63` sealed exact records and stopped before Rust/checkpoint/development/
+  product; do not retry it. The next proposal is separately frozen paired-query
+  conditional binding over the same exact source. CUDA and external GPU
+  execution are out of scope.
   Intrinsic/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and
   exact deployment are parked. D3 remains `NOT_RUN`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,10 +210,17 @@ The experiment must be able to change the next programme decision:
   opt-in, loopback-only dedicated native HTTP endpoint now pass. Dashboard
   wiring/readiness and static/WASM-isolation checks pass, but hosted Pages is
   static/offline without a functioning chat backend/artifact lowering. The Q16
-  suffix trace student is complete and `R4SoftmaxTraceStateStudentV1` is active.
+  suffix trace student, `R4SoftmaxTraceStateStudentV1`, and observability rung
+  are complete bounded negatives. #1014 established load-bearing ordinary
+  attention and #1017 remains the working bounded generator. #954 C1-SB4's
+  full-source record-margin successor failed at `70/126` fit and `35/63` sealed
+  exact records; it stopped before Rust/checkpoint/product and must not be
+  retried. Its next proposal is separately frozen paired-query conditional
+  binding over one exact source.
   Intrinsic/readout alternatives, resonance-based softmax replacement,
-  full-model recurrent lowering, and exact deployment are parked; GI-4/#954
-  remains blocked, with GI-5/#955 downstream.
+  full-model recurrent lowering, and exact deployment are parked; #973 still
+  blocks GI-4/#954's final source-free terminal, with GI-5/#955 downstream of
+  positive correctness.
 - **Exercise the accepted route path.** #953 geometry runs before token choice
   and emits admitted support and its fixed-point radius trace. The completed
   #973 localization kept its frozen split, trace identity, score-paired common
@@ -243,16 +250,18 @@ The experiment must be able to change the next programme decision:
   loopback-only dedicated native HTTP canary through the identical policy also
   passes. Dashboard wiring/readiness and static/WASM-isolation checks pass, but
   hosted Pages is static/offline without a functioning chat backend/artifact
-  lowering. The smallest current falsifier is whether
-  `R4SoftmaxTraceStateStudentV1` can compile construction traces into recurrent
-  source-free R4/Spin state that beats its frozen controls without looping.
+  lowering. The smallest current source-backed correctness falsifier is a newly
+  frozen paired-query conditional-binding mechanism that requires the same
+  candidate to change sign under same-source query relocation. C1-SB4 itself is
+  closed negative and cannot be retried.
   Pinned-source provenance, donor reproduction, and transported-R4 parity are
   recorded in `docs/helm_d_r4_softmax_decoder_973.md`; V1 and V2 outcomes are in
   `docs/intrinsic_lorentz_r4_attention_973.md` and
   `docs/helm_d_learned_manifold_r4_construction_973.md`, with localization in
   `docs/helm_d_score_centroid_localization_973.md`. Intrinsic/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
-  lowering, and exact deployment are parked; #954 remains blocked.
+  lowering, and exact deployment are parked; #954's final source-free terminal
+  remains blocked by #973.
   The PASS does not establish geometry advantage, softmax removal,
   source-free/table-native serving, correctness, reasoning, frontier quality,
   release readiness, or a static-WASM decoder.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,19 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > conflict `18/21`), with copies `19/21`. Rust parity, the sole full fit,
 > development, and the four committed but unopened product probes are
 > `NOT_RUN`; no final adapter exists. Do not tune or retry this
-> independent-candidate BCE adapter. The next proposed #954 mechanism is an
-> independently frozen joint-source candidate-set representation with a
-> record-level structured-margin objective through attention, retaining
-> exact-source-copy and typed-nonanswer semantics.
+> independent-candidate BCE adapter. C1-SB4
+> `R4JointCandidateMarginAdapterV1` then executed its independently frozen
+> full-source, record-level structured-margin run. All positive groups were
+> recovered, but negative specificity was only `394/478` fit and `197/239`
+> sealed; exact records were `70/126` and `35/63`, and same-source query
+> relocation was not exact. It stopped before Rust parity, checkpoint,
+> development, or its four committed unopened products. Do not retry C1-SB4.
+> A question-ignoring rule that marks text containing ` is inside ` as
+> supported reproduces every published C1-SB4 aggregate exactly; per-row model
+> scores were not retained, so this is aggregate-equivalent shortcut evidence,
+> not a claim about the model's internal computation.
+> The next proposal is a separately frozen paired-query conditional-binding
+> objective over the same exact source.
 > #954's final source-free terminal remains blocked behind #973, and #955
 > remains blocked behind #954.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
@@ -102,8 +111,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > [#1019 signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json),
 > [#1014 record](docs/r4_softmax_end_to_end_attention_1014.md) and
 > [structured aggregate](docs/r4_softmax_end_to_end_attention_1014_raw.json),
-> plus the [#954 correctness campaign](docs/r4_grounded_correctness_954.md) and
-> [corrected C1-SB3 aggregate](docs/r4_attended_relation_adapter_954_raw.json).
+> plus the [#954 correctness campaign](docs/r4_grounded_correctness_954.md),
+> [corrected C1-SB3 aggregate](docs/r4_attended_relation_adapter_954_raw.json),
+> and [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json).
 >
 > The completed #1017 checkpoint is the current working 7.15M
 > coherent-generation prototype. If its local export exists, run it directly
@@ -259,9 +269,12 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > rank-eight all-layer Q/K/V/O adapter then changed only the 24 attention
 > tensors and improved sealed positive recall from `0/76` to `73/76`, but it
 > missed the exact fit/sealed gates (`124/126`, `56/63`) and stopped before
-> parity, full fitting, development, or its unopened product reveal. The next
-> proposal is a jointly encoded candidate-set representation with a record-level
-> structured margin through attention. #954's final source-free terminal remains
+> parity, full fitting, development, or its unopened product reveal. C1-SB4's
+> full-source structured-margin successor then failed at `70/126` fit and
+> `35/63` sealed exact records, with perfect positive-group recall but only
+> `82.43%` negative specificity. Rust/checkpoint/development/product stayed
+> `NOT_RUN`; do not retry it. The next proposal is separately frozen
+> paired-query conditional binding. #954's final source-free terminal remains
 > blocked behind #973, and #955 remains blocked behind #954.
 > The trace/compiler rung
 > that followed that checkpoint is now complete: `R4SoftmaxTeacherTraceV1`
@@ -293,9 +306,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > C1-SB3's no-head, fixed-verbalizer rank-eight Q/K/V/O adapter established
 > bounded representation transfer but failed its exact gate at fit `124/126`
 > and sealed `56/63`; parity/full fit/development/product remain `NOT_RUN`.
-> The next proposal is an independently frozen joint-source candidate-set
-> representation with a record-level structured-margin objective through
-> attention while retaining exact-copy/typed-nonanswer behavior.
+> C1-SB4's independently frozen full-source structured-margin successor then
+> failed at `70/126` fit and `35/63` sealed exact records and stopped before
+> Rust/checkpoint/development/product. Do not retry it. The next proposal is
+> paired-query conditional binding over one shared exact source under a new
+> freeze.
 > CUDA and external GPU execution are out of scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
@@ -382,9 +397,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > full fit, development, or product reveal, and emitted no final head. C1-SB3's
 > rank-eight all-layer Q/K/V/O adapter then improved sealed positive recall from
 > `0/76` to `73/76` with no non-attention changes, but failed its exact outcome
-> gate at fit `124/126` and sealed `56/63`; later stages remain `NOT_RUN`. The
-> next proposal is joint-source candidate-set encoding with a record-level
-> structured margin through attention. CUDA and
+> gate at fit `124/126` and sealed `56/63`; later stages remain `NOT_RUN`.
+> C1-SB4's full-source record-margin successor then failed at `70/126` fit and
+> `35/63` sealed exact records. Rust/checkpoint/development/product remain
+> `NOT_RUN`; do not retry it. The next proposal is separately frozen
+> paired-query conditional binding. CUDA and
 > external GPU execution are out of scope. #954's final source-free terminal
 > remains blocked behind #973, and #955 remains blocked behind #954.
 > See the
@@ -455,8 +472,10 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > before Rust parity/full fit/development/product and emitted no final head.
 > C1-SB3 then showed bounded attention-representation transfer but missed its
 > exact preflight (`124/126` fit outcomes; `56/63` sealed), so parity/full fit/
-> development/product remain `NOT_RUN`. The next frozen mechanism is a
-> joint-source candidate-set structured-margin objective through attention. The
+> development/product remain `NOT_RUN`. C1-SB4's independently frozen
+> full-source structured-margin arm then failed at `70/126` fit and `35/63`
+> sealed exact records; no Rust/checkpoint/product followed and no retry is
+> authorized. The next proposal is paired-query conditional binding. The
 > final source-free terminal remains blocked behind #973, and #955 remains
 > blocked behind #954.
 > See the
@@ -536,9 +555,11 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > all-layer Q/K/V/O adapter changed only attention tensors and transferred most
 > sealed relations (`73/76` positive, `234/239` negative), but missed the exact
 > fit/sealed outcome gates (`124/126`, `56/63`) and stopped before all later
-> stages. The next proposal jointly encodes the source candidate set and trains
-> a record-level structured margin through attention while retaining
-> exact-copy/typed-nonanswer behavior. CUDA and external GPU execution
+> stages. C1-SB4's full-source structured-margin successor then recovered every
+> positive group but only `82.43%` of negative groups, yielding `70/126` fit and
+> `35/63` sealed exact records. Rust/checkpoint/development/product are
+> `NOT_RUN`; do not retry it. The next proposal is separately frozen
+> paired-query conditional binding. CUDA and external GPU execution
 > are out of scope. #954's final source-free terminal remains blocked behind
 > #973, and #955 remains blocked behind #954. General higher-scope attention,
 > correct answers, and reasoning do not exist yet. The
@@ -629,16 +650,22 @@ qualified answer mechanism: fit outcomes were `124/126`; sealed outcomes were
 `56/63` (answer `19/21`, abstain `19/21`, conflict `18/21`), and supported
 copies were `19/21`. The exact gate stopped Rust parity, the sole full fit,
 development, and all four committed but unopened product probes as `NOT_RUN`.
-Do not tune or retry this independent-candidate BCE adapter. The next proposed
-#954 mechanism independently freezes a joint-source candidate-set
-representation with a record-level structured-margin objective through
-attention, retaining exact-source-copy and typed-nonanswer semantics. #954's final
+Do not tune or retry this independent-candidate BCE adapter. C1-SB4 then ran
+the independently frozen full-source, record-level structured-margin
+representation. It recovered `126/126` fit and `63/63` sealed positive groups,
+but rejected only `394/478` and `197/239` negatives. Exact records were
+`70/126` fit and `35/63` sealed; same-source query relocation was not exact.
+Rust parity, checkpoint emission, development, and product remained `NOT_RUN`.
+Do not tune or retry C1-SB4. The next proposal is separately frozen
+paired-query conditional binding over the same exact source. #954's final
 source-free terminal remains blocked behind #973, and #955 remains blocked
 behind #954. See the
 [#954 record](docs/r4_grounded_correctness_954.md) and
 [C1-SB0 structured result](docs/r4_grounded_correctness_954_raw.json) plus the
 [C1-SB1 pointer result](docs/r4_source_span_pointer_954_raw.json) and
-[C1-SB2 relation result](docs/r4_source_relation_head_954_raw.json).
+[C1-SB2 relation result](docs/r4_source_relation_head_954_raw.json), the
+[corrected C1-SB3 result](docs/r4_attended_relation_adapter_954_raw.json), and
+[C1-SB4 result](docs/r4_joint_candidate_margin_954_raw.json).
 
 On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
 machine's Accelerate framework:
@@ -903,9 +930,11 @@ exact-descriptor/entity-binding path selector apiece at their respective
    parity/full fit/development/product and emitted no final head. C1-SB3's
    rank-eight all-layer Q/K/V/O adapter showed bounded transfer (`0/76` to
    `73/76` sealed positive recall) but failed exact outcomes at fit `124/126`
-   and sealed `56/63`; parity/full fit/development/product are `NOT_RUN`. The
-   next proposal is joint-source candidate-set encoding with a record-level
-   structured margin through attention. CUDA and
+   and sealed `56/63`; parity/full fit/development/product are `NOT_RUN`.
+   C1-SB4's full-source structured-margin successor then failed at `70/126` fit
+   and `35/63` sealed exact records and stopped before Rust/checkpoint/product;
+   do not retry it. The next proposal is separately frozen paired-query
+   conditional binding. CUDA and
    external GPU execution are out of scope. #954's final source-free terminal
    stays blocked behind #973, and #955 remains blocked behind #954.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
@@ -1060,9 +1089,10 @@ not become substitutes for working intelligence:
    before Rust parity/full fit/development/product and emitted no final head.
    C1-SB3's rank-eight all-layer Q/K/V/O adapter changed only attention tensors
    and transferred most sealed relations, but failed exact fit/sealed outcomes
-   (`124/126`, `56/63`); all later stages are `NOT_RUN`. The next proposal is a
-   joint-source candidate-set representation with a record-level structured
-   margin through attention. CUDA and
+   (`124/126`, `56/63`); all later stages are `NOT_RUN`. C1-SB4's full-source
+   record-margin successor then failed at `70/126` fit and `35/63` sealed exact
+   records and stopped before Rust/checkpoint/product; do not retry it. The
+   next proposal is separately frozen paired-query conditional binding. CUDA and
    external GPU execution are out of scope.
    Do not resume resonance substitutes. Product development continues through
    `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
@@ -1134,9 +1164,12 @@ matched-transfer preflight before Rust parity/full fit/development/product and
 emitted no final head. C1-SB3's rank-eight all-layer Q/K/V/O adapter produced
 bounded representation transfer but failed exact fit/sealed outcomes at
 `124/126` and `56/63`; parity/full fit/development and the unopened product
-population are `NOT_RUN`. The next proposal is a joint-source candidate-set
-representation with a record-level structured-margin objective through
-attention, retaining exact-copy/typed-nonanswer behavior. CUDA and external GPU execution are out of
+population are `NOT_RUN`. C1-SB4's independently frozen full-source
+structured-margin successor then failed at `70/126` fit and `35/63` sealed
+exact records, with perfect positive-group recall but only `82.43%` negative
+specificity. Rust/checkpoint/development/product are `NOT_RUN`; do not retry
+it. The next proposal is separately frozen paired-query conditional binding.
+CUDA and external GPU execution are out of
 scope. #954's final source-free terminal remains blocked behind #973, and #955
 remains blocked behind #954. The exact contract is
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,10 +110,14 @@ executed. Its construction fit passed `12/12` positive decisions, `20/20`
 negative labels, and `6/6` supported copies, but sealed transfer reached only
 `5/12`, `14/20`, and `0/6`; every semantic control except candidate order
 failed. It stopped before Python/Rust parity, the full fit, development, or
-product reveal, and emitted no final head. The next proposed mechanism is an
-independently frozen representation-trained or joint relation mechanism through
-the existing R4/Spin attention path, retaining the Rust exact-copy and typed
-non-answer seam. #954 remains open, #955 remains blocked, and #954's final
+product reveal, and emitted no final head. C1-SB3 then produced bounded
+attention-representation transfer but missed its exact gate. C1-SB4's
+independently frozen full-source record-margin successor reached only `70/126`
+fit and `35/63` sealed exact records; it stopped before Rust/checkpoint/
+development/product and must not be retried. A question-ignoring ` is inside `
+rule reproduces every aggregate count exactly. The next proposal is separately
+frozen paired-query conditional binding over one exact source. #954 remains
+open, #955 remains blocked, and #954's final
 source-free terminal remains behind #973. CUDA and
 external GPU execution are out of scope.
 Further 7.15M exposure and learning-rate tuning are prohibited. See the
@@ -198,9 +202,11 @@ The completed continuation and its NLL-only negative are in
 > `12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer fell
 > to `5/12`, `14/20`, and `0/6`; only candidate order survived the semantic
 > controls. It stopped before parity, full fit, development, or product reveal
-> and emitted no final head. The next proposal is a representation-trained or
-> joint relation mechanism through the existing R4/Spin attention path while
-> retaining Rust exact-copy and typed non-answer behavior.
+> and emitted no final head. C1-SB3 then transferred most relations through
+> attention but missed exact promotion. C1-SB4's full-source record-margin
+> successor failed at `70/126` fit and `35/63` sealed exact records and stopped
+> before Rust/checkpoint/product; do not retry it. The next proposal is
+> separately frozen paired-query conditional binding.
 > CUDA and external GPU execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
@@ -296,10 +302,11 @@ emitted and product probes were `NOT_RUN`; the independently frozen
 `12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer reached
 only `5/12`, `14/20`, and `0/6`; every semantic control except candidate order
 failed, so parity, full fit, development, and product reveal were not run and
-no final head was emitted; **Proposed next:** independently freeze a
-representation-trained or joint relation mechanism through the existing
-R4/Spin attention path while preserving the Rust exact-copy and typed
-non-answer seam;
+no final head was emitted; C1-SB3 produced bounded transfer but failed exact
+promotion; C1-SB4's full-source record-margin successor failed at `70/126` fit
+and `35/63` sealed exact records and stopped before Rust/checkpoint/product;
+**Proposed next:** independently freeze paired-query conditional binding over
+one exact source while preserving the Rust exact-copy and typed non-answer seam;
 CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
@@ -345,9 +352,12 @@ frozen and executed: construction fit passed at `12/12` positive, `20/20`
 negative, and `6/6` copy, while sealed transfer failed at `5/12`, `14/20`, and
 `0/6`. Every semantic control except candidate order failed, so the campaign
 stopped before parity, full fit, development, and product reveal with no final
-head. The new proposal is an independently frozen representation-trained or
-joint relation mechanism through the existing R4/Spin attention path, retaining
-Rust exact-copy and typed non-answer behavior. #954 remains open, #955 remains
+head. C1-SB3 then produced bounded attention-representation transfer but missed
+its exact gate. C1-SB4's full-source record-margin successor failed at
+`70/126` fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
+product; do not retry it. The new proposal is independently frozen paired-query
+conditional binding over one exact source, retaining Rust exact-copy and typed
+non-answer behavior. #954 remains open, #955 remains
 blocked, and the final source-free terminal remains behind #973. CUDA and
 external GPU execution are out of scope.
 Intrinsic/resonance/replacement work is
@@ -630,10 +640,12 @@ feasibility boundary remains in the
    no final head. CUDA and external GPU execution are out of scope.
    Intrinsic score/readout alternatives, paired-E8, resonance-based softmax
    replacement, and exact deployment are parked; #954's final source-free
-   terminal remains behind #973. The next proposed mechanism is an independently
-   frozen representation-trained or joint relation mechanism through the
-   existing R4/Spin attention path, retaining the Rust exact-copy and typed
-   non-answer seam. #954 remains open and #955 remains blocked.
+   terminal remains behind #973. C1-SB3 produced bounded transfer but missed
+   exact promotion; C1-SB4's full-source record-margin successor failed at
+   `70/126` fit and `35/63` sealed exact records and stopped before Rust/
+   checkpoint/product. Do not retry it. The next proposal is independently
+   frozen paired-query conditional binding over one exact source, retaining the
+   Rust exact-copy and typed non-answer seam. #954 remains open and #955 remains blocked.
    Every learned epoch receives a
    new kappa and reruns its owning
    construction gate. More documents, table density, or trace activity are
@@ -649,9 +661,12 @@ feasibility boundary remains in the
    successor then fit construction at `12/12` positive, `20/20` negative, and
    `6/6` copy, but its sealed transfer was `5/12`, `14/20`, and `0/6`; every
    semantic control except candidate order failed. It stopped before parity,
-   full fit, development, or product reveal and emitted no final head. The next
-   proposal is an independently frozen representation-trained or joint relation
-   mechanism through the existing R4/Spin attention path, retaining Rust
+   full fit, development, or product reveal and emitted no final head. C1-SB3
+   then transferred most relations through attention but missed exact
+   promotion. C1-SB4's full-source record-margin successor failed at `70/126`
+   fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
+   product; do not retry it. The next proposal is independently frozen
+   paired-query conditional binding over one exact source, retaining Rust
    exact-copy and typed non-answer behavior.
    The final source-free terminal still requires the accepted
    selector/#953/#973 artifact and evidence provenance #969 → #983 → #986;
@@ -738,8 +753,8 @@ historical evidence and comparators.
 
 ## Active
 
-- [ ] **#954 grounded correctness: representation-trained or joint relation
-  successor after the source-relative transfer failure** — retain the
+- [ ] **#954 grounded correctness: paired-query conditional binding after the
+  full-source structured-margin shortcut** — retain the
   bounded positives, #997 placement negative, bounded gated-delta negative, V2
   budget invalidation, equal-manifold-budget V3 mixed-gauge H4 negative, and
   V4's held-out 13/24 functional/control negative. The positive attention
@@ -794,14 +809,19 @@ historical evidence and comparators.
   `12/12` positive, `20/20` negative, and `6/6` copy, but sealed transfer reached
   only `5/12`, `14/20`, and `0/6`; every semantic control except candidate
   order failed. It stopped before Python/Rust parity, the full fit, development,
-  or product reveal and emitted no final head. The next proposed mechanism is
-  an independently frozen representation-trained or joint relation mechanism
-  through the existing R4/Spin attention path, retaining the Rust exact-copy
-  and typed non-answer seam. No product wiring is active. Apple
+  or product reveal and emitted no final head. C1-SB3 then produced bounded
+  attention-representation transfer but missed exact promotion. C1-SB4's
+  independently frozen full-source record-margin successor failed at `70/126`
+  fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
+  product; no retry is authorized. The next proposal is independently frozen
+  paired-query conditional binding over one exact source, retaining the Rust
+  exact-copy and typed non-answer seam. No product wiring is active. Apple
   Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
   external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
-  [signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
+  [signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json),
+  then the [#954 record](docs/r4_grounded_correctness_954.md) and
+  [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json).
   Do not extend
   exposure or tune learning rate on the 7.15M checkpoint. Intrinsic score/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
@@ -965,9 +985,12 @@ historical evidence and comparators.
   then passed construction fit at `12/12` positive, `20/20` negative, and
   `6/6` copy but failed sealed transfer at `5/12`, `14/20`, and `0/6`; every
   semantic control except candidate order failed. It stopped before parity,
-  full fit, development, or product reveal and emitted no final head. The next
-  proposal is an independently frozen representation-trained or joint relation
-  mechanism through the existing R4/Spin attention path, retaining Rust
+  full fit, development, or product reveal and emitted no final head. C1-SB3
+  then produced bounded attention-representation transfer but missed exact
+  promotion. C1-SB4's full-source record-margin successor failed at `70/126`
+  fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
+  product; do not retry it. The next proposal is independently frozen
+  paired-query conditional binding over one exact source, retaining Rust
   exact-copy and typed non-answer behavior.
   CUDA and external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -145,6 +145,21 @@ attention or coherent generation. See the
 [C1-SB2 aggregate](r4_source_relation_head_954_raw.json), followed by the
 [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json).
 
+C1-SB4 `R4JointCandidateMarginAdapterV1` then scored each candidate from the
+complete source and question and trained the independently frozen record-level
+structured margin for 270 MPS updates. Every positive group transferred, but
+negative specificity was only `394/478` fit and `197/239` sealed. Exact records
+were `70/126` and `35/63`; answer and abstain were one-third exact, conflicts
+were exact, and same-source query relocation was not. All 24 attention targets
+changed with no non-attention change. Terminal
+`FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT` stopped Rust parity, checkpoint
+emission, development, and the four committed unopened products as `NOT_RUN`.
+Do not tune or retry it. A question-ignoring ` is inside ` rule reproduces every
+published aggregate count exactly; per-row scores were not retained, so this is
+aggregate-equivalent shortcut evidence rather than an internal-mechanism claim.
+See the
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+
 The #1017 export remains the current working 7.15M coherent-generation
 prototype. `r4 generate --prompt "..."` defaults to
 `.uor-models/research/issue-1017/export`. #1019 is an optional quality-capacity
@@ -160,10 +175,10 @@ table-native, multiply-free, transformerless, browser-WASM, release, or
 frontier-model evidence.
 Intrinsic/readout alternatives, multi-resonance softmax replacement, full-model
 recurrent lowering, and exact H4/Q29/integer-table deployment are parked. #954
-remains open. Do not tune or retry the C1-SB3 independent-candidate BCE
-adapter. Its next proposed mechanism is an independently frozen joint-source
-candidate-set representation with a record-level structured-margin objective
-through attention while retaining the exact-copy and typed non-answer Rust
+remains open. Do not tune or retry the C1-SB3 or C1-SB4 adapters. The next
+proposal is a separately frozen paired-query conditional-binding objective:
+multiple questions share one exact source and the same candidate must change
+sign with the queried subject. Retain the exact-copy and typed non-answer Rust
 seam. #955 remains blocked on a positive
 correctness result, and #954's final source-free terminal remains blocked behind
 #973. Validation,
@@ -198,6 +213,10 @@ rank-eight all-layer Q/K/V/O adaptation, base-to-trained sealed positive recall
 tensors changed and no non-attention tensors changed, but exact fit outcomes
 `124/126`, sealed outcomes `56/63`, copies `19/21`, and Rust parity/full fit/
 development/product `NOT_RUN`;
+#954 C1-SB4 full-source record-level structured margin, `70/126` fit and
+`35/63` sealed exact records, positive groups `126/126` and `63/63`, negative
+groups `394/478` and `197/239`, all 24 attention tensors changed with no
+non-attention change, and Rust/checkpoint/development/product `NOT_RUN`;
 resonance replacement `NOT_RUN` and parked; full-model recurrent and
 exact lowering parked. See
 [`helm_d_r4_softmax_decoder_973.md`](helm_d_r4_softmax_decoder_973.md) and
@@ -206,7 +225,8 @@ then [`r4_softmax_trace_student_973.md`](r4_softmax_trace_student_973.md) and
 [`r4_softmax_trace_observability_1012.md`](r4_softmax_trace_observability_1012.md),
 followed by [`r4_softmax_quality_capacity_continuation_1017.md`](r4_softmax_quality_capacity_continuation_1017.md),
 [`r4_grounded_correctness_954.md`](r4_grounded_correctness_954.md), and
-[`r4_source_relation_head_954_raw.json`](r4_source_relation_head_954_raw.json).
+[`r4_source_relation_head_954_raw.json`](r4_source_relation_head_954_raw.json),
+then [`r4_joint_candidate_margin_954_raw.json`](r4_joint_candidate_margin_954_raw.json).
 
 ## Current route-native target lifecycle
 
@@ -253,7 +273,8 @@ canonical text/corpus
     -> cosine source-span pointer [#954 C1-SB1; DEVELOPMENT FAIL, NO FINAL HEAD]
     -> terminal-residual relation head [#954 C1-SB2; MATCHED-TRANSFER PREFLIGHT FAIL, NO FINAL HEAD]
     -> rank-8 all-layer Q/K/V/O relation adapter, fixed yes/no verbalizer, no head [#954 C1-SB3; BOUNDED TRANSFER, EXACT PREFLIGHT FAIL]
-    -> joint-source candidate-set representation + record-level structured margin through attention [#954; PROPOSED]
+    -> joint-source candidate-set representation + record-level structured margin through attention [#954 C1-SB4; EXACT PREFLIGHT FAIL, NO RUST/ARTIFACT]
+    -> paired-query conditional binding over one exact source [#954; PROPOSED, REQUIRES INDEPENDENT FREEZE]
     -> final source-free correctness terminal [#954; BLOCKED BEHIND #973]
     -> bounded reasoning [#955; BLOCKED ON POSITIVE CORRECTNESS]
     -> durable isolated CLI/HTTP chat + persisted hive memory (#962)
@@ -1635,9 +1656,12 @@ D3 on construction covariance, with diagnostic curved NLL worse than donor and
   tensors changed. It failed exact fit/sealed outcomes at `124/126` and `56/63`
   with copies `19/21`; Rust parity/full fit/development/product are `NOT_RUN`,
   and the committed product population stayed unopened. Do not tune or retry
-  that independent-candidate BCE adapter. The active proposed #954 step is an
-  independently frozen joint-source candidate-set representation with a
-  record-level structured-margin objective through attention, preserving the
+  that independent-candidate BCE adapter. C1-SB4's independently frozen
+  full-source record-margin successor then failed at `70/126` fit and `35/63`
+  sealed exact records despite exact positive-group recall; negative specificity
+  was `394/478` and `197/239`. It stopped before Rust/checkpoint/development/
+  product and must not be retried. The active proposal is separately frozen
+  paired-query conditional binding over the same exact source, preserving the
   exact-copy and typed non-answer Rust seam. CUDA and external GPU execution are out of scope.
   Further exposure and LR tuning of the 7.15M checkpoint are prohibited.
   Resonance substitutes, unrelated optimization, and release work

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,8 +130,21 @@ improvement and does not block using or productizing that bounded path. The
 the strict NLL target; it is not geometry advantage, transformerlessness,
 correctness, reasoning, frontier quality, browser/WASM readiness, or release
 readiness.
+
+#954's source-backed correctness campaign has now completed through C1-SB4.
+The independently frozen full-source, record-level structured-margin adapter
+recovered every positive group but reached only `70/126` fit and `35/63` sealed
+exact records, with negative specificity `394/478` and `197/239`. A
+question-ignoring ` is inside ` rule reproduces every aggregate count exactly.
+The run stopped before Rust parity, checkpoint emission, development, or its
+four committed unopened products; do not retry C1-SB4. The next proposal is
+separately frozen paired-query conditional binding over one exact source. See
+the [#954 record](r4_grounded_correctness_954.md) and
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+
 No tag, release, hosted promotion, or static-WASM claim is authorized. D3
-remains `NOT_RUN`; #973 remains open and #954 remains blocked.
+remains `NOT_RUN`; #973 remains open and continues to block #954's final
+source-free terminal. #955 remains blocked on positive correctness.
 
 Pinned-source provenance, ordinary-donor reproduction, transported-R4 parity,
 the frame-permutation control, and the causal audit now pass; see the
@@ -160,6 +173,10 @@ Choose the shortest path that matches what you need:
   [ADR-0005](adr/0005-predictive-geometric-connection-memory.md), then
   [ADR-0004](adr/0004-geometric-intelligence-route-hierarchy.md), and use the
   [glossary](transformerless/GLOSSARY.md) for unfamiliar terms.
+- **Advance grounded correctness:** start from the append-only
+  [#954 record](r4_grounded_correctness_954.md). C1-SB4 is a frozen negative;
+  the current proposal is a new paired-query conditional-binding mechanism,
+  not an SB4 retry.
 - **Improve the optional capacity rung:** start from live
   [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019) under #973 and
   programme root #820. Its population/smoke/random-export parity gates passed,

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -173,16 +173,24 @@ assumptions, or objectives rather than measured results.
 > outcomes `124/126`; sealed outcomes `56/63` (answer `19/21`, abstain `19/21`,
 > conflict `18/21`); supported copies `19/21`. Rust parity, the sole full fit,
 > development, and the four committed but unopened product probes are
-> `NOT_RUN`. Do not tune or retry this independent-candidate BCE adapter. The
-> next proposed mechanism is an independently frozen joint-source candidate-set
-> representation with a record-level structured-margin objective through
-> attention while preserving the exact-copy and typed non-answer Rust seam.
+> `NOT_RUN`. Do not tune or retry this independent-candidate BCE adapter.
+> C1-SB4 then executed the independently frozen full-source, record-level
+> structured-margin successor. Positive groups were exact, but negative
+> specificity was `394/478` fit and `197/239` sealed; exact records were
+> `70/126` and `35/63`, and same-source query relocation was not exact. All 24
+> attention targets changed with no non-attention change. It stopped before
+> Rust/checkpoint/development/product and must not be retried. The next proposal
+> is separately frozen paired-query conditional binding over one exact source.
+> A question-ignoring ` is inside ` rule reproduces every published aggregate
+> count exactly; because per-row model scores were not retained, this is
+> aggregate-equivalent shortcut evidence rather than an internal-mechanism claim.
 > #955 remains blocked on a
 > positive correctness result, and #954's final source-free terminal remains
 > blocked behind #973. CUDA and external GPU execution are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json),
-> [#954 correctness campaign](r4_grounded_correctness_954.md), and
-> [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json).
+> [#954 correctness campaign](r4_grounded_correctness_954.md),
+> [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json), and
+> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
 > the deployed destination remains exact and source-free. Resonance substitutes
@@ -195,8 +203,9 @@ assumptions, or objectives rather than measured results.
 > [#1012 observability record](r4_softmax_trace_observability_1012.md), and
 > [#1014 end-to-end record](r4_softmax_end_to_end_attention_1014.md), then the
 > [#1017 continuation record](r4_softmax_quality_capacity_continuation_1017.md),
-> the [#954 campaign record](r4_grounded_correctness_954.md), and the
-> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json).
+> the [#954 campaign record](r4_grounded_correctness_954.md),
+> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json), and
+> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 >
 > **Measured evidence status:** HELM-D pinned-source provenance `PASS`;
 > ordinary-donor reproduction `PASS`; transported-R4 parity, destructive
@@ -239,6 +248,11 @@ assumptions, or objectives rather than measured results.
 > attention tensors changed and no non-attention tensors changed, but exact fit
 > outcomes `124/126`, sealed outcomes `56/63`, copies `19/21`, and Rust
 > parity/full fit/development/product `NOT_RUN`;
+> #954 C1-SB4 `FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT`, with exact records
+> `70/126` fit and `35/63` sealed, positive groups `126/126` and `63/63`,
+> negative specificity `394/478` and `197/239`, all 24 attention targets changed
+> and no non-attention change, Rust/checkpoint/development/product `NOT_RUN`,
+> and products unopened;
 > D3 `NOT_RUN`; multi-resonance replacement `NOT_RUN` and parked; whole-decoder
 > recurrent factorization/lowering `NOT_RUN` and parked. See the
 > [`HELM-D-R4` record](helm_d_r4_softmax_decoder_973.md) and the
@@ -616,16 +630,19 @@ assumptions, or objectives rather than measured results.
 > sealed outcome gates at `124/126` and `56/63`. Rust parity/full fit/
 > development/product are `NOT_RUN`; the committed product text stayed
 > unopened. #954 remains open. Do not tune or retry this independent-candidate
-> BCE adapter. The next proposed mechanism jointly encodes the source candidate
-> set and trains a record-level structured margin through attention while
-> retaining the exact-copy and typed non-answer Rust seam. CUDA
+> BCE adapter. C1-SB4's full-source record-margin successor then failed at
+> `70/126` fit and `35/63` sealed exact records, with positive groups exact but
+> negative specificity only `394/478` and `197/239`. Rust/checkpoint/
+> development/product are `NOT_RUN`; do not retry it. The next proposal is
+> separately frozen paired-query conditional binding. CUDA
 > and external GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
 > exact deployment are parked. D3 remains `NOT_RUN`; #954's final source-free
 > terminal remains blocked behind #973, and #955 remains blocked on a positive
-> correctness result. See the [#954 campaign record](r4_grounded_correctness_954.md)
-> and [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json).
+> correctness result. See the [#954 campaign record](r4_grounded_correctness_954.md),
+> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json), and
+> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 > Legacy
 > tracker #949 is closed as superseded, and #958 is retained directly beneath
 > #820 as GI-0 foundation. Two
@@ -1163,10 +1180,13 @@ positive recall rose from base `0/76` to trained `73/76`, negative specificity
 was `234/239`, and only the 24 attention tensors changed—but failed its exact
 fit/sealed outcome gates (`124/126`, `56/63`) and supported copies (`19/21`).
 Rust parity, full fitting, development, and the unopened product reveal are
-`NOT_RUN`. Do not tune or retry this independent-candidate BCE adapter. The next
-proposal is an independently frozen joint-source candidate-set representation
-with a record-level structured-margin objective through attention, retaining
-the exact-copy and typed non-answer Rust seam. #955 remains blocked, and #954's
+`NOT_RUN`. Do not tune or retry this independent-candidate BCE adapter. C1-SB4
+then ran the independently frozen full-source, record-level structured-margin
+successor and failed at `70/126` fit and `35/63` sealed exact records. Positive
+groups were exact; negative specificity was `394/478` and `197/239`, and
+same-source query relocation was not exact. It stopped before Rust/checkpoint/
+development/product and must not be retried. The next proposal is separately
+frozen paired-query conditional binding over one exact source. #955 remains blocked, and #954's
 final source-free terminal remains behind #973.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
@@ -1249,12 +1269,16 @@ still missed the exact gate at fit outcomes `124/126`, sealed outcomes `56/63`
 (answer `19/21`, abstain `19/21`, conflict `18/21`), and copies `19/21`.
 Rust parity/full fit/development and all four committed but unopened product
 probes are `NOT_RUN`. Do not tune or retry this independent-candidate BCE
-adapter. The next proposed #954 mechanism jointly encodes the source candidate
-set and trains a record-level structured margin through attention, retaining
-deterministic exact copy and typed non-answer output.
+adapter. C1-SB4's independently frozen full-source record-margin successor then
+failed at `70/126` fit and `35/63` sealed exact records, despite exact positive
+groups; negative specificity was `394/478` and `197/239`. Rust/checkpoint/
+development/product remain `NOT_RUN`, and no retry is authorized. The next
+proposal is paired-query conditional binding over the same source under a new
+independent freeze, retaining deterministic exact copy and typed non-answer output.
 #954 remains open; #955 remains blocked, and the final source-free #954 terminal
-remains behind #973. See the [campaign record](r4_grounded_correctness_954.md)
-and [compact aggregate](r4_source_relation_head_954_raw.json).
+remains behind #973. See the [campaign record](r4_grounded_correctness_954.md),
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json), and
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 CUDA and external GPU execution remain out of scope. Fiber-preserving
 multi-resonance replacement, whole-decoder recurrent factorization, capacity
 expansion, and final source-free requalification are parked. Dependable broad
@@ -1877,13 +1901,17 @@ requalification are parked. D3 remains `NOT_RUN`; #954 remains open, with its
 no-head rank-eight all-layer Q/K/V/O C1-SB3 adapter retained as bounded
 mechanistic transfer evidence but rejected at the exact gate (`124/126` fit,
 `56/63` sealed). Rust parity/full fit/development/product are `NOT_RUN`. Do not
-tune or retry that independent-candidate BCE adapter. The next proposed
-mechanism is an independently frozen joint-source candidate-set representation
-with a record-level structured-margin objective through attention while
-preserving exact-copy and typed non-answer Rust behavior. Its final source-free terminal remains blocked behind
+tune or retry that independent-candidate BCE adapter. C1-SB4's full-source
+record-margin successor then failed at `70/126` fit and `35/63` sealed exact
+records; positive groups were exact, but negative specificity was `394/478`
+and `197/239`. It stopped before Rust/checkpoint/development/product and must
+not be retried. The next proposal is separately frozen paired-query
+conditional binding while preserving exact-copy and typed non-answer Rust
+behavior. Its final source-free terminal remains blocked behind
 #973, and #955 remains blocked on a positive correctness result. See the
-[#954 campaign record](r4_grounded_correctness_954.md) and
-[C1-SB2 aggregate](r4_source_relation_head_954_raw.json).
+[#954 campaign record](r4_grounded_correctness_954.md),
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json), and
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/r4_grounded_correctness_954.md
+++ b/docs/r4_grounded_correctness_954.md
@@ -1,6 +1,6 @@
 # Source-backed grounded answer campaigns (#954)
 
-Status: **C1-SB3 MECHANISM TRANSFER POSITIVE / EXACT PROMOTION NEGATIVE / NO QUALIFIED ANSWER ARTIFACT**
+Status: **C1-SB4 JOINT-CANDIDATE PREFLIGHT NEGATIVE / NO QUALIFIED ANSWER ARTIFACT**
 Parent programme: #820
 Working model: #1017 six-layer R4/Spin causal-softmax checkpoint
 Final source-free correctness terminal: still blocked by parked #973
@@ -274,3 +274,89 @@ boundary. This result does not revise #1017's bounded ordinary-attention or
 coherent-generation claims, establish an intrinsic-geometric advantage, or
 unblock #955. The final source-free #954 terminal remains separately blocked by
 #973.
+
+## C1-SB4 joint-source candidate-margin result — 2026-08-31
+
+`R4JointCandidateMarginAdapterV1` implemented the independently frozen
+successor rather than retrying C1-SB3. Every distinct exact-text candidate was
+scored from the complete source and question:
+
+```text
+E:<exact full source>
+Q:<question>
+C:<exact distinct candidate text>
+Supported:
+```
+
+The fixed tied-token score remained `yes[1771] - no[542] > 0`. Rank-eight,
+alpha-eight, dropout-zero LoRA updated Q/K/V/O in all six existing attention
+layers; there was no learned head. The complete-record objective used margin
+one:
+
+```text
+relu(1 - minimum positive-group score)
++ relu(1 + maximum negative-group score)
+```
+
+An absent positive or negative set contributed zero for that term. Exact
+duplicate text collapsed to one scored group and copied back to the earliest
+exact occurrence. The committed population contained 126 fit records and 604
+distinct groups, 63 independently sealed records and 302 groups, and four
+opaque product commitments. Exact sentences and complete generated composite
+world items were disjoint; primitive component vocabulary was deliberately
+shared. The longest prompt occupied 221 of 256 positions including BOS.
+
+The sole MPS run used seed 9544, 270 optimizer steps, seven complete records per
+step, and the frozen step-eight/600-second wall gate. It completed within the
+budget. Structured-margin loss moved from `2.2566068172454834` to
+`0.8698721528053284`, and the representation audit passed: all 24 targeted
+Q/K/V/O tensors changed and remained finite, while no non-attention tensor
+changed.
+
+The semantic gate nevertheless failed exactly and symmetrically:
+
+| Frozen metric | Untrained sealed | Trained fit | Trained sealed | Required |
+| --- | ---: | ---: | ---: | ---: |
+| exact records | `21/63` | `70/126` | `35/63` | exact |
+| answer outcomes | `0/21` | `14/42` | `7/21` | exact |
+| abstain outcomes | `21/21` | `14/42` | `7/21` | exact |
+| conflict outcomes | `0/21` | `42/42` | `21/21` | exact |
+| positive-group recall | `0/63` | `126/126` | `63/63` | exact |
+| negative-group specificity | `239/239` | `394/478` | `197/239` | exact |
+| supported copied span | `0/21` | `14/42` | `7/21` | exact |
+
+Duplicate agreement and distinct-conflict subsets were exact in both fit and
+sealed partitions. Same-source query relocation was not exact in either. The
+source-order reversal control was correctly `NOT_RUN_MAIN_GATE_NEGATIVE`.
+Terminal: **`FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT`**.
+
+The result is bound by:
+
+- result CID `blake3:82f83d865eaea24589cf8acdbcc4c83fd4714041c1d80e31a818d587664b7b84`;
+- manifest CID `blake3:4872dd1b70cebbd7c2cf9930389e73df52e2325f809b0d0e27763a588a88b04f`;
+- tree CID `blake3:5bcf79dfaef01b5357b831af5990bb36d5dc21a6c193a7c051eb701b79ba551e`;
+- run-contract CID `blake3:0b621e5a69b5660bd9f9df47cb3c4ce6d0dbe6d0f3d9f4236f8da4435686d02a`.
+
+The complete published metric pattern is reproduced exactly by the deterministic
+rule “predict supported iff the candidate text contains ` is inside `,” while
+ignoring the question: `70/126` and `35/63` exact records, every positive and
+negative count, every outcome count, and every copy count all match. Per-row
+model scores were not retained, so this is an aggregate-equivalent shortcut,
+not a proved description of the model's internal computation. It nevertheless
+shows that the observed evidence does not distinguish real subject-question
+binding from affirmative-locative syntax.
+
+Per the frozen decision, C1-SB4 stops here without retry, Rust parity, larger
+fit, development evaluation, checkpoint emission, or product reveal. The four
+product records remain committed and unopened. A genuinely distinct successor
+must make question conditioning identifiable at the objective itself: couple
+multiple questions over the same exact source and require the same candidate
+to change sign when the queried subject changes. That proposed paired-query
+conditional-binding rung must receive its own independent freeze; it is not an
+authorized C1-SB4 seed, threshold, rank, schedule, or corpus retry.
+
+The compact aggregate is
+[`r4_joint_candidate_margin_954_raw.json`](r4_joint_candidate_margin_954_raw.json).
+This negative does not revise #1014/#1017 ordinary-attention or bounded coherent
+generation evidence, establish intrinsic geometry, or unblock #955. #954's
+final source-free terminal remains separately blocked behind #973.

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -104,11 +104,28 @@
   manifest CID
   `blake3:e0faa45bb80b122d0e8a31ac6c582fd4b44b39ee20f5d49aeaca2f07deb21e71`.
   This result does not revise the established attention or generation results.
-  #954 remains open. Its next successor is a fresh joint-source/candidate-set,
-  record-level structured-margin mechanism over answer, abstain, conflict, and
-  exact-copy outcomes—not a C1-SB3 seed, rank, learning-rate, or threshold
-  retry. Retain the exact-copy and typed non-answer Rust seam. #955 remains
-  blocked, and #954's final source-free terminal remains blocked behind #973.
+  C1-SB4 `R4JointCandidateMarginAdapterV1` then executed the independently
+  frozen full-source successor: 270 MPS updates over 126 fit records, with 63
+  independently sealed records and four committed unopened products. All
+  positive groups were recovered, but negative specificity was only `394/478`
+  fit and `197/239` sealed. Exact records were `70/126` and `35/63`; answer and
+  abstain were each one-third exact, conflict and duplicate agreement were
+  exact, and same-source query relocation was not. All 24 attention targets
+  changed with no non-attention change. Terminal
+  `FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT` stops Rust parity, checkpoint
+  emission, development, and product reveal as `NOT_RUN`; do not tune or retry
+  C1-SB4. A question-ignoring ` is inside ` rule reproduces every aggregate
+  count exactly; this is aggregate-equivalent shortcut evidence because per-row
+  model scores were not retained. Result CID
+  `blake3:82f83d865eaea24589cf8acdbcc4c83fd4714041c1d80e31a818d587664b7b84`;
+  manifest CID
+  `blake3:4872dd1b70cebbd7c2cf9930389e73df52e2325f809b0d0e27763a588a88b04f`.
+  #954 remains open. The next proposal is a separately frozen paired-query
+  conditional-binding objective: multiple questions share the same exact
+  source and the same candidate must change sign with the queried subject. It
+  is not a C1-SB4 seed, rank, threshold, schedule, or corpus retry. Retain the
+  exact-copy and typed non-answer Rust seam. #955 remains blocked, and #954's
+  final source-free terminal remains blocked behind #973.
   UOR's deployed
   architecture/runtime remains CPU-native;
   Apple Accelerate/BLAS and MPS are local offline accelerators only; CUDA and
@@ -133,8 +150,9 @@
   then the [#1019 frozen contract](r4_softmax_parameter_capacity_1019.md) and
   [observed preflight](r4_softmax_parameter_capacity_preflight_1019_raw.json),
   followed by the [#954 campaign record](r4_grounded_correctness_954.md), the
-  [C1-SB2 aggregate](r4_source_relation_head_954_raw.json), and the
-  [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json).
+  [C1-SB2 aggregate](r4_source_relation_head_954_raw.json), the
+  [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json), and
+  the [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
   The intermediate
   [Geometric Causal Decoder Roadmap](geometric_causal_decoder_plan.md) records
   the superseded #948-#958 sequence.

--- a/docs/r4_joint_candidate_margin_954_raw.json
+++ b/docs/r4_joint_candidate_margin_954_raw.json
@@ -1,0 +1,210 @@
+{
+  "schema": "uor-r4.joint-candidate-margin-aggregate/1",
+  "issue": 954,
+  "policy": "R4JointCandidateMarginAdapterV1",
+  "observed_at": "2026-08-31",
+  "terminal": "FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT",
+  "claim_scope": "one independently frozen full-source, candidate-conditioned, record-level structured-margin preflight through rank-8 Q/K/V/O adapters on all six established R4/Spin ordinary causal-softmax layers",
+  "checkpoint": {
+    "model_weights_cid": "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d",
+    "tokenizer_cid": "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc"
+  },
+  "population": {
+    "fit_records": 126,
+    "fit_distinct_groups": 604,
+    "sealed_records": 63,
+    "sealed_distinct_groups": 302,
+    "product_probe_commitments": 4,
+    "dataset_cid": "blake3:46e95f83f05bd5a3bfd4ca0c39c4974f617ae9591ff083d3c6abb8f5593c0e51",
+    "preflight_cid": "blake3:b61a098a53fca1f30b69a0ef0d6e15c5b6fc5a310d0ac8f0f2df04d1fd208814",
+    "census_cid": "blake3:2531f2c19cc60570c3807aa117b97923d4ce0b0c8111a8c239861cbae4303a92",
+    "tokenizer_census_cid": "blake3:ff5c25b70d0940e0b43ec8cacc60c2b576ba069106d28c8ce58cb6b17f2cbc10",
+    "training_view_manifest_cid": "blake3:37fcac42e400c35df3d770b57032a528684e3cb6cbdfb4c3c80b88c1247c432a",
+    "product_probes_cid": "blake3:153f6075f165d6cf92aeb63c31f05c9a869cc94c4655f83b9fe036bf7c773e3e",
+    "product_manifest_cid": "blake3:886d931fd6dde610955c6eedff3181fbffa8d8590f300731387f225f0012197b",
+    "product_text_status": "COMMITTED_UNOPENED_NOT_RUN",
+    "disjointness_scope": "exact sentences and complete generated composite world items are disjoint; primitive component vocabulary is deliberately shared"
+  },
+  "mechanism": {
+    "representation_update": "lora_qkvo_all_layers",
+    "input": "E:<exact full source>\\nQ:<question>\\nC:<exact distinct group text>\\nSupported:",
+    "input_has_terminal_newline": false,
+    "duplicate_policy": "collapse exact-text groups and copy the earliest exact source occurrence",
+    "trainable_parameters": 110592,
+    "rank": 8,
+    "alpha": 8,
+    "dropout": 0,
+    "attention_layers": 6,
+    "adapted_projections": [
+      "q_proj",
+      "k_proj",
+      "v_proj",
+      "o_proj"
+    ],
+    "trainable_head": false,
+    "positive_token_id": 1771,
+    "negative_token_id": 542,
+    "decision_threshold": 0,
+    "record_objective": "relu(1 - minimum positive-group score) + relu(1 + maximum negative-group score), with an absent-set term of zero",
+    "optimizer_steps": 270,
+    "records_per_step": 7,
+    "seed": 9544,
+    "initial_structured_margin": 2.2566068172454834,
+    "final_structured_margin": 0.8698721528053284,
+    "eta_probe_step": 8,
+    "wall_ceiling_seconds": 600,
+    "eta_probe_passed": true,
+    "completed_within_wall_ceiling": true,
+    "timing_values": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM"
+  },
+  "untrained_sealed": {
+    "records_exact": {
+      "correct": 21,
+      "total": 63
+    },
+    "answer_outcomes": {
+      "correct": 0,
+      "total": 21
+    },
+    "abstain_outcomes": {
+      "correct": 21,
+      "total": 21
+    },
+    "conflict_outcomes": {
+      "correct": 0,
+      "total": 21
+    },
+    "positive_group_recall": {
+      "correct": 0,
+      "total": 63
+    },
+    "positive_relation_recall": {
+      "correct": 0,
+      "total": 76
+    },
+    "negative_group_specificity": {
+      "correct": 239,
+      "total": 239
+    },
+    "supported_copies": {
+      "correct": 0,
+      "total": 21
+    },
+    "mean_structured_margin": 2.1919445272475953
+  },
+  "trained_fit": {
+    "records_exact": {
+      "correct": 70,
+      "total": 126
+    },
+    "answer_outcomes": {
+      "correct": 14,
+      "total": 42
+    },
+    "abstain_outcomes": {
+      "correct": 14,
+      "total": 42
+    },
+    "conflict_outcomes": {
+      "correct": 42,
+      "total": 42
+    },
+    "positive_group_recall": {
+      "correct": 126,
+      "total": 126
+    },
+    "positive_relation_recall": {
+      "correct": 152,
+      "total": 152
+    },
+    "negative_group_specificity": {
+      "correct": 394,
+      "total": 478
+    },
+    "supported_copies": {
+      "correct": 14,
+      "total": 42
+    },
+    "mean_structured_margin": 0.842590963556653
+  },
+  "trained_sealed": {
+    "records_exact": {
+      "correct": 35,
+      "total": 63
+    },
+    "answer_outcomes": {
+      "correct": 7,
+      "total": 21
+    },
+    "abstain_outcomes": {
+      "correct": 7,
+      "total": 21
+    },
+    "conflict_outcomes": {
+      "correct": 21,
+      "total": 21
+    },
+    "positive_group_recall": {
+      "correct": 63,
+      "total": 63
+    },
+    "positive_relation_recall": {
+      "correct": 76,
+      "total": 76
+    },
+    "negative_group_specificity": {
+      "correct": 197,
+      "total": 239
+    },
+    "supported_copies": {
+      "correct": 7,
+      "total": 21
+    },
+    "mean_structured_margin": 0.8974597255388895
+  },
+  "controls": {
+    "fit_same_source_query_relocation_exact": false,
+    "sealed_same_source_query_relocation_exact": false,
+    "fit_duplicate_agreement_exact": true,
+    "sealed_duplicate_agreement_exact": true,
+    "fit_distinct_conflict_exact": true,
+    "sealed_distinct_conflict_exact": true,
+    "sealed_source_reversal": "NOT_RUN_MAIN_GATE_NEGATIVE",
+    "passed": false
+  },
+  "representation_audit": {
+    "changed_attention_tensors": 24,
+    "expected_attention_tensors": 24,
+    "all_changed_attention_tensors_finite": true,
+    "changed_nonattention_tensors": 0,
+    "passed": true
+  },
+  "qualification": {
+    "exact_fit_gate": "FAIL",
+    "exact_sealed_gate": "FAIL",
+    "rust_parity": "NOT_RUN",
+    "full_fit": "NOT_RUN",
+    "development": "NOT_RUN",
+    "product": "UNOPENED_NOT_RUN",
+    "checkpoint": "NOT_EMITTED",
+    "adapter_artifact": "NOT_EMITTED",
+    "result_cid": "blake3:82f83d865eaea24589cf8acdbcc4c83fd4714041c1d80e31a818d587664b7b84",
+    "manifest_cid": "blake3:4872dd1b70cebbd7c2cf9930389e73df52e2325f809b0d0e27763a588a88b04f",
+    "tree_cid": "blake3:5bcf79dfaef01b5357b831af5990bb36d5dc21a6c193a7c051eb701b79ba551e",
+    "run_contract_cid": "blake3:0b621e5a69b5660bd9f9df47cb3c4ce6d0dbe6d0f3d9f4236f8da4435686d02a"
+  },
+  "implementation_tree_cid": "blake3:0fe475a1b82f199b8b0bf18bf620d8a894f498e165a2e006d6db4e180e613054",
+  "shortcut_reproduction": {
+    "rule": "predict supported iff the exact candidate text contains ` is inside `; ignore the question",
+    "fit": "exactly reproduces 70/126 records, 126/126 positive groups, 394/478 negative groups, answer 14/42, abstain 14/42, conflict 42/42, and copy 14/42",
+    "sealed": "exactly reproduces 35/63 records, 63/63 positive groups, 197/239 negative groups, answer 7/21, abstain 7/21, conflict 21/21, and copy 7/21",
+    "status": "AGGREGATE_EQUIVALENT; per-row model scores were not retained, so this does not prove the model's internal rule"
+  },
+  "interpretation": "The entire published metric pattern is exactly reproduced by a question-ignoring affirmative-locative rule. The learned scorer therefore did not demonstrate subject-question binding; per-row scores were not retained, so the rule is aggregate-equivalent rather than a proved internal mechanism.",
+  "decision": "Stop this mechanism without retry, Rust parity, larger fit, development, or product reveal. A genuinely distinct successor must place multiple questions over the same exact source inside one coupled objective and require the same candidate to change sign when the queried subject changes, eliminating the shortcut before any product work.",
+  "nonclaims": [
+    "No qualified source-backed answer artifact was emitted.",
+    "This negative does not revoke the established ordinary causal-attention or coherent-generation results.",
+    "No intrinsic geometry advantage, reasoning, source-free correctness, transformerless runtime, exact lowering, browser, WASM, or release claim was established."
+  ]
+}

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -6,7 +6,8 @@ This package contains the bounded offline training paths authorized by issues
 preflight-recorded [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
 parameter-capacity campaign, and the bounded [#954](https://github.com/UOR-Foundation/uor-r4/issues/954)
 grounding fine-tune, frozen source-span-pointer successor, and independently
-frozen source-relative relation-head successor. They train
+frozen source-relative relation-head, attended-relation, and joint-candidate
+successors. They train
 and continue ordinary causal-softmax
 Llama-family models, export them in the existing Rust loaders' Hugging Face
 format, and freeze evidence before each sealed test is opened. They contain no
@@ -53,12 +54,16 @@ MPS fast-path test (10 warmup plus 40 measured steps) combined fused AdamW with
 deferred logging and measured `4.485223 s/step`, slower than the signed
 `3.491307 s/step`; `fused=True` was removed immediately. This is a bounded
 fast-path negative, not a model result. #1019 closed without a full run. #954's
-grounding fine-tune, positive-diagonal cosine pointer, and source-relative
-relation probe have also completed as bounded negatives. The relation probe fit
-both construction lexical families exactly but failed its independent
-12-record transfer gate, so no full fit or product reveal ran. The next #954
-mechanism must train relation supervision into the representation and be frozen
-independently; it is not a retry of any revealed readout. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+grounding fine-tune, positive-diagonal cosine pointer, source-relative relation
+probe, attended-relation adapter, and joint-candidate adapter have completed.
+C1-SB3 transferred most relations through the six attention layers but failed
+its exact gate. C1-SB4 then executed its independently frozen full-source,
+record-level structured-margin run: exact records were `70/126` fit and
+`35/63` sealed, with perfect positive-group recall and negative specificity
+`394/478` and `197/239`. It stopped before Rust/checkpoint/development/product
+and must not be retried. A question-ignoring ` is inside ` rule reproduces the
+entire published aggregate exactly. The next proposal is separately frozen
+paired-query conditional binding over one exact source. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
 and MPS are local offline accelerators only; CUDA and external GPU execution
 are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
@@ -66,6 +71,9 @@ established attention result. See the
 [#1017 record](../../docs/r4_softmax_quality_capacity_continuation_1017.md) and
 [#1019 frozen contract](../../docs/r4_softmax_parameter_capacity_1019.md) plus
 its [observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
+The #954 evidence is in the
+[#954 record](../../docs/r4_grounded_correctness_954.md) and
+[C1-SB4 aggregate](../../docs/r4_joint_candidate_margin_954_raw.json).
 
 For fast local #1017 inference on Apple Silicon, build the Rust CLI with
 `--features local-inference-accelerate`. The observed four-token comparison
@@ -164,6 +172,52 @@ preserved trainer/runtime seam is for replay and for a future independently
 frozen mechanism that trains relation semantics into the representation. See
 the [structured C1-SB2 result](../../docs/r4_source_relation_head_954_raw.json).
 
+## C1-SB3 attended-relation adapter result
+
+`prepare-attended-relation` and `train-attended-relation-preflight` implemented
+`R4AttendedRelationAdapterV1`: rank-eight Q/K/V/O LoRA in every one of the six
+attention layers, fixed tied-token yes/no scoring, and no learned head. Corrected
+evaluation showed bounded transfer—sealed positive recall `73/76`, negative
+specificity `234/239`, and only the 24 attention tensors changed—but the exact
+fit/sealed record gates failed at `124/126` and `56/63`. No merged checkpoint,
+Rust parity, full fit, development, or product reveal followed. Do not retry
+this independent-candidate BCE mechanism. See the
+[corrected C1-SB3 aggregate](../../docs/r4_attended_relation_adapter_954_raw.json).
+
+## C1-SB4 joint-candidate structured-margin result
+
+`prepare-joint-candidate-margin` commits the fresh data, tokenizer census, and
+four opaque product records without training. The separately consumed
+`train-joint-candidate-margin-preflight` used complete-source candidate prompts,
+collapsed exact duplicate groups, and optimized one record-level margin across
+positive and negative groups. Its only admitted configuration was seed 9544,
+270 MPS updates, seven complete records per update, and a step-eight/600-second
+wall gate.
+
+The run completed within budget but failed exactly: `70/126` fit and `35/63`
+sealed records, positive groups `126/126` and `63/63`, negative specificity
+`394/478` and `197/239`, and same-source query relocation false. All 24 Q/K/V/O
+targets changed and no non-attention tensor changed. Rust parity, checkpoint,
+development, reversal, and product are `NOT_RUN`; the products remain unopened.
+A question-ignoring ` is inside ` rule reproduces every published aggregate
+count exactly, so the next mechanism must couple multiple questions over one
+source. Do not rerun C1-SB4.
+
+The already-consumed invocation was:
+
+```bash
+PYTHONPATH="$PWD/tools/r4-softmax-trainer/src" \
+  "$UOR_MODEL_STORE/research/issue-1014/venv/bin/python" \
+  -c 'from r4_softmax_trainer.cli import main; main()' \
+  --root "$UOR_MODEL_STORE/research/issue-954/joint-candidate-margin" \
+  train-joint-candidate-margin-preflight \
+  --predecessor "$UOR_MODEL_STORE/research/issue-1017/export"
+```
+
+The started/result markers intentionally reject a second invocation. See the
+[#954 record](../../docs/r4_grounded_correctness_954.md) and
+[C1-SB4 aggregate](../../docs/r4_joint_candidate_margin_954_raw.json).
+
 ## Isolated environment
 
 Python is frozen to 3.12 and every dependency is exact in `pyproject.toml` and
@@ -186,8 +240,9 @@ instead used its own eight-hour backend-admission gate. MPS stopped
 `21.03%`. That result applies only to the frozen offline implementation. The
 subsequent fused-AdamW/deferred-logging fast path was slower (`4.485223` versus
 signed `3.491307 s/step`), so #1019 closed without a full run. #954's grounding
-fine-tune, source-span pointer, and source-relative relation probe also closed
-negative; none is rerun.
+fine-tune, source-span pointer, source-relative relation probe,
+attended-relation adapter, and joint-candidate adapter also closed negative;
+none is rerun.
 CUDA and external GPU execution are out of scope.
 
 ## One-way campaign
@@ -297,8 +352,9 @@ Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
 terminal applies only to the frozen offline implementation. Full training,
 final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
 fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-`3.491307 s/step`), so #1019 closed without a full run. #954's three bounded
-source-grounding mechanisms subsequently closed negative. CUDA and external GPU execution are out of scope. See the
+`3.491307 s/step`), so #1019 closed without a full run. #954's five bounded
+source-grounding mechanisms through C1-SB4 subsequently closed negative. CUDA
+and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 
 The Rust qualifier has a separate shape-bound campaign mode. After a #1019

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -37,12 +37,17 @@ from .continuation_data import (
 from .data import download_source, load_dataset_manifest, prepare_dataset
 from .finalize import finalize_continuation
 from .grounding import train_grounding
+from .joint_candidate_margin_campaign import (
+    prepare_joint_candidate_margin_data,
+    run_joint_candidate_margin_preflight,
+)
 from .paths import (
     default_attended_relation_adapter_root,
     default_capacity_root,
     default_continuation_root,
     default_grounding_predecessor_root,
     default_grounding_root,
+    default_joint_candidate_margin_root,
     default_research_root,
     default_source_relation_head_root,
     default_source_span_pointer_root,
@@ -309,6 +314,32 @@ def parser() -> argparse.ArgumentParser:
         default=default_grounding_predecessor_root(),
         help="immutable completed #1017 Hugging Face export",
     )
+    prepare_joint = subcommands.add_parser(
+        "prepare-joint-candidate-margin",
+        help=(
+            "commit the C1-SB4 fresh joint-candidate data and sealed product "
+            "CIDs without starting optimization"
+        ),
+    )
+    prepare_joint.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
+    train_joint = subcommands.add_parser(
+        "train-joint-candidate-margin-preflight",
+        help=(
+            "run the sole <=10 minute C1-SB4 complete-record structured-margin "
+            "preflight; never opens product text"
+        ),
+    )
+    train_joint.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
     return command
 
 
@@ -342,6 +373,10 @@ def main() -> None:
         "prepare-attended-relation",
         "train-attended-relation-preflight",
     }
+    joint_candidate_commands = {
+        "prepare-joint-candidate-margin",
+        "train-joint-candidate-margin-preflight",
+    }
     if arguments.root:
         root = arguments.root
     elif arguments.command in capacity_commands:
@@ -356,6 +391,8 @@ def main() -> None:
         root = default_source_relation_head_root()
     elif arguments.command in attended_relation_commands:
         root = default_attended_relation_adapter_root()
+    elif arguments.command in joint_candidate_commands:
+        root = default_joint_candidate_margin_root()
     else:
         root = default_research_root()
     if arguments.command == "download":
@@ -499,6 +536,20 @@ def main() -> None:
     if arguments.command == "train-attended-relation-preflight":
         _print_result(
             run_attended_relation_preflight(root, predecessor=arguments.predecessor)
+        )
+        return
+    if arguments.command == "prepare-joint-candidate-margin":
+        _print_result(
+            prepare_joint_candidate_margin_data(
+                root, predecessor=arguments.predecessor
+            )
+        )
+        return
+    if arguments.command == "train-joint-candidate-margin-preflight":
+        _print_result(
+            run_joint_candidate_margin_preflight(
+                root, predecessor=arguments.predecessor
+            )
         )
         return
     raise AssertionError(f"unhandled command: {arguments.command}")

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin.py
@@ -1,0 +1,893 @@
+"""Record-level structured-margin training over joint source/candidate prompts.
+
+This module is the small C1-SB4 mechanism core.  It deliberately reuses the
+mergeable all-layer Q/K/V/O LoRA representation and frozen tied-token readout
+from C1-SB3, but changes the unit of learning from independent candidate rows
+to complete records.  Exact duplicate text is one relation group, and every
+group prompt contains the complete source before it is scored.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from tokenizers import Tokenizer
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from .constants import BOS_TOKEN_ID, EOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .joint_candidate_margin_data import render_joint_candidate_input
+from .model import R4SoftmaxForCausalLM, expected_hf_tensor_names
+from .provenance import cid_bytes
+from .source_relation_adapter import (
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_RANK,
+    TRAINABLE_PARAMETER_COUNT,
+    LoRALinear,
+    tied_relation_scores,
+    validate_tokenizer_contract,
+)
+from .train import require_mps
+
+
+POLICY = "R4JointCandidateMarginAdapterV1"
+REPRESENTATION_UPDATE = "lora_qkvo_all_layers"
+OUTCOMES = ("answer", "abstain", "conflict")
+SOURCE_WIDTHS = tuple(range(2, 9))
+MARGIN = 1.0
+FIT_RECORDS_PER_WIDTH = 18
+OUTCOME_RECORDS_PER_WIDTH = 6
+RECORDS_PER_STEP = len(SOURCE_WIDTHS)
+STEPS_PER_EPOCH = FIT_RECORDS_PER_WIDTH
+OPTIMIZER_STEPS = 270
+FIT_SEED = 9_544
+
+
+@dataclass(frozen=True, slots=True)
+class JointCandidateMarginAdapterConfig:
+    """SB4's separately versioned all-layer representation contract."""
+
+    rank: int = LORA_RANK
+    alpha: int = LORA_ALPHA
+    dropout: float = LORA_DROPOUT
+    target_layer_indices: tuple[int, ...] = tuple(
+        range(FROZEN_MODEL_CONFIG.num_hidden_layers)
+    )
+    target_projections: tuple[str, ...] = ("q_proj", "k_proj", "v_proj", "o_proj")
+    initialization_seed: int = FIT_SEED
+
+    def validate(self) -> None:
+        if self != JointCandidateMarginAdapterConfig():
+            raise ValueError("joint candidate margin exposes one frozen adapter contract")
+        if self.rank != 8 or self.alpha != 8 or self.dropout != 0.0:
+            raise AssertionError("joint candidate margin LoRA shape drifted")
+        if self.target_layer_indices != tuple(range(6)):
+            raise AssertionError("joint candidate margin must adapt all six layers")
+        if self.target_projections != ("q_proj", "k_proj", "v_proj", "o_proj"):
+            raise AssertionError("joint candidate margin must adapt exactly Q/K/V/O")
+        if self.initialization_seed != 9_544:
+            raise AssertionError("joint candidate margin initialization seed drifted")
+
+    @property
+    def trainable_parameter_count(self) -> int:
+        self.validate()
+        return TRAINABLE_PARAMETER_COUNT
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "rank": self.rank,
+            "alpha": self.alpha,
+            "dropout": self.dropout,
+            "target_layer_indices": list(self.target_layer_indices),
+            "target_projections": list(self.target_projections),
+            "initialization_seed": self.initialization_seed,
+            "trainable_parameter_count": self.trainable_parameter_count,
+            "representation_update": REPRESENTATION_UPDATE,
+            "initialization": (
+                "Xavier-uniform A from isolated CPU generators seeded "
+                "initialization_seed + stable layer/projection ordinal; zero B"
+            ),
+            "score": "tied-logit[1771] - tied-logit[542] at final colon",
+            "decision": "supported iff score > +0.0",
+            "learned_head": False,
+        }
+
+
+class R4JointCandidateMarginAdapter(nn.Module):
+    """SB4 LoRA representation with the unchanged frozen tied-token score."""
+
+    def __init__(
+        self,
+        model: R4SoftmaxForCausalLM,
+        config: JointCandidateMarginAdapterConfig = JointCandidateMarginAdapterConfig(),
+    ) -> None:
+        super().__init__()
+        config.validate()
+        if model.config != FROZEN_MODEL_CONFIG:
+            raise ValueError("joint candidate margin requires the six-layer #1017 model")
+        model.requires_grad_(False)
+        self.model = model
+        self.config = config
+        self._adapters: dict[str, LoRALinear] = {}
+        adapter_ordinal = 0
+        for layer_index in config.target_layer_indices:
+            attention = self.model.model.layers[layer_index].self_attn
+            for projection_name in config.target_projections:
+                projection = getattr(attention, projection_name)
+                if not isinstance(projection, nn.Linear):
+                    raise TypeError(
+                        f"layer {layer_index} {projection_name} is not an unwrapped linear"
+                    )
+                adapter = LoRALinear(
+                    projection,
+                    rank=config.rank,
+                    alpha=config.alpha,
+                    dropout=config.dropout,
+                    initialization_seed=config.initialization_seed + adapter_ordinal,
+                )
+                setattr(attention, projection_name, adapter)
+                path = self._projection_weight_path(layer_index, projection_name)
+                self._adapters[path] = adapter
+                adapter_ordinal += 1
+        observed = sum(
+            parameter.numel()
+            for parameter in self.parameters()
+            if parameter.requires_grad
+        )
+        if observed != config.trainable_parameter_count:
+            raise AssertionError(
+                f"joint candidate margin has {observed} trainable parameters, "
+                f"expected {config.trainable_parameter_count}"
+            )
+
+    @staticmethod
+    def _projection_weight_path(layer_index: int, projection_name: str) -> str:
+        return f"model.layers.{layer_index}.self_attn.{projection_name}.weight"
+
+    def adapter_parameters(self) -> Iterable[nn.Parameter]:
+        return (parameter for parameter in self.parameters() if parameter.requires_grad)
+
+    def trainable_parameter_names(self) -> tuple[str, ...]:
+        return tuple(
+            name for name, parameter in self.named_parameters() if parameter.requires_grad
+        )
+
+    def forward(self, input_ids: Tensor, terminal_indices: Tensor | None = None) -> Tensor:
+        if input_ids.ndim != 2:
+            raise ValueError("joint candidate input_ids must have shape [batch, time]")
+        hidden = self.model.model(input_ids)
+        batch, time, width = hidden.shape
+        if width != FROZEN_MODEL_CONFIG.hidden_size:
+            raise RuntimeError("joint candidate hidden width differs from #1017")
+        if terminal_indices is None:
+            terminal_indices = torch.full(
+                (batch,), time - 1, dtype=torch.long, device=hidden.device
+            )
+        if terminal_indices.shape != (batch,) or terminal_indices.dtype != torch.long:
+            raise ValueError("terminal_indices must be int64 with shape [batch]")
+        if bool(((terminal_indices < 0) | (terminal_indices >= time)).any()):
+            raise ValueError("joint candidate terminal index is outside the sequence")
+        terminal = hidden[torch.arange(batch, device=hidden.device), terminal_indices]
+        return tied_relation_scores(terminal, self.model.model.embed_tokens.weight)
+
+    def merged_state_dict(self) -> dict[str, Tensor]:
+        wrapped_state = self.model.state_dict()
+        expected = expected_hf_tensor_names(self.model.config)
+        merged: dict[str, Tensor] = {}
+        for name in sorted(expected):
+            adapter = self._adapters.get(name)
+            if adapter is not None:
+                merged[name] = adapter.merged_weight()
+                continue
+            try:
+                value = wrapped_state[name]
+            except KeyError as error:
+                raise RuntimeError(
+                    f"joint candidate wrapped model is missing tensor {name}"
+                ) from error
+            merged[name] = (
+                value.detach().to(device="cpu", dtype=torch.float32).contiguous()
+            )
+        if set(merged) != expected or len(self._adapters) != 24:
+            raise RuntimeError("joint candidate merge did not cover 24 Q/K/V/O tensors")
+        return merged
+
+    def delta_audit(self) -> dict[str, Any]:
+        tensors: list[dict[str, Any]] = []
+        for name in sorted(self._adapters):
+            adapter = self._adapters[name]
+            delta = (
+                torch.matmul(
+                    adapter.lora_b.detach().float(), adapter.lora_a.detach().float()
+                )
+                * adapter.scaling
+            )
+            tensors.append(
+                {
+                    "name": name,
+                    "parameter_count": adapter.lora_a.numel()
+                    + adapter.lora_b.numel(),
+                    "nonzero": int(torch.count_nonzero(delta).item()),
+                    "l2_norm": float(torch.linalg.vector_norm(delta).cpu()),
+                    "finite": bool(torch.isfinite(delta).all()),
+                    "initialization_seed": adapter.initialization_seed,
+                }
+            )
+        if len(tensors) != 24 or any(not tensor["finite"] for tensor in tensors):
+            raise RuntimeError("joint candidate delta census is incomplete or nonfinite")
+        return {
+            "target_tensor_count": len(tensors),
+            "trainable_parameter_count": sum(
+                int(tensor["parameter_count"]) for tensor in tensors
+            ),
+            "tensors": tensors,
+        }
+
+    def merged_model(self) -> R4SoftmaxForCausalLM:
+        clean = R4SoftmaxForCausalLM(self.model.config)
+        clean.load_state_dict(self.merged_state_dict(), strict=True)
+        clean.eval()
+        return clean
+
+
+@dataclass(frozen=True, slots=True)
+class JointCandidateGroup:
+    """One exact-text equivalence class inside a complete source record."""
+
+    relation_group_cid: str
+    text: str
+    relation_label: int
+    occurrence_indices: tuple[int, ...]
+    relation_input: str
+    relation_input_cid: str
+
+
+@dataclass(frozen=True, slots=True)
+class JointCandidateRecord:
+    record_id: str
+    lexical_world: str
+    motif: str
+    target_outcome: str
+    source_width: int
+    source: str
+    question: str
+    groups: tuple[JointCandidateGroup, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedJointCandidateGroup:
+    relation_group_cid: str
+    text: str
+    relation_label: int
+    occurrence_indices: tuple[int, ...]
+    token_ids: tuple[int, ...]
+
+    @property
+    def terminal_index(self) -> int:
+        # BOS is inserted at lane zero; the last content token is the colon.
+        return len(self.token_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedJointCandidateRecord:
+    record_id: str
+    lexical_world: str
+    motif: str
+    target_outcome: str
+    source_width: int
+    groups: tuple[EncodedJointCandidateGroup, ...]
+
+
+@dataclass(slots=True)
+class JointCandidateMarginBatch:
+    input_ids: Tensor
+    terminal_indices: Tensor
+    group_labels: Tensor
+    record_slices: tuple[tuple[int, int], ...]
+    record_indices: tuple[int, ...]
+    group_identities: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class JointCandidateMarginFitConfig:
+    """The sole bounded optimizer contract; this is intentionally not a sweep."""
+
+    seed: int = FIT_SEED
+    optimizer_steps: int = OPTIMIZER_STEPS
+    records_per_step: int = RECORDS_PER_STEP
+    learning_rate: float = 0.001
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    adam_epsilon: float = 1e-8
+    weight_decay: float = 0.0
+    gradient_clip: float = 1.0
+    eta_probe_step: int = 8
+    wall_ceiling_seconds: float = 600.0
+    progress_interval: int = STEPS_PER_EPOCH
+
+    def validate(self) -> None:
+        if self != JointCandidateMarginFitConfig():
+            raise ValueError("joint candidate margin exposes one frozen fit contract")
+        if (
+            self.seed != 9_544
+            or self.optimizer_steps != 270
+            or self.records_per_step != 7
+            or self.weight_decay != 0.0
+        ):
+            raise AssertionError("joint candidate margin fit contract drifted")
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "seed": self.seed,
+            "optimizer_steps": self.optimizer_steps,
+            "records_per_step": self.records_per_step,
+            "learning_rate": self.learning_rate,
+            "adam_beta1": self.adam_beta1,
+            "adam_beta2": self.adam_beta2,
+            "adam_epsilon": self.adam_epsilon,
+            "weight_decay": self.weight_decay,
+            "gradient_clip": self.gradient_clip,
+            "eta_probe_step": self.eta_probe_step,
+            "wall_ceiling_seconds": self.wall_ceiling_seconds,
+            "progress_interval": self.progress_interval,
+            "margin": MARGIN,
+            "schedule": (
+                "18 steps/epoch; one complete record per width 2..8; outcome bucket "
+                "and lane offsets depend on width and epoch"
+            ),
+        }
+
+
+class JointCandidateMarginWallBudgetExceeded(RuntimeError):
+    def __init__(
+        self,
+        *,
+        step: int,
+        elapsed_seconds: float,
+        projected_seconds_at_eta_probe: float | None,
+        wall_ceiling_seconds: float,
+    ) -> None:
+        super().__init__("UNAVAILABLE_JOINT_CANDIDATE_MARGIN_WALL_BUDGET")
+        self.step = step
+        self.elapsed_seconds = elapsed_seconds
+        self.projected_seconds_at_eta_probe = projected_seconds_at_eta_probe
+        self.wall_ceiling_seconds = wall_ceiling_seconds
+
+    def as_result(self) -> dict[str, Any]:
+        return {
+            "status": "UNAVAILABLE_JOINT_CANDIDATE_MARGIN_WALL_BUDGET",
+            "stopped_after_step": self.step,
+            "elapsed_seconds": self.elapsed_seconds,
+            "projected_seconds_at_eta_probe": self.projected_seconds_at_eta_probe,
+            "wall_ceiling_seconds": self.wall_ceiling_seconds,
+        }
+
+
+def _record_identity(record: Mapping[str, Any], offset: int) -> str:
+    value = record.get("record_id", record.get("record_cid"))
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"joint candidate record {offset} has no stable identity")
+    return value
+
+
+def _record_from_mapping(
+    record: Mapping[str, Any], *, record_offset: int
+) -> JointCandidateRecord:
+    record_id = _record_identity(record, record_offset)
+    source = record.get("source")
+    question = record.get("question")
+    source_width = record.get("source_width")
+    target_outcome = record.get("target_outcome")
+    lexical_world = record.get("lexical_world")
+    motif = record.get("motif")
+    spans = record.get("sentence_spans")
+    if not isinstance(source, str) or not source or source != source.strip():
+        raise ValueError(f"joint candidate record {record_id} has no canonical source")
+    if not isinstance(question, str) or not question.endswith("?"):
+        raise ValueError(f"joint candidate record {record_id} has no canonical question")
+    if source_width not in SOURCE_WIDTHS:
+        raise ValueError(f"joint candidate record {record_id} has width outside 2..=8")
+    if target_outcome not in OUTCOMES:
+        raise ValueError(f"joint candidate record {record_id} has an invalid outcome")
+    if not isinstance(lexical_world, str) or not lexical_world:
+        raise ValueError(f"joint candidate record {record_id} has no lexical world")
+    if not isinstance(motif, str) or not motif:
+        raise ValueError(f"joint candidate record {record_id} has no motif")
+    if not isinstance(spans, Sequence) or isinstance(spans, (str, bytes)):
+        raise ValueError(f"joint candidate record {record_id} has invalid spans")
+    if len(spans) != source_width:
+        raise ValueError(f"joint candidate record {record_id} width differs from spans")
+
+    source_bytes = source.encode("utf-8")
+    grouped: dict[str, dict[str, Any]] = {}
+    text_to_group: dict[str, str] = {}
+    for expected_index, span in enumerate(spans):
+        if not isinstance(span, Mapping):
+            raise ValueError(f"joint candidate record {record_id} span is not a mapping")
+        candidate_index = span.get("candidate_index")
+        text = span.get("text")
+        group_cid = span.get("relation_group_cid")
+        label = span.get("relation_label")
+        byte_start = span.get("byte_start")
+        byte_end = span.get("byte_end")
+        if candidate_index != expected_index:
+            raise ValueError(
+                f"joint candidate record {record_id} candidate indices are not canonical"
+            )
+        if not isinstance(text, str) or not text:
+            raise ValueError(f"joint candidate record {record_id} has empty candidate text")
+        if not isinstance(group_cid, str) or group_cid != cid_bytes(text.encode("utf-8")):
+            raise ValueError(
+                f"joint candidate record {record_id} relation group is not exact text CID"
+            )
+        if label not in (0, 1):
+            raise ValueError(f"joint candidate record {record_id} has a nonbinary label")
+        if (
+            not isinstance(byte_start, int)
+            or not isinstance(byte_end, int)
+            or not 0 <= byte_start < byte_end <= len(source_bytes)
+            or source_bytes[byte_start:byte_end] != text.encode("utf-8")
+        ):
+            raise ValueError(
+                f"joint candidate record {record_id} span bytes do not bind exact source"
+            )
+        expected_input = render_joint_candidate_input(source, question, text)
+        embedded_input = span.get("relation_input")
+        embedded_input_cid = span.get("relation_input_cid")
+        if embedded_input != expected_input:
+            raise ValueError(
+                f"joint candidate record {record_id} committed renderer differs"
+            )
+        if embedded_input_cid != cid_bytes(expected_input.encode("utf-8")):
+            raise ValueError(
+                f"joint candidate record {record_id} committed input CID differs"
+            )
+        prior_group = text_to_group.setdefault(text, group_cid)
+        if prior_group != group_cid:
+            raise ValueError(
+                f"joint candidate record {record_id} exact text has multiple group IDs"
+            )
+        group = grouped.get(group_cid)
+        if group is None:
+            grouped[group_cid] = {
+                "text": text,
+                "label": int(label),
+                "occurrences": [candidate_index],
+            }
+        else:
+            if group["text"] != text:
+                raise ValueError(
+                    f"joint candidate record {record_id} group contains different text"
+                )
+            if group["label"] != int(label):
+                raise ValueError(
+                    f"joint candidate record {record_id} duplicate group labels disagree"
+                )
+            group["occurrences"].append(candidate_index)
+
+    groups: list[JointCandidateGroup] = []
+    for group_cid, value in sorted(
+        grouped.items(), key=lambda item: int(item[1]["occurrences"][0])
+    ):
+        relation_input = render_joint_candidate_input(source, question, value["text"])
+        groups.append(
+            JointCandidateGroup(
+                relation_group_cid=group_cid,
+                text=value["text"],
+                relation_label=int(value["label"]),
+                occurrence_indices=tuple(int(index) for index in value["occurrences"]),
+                relation_input=relation_input,
+                relation_input_cid=cid_bytes(relation_input.encode("utf-8")),
+            )
+        )
+    positive_groups = sorted(
+        group.relation_group_cid for group in groups if group.relation_label == 1
+    )
+    derived_outcome = (
+        "abstain"
+        if not positive_groups
+        else "answer"
+        if len(positive_groups) == 1
+        else "conflict"
+    )
+    if derived_outcome != target_outcome:
+        raise ValueError(
+            f"joint candidate record {record_id} labels derive {derived_outcome}, "
+            f"not {target_outcome}"
+        )
+    committed_positive = record.get("positive_relation_group_cids")
+    if committed_positive is not None and list(committed_positive) != positive_groups:
+        raise ValueError(
+            f"joint candidate record {record_id} positive group commitment differs"
+        )
+    return JointCandidateRecord(
+        record_id=record_id,
+        lexical_world=lexical_world,
+        motif=motif,
+        target_outcome=target_outcome,
+        source_width=int(source_width),
+        source=source,
+        question=question,
+        groups=tuple(groups),
+    )
+
+
+class EncodedJointCandidateMarginDataset:
+    """Tokenizer-bound complete records, exact groups, and frozen fit schedule."""
+
+    def __init__(self, records: Sequence[Mapping[str, Any]], tokenizer: Tokenizer) -> None:
+        if not records:
+            raise ValueError("joint candidate margin dataset is empty")
+        validate_tokenizer_contract(tokenizer)
+        parsed = [
+            _record_from_mapping(record, record_offset=offset)
+            for offset, record in enumerate(records)
+        ]
+        parsed.sort(key=lambda record: record.record_id)
+        identities = [record.record_id for record in parsed]
+        if len(set(identities)) != len(identities):
+            raise ValueError("joint candidate record identities are not unique")
+        self.records = tuple(parsed)
+        self.encoded: tuple[EncodedJointCandidateRecord, ...] = tuple(
+            self._encode_record(record, tokenizer) for record in self.records
+        )
+        self._fit_buckets: dict[tuple[int, str], tuple[int, ...]] | None = None
+
+    @staticmethod
+    def _encode_record(
+        record: JointCandidateRecord, tokenizer: Tokenizer
+    ) -> EncodedJointCandidateRecord:
+        groups: list[EncodedJointCandidateGroup] = []
+        for group in record.groups:
+            token_ids = tokenizer.encode(
+                group.relation_input, add_special_tokens=False
+            ).ids
+            if not token_ids:
+                raise ValueError("joint candidate input encoded to zero tokens")
+            if len(token_ids) + 1 > FROZEN_MODEL_CONFIG.max_position_embeddings:
+                raise ValueError(
+                    "joint candidate input exceeds the frozen 256-token context including BOS"
+                )
+            if tokenizer.decode([token_ids[-1]], skip_special_tokens=False) != ":":
+                raise ValueError("joint candidate input does not end in standalone colon")
+            groups.append(
+                EncodedJointCandidateGroup(
+                    relation_group_cid=group.relation_group_cid,
+                    text=group.text,
+                    relation_label=group.relation_label,
+                    occurrence_indices=group.occurrence_indices,
+                    token_ids=tuple(int(token_id) for token_id in token_ids),
+                )
+            )
+        return EncodedJointCandidateRecord(
+            record_id=record.record_id,
+            lexical_world=record.lexical_world,
+            motif=record.motif,
+            target_outcome=record.target_outcome,
+            source_width=record.source_width,
+            groups=tuple(groups),
+        )
+
+    def _validated_fit_buckets(self) -> dict[tuple[int, str], tuple[int, ...]]:
+        if self._fit_buckets is not None:
+            return self._fit_buckets
+        mutable: dict[tuple[int, str], list[int]] = defaultdict(list)
+        for index, record in enumerate(self.records):
+            mutable[(record.source_width, record.target_outcome)].append(index)
+        expected_keys = {
+            (width, outcome) for width in SOURCE_WIDTHS for outcome in OUTCOMES
+        }
+        if set(mutable) != expected_keys:
+            raise ValueError("fit schedule does not contain every width/outcome cell")
+        buckets: dict[tuple[int, str], tuple[int, ...]] = {}
+        for key in sorted(expected_keys):
+            indices = tuple(
+                sorted(
+                    mutable[key],
+                    key=lambda index: (
+                        self.records[index].lexical_world,
+                        self.records[index].motif,
+                        self.records[index].record_id,
+                    ),
+                )
+            )
+            if len(indices) != OUTCOME_RECORDS_PER_WIDTH:
+                raise ValueError(
+                    "fit schedule requires exactly six records per width/outcome cell"
+                )
+            buckets[key] = indices
+        if len(self.records) != len(SOURCE_WIDTHS) * FIT_RECORDS_PER_WIDTH:
+            raise ValueError("fit schedule requires exactly 126 complete records")
+        self._fit_buckets = buckets
+        return buckets
+
+    def record_indices_for_step(self, step: int) -> tuple[int, ...]:
+        if step < 1:
+            raise ValueError("joint candidate schedule step must be positive")
+        buckets = self._validated_fit_buckets()
+        slot = (step - 1) % STEPS_PER_EPOCH
+        epoch = (step - 1) // STEPS_PER_EPOCH
+        outcome_block = slot // OUTCOME_RECORDS_PER_WIDTH
+        lane = slot % OUTCOME_RECORDS_PER_WIDTH
+        selected: list[int] = []
+        for width in SOURCE_WIDTHS:
+            width_offset = width - SOURCE_WIDTHS[0]
+            outcome = OUTCOMES[(outcome_block + width_offset + epoch) % len(OUTCOMES)]
+            bucket_lane = (lane + width_offset + epoch) % OUTCOME_RECORDS_PER_WIDTH
+            selected.append(buckets[(width, outcome)][bucket_lane])
+        if len(selected) != RECORDS_PER_STEP or len(set(selected)) != RECORDS_PER_STEP:
+            raise RuntimeError("joint candidate schedule did not select seven records")
+        if [self.records[index].source_width for index in selected] != list(SOURCE_WIDTHS):
+            raise RuntimeError("joint candidate schedule is not one record per width")
+        return tuple(selected)
+
+    def validate_fit_schedule(self) -> None:
+        self._validated_fit_buckets()
+        for epoch in range(2):
+            selected = [
+                index
+                for step in range(
+                    epoch * STEPS_PER_EPOCH + 1,
+                    (epoch + 1) * STEPS_PER_EPOCH + 1,
+                )
+                for index in self.record_indices_for_step(step)
+            ]
+            if len(selected) != len(self.records) or set(selected) != set(
+                range(len(self.records))
+            ):
+                raise RuntimeError("joint candidate schedule does not cover one exact epoch")
+
+    def batch(
+        self, record_indices: Sequence[int], *, device: torch.device
+    ) -> JointCandidateMarginBatch:
+        if not record_indices:
+            raise ValueError("joint candidate record batch is empty")
+        if len(set(record_indices)) != len(record_indices):
+            raise ValueError("joint candidate record batch repeats a record")
+        selected = [self.encoded[index] for index in record_indices]
+        flat_groups = [group for record in selected for group in record.groups]
+        if not flat_groups:
+            raise RuntimeError("joint candidate batch contains no relation groups")
+        width = 1 + max(len(group.token_ids) for group in flat_groups)
+        input_ids = torch.full(
+            (len(flat_groups), width), EOS_TOKEN_ID, dtype=torch.long
+        )
+        terminal_indices = torch.empty(len(flat_groups), dtype=torch.long)
+        group_labels = torch.empty(len(flat_groups), dtype=torch.float32)
+        record_slices: list[tuple[int, int]] = []
+        group_identities: list[tuple[str, str]] = []
+        cursor = 0
+        for record in selected:
+            start = cursor
+            for group in record.groups:
+                input_ids[cursor, 0] = BOS_TOKEN_ID
+                input_ids[cursor, 1 : 1 + len(group.token_ids)] = torch.tensor(
+                    group.token_ids, dtype=torch.long
+                )
+                terminal_indices[cursor] = group.terminal_index
+                group_labels[cursor] = float(group.relation_label)
+                group_identities.append((record.record_id, group.relation_group_cid))
+                cursor += 1
+            record_slices.append((start, cursor))
+        return JointCandidateMarginBatch(
+            input_ids=input_ids.to(device),
+            terminal_indices=terminal_indices.to(device),
+            group_labels=group_labels.to(device),
+            record_slices=tuple(record_slices),
+            record_indices=tuple(int(index) for index in record_indices),
+            group_identities=tuple(group_identities),
+        )
+
+
+def structured_margin_per_record(
+    scores: Tensor,
+    group_labels: Tensor,
+    record_slices: Sequence[tuple[int, int]],
+    *,
+    margin: float = MARGIN,
+) -> Tensor:
+    """Return one threshold-aligned hinge loss for every complete record."""
+    if scores.ndim != 1 or group_labels.shape != scores.shape:
+        raise ValueError("joint candidate scores and labels must be matching vectors")
+    if group_labels.dtype not in (torch.float16, torch.float32, torch.float64):
+        raise ValueError("joint candidate labels must be floating point")
+    if bool(((group_labels != 0.0) & (group_labels != 1.0)).any()):
+        raise ValueError("joint candidate labels must be binary")
+    if not math.isfinite(margin) or margin != MARGIN:
+        raise ValueError("joint candidate margin is frozen at 1.0")
+    cursor = 0
+    losses: list[Tensor] = []
+    for start, end in record_slices:
+        if start != cursor or not start < end <= scores.numel():
+            raise ValueError("joint candidate record slices are not contiguous and complete")
+        record_scores = scores[start:end].float()
+        record_labels = group_labels[start:end]
+        positive = record_scores[record_labels == 1.0]
+        negative = record_scores[record_labels == 0.0]
+        loss = record_scores.sum() * 0.0
+        if positive.numel():
+            loss = loss + F.relu(record_scores.new_tensor(margin) - positive.min())
+        if negative.numel():
+            loss = loss + F.relu(record_scores.new_tensor(margin) + negative.max())
+        losses.append(loss)
+        cursor = end
+    if not losses or cursor != scores.numel():
+        raise ValueError("joint candidate record slices do not cover all group scores")
+    return torch.stack(losses)
+
+
+def joint_candidate_structured_margin_loss(
+    scores: Tensor,
+    group_labels: Tensor,
+    record_slices: Sequence[tuple[int, int]],
+) -> Tensor:
+    return structured_margin_per_record(scores, group_labels, record_slices).mean()
+
+
+@torch.no_grad()
+def evaluate_joint_candidate_margin_adapter(
+    adapter: R4JointCandidateMarginAdapter,
+    dataset: EncodedJointCandidateMarginDataset,
+    *,
+    device: torch.device,
+    record_batch_size: int = RECORDS_PER_STEP,
+) -> dict[str, Any]:
+    if record_batch_size < 1:
+        raise ValueError("joint candidate evaluation batch size must be positive")
+    adapter.eval()
+    evaluations: list[dict[str, Any]] = []
+    total_margin = 0.0
+    for base in range(0, len(dataset.encoded), record_batch_size):
+        record_indices = tuple(
+            range(base, min(base + record_batch_size, len(dataset.encoded)))
+        )
+        batch = dataset.batch(record_indices, device=device)
+        scores = adapter(batch.input_ids, batch.terminal_indices)
+        if scores.shape != batch.group_labels.shape:
+            raise RuntimeError("joint candidate adapter score cardinality differs")
+        losses = structured_margin_per_record(
+            scores, batch.group_labels, batch.record_slices
+        ).detach().cpu()
+        cpu_scores = scores.detach().cpu()
+        for lane, (start, end) in enumerate(batch.record_slices):
+            record = dataset.encoded[record_indices[lane]]
+            if end - start != len(record.groups):
+                raise RuntimeError("joint candidate score slice differs from record groups")
+            group_scores = []
+            for group, score in zip(record.groups, cpu_scores[start:end]):
+                group_scores.append(
+                    {
+                        "relation_group_cid": group.relation_group_cid,
+                        "text": group.text,
+                        "relation_label": group.relation_label,
+                        "occurrence_indices": list(group.occurrence_indices),
+                        "score": float(score),
+                    }
+                )
+            record_margin = float(losses[lane])
+            total_margin += record_margin
+            evaluations.append(
+                {
+                    "record_id": record.record_id,
+                    "source_width": record.source_width,
+                    "target_outcome": record.target_outcome,
+                    "structured_margin": record_margin,
+                    "group_scores": group_scores,
+                }
+            )
+    return {
+        "records": len(evaluations),
+        "groups": sum(len(record["group_scores"]) for record in evaluations),
+        "mean_structured_margin": total_margin / len(evaluations),
+        "record_evaluations": evaluations,
+    }
+
+
+def fit_joint_candidate_margin_adapter(
+    adapter: R4JointCandidateMarginAdapter,
+    dataset: EncodedJointCandidateMarginDataset,
+    *,
+    config: JointCandidateMarginFitConfig = JointCandidateMarginFitConfig(),
+) -> dict[str, Any]:
+    """Run the sole 270-update MPS fit without opening sealed/product data."""
+    config.validate()
+    if config.seed != adapter.config.initialization_seed:
+        raise ValueError("joint candidate fit seed differs from adapter initialization")
+    dataset.validate_fit_schedule()
+    device = require_mps(config.seed)
+    adapter.to(device)
+    adapter.train()
+    parameters = list(adapter.adapter_parameters())
+    if sum(parameter.numel() for parameter in parameters) != TRAINABLE_PARAMETER_COUNT:
+        raise RuntimeError("joint candidate optimizer parameter census differs")
+    optimizer = torch.optim.AdamW(
+        parameters,
+        lr=config.learning_rate,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_epsilon,
+        weight_decay=config.weight_decay,
+    )
+    started = time.monotonic()
+    initial_loss: float | None = None
+    final_loss = math.nan
+    projected_seconds: float | None = None
+    for step in range(1, config.optimizer_steps + 1):
+        record_indices = dataset.record_indices_for_step(step)
+        batch = dataset.batch(record_indices, device=device)
+        optimizer.zero_grad(set_to_none=True)
+        scores = adapter(batch.input_ids, batch.terminal_indices)
+        loss = joint_candidate_structured_margin_loss(
+            scores, batch.group_labels, batch.record_slices
+        )
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(parameters, config.gradient_clip)
+        optimizer.step()
+        final_loss = float(loss.detach().cpu())
+        if initial_loss is None:
+            initial_loss = final_loss
+        if not math.isfinite(final_loss):
+            raise RuntimeError("joint candidate adapter produced a nonfinite loss")
+        if step == config.eta_probe_step:
+            if hasattr(torch, "mps"):
+                torch.mps.synchronize()
+            elapsed = time.monotonic() - started
+            projected_seconds = elapsed * config.optimizer_steps / step
+            print(
+                f"joint_candidate_margin_eta_probe_step={step} "
+                f"elapsed_seconds={elapsed:.3f} "
+                f"projected_seconds={projected_seconds:.3f} "
+                f"ceiling_seconds={config.wall_ceiling_seconds:.3f}",
+                flush=True,
+            )
+            if projected_seconds > config.wall_ceiling_seconds:
+                raise JointCandidateMarginWallBudgetExceeded(
+                    step=step,
+                    elapsed_seconds=elapsed,
+                    projected_seconds_at_eta_probe=projected_seconds,
+                    wall_ceiling_seconds=config.wall_ceiling_seconds,
+                )
+        elapsed = time.monotonic() - started
+        if elapsed > config.wall_ceiling_seconds:
+            raise JointCandidateMarginWallBudgetExceeded(
+                step=step,
+                elapsed_seconds=elapsed,
+                projected_seconds_at_eta_probe=projected_seconds,
+                wall_ceiling_seconds=config.wall_ceiling_seconds,
+            )
+        if step % config.progress_interval == 0 or step == config.optimizer_steps:
+            print(
+                f"joint_candidate_margin_step={step}/{config.optimizer_steps} "
+                f"loss={final_loss:.6f}",
+                flush=True,
+            )
+    if hasattr(torch, "mps"):
+        torch.mps.synchronize()
+    elapsed_seconds = time.monotonic() - started
+    if elapsed_seconds > config.wall_ceiling_seconds:
+        raise JointCandidateMarginWallBudgetExceeded(
+            step=config.optimizer_steps,
+            elapsed_seconds=elapsed_seconds,
+            projected_seconds_at_eta_probe=projected_seconds,
+            wall_ceiling_seconds=config.wall_ceiling_seconds,
+        )
+    return {
+        "optimizer_steps": config.optimizer_steps,
+        "records_per_step": config.records_per_step,
+        "initial_structured_margin": initial_loss,
+        "final_structured_margin": final_loss,
+        "elapsed_seconds": elapsed_seconds,
+        "eta_probe_step": config.eta_probe_step,
+        "projected_seconds_at_eta_probe": projected_seconds,
+        "wall_ceiling_seconds": config.wall_ceiling_seconds,
+        "trainable_parameter_count": TRAINABLE_PARAMETER_COUNT,
+        "delta_audit": adapter.delta_audit(),
+    }

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin_campaign.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin_campaign.py
@@ -1,0 +1,1268 @@
+"""Prepared, one-shot C1-SB4 joint-candidate margin preflight.
+
+Preparation is the only phase allowed to construct the fresh population or
+open the four product records.  The optimizer entrypoint consumes a narrower
+manifest containing fit/sealed records, aggregate tokenizer evidence, and
+opaque product commitments only.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import torch
+from tokenizers import Tokenizer
+
+from .constants import FROZEN_MODEL_CONFIG
+from .joint_candidate_margin import (
+    FIT_SEED,
+    POLICY,
+    REPRESENTATION_UPDATE,
+    EncodedJointCandidateMarginDataset,
+    JointCandidateMarginAdapterConfig,
+    JointCandidateMarginFitConfig,
+    JointCandidateMarginWallBudgetExceeded,
+    R4JointCandidateMarginAdapter,
+    evaluate_joint_candidate_margin_adapter,
+    fit_joint_candidate_margin_adapter,
+)
+from .joint_candidate_margin_data import (
+    JOINT_CENSUS_SCHEMA,
+    JOINT_DATASET_SCHEMA,
+    JOINT_INPUT_POLICY,
+    JOINT_PREFLIGHT_SCHEMA,
+    build_joint_candidate_margin_population,
+    render_joint_candidate_input,
+)
+from .provenance import (
+    atomic_write_json,
+    canonical_json_bytes,
+    cid_bytes,
+    trainer_implementation_contract,
+    verify_bound_manifest,
+    write_bound_manifest,
+)
+from .source_relation_adapter import (
+    NO_TOKEN_ID,
+    YES_TOKEN_ID,
+    export_merged_attended_relation_checkpoint,
+    validate_tokenizer_contract,
+)
+from .source_relation_adapter_campaign import (
+    _delta_contract,
+    _load_base_model,
+    _rust_checkpoint_tree_binding,
+    _validate_roots,
+    _validated_predecessor,
+)
+from .source_relation_data import split_sentence_spans
+from .train import require_mps
+
+
+ISSUE = 954
+EXPECTED_WEIGHTS_CID = (
+    "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d"
+)
+EXPECTED_TOKENIZER_CID = (
+    "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc"
+)
+EXPECTED_CONFIG_CID = (
+    "blake3:1f1ddb6de22f5c81c04d3093eeff8e0991d63b79ee33bc8ff3cf7c68ef0a9497"
+)
+EXPECTED_DATASET_CID = (
+    "blake3:46e95f83f05bd5a3bfd4ca0c39c4974f617ae9591ff083d3c6abb8f5593c0e51"
+)
+EXPECTED_PREFLIGHT_CID = (
+    "blake3:b61a098a53fca1f30b69a0ef0d6e15c5b6fc5a310d0ac8f0f2df04d1fd208814"
+)
+EXPECTED_PRODUCT_CID = (
+    "blake3:153f6075f165d6cf92aeb63c31f05c9a869cc94c4655f83b9fe036bf7c773e3e"
+)
+EXPECTED_CENSUS_CID = (
+    "blake3:2531f2c19cc60570c3807aa117b97923d4ce0b0c8111a8c239861cbae4303a92"
+)
+EXPECTED_TOKENIZER_CENSUS_CID = (
+    "blake3:ff5c25b70d0940e0b43ec8cacc60c2b576ba069106d28c8ce58cb6b17f2cbc10"
+)
+EXPECTED_PREDECESSOR_MANIFEST_CID = (
+    "blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3"
+)
+EXPECTED_PRODUCT_MANIFEST_CID = (
+    "blake3:886d931fd6dde610955c6eedff3181fbffa8d8590f300731387f225f0012197b"
+)
+TOKENIZER_CENSUS_SCHEMA = "uor-r4.joint-candidate-margin-tokenizer-census/1"
+DATA_MANIFEST_SCHEMA = "uor-r4.joint-candidate-margin-training-view-manifest/1"
+PRODUCT_MANIFEST_SCHEMA = "uor-r4.joint-candidate-margin-product-manifest/1"
+RUN_SCHEMA = "uor-r4.joint-candidate-margin-run/1"
+RESULT_SCHEMA = "uor-r4.joint-candidate-margin-preflight-result/1"
+RESULT_MANIFEST_SCHEMA = "uor-r4.joint-candidate-margin-preflight-manifest/1"
+ARTIFACT_SCHEMA = "uor-r4.attended-relation-adapter/2"
+ARTIFACT_INPUT_TEMPLATE = "E:<source>\nQ:<question>\nC:<group>\nSupported:"
+RESEARCH_ADMISSION = "research_only"
+FROZEN_READOUT_UPDATE = "none_frozen_readout"
+MAXIMUM_SOURCE_SPANS = 8
+CHECKPOINT_DIRECTORY = "preflight-checkpoint"
+ADAPTER_ARTIFACT = "joint-candidate-margin-adapter.json"
+
+DATASET_FILE = "joint-candidate-margin-dataset.json"
+PREFLIGHT_FILE = "joint-candidate-margin-preflight.json"
+STRUCTURAL_CENSUS_FILE = "joint-candidate-margin-census.json"
+TOKENIZER_CENSUS_FILE = "joint-candidate-margin-tokenizer-census.json"
+PRODUCT_FILE = "product-probes.json"
+PRODUCT_MANIFEST_FILE = "product-commitments-manifest.json"
+TRAINING_MANIFEST_FILE = "training-view-manifest.json"
+
+TRAINING_VIEW_ARTIFACTS = {
+    DATASET_FILE,
+    PREFLIGHT_FILE,
+    STRUCTURAL_CENSUS_FILE,
+    TOKENIZER_CENSUS_FILE,
+}
+
+EXPECTED_TOKENIZER_PARTITIONS = {
+    "fit": {"records": 126, "groups": 604, "maximum_positions_including_bos": 221},
+    "sealed": {"records": 63, "groups": 302, "maximum_positions_including_bos": 197},
+    "product": {"records": 4, "groups": 11, "maximum_positions_including_bos": 114},
+}
+
+
+def _canonical_with_cid(value: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _verify_self_cid(value: Mapping[str, Any], field: str) -> None:
+    unsigned = dict(value)
+    observed = unsigned.pop(field, None)
+    if not isinstance(observed, str):
+        raise ValueError(f"C1-SB4 value has no {field}")
+    if observed != cid_bytes(canonical_json_bytes(unsigned)):
+        raise ValueError(f"C1-SB4 {field} does not reproduce")
+
+
+def _write_or_verify(path: Path, value: Mapping[str, Any]) -> None:
+    encoded = canonical_json_bytes(value)
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ValueError(f"existing C1-SB4 artifact differs: {path}")
+        return
+    atomic_write_json(path, value)
+
+
+def _tokenizer_partition(
+    records: Sequence[Mapping[str, Any]], tokenizer: Tokenizer
+) -> dict[str, Any]:
+    dataset = EncodedJointCandidateMarginDataset(records, tokenizer)
+    content_lengths = [
+        len(group.token_ids) for record in dataset.encoded for group in record.groups
+    ]
+    if not content_lengths:
+        raise RuntimeError("C1-SB4 tokenizer partition contains no group prompts")
+    positions = [length + 1 for length in content_lengths]
+    maximum = max(positions)
+    passed = (
+        maximum <= FROZEN_MODEL_CONFIG.max_position_embeddings
+        and all(length > 0 for length in content_lengths)
+    )
+    if not passed:
+        raise RuntimeError("C1-SB4 tokenizer census exceeds the frozen context")
+    return {
+        "records": len(dataset.records),
+        "groups": len(content_lengths),
+        "minimum_content_tokens": min(content_lengths),
+        "maximum_content_tokens": max(content_lengths),
+        "minimum_positions_including_bos": min(positions),
+        "maximum_positions_including_bos": maximum,
+        "context_ceiling_including_bos": FROZEN_MODEL_CONFIG.max_position_embeddings,
+        "terminal_token": "standalone colon",
+        "truncation": "FORBIDDEN_NOT_USED",
+        "passed": True,
+    }
+
+
+def _build_tokenizer_census(
+    *,
+    tokenizer: Tokenizer,
+    preflight: Mapping[str, Any],
+    products: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_tokenizer_contract(tokenizer)
+    partitions = {
+        "fit": _tokenizer_partition(list(preflight["fit"]), tokenizer),
+        "sealed": _tokenizer_partition(list(preflight["sealed"]), tokenizer),
+        "product": _tokenizer_partition(list(products["records"]), tokenizer),
+    }
+    compact = {
+        name: {
+            key: observed[key]
+            for key in ("records", "groups", "maximum_positions_including_bos")
+        }
+        for name, observed in partitions.items()
+    }
+    if compact != EXPECTED_TOKENIZER_PARTITIONS:
+        raise RuntimeError(f"C1-SB4 tokenizer census drifted: {compact}")
+    value = {
+        "schema": TOKENIZER_CENSUS_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "input_policy": JOINT_INPUT_POLICY,
+        "partitions": partitions,
+        "all_prompts_end_at_standalone_colon": True,
+        "no_prompt_truncated": True,
+        "passed": all(bool(partition["passed"]) for partition in partitions.values()),
+    }
+    if not value["passed"]:
+        raise RuntimeError("C1-SB4 tokenizer census is not positive")
+    return _canonical_with_cid(value, "tokenizer_census_cid")
+
+
+def prepare_joint_candidate_margin_data(
+    root: Path, *, predecessor: Path
+) -> dict[str, Any]:
+    """Commit fresh data and products without starting or constructing a model."""
+    root, predecessor = _validate_roots(root, predecessor)
+    predecessor_manifest = _validated_predecessor(predecessor)
+    dataset, preflight, products = build_joint_candidate_margin_population()
+    observed_cids = (
+        dataset["dataset_cid"],
+        preflight["preflight_cid"],
+        products["product_probes_cid"],
+        dataset["census_cid"],
+    )
+    expected_cids = (
+        EXPECTED_DATASET_CID,
+        EXPECTED_PREFLIGHT_CID,
+        EXPECTED_PRODUCT_CID,
+        EXPECTED_CENSUS_CID,
+    )
+    if observed_cids != expected_cids or not dataset["census"]["passed"]:
+        raise RuntimeError("C1-SB4 structural commitments do not match the freeze")
+    tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+    tokenizer_census = _build_tokenizer_census(
+        tokenizer=tokenizer, preflight=preflight, products=products
+    )
+
+    # Nothing is written until every structural and tokenizer check has passed.
+    root.mkdir(parents=True, exist_ok=True)
+    _write_or_verify(root / DATASET_FILE, dataset)
+    _write_or_verify(root / PREFLIGHT_FILE, preflight)
+    _write_or_verify(root / STRUCTURAL_CENSUS_FILE, dataset["census"])
+    _write_or_verify(root / TOKENIZER_CENSUS_FILE, tokenizer_census)
+    _write_or_verify(root / PRODUCT_FILE, products)
+
+    product_manifest_path = root / PRODUCT_MANIFEST_FILE
+    if product_manifest_path.exists():
+        product_manifest = verify_bound_manifest(product_manifest_path, artifact_root=root)
+    else:
+        product_manifest = write_bound_manifest(
+            product_manifest_path,
+            {
+                "schema": PRODUCT_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "product_probes_cid": products["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "access_policy": "opaque to every optimizer and preflight evaluator",
+            },
+            artifact_root=root,
+            relative_paths=[PRODUCT_FILE],
+        )
+
+    training_manifest_path = root / TRAINING_MANIFEST_FILE
+    if training_manifest_path.exists():
+        training_manifest = verify_bound_manifest(training_manifest_path, artifact_root=root)
+    else:
+        training_manifest = write_bound_manifest(
+            training_manifest_path,
+            {
+                "schema": DATA_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "dataset_cid": dataset["dataset_cid"],
+                "preflight_cid": preflight["preflight_cid"],
+                "split_policy_cid": dataset["split_policy_cid"],
+                "census_cid": dataset["census_cid"],
+                "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+                "product_probes_cid": products["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "product_probe_count": 4,
+                "product_manifest_cid": product_manifest["manifest_cid"],
+                "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+                "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+                "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                "product_text_access": "DENIED_TO_TRAINING_VIEW",
+            },
+            artifact_root=root,
+            relative_paths=[
+                DATASET_FILE,
+                PREFLIGHT_FILE,
+                STRUCTURAL_CENSUS_FILE,
+                TOKENIZER_CENSUS_FILE,
+            ],
+        )
+    if any(
+        record["path"] in {PRODUCT_FILE, PRODUCT_MANIFEST_FILE}
+        for record in training_manifest["artifacts"]
+    ):
+        raise RuntimeError("C1-SB4 training view accidentally contains product material")
+    return {
+        "terminal": "JOINT_CANDIDATE_MARGIN_DATA_COMMITTED_NO_TRAINING",
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "census_cid": dataset["census_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "product_probes_cid": products["product_probes_cid"],
+        "product_probe_commitments": dataset["product_probe_commitments"],
+        "training_view_manifest_cid": training_manifest["manifest_cid"],
+        "product_manifest_cid": product_manifest["manifest_cid"],
+        "product_text_status": "COMMITTED_UNOPENED_BY_TRAINER",
+    }
+
+
+def _load_training_view(
+    root: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load only artifacts explicitly admitted to the optimizer view."""
+    manifest = verify_bound_manifest(root / TRAINING_MANIFEST_FILE, artifact_root=root)
+    if manifest.get("schema") != DATA_MANIFEST_SCHEMA:
+        raise ValueError("unexpected C1-SB4 training-view schema")
+    dataset = json.loads((root / DATASET_FILE).read_text(encoding="utf-8"))
+    preflight = json.loads((root / PREFLIGHT_FILE).read_text(encoding="utf-8"))
+    structural = json.loads(
+        (root / STRUCTURAL_CENSUS_FILE).read_text(encoding="utf-8")
+    )
+    tokenizer_census = json.loads(
+        (root / TOKENIZER_CENSUS_FILE).read_text(encoding="utf-8")
+    )
+    _verify_self_cid(dataset, "dataset_cid")
+    _verify_self_cid(preflight, "preflight_cid")
+    _verify_self_cid(structural, "census_cid")
+    _verify_self_cid(tokenizer_census, "tokenizer_census_cid")
+    frozen_identity = {
+        "dataset_cid": EXPECTED_DATASET_CID,
+        "preflight_cid": EXPECTED_PREFLIGHT_CID,
+        "census_cid": EXPECTED_CENSUS_CID,
+        "tokenizer_census_cid": EXPECTED_TOKENIZER_CENSUS_CID,
+        "product_probes_cid": EXPECTED_PRODUCT_CID,
+        "product_manifest_cid": EXPECTED_PRODUCT_MANIFEST_CID,
+        "predecessor_export_manifest_cid": EXPECTED_PREDECESSOR_MANIFEST_CID,
+        "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+        "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+    }
+    if any(manifest.get(key) != value for key, value in frozen_identity.items()):
+        raise ValueError("C1-SB4 training view does not bind the frozen campaign")
+    if (
+        dataset.get("schema") != JOINT_DATASET_SCHEMA
+        or dataset.get("policy") != POLICY
+        or dataset.get("issue") != ISSUE
+        or dataset.get("dataset_cid") != EXPECTED_DATASET_CID
+        or dataset.get("preflight_cid") != EXPECTED_PREFLIGHT_CID
+        or dataset.get("census_cid") != EXPECTED_CENSUS_CID
+        or dataset.get("product_probes_cid") != EXPECTED_PRODUCT_CID
+        or dataset.get("relation_input_policy") != JOINT_INPUT_POLICY
+    ):
+        raise ValueError("C1-SB4 dataset identity or policy drifted")
+    if (
+        preflight.get("schema") != JOINT_PREFLIGHT_SCHEMA
+        or preflight.get("policy") != POLICY
+        or preflight.get("issue") != ISSUE
+        or preflight.get("preflight_cid") != EXPECTED_PREFLIGHT_CID
+        or preflight.get("census_cid") != EXPECTED_CENSUS_CID
+    ):
+        raise ValueError("C1-SB4 preflight identity or policy drifted")
+    if (
+        structural.get("schema") != JOINT_CENSUS_SCHEMA
+        or structural.get("policy") != POLICY
+        or structural.get("census_cid") != EXPECTED_CENSUS_CID
+        or not structural.get("passed")
+    ):
+        raise ValueError("C1-SB4 structural census identity or policy drifted")
+    tokenizer_compact = {
+        name: {
+            key: tokenizer_census.get("partitions", {}).get(name, {}).get(key)
+            for key in ("records", "groups", "maximum_positions_including_bos")
+        }
+        for name in EXPECTED_TOKENIZER_PARTITIONS
+    }
+    if (
+        tokenizer_census.get("schema") != TOKENIZER_CENSUS_SCHEMA
+        or tokenizer_census.get("policy") != POLICY
+        or tokenizer_census.get("issue") != ISSUE
+        or tokenizer_census.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID
+        or tokenizer_census.get("input_policy") != JOINT_INPUT_POLICY
+        or tokenizer_census.get("tokenizer_census_cid")
+        != EXPECTED_TOKENIZER_CENSUS_CID
+        or tokenizer_compact != EXPECTED_TOKENIZER_PARTITIONS
+        or not tokenizer_census.get("all_prompts_end_at_standalone_colon")
+        or not tokenizer_census.get("no_prompt_truncated")
+        or not tokenizer_census.get("passed")
+    ):
+        raise ValueError("C1-SB4 tokenizer census identity or policy drifted")
+    expected = {
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "census_cid": structural["census_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "product_probes_cid": dataset["product_probes_cid"],
+        "product_probe_commitments": dataset["product_probe_commitments"],
+        "product_probe_count": 4,
+    }
+    if any(manifest.get(key) != value for key, value in expected.items()):
+        raise ValueError("C1-SB4 training view differs from its frozen commitments")
+    if dataset["census"] != structural or not structural["passed"]:
+        raise ValueError("C1-SB4 structural census differs or is not positive")
+    artifact_paths = [record.get("path") for record in manifest.get("artifacts", [])]
+    if len(artifact_paths) != len(TRAINING_VIEW_ARTIFACTS) or set(
+        artifact_paths
+    ) != TRAINING_VIEW_ARTIFACTS:
+        raise ValueError("C1-SB4 training view artifact whitelist drifted")
+    return dataset, preflight, tokenizer_census, manifest
+
+
+def _record_metrics(
+    records: Sequence[Mapping[str, Any]],
+    raw: Mapping[str, Any],
+    *,
+    include_records: bool,
+) -> dict[str, Any]:
+    evaluations = raw.get("record_evaluations")
+    if not isinstance(evaluations, list) or len(evaluations) != len(records):
+        raise RuntimeError("C1-SB4 evaluation/record cardinality differs")
+    by_id: dict[str, Mapping[str, Any]] = {}
+    for evaluation in evaluations:
+        record_id = evaluation.get("record_id")
+        if not isinstance(record_id, str) or record_id in by_id:
+            raise ValueError("C1-SB4 evaluation identities are missing or duplicated")
+        by_id[record_id] = evaluation
+
+    outcome = {
+        name: {"correct": 0, "total": 0, "accuracy": 0.0}
+        for name in ("answer", "abstain", "conflict")
+    }
+    positive_group_correct = positive_group_total = 0
+    negative_group_correct = negative_group_total = 0
+    positive_occurrence_correct = positive_occurrence_total = 0
+    negative_occurrence_correct = negative_occurrence_total = 0
+    copy_correct = copy_total = 0
+    record_correct = 0
+    details: list[dict[str, Any]] = []
+    all_scores: list[float] = []
+    for record in records:
+        record_id = str(record.get("record_id", record.get("record_cid", "")))
+        evaluation = by_id.get(record_id)
+        if evaluation is None:
+            raise RuntimeError(f"C1-SB4 record {record_id} has no evaluation")
+        expected_groups: dict[str, dict[str, Any]] = {}
+        for span in record["sentence_spans"]:
+            group_cid = str(span["relation_group_cid"])
+            group = expected_groups.setdefault(
+                group_cid,
+                {
+                    "text": str(span["text"]),
+                    "label": int(span["relation_label"]),
+                    "occurrences": [],
+                },
+            )
+            if group["text"] != span["text"] or group["label"] != span["relation_label"]:
+                raise ValueError("C1-SB4 committed duplicate group disagrees")
+            group["occurrences"].append(int(span["candidate_index"]))
+        observed_rows = evaluation.get("group_scores")
+        if not isinstance(observed_rows, list) or len(observed_rows) != len(expected_groups):
+            raise RuntimeError("C1-SB4 group score cardinality differs")
+        observed_groups: dict[str, Mapping[str, Any]] = {}
+        for row in observed_rows:
+            group_cid = row.get("relation_group_cid")
+            score = row.get("score")
+            if (
+                not isinstance(group_cid, str)
+                or group_cid in observed_groups
+                or not isinstance(score, (int, float))
+                or not math.isfinite(float(score))
+            ):
+                raise ValueError("C1-SB4 group score is missing, duplicated, or nonfinite")
+            observed_groups[group_cid] = row
+            all_scores.append(float(score))
+        if set(observed_groups) != set(expected_groups):
+            raise RuntimeError("C1-SB4 scored group identities differ")
+
+        group_exact = True
+        positive_observed: list[str] = []
+        for group_cid, expected_group in expected_groups.items():
+            observed = observed_groups[group_cid]
+            if (
+                observed.get("text") != expected_group["text"]
+                or int(observed.get("relation_label", -1)) != expected_group["label"]
+                or list(observed.get("occurrence_indices", []))
+                != expected_group["occurrences"]
+            ):
+                raise RuntimeError("C1-SB4 score row metadata differs from the record")
+            score = float(observed["score"])
+            predicted = score > 0.0
+            expected_positive = bool(expected_group["label"])
+            group_exact = group_exact and predicted == expected_positive
+            occurrences = len(expected_group["occurrences"])
+            if expected_positive:
+                positive_group_total += 1
+                positive_group_correct += int(predicted)
+                positive_occurrence_total += occurrences
+                positive_occurrence_correct += occurrences * int(predicted)
+            else:
+                negative_group_total += 1
+                negative_group_correct += int(not predicted)
+                negative_occurrence_total += occurrences
+                negative_occurrence_correct += occurrences * int(not predicted)
+            if predicted:
+                positive_observed.append(group_cid)
+
+        if not positive_observed:
+            decision = "abstain"
+            selected_index = None
+        elif len(positive_observed) == 1:
+            decision = "answer"
+            selected_index = min(expected_groups[positive_observed[0]]["occurrences"])
+        else:
+            decision = "conflict"
+            selected_index = None
+        expected_outcome = str(record["target_outcome"])
+        outcome[expected_outcome]["total"] += 1
+        outcome_exact = decision == expected_outcome
+        outcome[expected_outcome]["correct"] += int(outcome_exact)
+        copy_exact = True
+        if expected_outcome == "answer":
+            copy_total += 1
+            copy_exact = bool(
+                decision == "answer"
+                and selected_index == record["target_span_index"]
+                and selected_index is not None
+                and record["sentence_spans"][selected_index]["text"] == record["answer"]
+            )
+            copy_correct += int(copy_exact)
+        exact = group_exact and outcome_exact and copy_exact
+        record_correct += int(exact)
+        details.append(
+            {
+                "record_id": record_id,
+                "lexical_world": record.get("lexical_world"),
+                "motif": record["motif"],
+                "target_outcome": expected_outcome,
+                "decision": decision,
+                "selected_span_index": selected_index,
+                "target_span_index": record["target_span_index"],
+                "group_signs_exact": group_exact,
+                "outcome_exact": outcome_exact,
+                "copy_exact": copy_exact,
+                "record_exact": exact,
+            }
+        )
+    for cell in outcome.values():
+        cell["accuracy"] = cell["correct"] / cell["total"] if cell["total"] else 0.0
+    value: dict[str, Any] = {
+        "records": len(records),
+        "record_exact": {
+            "correct": record_correct,
+            "total": len(records),
+            "accuracy": record_correct / len(records),
+        },
+        "outcome": outcome,
+        "positive_group_recall": {
+            "correct": positive_group_correct,
+            "total": positive_group_total,
+            "accuracy": positive_group_correct / positive_group_total,
+        },
+        "negative_group_specificity": {
+            "correct": negative_group_correct,
+            "total": negative_group_total,
+            "accuracy": negative_group_correct / negative_group_total,
+        },
+        "positive_relation_recall": {
+            "correct": positive_occurrence_correct,
+            "total": positive_occurrence_total,
+            "accuracy": positive_occurrence_correct / positive_occurrence_total,
+        },
+        "negative_relation_specificity": {
+            "correct": negative_occurrence_correct,
+            "total": negative_occurrence_total,
+            "accuracy": negative_occurrence_correct / negative_occurrence_total,
+        },
+        "supported_copied_span": {
+            "correct": copy_correct,
+            "total": copy_total,
+            "accuracy": copy_correct / copy_total,
+        },
+        "mean_structured_margin": float(raw["mean_structured_margin"]),
+        "score_range": {"minimum": min(all_scores), "maximum": max(all_scores)},
+    }
+    if include_records:
+        value["record_evaluations"] = details
+    return value
+
+
+def _evaluate_records(
+    adapter: R4JointCandidateMarginAdapter,
+    records: Sequence[Mapping[str, Any]],
+    *,
+    tokenizer: Tokenizer,
+    device: torch.device,
+    include_records: bool = False,
+) -> dict[str, Any]:
+    dataset = EncodedJointCandidateMarginDataset(records, tokenizer)
+    raw = evaluate_joint_candidate_margin_adapter(
+        adapter, dataset, device=device, record_batch_size=7
+    )
+    return _record_metrics(records, raw, include_records=include_records)
+
+
+def _all_exact(metrics: Mapping[str, Any]) -> bool:
+    return metrics["record_exact"]["correct"] == metrics["record_exact"]["total"]
+
+
+def _without_records(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in metrics.items() if key != "record_evaluations"}
+
+
+def _named_controls(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    evaluations = list(metrics.get("record_evaluations", []))
+    query_motifs = {
+        "matched-primary-answer",
+        "matched-secondary-answer",
+        "primary-source-secondary-abstain",
+        "secondary-source-primary-abstain",
+        "primary-distinct-location-conflict",
+        "secondary-distinct-location-conflict",
+    }
+    query = [row for row in evaluations if row["motif"] in query_motifs]
+    duplicate = [row for row in evaluations if row["motif"] == "exact-duplicate-agreement"]
+    conflict = [row for row in evaluations if row["target_outcome"] == "conflict"]
+    return {
+        "same_source_query_relocation_exact": bool(query)
+        and all(bool(row["record_exact"]) for row in query),
+        "same_source_query_relocation_records": len(query),
+        "duplicate_agreement_exact": bool(duplicate)
+        and all(bool(row["record_exact"]) for row in duplicate),
+        "duplicate_agreement_records": len(duplicate),
+        "distinct_conflict_exact": bool(conflict)
+        and all(bool(row["record_exact"]) for row in conflict),
+        "distinct_conflict_records": len(conflict),
+    }
+
+
+def _reversed_records(
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Rebuild full-source reversals; the SB3 row-only helper is invalid here."""
+    reversed_records: list[dict[str, Any]] = []
+    identity = 0
+    for record in records:
+        old_spans = [dict(span) for span in reversed(record["sentence_spans"])]
+        source = " ".join(str(span["text"]) for span in old_spans)
+        parsed = split_sentence_spans(source)
+        spans: list[dict[str, Any]] = []
+        for index, (old_span, parsed_span) in enumerate(zip(old_spans, parsed)):
+            span = dict(old_span)
+            span["candidate_index"] = index
+            span["byte_start"] = int(parsed_span["byte_start"])
+            span["byte_end"] = int(parsed_span["byte_end"])
+            relation_input = render_joint_candidate_input(
+                source, str(record["question"]), str(span["text"])
+            )
+            span["relation_input"] = relation_input
+            span["relation_input_cid"] = cid_bytes(relation_input.encode("utf-8"))
+            spans.append(span)
+        value = dict(record)
+        value.pop("record_cid", None)
+        value["record_id"] = f"{record['record_cid']}:source-reversed"
+        value["population"] = "preflight-source-order-control"
+        value["motif"] = f"source-reversed-{record['motif']}"
+        value["source"] = source
+        value["source_cid"] = cid_bytes(source.encode("utf-8"))
+        value["sentence_spans"] = spans
+        value["positive_span_indices"] = [
+            index for index, span in enumerate(spans) if int(span["relation_label"]) == 1
+        ]
+        if record["target_outcome"] == "answer":
+            value["target_span_index"] = min(
+                index
+                for index, span in enumerate(spans)
+                if int(span["relation_label"]) == 1 and span["text"] == record["answer"]
+            )
+        else:
+            value["target_span_index"] = None
+        is_identity = source == record["source"]
+        value["source_reversal_identity"] = is_identity
+        value["candidate_original_indices"] = list(
+            reversed(range(int(record["source_width"])))
+        )
+        identity += int(is_identity)
+        reversed_records.append(value)
+    return reversed_records, {
+        "records": len(reversed_records),
+        "nontrivial_reversals": len(reversed_records) - identity,
+        "byte_identical_reversals": identity,
+    }
+
+
+def _run_contract(
+    *,
+    predecessor_manifest: Mapping[str, Any],
+    dataset: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    tokenizer_census: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _canonical_with_cid(
+        {
+            "schema": RUN_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+            "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "model_contract": FROZEN_MODEL_CONFIG.as_contract(),
+            "adapter_contract": JointCandidateMarginAdapterConfig().as_contract(),
+            "optimizer_contract": JointCandidateMarginFitConfig().as_contract(),
+            "dataset_cid": dataset["dataset_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "census_cid": dataset["census_cid"],
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "training_view_manifest_cid": training_manifest["manifest_cid"],
+            "product_probes_cid": dataset["product_probes_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+            "product_text_access": "DENIED_TO_PYTHON_TRAINER_AND_EVALUATOR",
+            "mechanism": (
+                "full-source/question/distinct-exact-text candidate prompts through "
+                "rank-8 Q/K/V/O LoRA in all six attention layers; fixed tied yes/no "
+                "readout; duplicate groups collapsed; no learned head"
+            ),
+            "objective": (
+                "mean records of relu(1-min positive group score) plus "
+                "relu(1+max negative group score); absent-set term zero"
+            ),
+            "reachability_ceiling": "189/189 fit+sealed records = 100%",
+            "instrument": {
+                "fit_maximum_positions_including_bos": 221,
+                "sealed_maximum_positions_including_bos": 197,
+                "frozen_context_ceiling": 256,
+                "measured_warm_step_seconds": 0.7586764579173177,
+                "projected_270_step_seconds": 204.8426436376478,
+            },
+            "preflight_gate": {
+                "fit_records": 126,
+                "sealed_records": 63,
+                "all_group_signs_outcomes_and_copies": "exact",
+                "sealed_source_reversal": "exact after main gate only",
+                "base_selection": (
+                    "if the untrained sealed partition is exact, retain the simpler "
+                    "frozen readout; otherwise the learned arm must be exact on fit "
+                    "and sealed"
+                ),
+                "wall_ceiling_seconds": 600.0,
+            },
+            "if_positive": (
+                "emit one research-only merged checkpoint and adapter/2 descriptor "
+                "for one Rust parity probe"
+            ),
+            "if_negative": (
+                "stop before Rust parity, full fit, development, or product without retry"
+            ),
+            "implementation": trainer_implementation_contract(),
+        },
+        "run_contract_cid",
+    )
+
+
+def _sanitized_budget_failure(
+    error: JointCandidateMarginWallBudgetExceeded,
+) -> dict[str, Any]:
+    """Record the binding budget verdict without timing-dependent CID bytes."""
+    observation = error.as_result()
+    observation.pop("stopped_after_step", None)
+    observation.pop("elapsed_seconds", None)
+    observation.pop("projected_seconds_at_eta_probe", None)
+    observation.update(
+        {
+            "budget_gate_passed": False,
+            "timing_values": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM",
+        }
+    )
+    return observation
+
+
+def _sanitized_optimization(optimization: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep a deterministic success verdict while excluding wall-clock noise."""
+    result = {
+        key: value
+        for key, value in optimization.items()
+        if key not in {"elapsed_seconds", "projected_seconds_at_eta_probe"}
+    }
+    if "optimizer_steps" in optimization:
+        fit_contract = JointCandidateMarginFitConfig()
+        result["operational_budget_observation"] = {
+            "eta_probe_step": optimization.get(
+                "eta_probe_step", fit_contract.eta_probe_step
+            ),
+            "wall_ceiling_seconds": optimization.get(
+                "wall_ceiling_seconds", fit_contract.wall_ceiling_seconds
+            ),
+            "eta_probe_passed": True,
+            "completed_within_wall_ceiling": True,
+            "timing_values": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM",
+        }
+    return result
+
+
+def _build_adapter_artifact(
+    *,
+    representation_update: str,
+    checkpoint_manifest: Mapping[str, Any],
+    checkpoint_tree_cid: str,
+    dataset: Mapping[str, Any],
+    run_contract: Mapping[str, Any],
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _canonical_with_cid(
+        {
+            "schema": ARTIFACT_SCHEMA,
+            "policy": POLICY,
+            "issue": ISSUE,
+            "admission": RESEARCH_ADMISSION,
+            "representation_update": representation_update,
+            "predecessor_model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "model_weights_cid": checkpoint_manifest["weights_cid"],
+            "checkpoint_tree_cid": checkpoint_tree_cid,
+            "config_cid": checkpoint_manifest["config_cid"],
+            "tokenizer_cid": checkpoint_manifest["tokenizer_cid"],
+            "hidden_size": FROZEN_MODEL_CONFIG.hidden_size,
+            "supported_token_id": YES_TOKEN_ID,
+            "unsupported_token_id": NO_TOKEN_ID,
+            "threshold": 0.0,
+            "maximum_source_spans": MAXIMUM_SOURCE_SPANS,
+            "relation_input_policy": ARTIFACT_INPUT_TEMPLATE,
+            "dataset_cid": dataset["dataset_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "training_result_cid": result["result_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+        },
+        "artifact_cid",
+    )
+
+
+def _persist_positive_delivery(
+    root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: Mapping[str, Any],
+    adapter: R4JointCandidateMarginAdapter,
+    representation_update: str,
+    result: Mapping[str, Any],
+    dataset: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+    run_contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    relative_paths: list[str] = []
+    if representation_update == REPRESENTATION_UPDATE:
+        checkpoint = root / CHECKPOINT_DIRECTORY
+        if checkpoint.exists():
+            raise FileExistsError(f"C1-SB4 checkpoint already exists: {checkpoint}")
+        export_merged_attended_relation_checkpoint(
+            adapter,
+            output_dir=checkpoint,
+            tokenizer_path=predecessor / "tokenizer.json",
+            training_result=dict(result),
+            dataset_manifest_cid=str(dataset["dataset_cid"]),
+            training_view_manifest_cid=str(training_manifest["manifest_cid"]),
+            split_policy_cid=str(dataset["split_policy_cid"]),
+            run_contract_cid=str(run_contract["run_contract_cid"]),
+            selected_checkpoint_cid=None,
+        )
+        checkpoint_manifest = verify_bound_manifest(
+            checkpoint / "export-manifest.json", artifact_root=checkpoint
+        )
+        relative_paths.extend(
+            f"{CHECKPOINT_DIRECTORY}/{record['path']}"
+            for record in checkpoint_manifest["artifacts"]
+        )
+        relative_paths.append(f"{CHECKPOINT_DIRECTORY}/export-manifest.json")
+    elif representation_update == FROZEN_READOUT_UPDATE:
+        checkpoint = predecessor
+        checkpoint_manifest = dict(predecessor_manifest)
+    else:
+        raise ValueError("C1-SB4 positive delivery has unknown representation update")
+    if (
+        checkpoint_manifest["config_cid"] != EXPECTED_CONFIG_CID
+        or checkpoint_manifest["tokenizer_cid"] != EXPECTED_TOKENIZER_CID
+        or checkpoint_manifest["model_contract"] != FROZEN_MODEL_CONFIG.as_contract()
+    ):
+        raise ValueError("C1-SB4 positive checkpoint identity drifted")
+    if representation_update == REPRESENTATION_UPDATE:
+        if checkpoint_manifest["weights_cid"] == EXPECTED_WEIGHTS_CID:
+            raise ValueError("C1-SB4 LoRA checkpoint did not change weights")
+        if checkpoint_manifest["training_result_cid"] != result["result_cid"]:
+            raise ValueError("C1-SB4 checkpoint does not bind its result")
+    elif checkpoint_manifest["weights_cid"] != EXPECTED_WEIGHTS_CID:
+        raise ValueError("C1-SB4 frozen readout changed predecessor weights")
+    checkpoint_tree = _rust_checkpoint_tree_binding(checkpoint)
+    artifact = _build_adapter_artifact(
+        representation_update=representation_update,
+        checkpoint_manifest=checkpoint_manifest,
+        checkpoint_tree_cid=checkpoint_tree["checkpoint_tree_cid"],
+        dataset=dataset,
+        run_contract=run_contract,
+        result=result,
+    )
+    _write_or_verify(root / ADAPTER_ARTIFACT, artifact)
+    relative_paths.append(ADAPTER_ARTIFACT)
+    return {
+        "checkpoint": checkpoint,
+        "checkpoint_manifest": checkpoint_manifest,
+        "checkpoint_tree": checkpoint_tree,
+        "artifact": artifact,
+        "relative_paths": relative_paths,
+    }
+
+
+def _finalize_result(
+    root: Path,
+    *,
+    predecessor: Path,
+    predecessor_manifest: Mapping[str, Any],
+    adapter: R4JointCandidateMarginAdapter | None,
+    representation_update: str,
+    result: dict[str, Any],
+    dataset: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    tokenizer_census: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+    run_contract: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    delivery = None
+    if str(result["terminal"]).startswith("PASS_"):
+        if adapter is None:
+            raise ValueError("C1-SB4 passing preflight has no adapter")
+        delivery = _persist_positive_delivery(
+            root,
+            predecessor=predecessor,
+            predecessor_manifest=predecessor_manifest,
+            adapter=adapter,
+            representation_update=representation_update,
+            result=result,
+            dataset=dataset,
+            training_manifest=training_manifest,
+            run_contract=run_contract,
+        )
+    atomic_write_json(root / "preflight-result.json", result)
+    relative_paths = [
+        DATASET_FILE,
+        PREFLIGHT_FILE,
+        STRUCTURAL_CENSUS_FILE,
+        TOKENIZER_CENSUS_FILE,
+        TRAINING_MANIFEST_FILE,
+        "run-contract.json",
+        "preflight-started.json",
+        "preflight-result.json",
+    ]
+    payload: dict[str, Any] = {
+        "schema": RESULT_MANIFEST_SCHEMA,
+        "issue": ISSUE,
+        "policy": POLICY,
+        "terminal": result["terminal"],
+        "representation_update": representation_update,
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "run_contract_cid": run_contract["run_contract_cid"],
+        "result_cid": result["result_cid"],
+        "product_status": "UNOPENED_NOT_RUN",
+    }
+    if delivery is not None:
+        payload.update(
+            {
+                "adapter_artifact_cid": delivery["artifact"]["artifact_cid"],
+                "checkpoint_tree_cid": delivery["checkpoint_tree"]["checkpoint_tree_cid"],
+                "model_weights_cid": delivery["checkpoint_manifest"]["weights_cid"],
+                "config_cid": delivery["checkpoint_manifest"]["config_cid"],
+                "tokenizer_cid": delivery["checkpoint_manifest"]["tokenizer_cid"],
+            }
+        )
+        relative_paths.extend(delivery["relative_paths"])
+    manifest = write_bound_manifest(
+        root / "preflight-manifest.json",
+        payload,
+        artifact_root=root,
+        relative_paths=relative_paths,
+    )
+    return manifest, delivery
+
+
+def run_joint_candidate_margin_preflight(
+    root: Path, *, predecessor: Path
+) -> dict[str, Any]:
+    """Run exactly one frozen C1-SB4 preflight without product access."""
+    root, predecessor = _validate_roots(root, predecessor)
+    predecessor_manifest = _validated_predecessor(predecessor)
+    dataset, preflight, tokenizer_census, training_manifest = _load_training_view(root)
+    if (root / "preflight-result.json").exists() or (
+        root / "preflight-started.json"
+    ).exists():
+        raise FileExistsError("the sole C1-SB4 preflight was already started")
+    run_contract = _run_contract(
+        predecessor_manifest=predecessor_manifest,
+        dataset=dataset,
+        preflight=preflight,
+        tokenizer_census=tokenizer_census,
+        training_manifest=training_manifest,
+    )
+    _write_or_verify(root / "run-contract.json", run_contract)
+    atomic_write_json(
+        root / "preflight-started.json",
+        {
+            "schema": RUN_SCHEMA,
+            "phase": "SOLE_C1_SB4_PREFLIGHT_STARTED",
+            "run_contract_cid": run_contract["run_contract_cid"],
+        },
+    )
+
+    device = require_mps(FIT_SEED)
+    tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+    validate_tokenizer_contract(tokenizer)
+    fit_records = list(preflight["fit"])
+    sealed_records = list(preflight["sealed"])
+    # Reproduce only the two admitted partitions. Product aggregate evidence is
+    # bound from preparation and its text remains inaccessible here.
+    for name, records in (("fit", fit_records), ("sealed", sealed_records)):
+        observed = _tokenizer_partition(records, tokenizer)
+        committed = tokenizer_census["partitions"][name]
+        if observed != committed:
+            raise ValueError(f"C1-SB4 {name} tokenizer census does not reproduce")
+
+    model, base_state = _load_base_model(predecessor)
+    adapter = R4JointCandidateMarginAdapter(model).to(device)
+    untrained_sealed_detailed = _evaluate_records(
+        adapter,
+        sealed_records,
+        tokenizer=tokenizer,
+        device=device,
+        include_records=True,
+    )
+    untrained_sealed = _without_records(untrained_sealed_detailed)
+    representation_update = REPRESENTATION_UPDATE
+    base_sealed_exact = _all_exact(untrained_sealed_detailed)
+    untrained_fit_detailed = (
+        _evaluate_records(
+            adapter,
+            fit_records,
+            tokenizer=tokenizer,
+            device=device,
+            include_records=True,
+        )
+        if base_sealed_exact
+        else None
+    )
+    if base_sealed_exact:
+        representation_update = FROZEN_READOUT_UPDATE
+        optimization: Mapping[str, Any] = {
+            "status": "SKIPPED_SIMPLER_SEALED_READOUT_ALREADY_EXACT"
+        }
+        if untrained_fit_detailed is None:
+            raise AssertionError("exact frozen gate has no fit evaluation")
+        fit_detailed = untrained_fit_detailed
+        sealed_detailed = untrained_sealed_detailed
+        delta = {
+            "status": "NOT_APPLICABLE_FROZEN_READOUT",
+            "passed": True,
+            "representation_update": FROZEN_READOUT_UPDATE,
+        }
+    else:
+        fit_dataset = EncodedJointCandidateMarginDataset(fit_records, tokenizer)
+        try:
+            optimization = fit_joint_candidate_margin_adapter(adapter, fit_dataset)
+        except JointCandidateMarginWallBudgetExceeded as error:
+            result = _canonical_with_cid(
+                {
+                    "schema": RESULT_SCHEMA,
+                    "issue": ISSUE,
+                    "policy": POLICY,
+                    "terminal": "UNAVAILABLE_JOINT_CANDIDATE_MARGIN_BUDGET",
+                    "representation_update": REPRESENTATION_UPDATE,
+                    "run_contract_cid": run_contract["run_contract_cid"],
+                    "dataset_cid": dataset["dataset_cid"],
+                    "preflight_cid": preflight["preflight_cid"],
+                    "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+                    "training_view_manifest_cid": training_manifest["manifest_cid"],
+                    "untrained_sealed_metrics": untrained_sealed,
+                    "operational_budget_observation": _sanitized_budget_failure(
+                        error
+                    ),
+                    "fit_metrics": "NOT_RUN",
+                    "sealed_metrics": "NOT_RUN",
+                    "controls": "NOT_RUN",
+                    "delta_audit": _delta_contract(adapter, base_state),
+                    "rust_parity": "NOT_RUN",
+                    "full_fit": "NOT_RUN",
+                    "development": "NOT_RUN",
+                    "product": "UNOPENED_NOT_RUN",
+                },
+                "result_cid",
+            )
+            manifest, _ = _finalize_result(
+                root,
+                predecessor=predecessor,
+                predecessor_manifest=predecessor_manifest,
+                adapter=None,
+                representation_update=REPRESENTATION_UPDATE,
+                result=result,
+                dataset=dataset,
+                preflight=preflight,
+                tokenizer_census=tokenizer_census,
+                training_manifest=training_manifest,
+                run_contract=run_contract,
+            )
+            return {**result, "manifest_cid": manifest["manifest_cid"]}
+        fit_detailed = _evaluate_records(
+            adapter,
+            fit_records,
+            tokenizer=tokenizer,
+            device=device,
+            include_records=True,
+        )
+        sealed_detailed = _evaluate_records(
+            adapter,
+            sealed_records,
+            tokenizer=tokenizer,
+            device=device,
+            include_records=True,
+        )
+        delta = _delta_contract(adapter, base_state)
+
+    if representation_update == FROZEN_READOUT_UPDATE:
+        # The predeclared decision says an exact untrained sealed partition selects
+        # the simpler mechanism.  Fit remains visible diagnostic evidence, not a
+        # post-hoc extra gate on that frozen branch.
+        main_passed = _all_exact(sealed_detailed) and bool(delta["passed"])
+    else:
+        main_passed = (
+            not base_sealed_exact
+            and _all_exact(fit_detailed)
+            and _all_exact(sealed_detailed)
+            and bool(delta["passed"])
+        )
+    named = {
+        "fit": _named_controls(fit_detailed),
+        "sealed": _named_controls(sealed_detailed),
+    }
+    if main_passed:
+        reversed_sealed, reversal_scope = _reversed_records(sealed_records)
+        if reversal_scope != {
+            "records": 63,
+            "nontrivial_reversals": 62,
+            "byte_identical_reversals": 1,
+        }:
+            raise RuntimeError(f"C1-SB4 reversal scope drifted: {reversal_scope}")
+        reversal_metrics = _evaluate_records(
+            adapter,
+            reversed_sealed,
+            tokenizer=tokenizer,
+            device=device,
+        )
+        reversal_exact = _all_exact(reversal_metrics)
+        controls: Mapping[str, Any] = {
+            "named_subsets": named,
+            "sealed_source_reversal_scope": reversal_scope,
+            "sealed_source_reversal_metrics": reversal_metrics,
+            "sealed_source_reversal_exact": reversal_exact,
+            "passed": reversal_exact,
+        }
+    else:
+        controls = {
+            "named_subsets": named,
+            "sealed_source_reversal": "NOT_RUN_MAIN_GATE_NEGATIVE",
+            "passed": False,
+        }
+    passed = main_passed and bool(controls["passed"])
+    if passed and representation_update == FROZEN_READOUT_UPDATE:
+        terminal = "PASS_FROZEN_JOINT_SOURCE_READOUT_AWAITING_RUST_PARITY"
+    elif passed:
+        terminal = "PASS_JOINT_CANDIDATE_MARGIN_PREFLIGHT_AWAITING_RUST_PARITY"
+    else:
+        terminal = "FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT"
+
+    sanitized_optimization = _sanitized_optimization(optimization)
+    fit_metrics = _without_records(fit_detailed)
+    sealed_metrics = _without_records(sealed_detailed)
+    result = _canonical_with_cid(
+        {
+            "schema": RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": terminal,
+            "representation_update": representation_update,
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "training_view_manifest_cid": training_manifest["manifest_cid"],
+            "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+            "tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "untrained_sealed_metrics": untrained_sealed,
+            "optimization": sanitized_optimization,
+            "fit_metrics": fit_metrics,
+            "sealed_metrics": sealed_metrics,
+            "controls": controls,
+            "delta_audit": delta,
+            "rust_parity": "NOT_RUN",
+            "full_fit": "NOT_RUN",
+            "development": "NOT_RUN",
+            "product": "UNOPENED_NOT_RUN",
+        },
+        "result_cid",
+    )
+    manifest, delivery = _finalize_result(
+        root,
+        predecessor=predecessor,
+        predecessor_manifest=predecessor_manifest,
+        adapter=adapter,
+        representation_update=representation_update,
+        result=result,
+        dataset=dataset,
+        preflight=preflight,
+        tokenizer_census=tokenizer_census,
+        training_manifest=training_manifest,
+        run_contract=run_contract,
+    )
+    response: dict[str, Any] = {
+        "terminal": terminal,
+        "result_cid": result["result_cid"],
+        "manifest_cid": manifest["manifest_cid"],
+        "fit_metrics": fit_metrics,
+        "sealed_metrics": sealed_metrics,
+        "controls": controls,
+        "delta_audit": delta,
+        "rust_parity": "NOT_RUN",
+        "full_fit": "NOT_RUN",
+        "development": "NOT_RUN",
+        "product": "UNOPENED_NOT_RUN",
+    }
+    if delivery is not None:
+        response.update(
+            {
+                "adapter_artifact_cid": delivery["artifact"]["artifact_cid"],
+                "checkpoint_tree_cid": delivery["checkpoint_tree"]["checkpoint_tree_cid"],
+                "model_weights_cid": delivery["checkpoint_manifest"]["weights_cid"],
+                "checkpoint": str(delivery["checkpoint"]),
+            }
+        )
+    return response
+
+
+__all__ = [
+    "prepare_joint_candidate_margin_data",
+    "run_joint_candidate_margin_preflight",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin_data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/joint_candidate_margin_data.py
@@ -1,0 +1,634 @@
+"""Frozen C1-SB4 joint-candidate preflight data and sealed products.
+
+The population deliberately reuses the nine C1-SB3 structural motifs while
+starting from the first lexical-world ordinal after every C1-SB3 partition and
+product.  Its prompt differs materially: every distinct exact-text candidate
+group is scored while the model sees the complete source candidate set.
+
+This module contains data, labels, commitments, and zero-training census
+evidence only.  Tokenization is intentionally left to the later campaign code,
+which must bind the pinned checkpoint tokenizer before any optimization.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Iterable, Sequence
+
+from .provenance import canonical_json_bytes, cid_bytes
+from .source_relation_adapter_data import (
+    NO_TOKEN_ID,
+    NO_TOKEN_TEXT,
+    OUTCOMES,
+    SOURCE_WIDTHS,
+    YES_TOKEN_ID,
+    YES_TOKEN_TEXT,
+    LexicalWorld,
+    _canonical_with_cid,
+    _polarity_by_locative,
+    _position_labels,
+    _query_outcomes,
+    _world,
+    _world_inventory,
+    _world_partition,
+    _world_records,
+    build_source_relation_adapter_population,
+)
+from .source_relation_data import parse_subject, split_sentence_spans
+
+
+ISSUE = 954
+POLICY = "R4JointCandidateMarginAdapterV1"
+JOINT_RECORD_SCHEMA = "uor-r4.joint-candidate-margin-record/1"
+JOINT_DATASET_SCHEMA = "uor-r4.joint-candidate-margin-dataset/1"
+JOINT_PREFLIGHT_SCHEMA = "uor-r4.joint-candidate-margin-preflight/1"
+JOINT_PRODUCT_SCHEMA = "uor-r4.joint-candidate-margin-products/1"
+JOINT_CENSUS_SCHEMA = "uor-r4.joint-candidate-margin-census/1"
+JOINT_SPLIT_SCHEMA = "uor-r4.joint-candidate-margin-split/1"
+JOINT_INPUT_POLICY = (
+    "exact UTF-8 `E:<exact full source>\\nQ:<question>\\nC:<exact distinct "
+    "group text>\\nSupported:` with no terminal newline; duplicate exact-text "
+    "spans share one group prompt; score the fixed next-token yes/no verbalizer "
+    "at the final colon"
+)
+QUESTION_POLICY = "Where is the <subject>?"
+SENTENCE_POLICY = "exact .!? terminated UTF-8 byte spans"
+FRESH_WORLD_ORDINAL_START = 137
+PREFLIGHT_FIT_WORLDS_PER_WIDTH = 2
+PREFLIGHT_SEALED_WORLDS_PER_WIDTH = 1
+MOTIFS_PER_OUTCOME = 3
+
+
+def render_joint_candidate_input(
+    source: str, question: str, group_text: str
+) -> str:
+    """Render one exact full-source, candidate-conditioned scoring prefix."""
+    if not source or source != source.strip():
+        raise ValueError("joint-candidate source must be nonempty and trimmed")
+    spans = split_sentence_spans(source)
+    if not spans or " ".join(str(span["text"]) for span in spans) != source:
+        raise ValueError("joint-candidate source must be exact terminated spans")
+    if (
+        not group_text
+        or group_text != group_text.strip()
+        or group_text[-1] not in ".!?"
+    ):
+        raise ValueError("joint-candidate group text must be one trimmed span")
+    if group_text not in {str(span["text"]) for span in spans}:
+        raise ValueError("joint-candidate group text is not an exact source span")
+    parse_subject(question)
+    return f"E:{source}\nQ:{question}\nC:{group_text}\nSupported:"
+
+
+def _restamp_record(
+    record: dict[str, Any],
+    *,
+    population: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Bind an existing structural motif to the independently versioned policy."""
+    value = dict(record)
+    value.pop("record_cid", None)
+    value["schema"] = JOINT_RECORD_SCHEMA
+    value["policy"] = POLICY
+    value["population"] = population
+    source = str(value["source"])
+    question = str(value["question"])
+    sentence_spans: list[dict[str, Any]] = []
+    for original_span in value["sentence_spans"]:
+        span = dict(original_span)
+        relation_input = render_joint_candidate_input(
+            source, question, str(span["text"])
+        )
+        span["relation_input"] = relation_input
+        span["relation_input_cid"] = cid_bytes(relation_input.encode("utf-8"))
+        sentence_spans.append(span)
+    value["sentence_spans"] = sentence_spans
+    if extra:
+        overlap = set(value).intersection(extra)
+        if overlap:
+            raise ValueError(f"joint record extra fields collide: {sorted(overlap)}")
+        value.update(extra)
+    return _canonical_with_cid(value, "record_cid")
+
+
+def _product_population(
+    *, ordinal_start: int
+) -> tuple[list[LexicalWorld], dict[str, Any]]:
+    selections = (
+        ("answer", 0, "answer-supported"),
+        ("abstain", 3, "abstain-negated-nonlocative"),
+        ("conflict", 6, "conflict-distinct-values"),
+        ("answer", 2, "answer-duplicate-agreement"),
+    )
+    worlds: list[LexicalWorld] = []
+    records: list[dict[str, Any]] = []
+    for lane, (outcome, motif_index, probe) in enumerate(selections):
+        world = _world(
+            partition="c1-sb4-product",
+            width=3,
+            lane=lane,
+            ordinal=ordinal_start + lane,
+        )
+        worlds.append(world)
+        candidates = _world_records(world, population="product")
+        selected = candidates[motif_index]
+        if selected["target_outcome"] != outcome:
+            raise RuntimeError("joint product motif outcome drifted")
+        records.append(
+            _restamp_record(selected, population="product", extra={"probe": probe})
+        )
+    value = {
+        "schema": JOINT_PRODUCT_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "access_policy": (
+            "write and bind this envelope before optimization; the trainer receives "
+            "only product_probes_cid and four record commitments and must not open "
+            "record text until every pre-product gate passes"
+        ),
+        "records": records,
+    }
+    return worlds, _canonical_with_cid(value, "product_probes_cid")
+
+
+def _sentence_inventory(records: Iterable[dict[str, Any]]) -> set[str]:
+    return {
+        str(span["text"])
+        for record in records
+        for span in record["sentence_spans"]
+    }
+
+
+def _worlds_from_records(records: Sequence[dict[str, Any]]) -> list[LexicalWorld]:
+    worlds: dict[int, LexicalWorld] = {}
+    for record in records:
+        ordinal = int(record["world_ordinal"])
+        reconstructed = _world(
+            partition="c1-sb3-reference",
+            width=int(record["source_width"]),
+            lane=int(record["world_lane"]),
+            ordinal=ordinal,
+        )
+        previous = worlds.setdefault(ordinal, reconstructed)
+        if (
+            previous.width != reconstructed.width
+            or previous.lane != reconstructed.lane
+        ):
+            raise RuntimeError("one lexical ordinal described incompatible worlds")
+    return list(worlds.values())
+
+
+def _group_rows(record: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for span in record["sentence_spans"]:
+        groups[str(span["relation_group_cid"])].append(span)
+    return dict(groups)
+
+
+def _group_contract(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    prompt_cids: list[str] = []
+    distinct_groups = 0
+    positive_groups = 0
+    negative_groups = 0
+    duplicate_records = 0
+    exact = True
+    for record in records:
+        groups = _group_rows(record)
+        distinct_groups += len(groups)
+        if len(groups) < len(record["sentence_spans"]):
+            duplicate_records += 1
+        observed_positive: set[str] = set()
+        for group_cid, rows in groups.items():
+            texts = {str(row["text"]) for row in rows}
+            labels = {int(row["relation_label"]) for row in rows}
+            inputs = {str(row["relation_input"]) for row in rows}
+            input_cids = {str(row["relation_input_cid"]) for row in rows}
+            if len(texts) != 1 or len(labels) != 1 or len(inputs) != 1:
+                exact = False
+                continue
+            text = next(iter(texts))
+            relation_input = render_joint_candidate_input(
+                str(record["source"]), str(record["question"]), text
+            )
+            expected_input_cid = cid_bytes(relation_input.encode("utf-8"))
+            if (
+                group_cid != cid_bytes(text.encode("utf-8"))
+                or inputs != {relation_input}
+                or input_cids != {expected_input_cid}
+            ):
+                exact = False
+            prompt_cids.append(expected_input_cid)
+            label = next(iter(labels))
+            if label == 1:
+                positive_groups += 1
+                observed_positive.add(group_cid)
+            elif label == 0:
+                negative_groups += 1
+            else:
+                exact = False
+        declared_positive = {
+            str(value) for value in record["positive_relation_group_cids"]
+        }
+        derived_outcome = (
+            "abstain"
+            if not observed_positive
+            else "answer"
+            if len(observed_positive) == 1
+            else "conflict"
+        )
+        if (
+            observed_positive != declared_positive
+            or derived_outcome != record["target_outcome"]
+        ):
+            exact = False
+        if record["duplicate_agreement"]:
+            positive_rows = [
+                row
+                for row in record["sentence_spans"]
+                if int(row["relation_label"]) == 1
+            ]
+            if (
+                len(positive_rows) != 2
+                or len({str(row["relation_group_cid"]) for row in positive_rows}) != 1
+                or record["target_span_index"]
+                != min(int(row["candidate_index"]) for row in positive_rows)
+            ):
+                exact = False
+    return {
+        "distinct_groups": distinct_groups,
+        "positive_groups": positive_groups,
+        "negative_groups": negative_groups,
+        "records_with_duplicate_spans": duplicate_records,
+        "group_prompts_and_labels_exact": exact,
+        "distinct_group_prompt_cids_unique": len(prompt_cids) == len(set(prompt_cids)),
+    }
+
+
+def _partition_contract(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    cells = Counter(
+        (int(record["source_width"]), str(record["target_outcome"]))
+        for record in records
+    )
+    complete_cells = set(cells) == {
+        (width, outcome) for width in SOURCE_WIDTHS for outcome in OUTCOMES
+    }
+    balanced = complete_cells and all(
+        cells[(width, "answer")]
+        == cells[(width, "abstain")]
+        == cells[(width, "conflict")]
+        for width in SOURCE_WIDTHS
+    )
+    locative_polarities = _polarity_by_locative(list(records))
+    query_outcomes = _query_outcomes(list(records))
+    position_labels = _position_labels(list(records))
+    group_contract = _group_contract(records)
+    return {
+        "records": len(records),
+        "width_outcome_cell_counts": {
+            str(width): {
+                outcome: cells[(width, outcome)] for outcome in OUTCOMES
+            }
+            for width in SOURCE_WIDTHS
+        },
+        "complete_width_2_through_8_cells": complete_cells,
+        "balanced_three_outcomes_per_width": balanced,
+        "every_locative_text_has_both_labels": bool(locative_polarities)
+        and all(labels == {0, 1} for labels in locative_polarities.values()),
+        "every_query_subject_has_answer_and_nonanswer": bool(query_outcomes)
+        and all(values == {"answer", "nonanswer"} for values in query_outcomes.values()),
+        "every_candidate_position_has_both_labels": bool(position_labels)
+        and all(labels == {0, 1} for labels in position_labels.values()),
+        **group_contract,
+    }
+
+
+def _population_census(
+    *,
+    fit_worlds: Sequence[LexicalWorld],
+    fit: Sequence[dict[str, Any]],
+    sealed_worlds: Sequence[LexicalWorld],
+    sealed: Sequence[dict[str, Any]],
+    product_worlds: Sequence[LexicalWorld],
+    products: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    sb3_dataset, sb3_preflight, sb3_products = (
+        build_source_relation_adapter_population()
+    )
+    new_records = {
+        "preflight-fit": fit,
+        "preflight-sealed": sealed,
+        "product": products,
+    }
+    sb3_records = {
+        "sb3-preflight-fit": sb3_preflight["fit"],
+        "sb3-preflight-sealed": sb3_preflight["sealed"],
+        "sb3-construction": sb3_dataset["construction"],
+        "sb3-development": sb3_dataset["development"],
+        "sb3-development-reversal-controls": sb3_dataset["development_controls"][
+            "reversal"
+        ],
+        "sb3-development-query-swap-controls": sb3_dataset[
+            "development_controls"
+        ]["query_swap"],
+        "sb3-product": sb3_products["records"],
+    }
+    new_sentence_sets = {
+        name: _sentence_inventory(records) for name, records in new_records.items()
+    }
+    sb3_sentence_sets = {
+        name: _sentence_inventory(records) for name, records in sb3_records.items()
+    }
+    new_names = sorted(new_sentence_sets)
+    new_sentences_pairwise_disjoint = all(
+        new_sentence_sets[left].isdisjoint(new_sentence_sets[right])
+        for left_index, left in enumerate(new_names)
+        for right in new_names[left_index + 1 :]
+    )
+    new_vs_sb3_sentences = {
+        new_name: {
+            old_name: new_sentence_sets[new_name].isdisjoint(old_sentences)
+            for old_name, old_sentences in sorted(sb3_sentence_sets.items())
+        }
+        for new_name in new_names
+    }
+
+    new_worlds = {
+        "preflight-fit": list(fit_worlds),
+        "preflight-sealed": list(sealed_worlds),
+        "product": list(product_worlds),
+    }
+    sb3_primary_records = {
+        "sb3-preflight-fit": sb3_preflight["fit"],
+        "sb3-preflight-sealed": sb3_preflight["sealed"],
+        "sb3-construction": sb3_dataset["construction"],
+        "sb3-development": sb3_dataset["development"],
+        "sb3-product": sb3_products["records"],
+    }
+    new_lexical_sets = {
+        name: _world_inventory(worlds) for name, worlds in new_worlds.items()
+    }
+    sb3_lexical_sets = {
+        name: _world_inventory(_worlds_from_records(list(records)))
+        for name, records in sb3_primary_records.items()
+    }
+    sb3_lexical_sets["sb3-development-reversal-controls"] = set(
+        sb3_lexical_sets["sb3-development"]
+    )
+    sb3_lexical_sets["sb3-development-query-swap-controls"] = set(
+        sb3_lexical_sets["sb3-development"]
+    )
+    new_composite_world_item_banks_pairwise_disjoint = all(
+        new_lexical_sets[left].isdisjoint(new_lexical_sets[right])
+        for left_index, left in enumerate(new_names)
+        for right in new_names[left_index + 1 :]
+    )
+    new_vs_sb3_lexical_banks = {
+        new_name: {
+            old_name: new_lexical_sets[new_name].isdisjoint(old_lexemes)
+            for old_name, old_lexemes in sorted(sb3_lexical_sets.items())
+        }
+        for new_name in new_names
+    }
+
+    checks = {
+        "preflight-fit": _partition_contract(fit),
+        "preflight-sealed": _partition_contract(sealed),
+    }
+    product_group_contract = _group_contract(products)
+    old_ordinals = {
+        int(record["world_ordinal"])
+        for records in sb3_primary_records.values()
+        for record in records
+    }
+    new_ordinals = {
+        world.ordinal for worlds in new_worlds.values() for world in worlds
+    }
+    ordinal_boundary = {
+        "sb3_max_world_ordinal": max(old_ordinals),
+        "sb4_min_world_ordinal": min(new_ordinals),
+        "sb4_starts_exactly_after_sb3": min(new_ordinals) == max(old_ordinals) + 1,
+        "sb4_ordinals_contiguous": new_ordinals
+        == set(range(FRESH_WORLD_ORDINAL_START, FRESH_WORLD_ORDINAL_START + 25)),
+    }
+    all_partition_checks_pass = all(
+        all(
+            bool(partition[field])
+            for field in (
+                "complete_width_2_through_8_cells",
+                "balanced_three_outcomes_per_width",
+                "every_locative_text_has_both_labels",
+                "every_query_subject_has_answer_and_nonanswer",
+                "every_candidate_position_has_both_labels",
+                "group_prompts_and_labels_exact",
+                "distinct_group_prompt_cids_unique",
+            )
+        )
+        for partition in checks.values()
+    )
+    passed = (
+        new_sentences_pairwise_disjoint
+        and new_composite_world_item_banks_pairwise_disjoint
+        and all(
+            passed
+            for comparisons in new_vs_sb3_sentences.values()
+            for passed in comparisons.values()
+        )
+        and all(
+            passed
+            for comparisons in new_vs_sb3_lexical_banks.values()
+            for passed in comparisons.values()
+        )
+        and all_partition_checks_pass
+        and bool(product_group_contract["group_prompts_and_labels_exact"])
+        and bool(product_group_contract["distinct_group_prompt_cids_unique"])
+        and bool(ordinal_boundary["sb4_starts_exactly_after_sb3"])
+        and bool(ordinal_boundary["sb4_ordinals_contiguous"])
+    )
+    value = {
+        "schema": JOINT_CENSUS_SCHEMA,
+        "policy": POLICY,
+        "fresh_world_ordinal_start": FRESH_WORLD_ORDINAL_START,
+        "ordinal_boundary": ordinal_boundary,
+        "new_sentence_partitions_pairwise_disjoint": new_sentences_pairwise_disjoint,
+        "new_vs_every_sb3_partition_sentences_disjoint": new_vs_sb3_sentences,
+        "composite_world_item_definition": (
+            "complete generated subject phrases, complete generated location phrases, "
+            "and complete generated nonlocative phrases"
+        ),
+        "primitive_component_vocabulary": (
+            "DELIBERATELY_SHARED_ACROSS_SB3_AND_SB4; not a disjointness claim"
+        ),
+        "new_composite_world_item_banks_pairwise_disjoint": (
+            new_composite_world_item_banks_pairwise_disjoint
+        ),
+        "new_vs_every_sb3_partition_composite_world_item_bank_disjoint": (
+            new_vs_sb3_lexical_banks
+        ),
+        "sb3_controls_composite_world_item_coverage": (
+            "development reversal and query-swap controls reuse the bound SB3 "
+            "development worlds; their sentence inventories are checked separately"
+        ),
+        "partition_checks": checks,
+        "product_group_check": product_group_contract,
+        "tokenizer_census": {
+            "status": "CAMPAIGN_BOUND_NOT_RUN",
+            "exact_inputs": (
+                "every distinct relation_input string and CID is committed in the "
+                "preflight or separately sealed product record"
+            ),
+            "required_next_action": (
+                "before optimization, bind the pinned #1017 tokenizer, include BOS, "
+                "reject any prompt over the frozen context budget, and never truncate"
+            ),
+        },
+        "sb3_reference_cids": {
+            "dataset_cid": sb3_dataset["dataset_cid"],
+            "preflight_cid": sb3_preflight["preflight_cid"],
+            "product_probes_cid": sb3_products["product_probes_cid"],
+        },
+        "passed": passed,
+    }
+    if not passed:
+        raise RuntimeError(f"C1-SB4 zero-training census failed: {value}")
+    return _canonical_with_cid(value, "census_cid")
+
+
+def build_joint_candidate_margin_population(
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build the frozen C1-SB4 dataset, preflight, and unopened products."""
+    ordinal = FRESH_WORLD_ORDINAL_START
+    fit_worlds, raw_fit, ordinal = _world_partition(
+        partition="c1-sb4-preflight-fit",
+        worlds_per_width=PREFLIGHT_FIT_WORLDS_PER_WIDTH,
+        ordinal_start=ordinal,
+    )
+    sealed_worlds, raw_sealed, ordinal = _world_partition(
+        partition="c1-sb4-preflight-sealed",
+        worlds_per_width=PREFLIGHT_SEALED_WORLDS_PER_WIDTH,
+        ordinal_start=ordinal,
+    )
+    fit = [
+        _restamp_record(record, population="preflight-fit") for record in raw_fit
+    ]
+    sealed = [
+        _restamp_record(record, population="preflight-sealed")
+        for record in raw_sealed
+    ]
+    product_worlds, products = _product_population(ordinal_start=ordinal)
+    ordinal += len(products["records"])
+    if ordinal != FRESH_WORLD_ORDINAL_START + 25:
+        raise RuntimeError("C1-SB4 lexical-world ordinal allocation drifted")
+
+    census = _population_census(
+        fit_worlds=fit_worlds,
+        fit=fit,
+        sealed_worlds=sealed_worlds,
+        sealed=sealed,
+        product_worlds=product_worlds,
+        products=list(products["records"]),
+    )
+    counts = {
+        "preflight_fit": len(fit),
+        "preflight_sealed": len(sealed),
+        "product_probe_commitments": len(products["records"]),
+        "preflight_fit_distinct_groups": int(
+            census["partition_checks"]["preflight-fit"]["distinct_groups"]
+        ),
+        "preflight_sealed_distinct_groups": int(
+            census["partition_checks"]["preflight-sealed"]["distinct_groups"]
+        ),
+    }
+    expected_counts = {
+        "preflight_fit": 126,
+        "preflight_sealed": 63,
+        "product_probe_commitments": 4,
+        "preflight_fit_distinct_groups": 604,
+        "preflight_sealed_distinct_groups": 302,
+    }
+    if counts != expected_counts:
+        raise RuntimeError(f"C1-SB4 population count drifted: {counts}")
+
+    preflight_value = {
+        "schema": JOINT_PREFLIGHT_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "selection": (
+            "two fresh fit lexical worlds and one independently sealed fresh lexical "
+            "world for each source width 2..8; every world has the same nine matched "
+            "structural motifs as C1-SB3, with no identical composite subject, "
+            "location, or nonlocative item and no identical exact sentence; primitive "
+            "component vocabulary is deliberately shared"
+        ),
+        "counts": {"fit": len(fit), "sealed": len(sealed)},
+        "fit_world_names": [world.name for world in fit_worlds],
+        "sealed_world_names": [world.name for world in sealed_worlds],
+        "fit": fit,
+        "sealed": sealed,
+        "census_cid": census["census_cid"],
+    }
+    preflight = _canonical_with_cid(preflight_value, "preflight_cid")
+    split_policy = _canonical_with_cid(
+        {
+            "schema": JOINT_SPLIT_SCHEMA,
+            "policy": POLICY,
+            "selection": (
+                "start at lexical-world ordinal 137, enumerate widths 2..8 and fixed "
+                "lanes without shuffling, then reserve four later product worlds"
+            ),
+            "source_widths": list(SOURCE_WIDTHS),
+            "motifs_per_outcome": MOTIFS_PER_OUTCOME,
+            "worlds_per_width": {
+                "preflight_fit": PREFLIGHT_FIT_WORLDS_PER_WIDTH,
+                "preflight_sealed": PREFLIGHT_SEALED_WORLDS_PER_WIDTH,
+            },
+            "fresh_world_ordinal_start": FRESH_WORLD_ORDINAL_START,
+            "product_policy": (
+                "four product records are separately committed and unopened by training"
+            ),
+        },
+        "split_policy_cid",
+    )
+    dataset_value = {
+        "schema": JOINT_DATASET_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "question_policy": QUESTION_POLICY,
+        "sentence_policy": SENTENCE_POLICY,
+        "relation_input_policy": JOINT_INPUT_POLICY,
+        "fixed_verbalizer": {
+            "positive_token_id": YES_TOKEN_ID,
+            "positive_token_text": YES_TOKEN_TEXT,
+            "negative_token_id": NO_TOKEN_ID,
+            "negative_token_text": NO_TOKEN_TEXT,
+            "decision": "positive iff yes_logit - no_logit > 0; zero is negative",
+        },
+        "counts": counts,
+        "split_policy": split_policy,
+        "split_policy_cid": split_policy["split_policy_cid"],
+        "census": census,
+        "census_cid": census["census_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "product_probes_cid": products["product_probes_cid"],
+        "product_probe_commitments": [
+            record["record_cid"] for record in products["records"]
+        ],
+    }
+    dataset = _canonical_with_cid(dataset_value, "dataset_cid")
+    return dataset, preflight, products
+
+
+__all__ = [
+    "FRESH_WORLD_ORDINAL_START",
+    "ISSUE",
+    "JOINT_CENSUS_SCHEMA",
+    "JOINT_DATASET_SCHEMA",
+    "JOINT_INPUT_POLICY",
+    "JOINT_PREFLIGHT_SCHEMA",
+    "JOINT_PRODUCT_SCHEMA",
+    "JOINT_RECORD_SCHEMA",
+    "JOINT_SPLIT_SCHEMA",
+    "POLICY",
+    "build_joint_candidate_margin_population",
+    "render_joint_candidate_input",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
@@ -54,3 +54,7 @@ def default_source_relation_head_root() -> Path:
 
 def default_attended_relation_adapter_root() -> Path:
     return model_store_root() / "research" / "issue-954" / "attended-relation-adapter"
+
+
+def default_joint_candidate_margin_root() -> Path:
+    return model_store_root() / "research" / "issue-954" / "joint-candidate-margin"

--- a/tools/r4-softmax-trainer/tests/test_joint_candidate_margin.py
+++ b/tools/r4-softmax-trainer/tests/test_joint_candidate_margin.py
@@ -1,0 +1,400 @@
+"""Focused checks for complete-record joint candidate margin learning."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+
+import torch
+
+from r4_softmax_trainer.model import R4SoftmaxForCausalLM, expected_hf_tensor_names
+from r4_softmax_trainer.provenance import cid_bytes
+from r4_softmax_trainer.source_relation_adapter import (
+    NO_TOKEN_ID,
+    YES_TOKEN_ID,
+    AttendedRelationAdapterConfig,
+    LoRALinear,
+)
+from r4_softmax_trainer.joint_candidate_margin import (
+    FIT_SEED,
+    MARGIN,
+    OPTIMIZER_STEPS,
+    OUTCOMES,
+    POLICY,
+    RECORDS_PER_STEP,
+    SOURCE_WIDTHS,
+    STEPS_PER_EPOCH,
+    EncodedJointCandidateMarginDataset,
+    JointCandidateMarginAdapterConfig,
+    JointCandidateMarginFitConfig,
+    R4JointCandidateMarginAdapter,
+    evaluate_joint_candidate_margin_adapter,
+    joint_candidate_structured_margin_loss,
+    structured_margin_per_record,
+)
+from r4_softmax_trainer.joint_candidate_margin_data import (
+    render_joint_candidate_input,
+)
+
+
+class _StubTokenizer:
+    def encode(self, text: str, *, add_special_tokens: bool) -> SimpleNamespace:
+        if add_special_tokens:
+            raise AssertionError("joint candidate tokenizer must disable implicit specials")
+        if text == " yes":
+            return SimpleNamespace(ids=[YES_TOKEN_ID])
+        if text == " no":
+            return SimpleNamespace(ids=[NO_TOKEN_ID])
+        if "force-overflow" in text:
+            return SimpleNamespace(ids=[11] * 255 + [13])
+        if text.endswith("\nSupported:"):
+            return SimpleNamespace(ids=[11, 12, 13])
+        return SimpleNamespace(ids=[99])
+
+    def decode(self, token_ids: list[int], *, skip_special_tokens: bool) -> str:
+        if skip_special_tokens:
+            raise AssertionError("joint candidate tokenizer must inspect exact tokens")
+        return {
+            (YES_TOKEN_ID,): " yes",
+            (NO_TOKEN_ID,): " no",
+            (13,): ":",
+        }.get(tuple(token_ids), "fixture")
+
+
+def _record(
+    record_id: str,
+    *,
+    width: int,
+    outcome: str,
+    texts: list[str] | None = None,
+    labels: list[int] | None = None,
+    lexical_world: str | None = None,
+    motif: str | None = None,
+) -> dict[str, object]:
+    if texts is None:
+        texts = [f"The {record_id} item {index} was observed." for index in range(width)]
+    if labels is None:
+        labels = (
+            [1, *([0] * (width - 1))]
+            if outcome == "answer"
+            else [0] * width
+            if outcome == "abstain"
+            else [1, 1, *([0] * (width - 2))]
+        )
+    source = " ".join(texts)
+    source_bytes = source.encode("utf-8")
+    spans = []
+    cursor = 0
+    for index, (text, label) in enumerate(zip(texts, labels)):
+        encoded = text.encode("utf-8")
+        start = source_bytes.index(encoded, cursor)
+        end = start + len(encoded)
+        group_cid = cid_bytes(encoded)
+        spans.append(
+            {
+                "candidate_index": index,
+                "byte_start": start,
+                "byte_end": end,
+                "text": text,
+                "relation_group_cid": group_cid,
+                "relation_label": label,
+            }
+        )
+        cursor = end
+    positive_groups = sorted(
+        {span["relation_group_cid"] for span in spans if span["relation_label"] == 1}
+    )
+    question = f"Where is the {record_id} item?"
+    for span in spans:
+        relation_input = render_joint_candidate_input(
+            source, question, str(span["text"])
+        )
+        span["relation_input"] = relation_input
+        span["relation_input_cid"] = cid_bytes(relation_input.encode("utf-8"))
+    return {
+        "record_cid": record_id,
+        "lexical_world": lexical_world or f"world-{record_id}",
+        "motif": motif or f"motif-{outcome}",
+        "target_outcome": outcome,
+        "source_width": width,
+        "source": source,
+        "question": question,
+        "sentence_spans": spans,
+        "positive_relation_group_cids": positive_groups,
+    }
+
+
+def _complete_fit_records() -> list[dict[str, object]]:
+    return [
+        _record(
+            f"record-w{width}-{outcome}-{lane}",
+            width=width,
+            outcome=outcome,
+            lexical_world=f"world-w{width}-{lane // 3}",
+            motif=f"motif-{outcome}-{lane}",
+        )
+        for width in SOURCE_WIDTHS
+        for outcome in OUTCOMES
+        for lane in range(6)
+    ]
+
+
+class _FixedScoreAdapter:
+    def __init__(self, scores: list[float]) -> None:
+        self._scores = torch.tensor(scores, dtype=torch.float32)
+        self._cursor = 0
+
+    def eval(self) -> "_FixedScoreAdapter":
+        return self
+
+    def __call__(self, input_ids: torch.Tensor, terminal_indices: torch.Tensor) -> torch.Tensor:
+        self.last_terminal_indices = terminal_indices.detach().cpu().tolist()
+        end = self._cursor + input_ids.shape[0]
+        result = self._scores[self._cursor:end].to(input_ids.device)
+        self._cursor = end
+        return result
+
+
+class JointCandidateMarginTests(unittest.TestCase):
+    def test_contract_and_exact_renderer_are_frozen(self) -> None:
+        self.assertEqual(POLICY, "R4JointCandidateMarginAdapterV1")
+        self.assertEqual(MARGIN, 1.0)
+        self.assertEqual(FIT_SEED, 9_544)
+        self.assertEqual(OPTIMIZER_STEPS, 270)
+        self.assertEqual(RECORDS_PER_STEP, 7)
+        rendered = render_joint_candidate_input(
+            "The opal dial is inside the oak case.",
+            "Where is the opal dial?",
+            "The opal dial is inside the oak case.",
+        )
+        self.assertEqual(
+            rendered,
+            "E:The opal dial is inside the oak case.\n"
+            "Q:Where is the opal dial?\n"
+            "C:The opal dial is inside the oak case.\nSupported:",
+        )
+        self.assertFalse(rendered.endswith("\n"))
+
+        config = JointCandidateMarginFitConfig()
+        config.validate()
+        with self.assertRaisesRegex(ValueError, "frozen"):
+            replace(config, learning_rate=0.002).validate()
+
+    def test_adapter_seed_is_versioned_from_sb3_without_a_trainable_head(self) -> None:
+        self.assertEqual(AttendedRelationAdapterConfig().initialization_seed, 9_543)
+        config = JointCandidateMarginAdapterConfig()
+        config.validate()
+        self.assertEqual(config.initialization_seed, 9_544)
+        self.assertEqual(config.trainable_parameter_count, 110_592)
+        with self.assertRaisesRegex(ValueError, "frozen"):
+            replace(config, initialization_seed=9_543).validate()
+
+        model = R4SoftmaxForCausalLM()
+        adapter = R4JointCandidateMarginAdapter(model)
+        names = adapter.trainable_parameter_names()
+        self.assertEqual(len(names), 48)
+        self.assertTrue(all(name.endswith(("lora_a", "lora_b")) for name in names))
+        self.assertEqual(
+            sum(parameter.numel() for parameter in adapter.adapter_parameters()),
+            110_592,
+        )
+        for layer in model.model.layers:
+            for name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                self.assertIsInstance(getattr(layer.self_attn, name), LoRALinear)
+        self.assertFalse(model.model.embed_tokens.weight.requires_grad)
+        self.assertEqual(
+            {tensor["initialization_seed"] for tensor in adapter.delta_audit()["tensors"]},
+            set(range(9_544, 9_568)),
+        )
+        first_query = model.model.layers[0].self_attn.q_proj
+        self.assertIsInstance(first_query, LoRALinear)
+        with torch.no_grad():
+            first_query.lora_b[0, 0] = 0.125
+        merged = adapter.merged_state_dict()
+        self.assertEqual(set(merged), expected_hf_tensor_names())
+        self.assertNotEqual(
+            torch.count_nonzero(
+                merged["model.layers.0.self_attn.q_proj.weight"]
+                - first_query.base.weight
+            ).item(),
+            0,
+        )
+
+    def test_duplicate_occurrences_collapse_and_disagreement_rejects(self) -> None:
+        text = "The amber dial is inside the oak case."
+        record = _record(
+            "duplicate",
+            width=2,
+            outcome="answer",
+            texts=[text, text],
+            labels=[1, 1],
+        )
+        dataset = EncodedJointCandidateMarginDataset(
+            [record], _StubTokenizer()  # type: ignore[arg-type]
+        )
+        self.assertEqual(len(dataset.records[0].groups), 1)
+        group = dataset.records[0].groups[0]
+        self.assertEqual(group.occurrence_indices, (0, 1))
+        self.assertEqual(group.relation_label, 1)
+        self.assertIn(f"C:{text}", group.relation_input)
+
+        disagreement = _record(
+            "disagreement",
+            width=2,
+            outcome="answer",
+            texts=[text, text],
+            labels=[1, 0],
+        )
+        # The helper's committed positive-group list cannot express the invalid
+        # disagreement; the model layer must reject the row-level mismatch first.
+        with self.assertRaisesRegex(ValueError, "labels disagree"):
+            EncodedJointCandidateMarginDataset(
+                [disagreement], _StubTokenizer()  # type: ignore[arg-type]
+            )
+
+    def test_terminal_colon_and_context_limit_include_bos(self) -> None:
+        dataset = EncodedJointCandidateMarginDataset(
+            [_record("normal", width=2, outcome="answer")],
+            _StubTokenizer(),  # type: ignore[arg-type]
+        )
+        batch = dataset.batch([0], device=torch.device("cpu"))
+        self.assertEqual(batch.input_ids[:, 0].tolist(), [0, 0])
+        self.assertEqual(batch.terminal_indices.tolist(), [3, 3])
+        self.assertEqual(batch.input_ids[:, 3].tolist(), [13, 13])
+        self.assertEqual(batch.record_slices, ((0, 2),))
+
+        tampered = _record("tampered", width=2, outcome="answer")
+        tampered["sentence_spans"][0]["relation_input"] += "\n"  # type: ignore[index]
+        with self.assertRaisesRegex(ValueError, "renderer differs"):
+            EncodedJointCandidateMarginDataset(
+                [tampered], _StubTokenizer()  # type: ignore[arg-type]
+            )
+
+        overflow = _record(
+            "overflow",
+            width=2,
+            outcome="answer",
+            texts=["The force-overflow candidate is here.", "A second candidate is here."],
+        )
+        with self.assertRaisesRegex(ValueError, "256-token context"):
+            EncodedJointCandidateMarginDataset(
+                [overflow], _StubTokenizer()  # type: ignore[arg-type]
+            )
+
+    def test_structured_margin_matches_answer_abstain_conflict_semantics(self) -> None:
+        labels = torch.tensor(
+            [1.0, 0.0, 0.0, 0.0, 1.0, 1.0], dtype=torch.float32
+        )
+        slices = ((0, 2), (2, 4), (4, 6))
+        exact_scores = torch.tensor([1.0, -1.0, -2.0, -1.0, 1.0, 2.0])
+        per_record = structured_margin_per_record(exact_scores, labels, slices)
+        self.assertTrue(torch.equal(per_record, torch.zeros(3)))
+        self.assertEqual(
+            float(joint_candidate_structured_margin_loss(exact_scores, labels, slices)),
+            0.0,
+        )
+
+        violating_scores = torch.zeros(6)
+        violating = structured_margin_per_record(violating_scores, labels, slices)
+        self.assertTrue(torch.equal(violating, torch.tensor([2.0, 1.0, 1.0])))
+        self.assertAlmostEqual(
+            float(
+                joint_candidate_structured_margin_loss(
+                    violating_scores, labels, slices
+                )
+            ),
+            4.0 / 3.0,
+        )
+        with self.assertRaisesRegex(ValueError, "contiguous"):
+            structured_margin_per_record(exact_scores, labels, ((0, 2), (3, 6)))
+
+    def test_schedule_is_one_per_width_and_exactly_covers_each_epoch(self) -> None:
+        dataset = EncodedJointCandidateMarginDataset(
+            list(reversed(_complete_fit_records())),
+            _StubTokenizer(),  # type: ignore[arg-type]
+        )
+        dataset.validate_fit_schedule()
+        first_epoch = [
+            dataset.record_indices_for_step(step)
+            for step in range(1, STEPS_PER_EPOCH + 1)
+        ]
+        for selected in first_epoch:
+            self.assertEqual(len(selected), 7)
+            self.assertEqual(
+                [dataset.records[index].source_width for index in selected],
+                list(SOURCE_WIDTHS),
+            )
+            outcome_counts = {
+                outcome: sum(
+                    dataset.records[index].target_outcome == outcome
+                    for index in selected
+                )
+                for outcome in OUTCOMES
+            }
+            self.assertEqual(sorted(outcome_counts.values()), [2, 2, 3])
+        for width in SOURCE_WIDTHS:
+            observed = [
+                index
+                for selected in first_epoch
+                for index in selected
+                if dataset.records[index].source_width == width
+            ]
+            expected = [
+                index
+                for index, record in enumerate(dataset.records)
+                if record.source_width == width
+            ]
+            self.assertEqual(len(observed), 18)
+            self.assertEqual(set(observed), set(expected))
+        self.assertNotEqual(
+            dataset.record_indices_for_step(1),
+            dataset.record_indices_for_step(1 + STEPS_PER_EPOCH),
+        )
+        self.assertEqual(
+            dataset.record_indices_for_step(1),
+            dataset.record_indices_for_step(1),
+        )
+
+    def test_evaluation_preserves_stable_record_and_group_score_alignment(self) -> None:
+        records = [
+            _record("record-b", width=2, outcome="abstain"),
+            _record("record-a", width=2, outcome="answer"),
+        ]
+        dataset = EncodedJointCandidateMarginDataset(
+            records, _StubTokenizer()  # type: ignore[arg-type]
+        )
+        # Dataset order is record-a then record-b; each record has two groups.
+        adapter = _FixedScoreAdapter([2.0, -2.0, -3.0, -2.0])
+        result = evaluate_joint_candidate_margin_adapter(
+            adapter,  # type: ignore[arg-type]
+            dataset,
+            device=torch.device("cpu"),
+            record_batch_size=2,
+        )
+        self.assertEqual(result["records"], 2)
+        self.assertEqual(result["groups"], 4)
+        self.assertEqual(result["mean_structured_margin"], 0.0)
+        self.assertEqual(
+            [record["record_id"] for record in result["record_evaluations"]],
+            ["record-a", "record-b"],
+        )
+        self.assertEqual(
+            [
+                group["score"]
+                for record in result["record_evaluations"]
+                for group in record["group_scores"]
+            ],
+            [2.0, -2.0, -3.0, -2.0],
+        )
+        with self.assertRaisesRegex(RuntimeError, "cardinality differs"):
+            evaluate_joint_candidate_margin_adapter(
+                _FixedScoreAdapter([1.0]),  # type: ignore[arg-type]
+                dataset,
+                device=torch.device("cpu"),
+                record_batch_size=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_joint_candidate_margin_campaign.py
+++ b/tools/r4-softmax-trainer/tests/test_joint_candidate_margin_campaign.py
@@ -1,0 +1,431 @@
+"""Focused preparation, aggregation, and product-isolation tests for C1-SB4."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from r4_softmax_trainer import joint_candidate_margin_campaign as campaign
+from r4_softmax_trainer.joint_candidate_margin_data import (
+    build_joint_candidate_margin_population,
+    render_joint_candidate_input,
+)
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+
+
+def _with_cid(value: dict[str, object], field: str) -> dict[str, object]:
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _fake_tokenizer_census() -> dict[str, object]:
+    partitions: dict[str, object] = {}
+    for name, frozen in campaign.EXPECTED_TOKENIZER_PARTITIONS.items():
+        maximum = int(frozen["maximum_positions_including_bos"])
+        partitions[name] = {
+            "records": int(frozen["records"]),
+            "groups": int(frozen["groups"]),
+            "minimum_content_tokens": 1,
+            "maximum_content_tokens": maximum - 1,
+            "minimum_positions_including_bos": 2,
+            "maximum_positions_including_bos": maximum,
+            "context_ceiling_including_bos": 256,
+            "terminal_token": "standalone colon",
+            "truncation": "FORBIDDEN_NOT_USED",
+            "passed": True,
+        }
+    return _with_cid(
+        {
+            "schema": campaign.TOKENIZER_CENSUS_SCHEMA,
+            "policy": campaign.POLICY,
+            "issue": 954,
+            "tokenizer_cid": campaign.EXPECTED_TOKENIZER_CID,
+            "input_policy": campaign.JOINT_INPUT_POLICY,
+            "partitions": partitions,
+            "all_prompts_end_at_standalone_colon": True,
+            "no_prompt_truncated": True,
+            "passed": True,
+        },
+        "tokenizer_census_cid",
+    )
+
+
+def _raw_exact(records: list[dict[str, object]]) -> dict[str, object]:
+    evaluations = []
+    total_margin = 0.0
+    for record in records:
+        groups: dict[str, dict[str, object]] = {}
+        for span in record["sentence_spans"]:  # type: ignore[index]
+            group_cid = str(span["relation_group_cid"])
+            group = groups.setdefault(
+                group_cid,
+                {
+                    "relation_group_cid": group_cid,
+                    "text": str(span["text"]),
+                    "relation_label": int(span["relation_label"]),
+                    "occurrence_indices": [],
+                },
+            )
+            group["occurrence_indices"].append(int(span["candidate_index"]))  # type: ignore[union-attr]
+        rows = []
+        for group in groups.values():
+            row = dict(group)
+            row["score"] = 2.0 if row["relation_label"] == 1 else -2.0
+            rows.append(row)
+        evaluations.append(
+            {
+                "record_id": record["record_cid"],
+                "source_width": record["source_width"],
+                "target_outcome": record["target_outcome"],
+                "structured_margin": 0.0,
+                "group_scores": rows,
+            }
+        )
+    return {
+        "records": len(records),
+        "groups": sum(len(row["group_scores"]) for row in evaluations),
+        "mean_structured_margin": total_margin,
+        "record_evaluations": list(reversed(evaluations)),
+    }
+
+
+def _mock_metrics(records: list[dict[str, object]], *, exact: bool) -> dict[str, object]:
+    details = [
+        {
+            "record_id": record.get("record_id", record.get("record_cid")),
+            "lexical_world": record["lexical_world"],
+            "motif": record["motif"],
+            "target_outcome": record["target_outcome"],
+            "record_exact": exact or index > 0,
+        }
+        for index, record in enumerate(records)
+    ]
+    correct = len(records) if exact else len(records) - 1
+    return {
+        "records": len(records),
+        "record_exact": {
+            "correct": correct,
+            "total": len(records),
+            "accuracy": correct / len(records),
+        },
+        "record_evaluations": details,
+    }
+
+
+class JointCandidateMarginCampaignTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset, cls.preflight, cls.products = (
+            build_joint_candidate_margin_population()
+        )
+
+    def test_metrics_align_by_record_and_group_identity(self) -> None:
+        records = list(self.preflight["sealed"][:9])
+        metrics = campaign._record_metrics(
+            records, _raw_exact(records), include_records=True
+        )
+        self.assertTrue(campaign._all_exact(metrics))
+        self.assertEqual(metrics["record_exact"]["correct"], 9)
+        self.assertEqual(
+            metrics["positive_group_recall"]["correct"],
+            metrics["positive_group_recall"]["total"],
+        )
+        self.assertEqual(
+            metrics["negative_group_specificity"]["correct"],
+            metrics["negative_group_specificity"]["total"],
+        )
+
+    def test_full_source_reversal_rebuilds_every_bound_field(self) -> None:
+        reversed_records, scope = campaign._reversed_records(
+            list(self.preflight["sealed"])
+        )
+        self.assertEqual(
+            scope,
+            {
+                "records": 63,
+                "nontrivial_reversals": 62,
+                "byte_identical_reversals": 1,
+            },
+        )
+        for record in reversed_records:
+            parsed = campaign.split_sentence_spans(record["source"])
+            self.assertEqual(len(parsed), record["source_width"])
+            for index, (parsed_span, span) in enumerate(
+                zip(parsed, record["sentence_spans"])
+            ):
+                self.assertEqual(span["candidate_index"], index)
+                self.assertEqual(span["byte_start"], parsed_span["byte_start"])
+                self.assertEqual(span["byte_end"], parsed_span["byte_end"])
+                expected = render_joint_candidate_input(
+                    record["source"], record["question"], span["text"]
+                )
+                self.assertEqual(span["relation_input"], expected)
+                self.assertEqual(
+                    span["relation_input_cid"], cid_bytes(expected.encode("utf-8"))
+                )
+
+    def test_prepare_binds_product_outside_training_view(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            fake_census = _fake_tokenizer_census()
+            predecessor_manifest = {
+                "manifest_cid": campaign.EXPECTED_PREDECESSOR_MANIFEST_CID,
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            with (
+                patch.object(campaign, "_validated_predecessor", return_value=predecessor_manifest),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(campaign, "_build_tokenizer_census", return_value=fake_census),
+                patch.object(
+                    campaign,
+                    "EXPECTED_TOKENIZER_CENSUS_CID",
+                    fake_census["tokenizer_census_cid"],
+                ),
+            ):
+                result = campaign.prepare_joint_candidate_margin_data(
+                    root, predecessor=predecessor
+                )
+                self.assertEqual(
+                    result["terminal"],
+                    "JOINT_CANDIDATE_MARGIN_DATA_COMMITTED_NO_TRAINING",
+                )
+                _, _, census, manifest = campaign._load_training_view(root)
+            self.assertTrue(census["passed"])
+            paths = {record["path"] for record in manifest["artifacts"]}
+            self.assertNotIn(campaign.PRODUCT_FILE, paths)
+            self.assertNotIn(campaign.PRODUCT_MANIFEST_FILE, paths)
+            self.assertTrue((root / campaign.PRODUCT_FILE).is_file())
+            with (
+                patch.object(
+                    campaign,
+                    "EXPECTED_TOKENIZER_CENSUS_CID",
+                    fake_census["tokenizer_census_cid"],
+                ),
+                patch.object(
+                    campaign, "EXPECTED_DATASET_CID", "blake3:" + "0" * 64
+                ),
+                self.assertRaisesRegex(ValueError, "frozen campaign"),
+            ):
+                campaign._load_training_view(root)
+
+    def test_negative_run_never_rebuilds_or_reads_product(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            predecessor_manifest = {
+                "manifest_cid": campaign.EXPECTED_PREDECESSOR_MANIFEST_CID,
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            fake_census = _fake_tokenizer_census()
+            with (
+                patch.object(campaign, "_validated_predecessor", return_value=predecessor_manifest),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(campaign, "_build_tokenizer_census", return_value=fake_census),
+                patch.object(
+                    campaign,
+                    "EXPECTED_TOKENIZER_CENSUS_CID",
+                    fake_census["tokenizer_census_cid"],
+                ),
+            ):
+                campaign.prepare_joint_candidate_margin_data(
+                    root, predecessor=predecessor
+                )
+
+            original_read_text = Path.read_text
+
+            def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+                if path.name == campaign.PRODUCT_FILE:
+                    raise AssertionError("optimizer attempted to read sealed product text")
+                return original_read_text(path, *args, **kwargs)
+
+            calls = {"evaluation": 0}
+
+            def fake_evaluate(
+                _adapter: object,
+                records: list[dict[str, object]],
+                **_kwargs: object,
+            ) -> dict[str, object]:
+                calls["evaluation"] += 1
+                # Untouched sealed misses; fit is exact; trained sealed retains one miss.
+                return _mock_metrics(
+                    records,
+                    exact=calls["evaluation"] == 2,
+                )
+
+            class FakeAdapter:
+                def to(self, _device: torch.device) -> "FakeAdapter":
+                    return self
+
+            partition_by_count = {
+                126: fake_census["partitions"]["fit"],  # type: ignore[index]
+                63: fake_census["partitions"]["sealed"],  # type: ignore[index]
+            }
+            with (
+                patch.object(Path, "read_text", guarded_read_text),
+                patch.object(
+                    campaign,
+                    "build_joint_candidate_margin_population",
+                    side_effect=AssertionError("optimizer rebuilt sealed products"),
+                ),
+                patch.object(
+                    campaign,
+                    "EXPECTED_TOKENIZER_CENSUS_CID",
+                    fake_census["tokenizer_census_cid"],
+                ),
+                patch.object(campaign, "_validated_predecessor", return_value=predecessor_manifest),
+                patch.object(campaign, "require_mps", return_value=torch.device("cpu")),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(campaign, "validate_tokenizer_contract"),
+                patch.object(
+                    campaign,
+                    "_tokenizer_partition",
+                    side_effect=lambda records, _tokenizer: partition_by_count[len(records)],
+                ),
+                patch.object(campaign, "_load_base_model", return_value=(object(), {})),
+                patch.object(campaign, "R4JointCandidateMarginAdapter", return_value=FakeAdapter()),
+                patch.object(campaign, "_evaluate_records", side_effect=fake_evaluate),
+                patch.object(
+                    campaign,
+                    "EncodedJointCandidateMarginDataset",
+                    return_value=object(),
+                ),
+                patch.object(
+                    campaign,
+                    "fit_joint_candidate_margin_adapter",
+                    return_value={
+                        "optimizer_steps": 270,
+                        "records_per_step": 7,
+                        "initial_structured_margin": 3.0,
+                        "final_structured_margin": 0.5,
+                    },
+                ),
+                patch.object(
+                    campaign,
+                    "_delta_contract",
+                    return_value={"passed": True},
+                ),
+            ):
+                result = campaign.run_joint_candidate_margin_preflight(
+                    root, predecessor=predecessor
+                )
+            self.assertEqual(
+                result["terminal"], "FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT"
+            )
+            self.assertEqual(result["product"], "UNOPENED_NOT_RUN")
+
+    def test_sealed_exact_base_selects_frozen_readout_even_if_fit_misses(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            predecessor_manifest = {
+                "manifest_cid": campaign.EXPECTED_PREDECESSOR_MANIFEST_CID,
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            fake_census = _fake_tokenizer_census()
+            token_census_cid = fake_census["tokenizer_census_cid"]
+            with (
+                patch.object(
+                    campaign,
+                    "_validated_predecessor",
+                    return_value=predecessor_manifest,
+                ),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(
+                    campaign,
+                    "_build_tokenizer_census",
+                    return_value=fake_census,
+                ),
+                patch.object(
+                    campaign, "EXPECTED_TOKENIZER_CENSUS_CID", token_census_cid
+                ),
+            ):
+                campaign.prepare_joint_candidate_margin_data(
+                    root, predecessor=predecessor
+                )
+
+            calls = {"evaluation": 0}
+
+            def fake_evaluate(
+                _adapter: object,
+                records: list[dict[str, object]],
+                **_kwargs: object,
+            ) -> dict[str, object]:
+                calls["evaluation"] += 1
+                # Frozen sealed, diagnostic fit, then reversed sealed.
+                exact = calls["evaluation"] != 2
+                return _mock_metrics(records, exact=exact)
+
+            class FakeAdapter:
+                def to(self, _device: torch.device) -> "FakeAdapter":
+                    return self
+
+            partition_by_count = {
+                126: fake_census["partitions"]["fit"],  # type: ignore[index]
+                63: fake_census["partitions"]["sealed"],  # type: ignore[index]
+            }
+            with (
+                patch.object(
+                    campaign, "EXPECTED_TOKENIZER_CENSUS_CID", token_census_cid
+                ),
+                patch.object(
+                    campaign,
+                    "_validated_predecessor",
+                    return_value=predecessor_manifest,
+                ),
+                patch.object(campaign, "require_mps", return_value=torch.device("cpu")),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(campaign, "validate_tokenizer_contract"),
+                patch.object(
+                    campaign,
+                    "_tokenizer_partition",
+                    side_effect=lambda records, _tokenizer: partition_by_count[
+                        len(records)
+                    ],
+                ),
+                patch.object(campaign, "_load_base_model", return_value=(object(), {})),
+                patch.object(
+                    campaign,
+                    "R4JointCandidateMarginAdapter",
+                    return_value=FakeAdapter(),
+                ),
+                patch.object(campaign, "_evaluate_records", side_effect=fake_evaluate),
+                patch.object(
+                    campaign,
+                    "fit_joint_candidate_margin_adapter",
+                    side_effect=AssertionError("frozen branch started optimization"),
+                ),
+                patch.object(
+                    campaign,
+                    "_delta_contract",
+                    return_value={"passed": True},
+                ),
+                patch.object(
+                    campaign,
+                    "_finalize_result",
+                    return_value=({"manifest_cid": "blake3:" + "d" * 64}, None),
+                ),
+            ):
+                result = campaign.run_joint_candidate_margin_preflight(
+                    root, predecessor=predecessor
+                )
+            self.assertEqual(
+                result["terminal"],
+                "PASS_FROZEN_JOINT_SOURCE_READOUT_AWAITING_RUST_PARITY",
+            )
+            self.assertEqual(calls["evaluation"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_joint_candidate_margin_data.py
+++ b/tools/r4-softmax-trainer/tests/test_joint_candidate_margin_data.py
@@ -1,0 +1,320 @@
+"""Focused contract tests for the frozen C1-SB4 data and commitments."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from copy import deepcopy
+import unittest
+
+from r4_softmax_trainer.joint_candidate_margin_data import (
+    FRESH_WORLD_ORDINAL_START,
+    JOINT_CENSUS_SCHEMA,
+    JOINT_DATASET_SCHEMA,
+    JOINT_INPUT_POLICY,
+    JOINT_PREFLIGHT_SCHEMA,
+    JOINT_PRODUCT_SCHEMA,
+    JOINT_RECORD_SCHEMA,
+    POLICY,
+    build_joint_candidate_margin_population,
+    render_joint_candidate_input,
+)
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+from r4_softmax_trainer.source_relation_adapter_data import (
+    OUTCOMES,
+    SOURCE_WIDTHS,
+    build_source_relation_adapter_population,
+)
+from r4_softmax_trainer.source_relation_data import split_sentence_spans
+
+
+SB3_FROZEN_CIDS = {
+    "dataset": "blake3:ec211ee1397e1fae7a20597a2efec5c0fadb525a79c8babb859974b31e1adc24",
+    "preflight": "blake3:639a7ad3c897c7bb360ec49204bf32f5ef48d3d42d5c396f1fa94a4a2c50ef24",
+    "products": "blake3:05d4bc2f87761059d8c932906cd07b73f7a0d4dd42548ee2b4d0660d623669d3",
+    "census": "blake3:b59391706078e9418829d28e20b1f73cfb808bec9b0e1da354592e3c7b192bb9",
+}
+SB4_FROZEN_CIDS = {
+    "dataset": "blake3:46e95f83f05bd5a3bfd4ca0c39c4974f617ae9591ff083d3c6abb8f5593c0e51",
+    "preflight": "blake3:b61a098a53fca1f30b69a0ef0d6e15c5b6fc5a310d0ac8f0f2df04d1fd208814",
+    "products": "blake3:153f6075f165d6cf92aeb63c31f05c9a869cc94c4655f83b9fe036bf7c773e3e",
+    "census": "blake3:2531f2c19cc60570c3807aa117b97923d4ce0b0c8111a8c239861cbae4303a92",
+}
+
+
+def _reproduce_cid(value: dict[str, object], field: str) -> str:
+    unsigned = dict(value)
+    expected = str(unsigned.pop(field))
+    actual = cid_bytes(canonical_json_bytes(unsigned))
+    if actual != expected:
+        raise AssertionError(f"{field} does not reproduce: {expected} != {actual}")
+    return actual
+
+
+class JointCandidateInputTests(unittest.TestCase):
+    def test_renderer_is_exact_full_source_candidate_conditioned_prefix(self) -> None:
+        source = (
+            "The amber alder abacus is above the arched alcove. "
+            "The azure aspen astrolabe was audited after breakfast."
+        )
+        question = "Where is the amber alder abacus?"
+        group = "The amber alder abacus is above the arched alcove."
+        value = render_joint_candidate_input(source, question, group)
+        self.assertEqual(
+            value,
+            f"E:{source}\nQ:{question}\nC:{group}\nSupported:",
+        )
+        self.assertTrue(value.endswith("Supported:"))
+        self.assertFalse(value.endswith("\n"))
+        self.assertIn("exact full source", JOINT_INPUT_POLICY)
+        with self.assertRaisesRegex(ValueError, "not an exact source span"):
+            render_joint_candidate_input(
+                source,
+                question,
+                "The amber alder abacus is beneath the arched alcove.",
+            )
+
+
+class JointCandidatePopulationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset, cls.preflight, cls.products = (
+            build_joint_candidate_margin_population()
+        )
+
+    def test_independent_schemas_counts_and_balanced_width_cells(self) -> None:
+        self.assertEqual(self.dataset["schema"], JOINT_DATASET_SCHEMA)
+        self.assertEqual(self.preflight["schema"], JOINT_PREFLIGHT_SCHEMA)
+        self.assertEqual(self.products["schema"], JOINT_PRODUCT_SCHEMA)
+        self.assertEqual(self.dataset["census"]["schema"], JOINT_CENSUS_SCHEMA)
+        self.assertEqual(self.dataset["policy"], POLICY)
+        self.assertEqual(
+            self.dataset["counts"],
+            {
+                "preflight_fit": 126,
+                "preflight_sealed": 63,
+                "product_probe_commitments": 4,
+                "preflight_fit_distinct_groups": 604,
+                "preflight_sealed_distinct_groups": 302,
+            },
+        )
+        for records, worlds_per_width in (
+            (self.preflight["fit"], 2),
+            (self.preflight["sealed"], 1),
+        ):
+            cells = Counter(
+                (record["target_outcome"], record["source_width"])
+                for record in records
+            )
+            self.assertEqual(
+                cells,
+                Counter(
+                    {
+                        (outcome, width): worlds_per_width * 3
+                        for outcome in OUTCOMES
+                        for width in SOURCE_WIDTHS
+                    }
+                ),
+            )
+
+    def test_fresh_worlds_and_every_sb3_partition_are_disjoint(self) -> None:
+        census = self.dataset["census"]
+        self.assertTrue(census["passed"])
+        self.assertEqual(census["fresh_world_ordinal_start"], 137)
+        self.assertEqual(FRESH_WORLD_ORDINAL_START, 137)
+        self.assertEqual(
+            census["ordinal_boundary"],
+            {
+                "sb3_max_world_ordinal": 136,
+                "sb4_min_world_ordinal": 137,
+                "sb4_starts_exactly_after_sb3": True,
+                "sb4_ordinals_contiguous": True,
+            },
+        )
+        self.assertTrue(census["new_sentence_partitions_pairwise_disjoint"])
+        self.assertTrue(census["new_composite_world_item_banks_pairwise_disjoint"])
+        self.assertEqual(
+            census["primitive_component_vocabulary"],
+            "DELIBERATELY_SHARED_ACROSS_SB3_AND_SB4; not a disjointness claim",
+        )
+        self.assertTrue(
+            all(
+                value
+                for comparisons in census[
+                    "new_vs_every_sb3_partition_sentences_disjoint"
+                ].values()
+                for value in comparisons.values()
+            )
+        )
+        self.assertTrue(
+            all(
+                value
+                for comparisons in census[
+                    "new_vs_every_sb3_partition_composite_world_item_bank_disjoint"
+                ].values()
+                for value in comparisons.values()
+            )
+        )
+
+    def test_exact_spans_labels_and_duplicate_collapse_are_ready(self) -> None:
+        records = [
+            *self.preflight["fit"],
+            *self.preflight["sealed"],
+            *self.products["records"],
+        ]
+        duplicate_records = 0
+        for record in records:
+            self.assertEqual(record["schema"], JOINT_RECORD_SCHEMA)
+            self.assertEqual(record["policy"], POLICY)
+            parsed = split_sentence_spans(record["source"])
+            self.assertEqual(
+                [span["text"] for span in parsed],
+                [span["text"] for span in record["sentence_spans"]],
+            )
+            groups: dict[str, list[dict[str, object]]] = defaultdict(list)
+            for span in record["sentence_spans"]:
+                groups[str(span["relation_group_cid"])].append(span)
+                expected_input = render_joint_candidate_input(
+                    record["source"], record["question"], span["text"]
+                )
+                self.assertEqual(span["relation_input"], expected_input)
+                self.assertEqual(
+                    span["relation_input_cid"],
+                    cid_bytes(expected_input.encode("utf-8")),
+                )
+            for group_cid, rows in groups.items():
+                self.assertEqual({row["relation_group_cid"] for row in rows}, {group_cid})
+                self.assertEqual(len({row["text"] for row in rows}), 1)
+                self.assertEqual(len({row["relation_label"] for row in rows}), 1)
+                self.assertEqual(len({row["relation_input"] for row in rows}), 1)
+            positive_groups = {
+                group_cid
+                for group_cid, rows in groups.items()
+                if int(rows[0]["relation_label"]) == 1
+            }
+            self.assertEqual(
+                positive_groups, set(record["positive_relation_group_cids"])
+            )
+            if record["duplicate_agreement"]:
+                duplicate_records += 1
+                positive_rows = [
+                    span
+                    for span in record["sentence_spans"]
+                    if span["relation_label"] == 1
+                ]
+                self.assertEqual(len(positive_rows), 2)
+                self.assertEqual(
+                    len({span["relation_group_cid"] for span in positive_rows}), 1
+                )
+                self.assertEqual(
+                    record["target_span_index"],
+                    min(span["candidate_index"] for span in positive_rows),
+                )
+            if record["target_outcome"] == "conflict":
+                self.assertEqual(len(positive_groups), 2)
+        self.assertEqual(duplicate_records, 22)
+
+    def test_census_binds_grouping_and_defers_tokenizer_without_truncation(self) -> None:
+        census = self.dataset["census"]
+        for checks in census["partition_checks"].values():
+            self.assertTrue(checks["complete_width_2_through_8_cells"])
+            self.assertTrue(checks["balanced_three_outcomes_per_width"])
+            self.assertTrue(checks["every_locative_text_has_both_labels"])
+            self.assertTrue(checks["every_query_subject_has_answer_and_nonanswer"])
+            self.assertTrue(checks["every_candidate_position_has_both_labels"])
+            self.assertTrue(checks["group_prompts_and_labels_exact"])
+            self.assertTrue(checks["distinct_group_prompt_cids_unique"])
+        self.assertEqual(
+            census["tokenizer_census"]["status"], "CAMPAIGN_BOUND_NOT_RUN"
+        )
+        self.assertIn("never truncate", census["tokenizer_census"]["required_next_action"])
+
+    def test_products_are_separate_unopened_and_exactly_committed(self) -> None:
+        records = self.products["records"]
+        self.assertEqual(len(records), 4)
+        self.assertEqual(
+            [record["probe"] for record in records],
+            [
+                "answer-supported",
+                "abstain-negated-nonlocative",
+                "conflict-distinct-values",
+                "answer-duplicate-agreement",
+            ],
+        )
+        self.assertEqual(
+            [record["target_outcome"] for record in records],
+            ["answer", "abstain", "conflict", "answer"],
+        )
+        self.assertTrue(records[-1]["duplicate_agreement"])
+        self.assertEqual(
+            self.dataset["product_probe_commitments"],
+            [record["record_cid"] for record in records],
+        )
+        self.assertEqual(
+            self.dataset["product_probes_cid"], self.products["product_probes_cid"]
+        )
+        self.assertNotIn("records", self.dataset)
+        self.assertNotIn("product", self.preflight)
+        self.assertIn("must not open", self.products["access_policy"])
+
+    def test_all_cids_reproduce_and_tampering_changes_commitments(self) -> None:
+        all_records = [
+            *self.preflight["fit"],
+            *self.preflight["sealed"],
+            *self.products["records"],
+        ]
+        for record in all_records:
+            _reproduce_cid(record, "record_cid")
+        _reproduce_cid(self.dataset["census"], "census_cid")
+        _reproduce_cid(self.dataset["split_policy"], "split_policy_cid")
+        _reproduce_cid(self.dataset, "dataset_cid")
+        _reproduce_cid(self.preflight, "preflight_cid")
+        _reproduce_cid(self.products, "product_probes_cid")
+
+        tampered_record = deepcopy(all_records[0])
+        original_record_cid = tampered_record.pop("record_cid")
+        tampered_record["sentence_spans"][0]["relation_label"] ^= 1
+        self.assertNotEqual(
+            cid_bytes(canonical_json_bytes(tampered_record)), original_record_cid
+        )
+        tampered_dataset = deepcopy(self.dataset)
+        original_dataset_cid = tampered_dataset.pop("dataset_cid")
+        tampered_dataset["counts"]["preflight_fit"] += 1
+        self.assertNotEqual(
+            cid_bytes(canonical_json_bytes(tampered_dataset)), original_dataset_cid
+        )
+
+    def test_sb3_bytes_remain_frozen_and_sb4_bytes_are_deterministic(self) -> None:
+        sb3_dataset, sb3_preflight, sb3_products = (
+            build_source_relation_adapter_population()
+        )
+        self.assertEqual(sb3_dataset["dataset_cid"], SB3_FROZEN_CIDS["dataset"])
+        self.assertEqual(sb3_preflight["preflight_cid"], SB3_FROZEN_CIDS["preflight"])
+        self.assertEqual(
+            sb3_products["product_probes_cid"], SB3_FROZEN_CIDS["products"]
+        )
+        self.assertEqual(
+            sb3_dataset["census"]["census_cid"], SB3_FROZEN_CIDS["census"]
+        )
+        self.assertEqual(self.dataset["dataset_cid"], SB4_FROZEN_CIDS["dataset"])
+        self.assertEqual(
+            self.preflight["preflight_cid"], SB4_FROZEN_CIDS["preflight"]
+        )
+        self.assertEqual(
+            self.products["product_probes_cid"], SB4_FROZEN_CIDS["products"]
+        )
+        self.assertEqual(
+            self.dataset["census"]["census_cid"], SB4_FROZEN_CIDS["census"]
+        )
+        rebuilt = build_joint_candidate_margin_population()
+        self.assertEqual(
+            [canonical_json_bytes(value) for value in rebuilt],
+            [
+                canonical_json_bytes(self.dataset),
+                canonical_json_bytes(self.preflight),
+                canonical_json_bytes(self.products),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- implement the independently frozen C1-SB4 full-source candidate-set structured-margin preflight
- record the sole bounded MPS result and its content-addressed evidence
- update the current programme documents to the binding negative result and paired-query conditional-binding successor

## Result

Terminal: `FAIL_JOINT_CANDIDATE_MARGIN_PREFLIGHT`

- fit exact records: `70/126`
- sealed exact records: `35/63`
- all `24/24` targeted attention tensors changed; no non-attention tensors changed
- same-source query relocation was not exact
- Rust parity, full fit, development, checkpoint emission, and product reveal remain `NOT_RUN`
- no retry is authorized by the frozen contract

A question-ignoring affirmative-locative rule reproduces every published aggregate count, so the evidence does not establish subject-question binding.

## Focused verification

- 39 relevant Python unit tests passed
- Python compileall passed
- claim-wording gate passed
- `cargo fmt --check` passed
- staged diff and JSON validation passed

The broad workspace suite was intentionally not run: this is Python research tooling plus evidence/documentation, and the predeclared negative branch forbids downstream Rust implementation or product work.

References #954