### PR TITLE
research: record paired-query binding negative for #954

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ is the current architecture and claim-boundary companion.
 The active mechanism contract is
 [`ADR-0005`](docs/adr/0005-predictive-geometric-connection-memory.md). The
 current evidence handoff is the append-only
-[#954 grounded-correctness record](docs/r4_grounded_correctness_954.md). The
+[#954 grounded-correctness record](docs/r4_grounded_correctness_954.md) and
+[C1-SB5 aggregate](docs/r4_paired_query_binding_954_raw.json). The
 earlier frozen [#1019 parameter-capacity contract](docs/r4_softmax_parameter_capacity_1019.md)
 and its [signed preflight result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json)
 remain reference history.
@@ -49,11 +50,17 @@ record-level structured-margin successor also failed: exact records were
 `70/126` fit and `35/63` sealed; positive groups were exact, negative-group
 specificity was `394/478` and `197/239`, and same-source query relocation was
 not exact. It stopped before Rust parity, checkpoint emission, development, or
-the four committed product probes; do not tune or retry it. The next proposal
-is a separately frozen paired-query conditional-binding objective over the same
-source, not another C1-SB4 seed/rank/threshold/schedule run. #954's final
-source-free terminal remains blocked behind #973, and #955 remains blocked
-behind #954. The #1017 `r4 generate` path remains the working
+the four committed product probes; do not tune or retry it. C1-SB5
+`R4PairedQueryCandidateMatrixV1` then fit all `56/56` paired records but reached
+only `14/28` exact sealed pairs. Query-row-swap equivariance was bit-exact;
+pair-mean-query and inference-time attention-off controls were each `0/28`.
+The product population remained unopened, and checkpoint/binding-head emission,
+Rust parity, development, and product evaluation were `NOT_RUN`. Terminal
+`FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` retires C1-SB5 without retry. It preserves
+only bounded source-backed attention evidence; it does not establish generation,
+reasoning, correctness, or a source-free runtime. #954's final source-free
+terminal remains blocked behind #973, and #955 remains blocked behind #954. The
+#1017 `r4 generate` path remains the working
 coherent-generation prototype.
 Prototype iteration uses
 one targeted compile plus one real behavior check; do not run a broad local
@@ -142,11 +149,12 @@ implementation, and the full campaign remains `NOT_RUN`. The subsequent fused-
 AdamW/deferred-logging fast path was slower (`4.485223` versus signed
 `3.491307 s/step`), so `fused=True` was removed and #1019 is optional/paused.
 The #1017 `r4 generate` path remains the working coherent-generation prototype.
-#954 C1-SB2, C1-SB3, and C1-SB4 are bounded negatives, not active answer
-artifacts. C1-SB4's full-source structured-margin arm reached only `70/126` fit
+#954 C1-SB2 through C1-SB5 are bounded negatives, not active answer artifacts.
+C1-SB4's full-source structured-margin arm reached only `70/126` fit
 and `35/63` sealed exact records and stopped before Rust/checkpoint/product.
-Its product text remains unopened and it must not be retried. The next proposal
-is paired-query conditional binding under a separate freeze. CUDA and external
+Its product text remains unopened and it must not be retried. C1-SB5 then fit
+`56/56` pairs but reached only `14/28` sealed; its products stayed unopened and
+the rung retired before checkpoint/head/Rust/development work. CUDA and external
 GPU execution are out of scope. This reference remains
 transformer-compatible and `f32`/multiply/alloc/source-weight backed—not
 table-native, multiply-free, or transformerless. It does not establish geometry
@@ -302,8 +310,10 @@ optional/paused. The #1017 `r4 generate` path remains the working prototype;
 full-source structured-margin attention representation but reached only
 `70/126` fit and `35/63` sealed exact records; it stopped before Rust parity,
 checkpoint emission, development, or its unopened products. Do not retry it.
-The next proposal couples multiple questions over the same source so candidate
-sign must change with the queried subject, under a new independent freeze.
+C1-SB5 subsequently tested that paired-query contrast: fit was `56/56`, sealed
+was `14/28`, row-swap equivariance was bit-exact, and mean-query plus
+attention-off controls were each `0/28`. Its products stayed unopened and the
+rung retired before checkpoint/head/Rust/development work.
 CUDA and external GPU execution are out of scope.
 Intrinsic/readout, resonance, recurrence,
 and lowering are parked. D3 remains `NOT_RUN`; #954's final source-free
@@ -682,8 +692,10 @@ PR (a bump can shift libm-sensitive teacher logprobs — see Gate E below).
   #954 C1-SB2 and C1-SB3 are preserved negatives. C1-SB4's independently frozen
   full-source structured-margin attention arm reached only `70/126` fit and
   `35/63` sealed exact records and stopped before Rust/checkpoint/development/
-  product; do not retry it. The next proposal is separately frozen paired-query
-  conditional binding over the same exact source. CUDA and external GPU
+  product; do not retry it. C1-SB5 then fit `56/56` paired records but reached
+  only `14/28` sealed, with bit-exact row-swap equivariance and `0/28`
+  mean-query/attention-off controls. Its products remained unopened and the rung
+  retired before checkpoint/head/Rust/development work. CUDA and external GPU
   execution are out of scope.
   Intrinsic/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,17 @@ results, parked intrinsic-replacement lane, autonomous-generation gate, and
 native bridge result are frozen in
 [ADR-0005](docs/adr/0005-predictive-geometric-connection-memory.md).
 The current handoff is the
-[`R4SoftmaxTraceStudentV1` record](docs/r4_softmax_trace_student_973.md): ordinary
-causal R4/Spin Q/K/V plus stable softmax is established as the equivalence
-baseline; the source-free Q16 suffix student shows bounded distillation but
-loops autonomously. Contribute next only to `R4SoftmaxTraceStateStudentV1`,
-which compiles construction traces into recurrent source-free R4/Spin state and
-must beat frozen suffix/plain-recurrent/transport-permuted controls. Offline
+[#954 grounded-correctness record](docs/r4_grounded_correctness_954.md) and
+[C1-SB5 aggregate](docs/r4_paired_query_binding_954_raw.json): ordinary
+causal R4/Spin Q/K/V plus stable softmax remains the bounded source-backed
+attention baseline, while C1-SB5 paired-query binding fit `56/56` but reached
+only `14/28` sealed. Row-swap equivariance was bit-exact; mean-query and
+attention-off controls were each `0/28`. Products remained unopened and no
+checkpoint/head/Rust/development stage followed. The rung is retired without
+retry and establishes neither generation, reasoning, correctness, nor a
+source-free runtime. Do not contribute a C1-SB5 retry or its downstream artifact
+work; #954's final source-free terminal remains blocked behind #973, with #955
+downstream of positive correctness. Offline
 teacher/compiler floats, matrix operations, and softmax are permitted; deployed
 runtime remains exact and source-free. Hosted Pages is currently a static,
 WASM-offline surface without a functioning chat backend/artifact lowering, not
@@ -215,8 +220,9 @@ The experiment must be able to change the next programme decision:
   attention and #1017 remains the working bounded generator. #954 C1-SB4's
   full-source record-margin successor failed at `70/126` fit and `35/63` sealed
   exact records; it stopped before Rust/checkpoint/product and must not be
-  retried. Its next proposal is separately frozen paired-query conditional
-  binding over one exact source.
+  retried. C1-SB5 then fit `56/56` paired records but reached only `14/28`
+  sealed and retired before checkpoint/head/Rust/development, with products
+  unopened.
   Intrinsic/readout alternatives, resonance-based softmax replacement,
   full-model recurrent lowering, and exact deployment are parked; #973 still
   blocks GI-4/#954's final source-free terminal, with GI-5/#955 downstream of
@@ -250,10 +256,9 @@ The experiment must be able to change the next programme decision:
   loopback-only dedicated native HTTP canary through the identical policy also
   passes. Dashboard wiring/readiness and static/WASM-isolation checks pass, but
   hosted Pages is static/offline without a functioning chat backend/artifact
-  lowering. The smallest current source-backed correctness falsifier is a newly
-  frozen paired-query conditional-binding mechanism that requires the same
-  candidate to change sign under same-source query relocation. C1-SB4 itself is
-  closed negative and cannot be retried.
+  lowering. The paired-query C1-SB5 source-backed correctness falsifier has now
+  closed negative at `56/56` fit and `14/28` sealed; its controls do not rescue
+  promotion, and neither C1-SB4 nor C1-SB5 may be retried.
   Pinned-source provenance, donor reproduction, and transported-R4 parity are
   recorded in `docs/helm_d_r4_softmax_decoder_973.md`; V1 and V2 outcomes are in
   `docs/intrinsic_lorentz_r4_attention_973.md` and

--- a/README.md
+++ b/README.md
@@ -100,8 +100,15 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > supported reproduces every published C1-SB4 aggregate exactly; per-row model
 > scores were not retained, so this is aggregate-equivalent shortcut evidence,
 > not a claim about the model's internal computation.
-> The next proposal is a separately frozen paired-query conditional-binding
-> objective over the same exact source.
+> C1-SB5 `R4PairedQueryCandidateMatrixV1` then fit `56/56` paired records but
+> reached only `14/28` exact sealed pairs. Query-row-swap equivariance was
+> bit-exact, while pair-mean-query and inference-time attention-off controls were
+> each `0/28`. The product population remained unopened; no checkpoint or
+> binding-head artifact was emitted, and Rust parity, development, and product
+> evaluation were `NOT_RUN`. Terminal `FAIL_PAIRED_QUERY_BINDING_PREFLIGHT`
+> retires this rung without retry. It leaves attention established only at the
+> bounded source-backed scope and does not establish generation, reasoning,
+> correctness, or a source-free runtime.
 > #954's final source-free terminal remains blocked behind #973, and #955
 > remains blocked behind #954.
 > See the [#1017 record](docs/r4_softmax_quality_capacity_continuation_1017.md),
@@ -113,7 +120,8 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > [structured aggregate](docs/r4_softmax_end_to_end_attention_1014_raw.json),
 > plus the [#954 correctness campaign](docs/r4_grounded_correctness_954.md),
 > [corrected C1-SB3 aggregate](docs/r4_attended_relation_adapter_954_raw.json),
-> and [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json).
+> [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json), and
+> [C1-SB5 aggregate](docs/r4_paired_query_binding_954_raw.json).
 >
 > The completed #1017 checkpoint is the current working 7.15M
 > coherent-generation prototype. If its local export exists, run it directly
@@ -273,8 +281,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > full-source structured-margin successor then failed at `70/126` fit and
 > `35/63` sealed exact records, with perfect positive-group recall but only
 > `82.43%` negative specificity. Rust/checkpoint/development/product stayed
-> `NOT_RUN`; do not retry it. The next proposal is separately frozen
-> paired-query conditional binding. #954's final source-free terminal remains
+> `NOT_RUN`; do not retry it. C1-SB5 later fit `56/56` pairs but reached only
+> `14/28` sealed and retired before checkpoint/head/Rust/development work, with
+> its product population unopened. #954's final source-free terminal remains
 > blocked behind #973, and #955 remains blocked behind #954.
 > The trace/compiler rung
 > that followed that checkpoint is now complete: `R4SoftmaxTeacherTraceV1`
@@ -308,9 +317,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > and sealed `56/63`; parity/full fit/development/product remain `NOT_RUN`.
 > C1-SB4's independently frozen full-source structured-margin successor then
 > failed at `70/126` fit and `35/63` sealed exact records and stopped before
-> Rust/checkpoint/development/product. Do not retry it. The next proposal is
-> paired-query conditional binding over one shared exact source under a new
-> freeze.
+> Rust/checkpoint/development/product. Do not retry it. C1-SB5 subsequently fit
+> `56/56` paired records but generalized to `14/28` sealed and retired without a
+> checkpoint/head/Rust/development stage; its products remained unopened.
 > CUDA and external GPU execution are out of scope. No
 > further 7.15M exposure or learning-rate tuning is authorized.
 > Intrinsic/readout substitution, resonance, softmax replacement, scale, and
@@ -400,8 +409,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > gate at fit `124/126` and sealed `56/63`; later stages remain `NOT_RUN`.
 > C1-SB4's full-source record-margin successor then failed at `70/126` fit and
 > `35/63` sealed exact records. Rust/checkpoint/development/product remain
-> `NOT_RUN`; do not retry it. The next proposal is separately frozen
-> paired-query conditional binding. CUDA and
+> `NOT_RUN`; do not retry it. C1-SB5 later fit `56/56` paired records but reached
+> `14/28` sealed and retired with products unopened and no emitted artifacts.
+> CUDA and
 > external GPU execution are out of scope. #954's final source-free terminal
 > remains blocked behind #973, and #955 remains blocked behind #954.
 > See the
@@ -475,7 +485,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > development/product remain `NOT_RUN`. C1-SB4's independently frozen
 > full-source structured-margin arm then failed at `70/126` fit and `35/63`
 > sealed exact records; no Rust/checkpoint/product followed and no retry is
-> authorized. The next proposal is paired-query conditional binding. The
+> authorized. C1-SB5 then fit `56/56` pairs but reached `14/28` sealed and
+> retired before checkpoint/head/Rust/development; products remained unopened.
+> The
 > final source-free terminal remains blocked behind #973, and #955 remains
 > blocked behind #954.
 > See the
@@ -558,8 +570,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > stages. C1-SB4's full-source structured-margin successor then recovered every
 > positive group but only `82.43%` of negative groups, yielding `70/126` fit and
 > `35/63` sealed exact records. Rust/checkpoint/development/product are
-> `NOT_RUN`; do not retry it. The next proposal is separately frozen
-> paired-query conditional binding. CUDA and external GPU execution
+> `NOT_RUN`; do not retry it. C1-SB5 later fit `56/56` pairs but reached `14/28`
+> sealed and retired before checkpoint/head/Rust/development, with products
+> unopened. CUDA and external GPU execution
 > are out of scope. #954's final source-free terminal remains blocked behind
 > #973, and #955 remains blocked behind #954. General higher-scope attention,
 > correct answers, and reasoning do not exist yet. The
@@ -656,8 +669,11 @@ representation. It recovered `126/126` fit and `63/63` sealed positive groups,
 but rejected only `394/478` and `197/239` negatives. Exact records were
 `70/126` fit and `35/63` sealed; same-source query relocation was not exact.
 Rust parity, checkpoint emission, development, and product remained `NOT_RUN`.
-Do not tune or retry C1-SB4. The next proposal is separately frozen
-paired-query conditional binding over the same exact source. #954's final
+Do not tune or retry C1-SB4. C1-SB5 then fit `56/56` paired records but reached
+only `14/28` sealed; row-swap equivariance was bit-exact and mean-query plus
+attention-off controls were `0/28`. Its products remained unopened, no
+checkpoint/head was emitted, and Rust/development were `NOT_RUN`; retire the
+rung without retry. #954's final
 source-free terminal remains blocked behind #973, and #955 remains blocked
 behind #954. See the
 [#954 record](docs/r4_grounded_correctness_954.md) and
@@ -665,7 +681,8 @@ behind #954. See the
 [C1-SB1 pointer result](docs/r4_source_span_pointer_954_raw.json) and
 [C1-SB2 relation result](docs/r4_source_relation_head_954_raw.json), the
 [corrected C1-SB3 result](docs/r4_attended_relation_adapter_954_raw.json), and
-[C1-SB4 result](docs/r4_joint_candidate_margin_954_raw.json).
+[C1-SB4 result](docs/r4_joint_candidate_margin_954_raw.json), followed by the
+[C1-SB5 result](docs/r4_paired_query_binding_954_raw.json).
 
 On Apple Silicon, build the opt-in CPU-BLAS version so local inference uses the
 machine's Accelerate framework:
@@ -933,9 +950,9 @@ exact-descriptor/entity-binding path selector apiece at their respective
    and sealed `56/63`; parity/full fit/development/product are `NOT_RUN`.
    C1-SB4's full-source structured-margin successor then failed at `70/126` fit
    and `35/63` sealed exact records and stopped before Rust/checkpoint/product;
-   do not retry it. The next proposal is separately frozen paired-query
-   conditional binding. CUDA and
-   external GPU execution are out of scope. #954's final source-free terminal
+   do not retry it. C1-SB5 later fit `56/56` pairs but reached `14/28` sealed and
+   retired before checkpoint/head/Rust/development, with products unopened.
+   CUDA and external GPU execution are out of scope. #954's final source-free terminal
    stays blocked behind #973, and #955 remains blocked behind #954.
 See the [append-only #953 record](docs/local_geometric_generation_953.md).
 See the [accepted table-tie record](docs/source_free_table_geometric_intervention_953.md).
@@ -1091,8 +1108,9 @@ not become substitutes for working intelligence:
    and transferred most sealed relations, but failed exact fit/sealed outcomes
    (`124/126`, `56/63`); all later stages are `NOT_RUN`. C1-SB4's full-source
    record-margin successor then failed at `70/126` fit and `35/63` sealed exact
-   records and stopped before Rust/checkpoint/product; do not retry it. The
-   next proposal is separately frozen paired-query conditional binding. CUDA and
+   records and stopped before Rust/checkpoint/product; do not retry it. C1-SB5
+   later fit `56/56` pairs but reached `14/28` sealed and retired before
+   checkpoint/head/Rust/development, with products unopened. CUDA and
    external GPU execution are out of scope.
    Do not resume resonance substitutes. Product development continues through
    `r4 generate`, but no production-readiness or release claim follows yet. This intermediate
@@ -1168,7 +1186,8 @@ population are `NOT_RUN`. C1-SB4's independently frozen full-source
 structured-margin successor then failed at `70/126` fit and `35/63` sealed
 exact records, with perfect positive-group recall but only `82.43%` negative
 specificity. Rust/checkpoint/development/product are `NOT_RUN`; do not retry
-it. The next proposal is separately frozen paired-query conditional binding.
+it. C1-SB5 later fit `56/56` pairs but reached `14/28` sealed and retired before
+checkpoint/head/Rust/development, with products unopened.
 CUDA and external GPU execution are out of
 scope. #954's final source-free terminal remains blocked behind #973, and #955
 remains blocked behind #954. The exact contract is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,8 +115,14 @@ attention-representation transfer but missed its exact gate. C1-SB4's
 independently frozen full-source record-margin successor reached only `70/126`
 fit and `35/63` sealed exact records; it stopped before Rust/checkpoint/
 development/product and must not be retried. A question-ignoring ` is inside `
-rule reproduces every aggregate count exactly. The next proposal is separately
-frozen paired-query conditional binding over one exact source. #954 remains
+rule reproduces every aggregate count exactly. C1-SB5
+`R4PairedQueryCandidateMatrixV1` then fit `56/56` pairs but reached only `14/28`
+sealed. Row-swap equivariance was bit-exact; pair-mean-query and attention-off
+controls were each `0/28`. Products remained unopened, no checkpoint or binding
+head was emitted, and Rust parity, development, and product evaluation were
+`NOT_RUN`. Retire the rung without retry. This remains bounded source-backed
+attention evidence, not generation, reasoning, correctness, or a source-free
+runtime. #954 remains
 open, #955 remains blocked, and #954's final
 source-free terminal remains behind #973. CUDA and
 external GPU execution are out of scope.
@@ -205,8 +211,9 @@ The completed continuation and its NLL-only negative are in
 > and emitted no final head. C1-SB3 then transferred most relations through
 > attention but missed exact promotion. C1-SB4's full-source record-margin
 > successor failed at `70/126` fit and `35/63` sealed exact records and stopped
-> before Rust/checkpoint/product; do not retry it. The next proposal is
-> separately frozen paired-query conditional binding.
+> before Rust/checkpoint/product; do not retry it. C1-SB5 later fit `56/56`
+> paired records but reached `14/28` sealed and retired before
+> checkpoint/head/Rust/development, with products unopened.
 > CUDA and external GPU execution are out of scope.
 > Offline teacher/compiler work remains transformer-compatible and
 > `f32`/multiply/alloc/source-weight backed—not the final
@@ -305,8 +312,10 @@ failed, so parity, full fit, development, and product reveal were not run and
 no final head was emitted; C1-SB3 produced bounded transfer but failed exact
 promotion; C1-SB4's full-source record-margin successor failed at `70/126` fit
 and `35/63` sealed exact records and stopped before Rust/checkpoint/product;
-**Proposed next:** independently freeze paired-query conditional binding over
-one exact source while preserving the Rust exact-copy and typed non-answer seam;
+**Retired negative:** C1-SB5 fit `56/56` paired records but reached only `14/28`
+sealed, with bit-exact row-swap equivariance and `0/28` mean-query plus
+attention-off controls; products stayed unopened and checkpoint/head/Rust/
+development were `NOT_RUN`;
 CUDA and external GPU execution are out of scope; **Parked:** further 7.15M exposure
 or LR tuning, intrinsic score/readout alternatives,
 resonance-based softmax replacement, full-model recurrent lowering, and exact
@@ -355,9 +364,9 @@ stopped before parity, full fit, development, and product reveal with no final
 head. C1-SB3 then produced bounded attention-representation transfer but missed
 its exact gate. C1-SB4's full-source record-margin successor failed at
 `70/126` fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
-product; do not retry it. The new proposal is independently frozen paired-query
-conditional binding over one exact source, retaining Rust exact-copy and typed
-non-answer behavior. #954 remains open, #955 remains
+product; do not retry it. C1-SB5 then fit `56/56` pairs but reached `14/28`
+sealed and retired before checkpoint/head/Rust/development, with products
+unopened. #954 remains open, #955 remains
 blocked, and the final source-free terminal remains behind #973. CUDA and
 external GPU execution are out of scope.
 Intrinsic/resonance/replacement work is
@@ -643,9 +652,9 @@ feasibility boundary remains in the
    terminal remains behind #973. C1-SB3 produced bounded transfer but missed
    exact promotion; C1-SB4's full-source record-margin successor failed at
    `70/126` fit and `35/63` sealed exact records and stopped before Rust/
-   checkpoint/product. Do not retry it. The next proposal is independently
-   frozen paired-query conditional binding over one exact source, retaining the
-   Rust exact-copy and typed non-answer seam. #954 remains open and #955 remains blocked.
+   checkpoint/product. Do not retry it. C1-SB5 then fit `56/56` pairs but reached
+   `14/28` sealed and retired before checkpoint/head/Rust/development; products
+   remained unopened. #954 remains open and #955 remains blocked.
    Every learned epoch receives a
    new kappa and reruns its owning
    construction gate. More documents, table density, or trace activity are
@@ -665,9 +674,9 @@ feasibility boundary remains in the
    then transferred most relations through attention but missed exact
    promotion. C1-SB4's full-source record-margin successor failed at `70/126`
    fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
-   product; do not retry it. The next proposal is independently frozen
-   paired-query conditional binding over one exact source, retaining Rust
-   exact-copy and typed non-answer behavior.
+   product; do not retry it. C1-SB5 then fit `56/56` pairs but reached `14/28`
+   sealed and retired before checkpoint/head/Rust/development; products remained
+   unopened.
    The final source-free terminal still requires the accepted
    selector/#953/#973 artifact and evidence provenance #969 → #983 → #986;
    source-backed prototype evidence does not satisfy it. #954 remains open and
@@ -753,8 +762,8 @@ historical evidence and comparators.
 
 ## Active
 
-- [ ] **#954 grounded correctness: paired-query conditional binding after the
-  full-source structured-margin shortcut** — retain the
+- [ ] **#954 grounded correctness: C1-SB5 retired negative; final source-free
+  terminal blocked behind #973** — retain the
   bounded positives, #997 placement negative, bounded gated-delta negative, V2
   budget invalidation, equal-manifold-budget V3 mixed-gauge H4 negative, and
   V4's held-out 13/24 functional/control negative. The positive attention
@@ -813,15 +822,18 @@ historical evidence and comparators.
   attention-representation transfer but missed exact promotion. C1-SB4's
   independently frozen full-source record-margin successor failed at `70/126`
   fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
-  product; no retry is authorized. The next proposal is independently frozen
-  paired-query conditional binding over one exact source, retaining the Rust
-  exact-copy and typed non-answer seam. No product wiring is active. Apple
+  product; no retry is authorized. C1-SB5 then fit all `56/56` paired records
+  but reached only `14/28` sealed. Its row-swap control was bit-exact;
+  mean-query and attention-off were `0/28`. Products remained unopened and no
+  checkpoint/head/Rust/development stage followed; retire the rung without
+  retry. No product wiring is active. Apple
   Accelerate/BLAS and MPS remain local offline accelerators only; CUDA and
   external GPU execution are out of scope. See the
   [frozen contract](docs/r4_softmax_parameter_capacity_1019.md) and
   [signed preflight/admission result](docs/r4_softmax_parameter_capacity_preflight_1019_raw.json),
   then the [#954 record](docs/r4_grounded_correctness_954.md) and
-  [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json).
+  [C1-SB4 aggregate](docs/r4_joint_candidate_margin_954_raw.json), followed by
+  the [C1-SB5 aggregate](docs/r4_paired_query_binding_954_raw.json).
   Do not extend
   exposure or tune learning rate on the 7.15M checkpoint. Intrinsic score/readout
   alternatives, resonance-based softmax replacement, full-model recurrent
@@ -989,9 +1001,9 @@ historical evidence and comparators.
   then produced bounded attention-representation transfer but missed exact
   promotion. C1-SB4's full-source record-margin successor failed at `70/126`
   fit and `35/63` sealed exact records and stopped before Rust/checkpoint/
-  product; do not retry it. The next proposal is independently frozen
-  paired-query conditional binding over one exact source, retaining Rust
-  exact-copy and typed non-answer behavior.
+  product; do not retry it. C1-SB5 then fit `56/56` pairs but reached `14/28`
+  sealed and retired before checkpoint/head/Rust/development; products remained
+  unopened.
   CUDA and external GPU execution are out of scope. Intrinsic score/readout alternatives,
   resonance-based softmax replacement, full-model recurrent lowering, and exact
   deployment are parked. D3 remains `NOT_RUN`; #954 remains open, its final

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -160,6 +160,16 @@ aggregate-equivalent shortcut evidence rather than an internal-mechanism claim.
 See the
 [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
 
+C1-SB5 `R4PairedQueryCandidateMatrixV1` then executed the independently frozen
+same-source paired-query contrast. It fit all `56/56` pairs but reached only
+`14/28` sealed pairs. Query-row-swap equivariance was bit-exact;
+pair-mean-query and inference-time attention-off controls were each `0/28`.
+The product population remained unopened, no checkpoint or binding head was
+emitted, and Rust parity, development, and product evaluation were `NOT_RUN`.
+Terminal `FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` retires the rung without retry.
+This preserves bounded source-backed attention evidence only; it does not
+establish generation, reasoning, correctness, or a source-free runtime.
+
 The #1017 export remains the current working 7.15M coherent-generation
 prototype. `r4 generate --prompt "..."` defaults to
 `.uor-models/research/issue-1017/export`. #1019 is an optional quality-capacity
@@ -175,11 +185,8 @@ table-native, multiply-free, transformerless, browser-WASM, release, or
 frontier-model evidence.
 Intrinsic/readout alternatives, multi-resonance softmax replacement, full-model
 recurrent lowering, and exact H4/Q29/integer-table deployment are parked. #954
-remains open. Do not tune or retry the C1-SB3 or C1-SB4 adapters. The next
-proposal is a separately frozen paired-query conditional-binding objective:
-multiple questions share one exact source and the same candidate must change
-sign with the queried subject. Retain the exact-copy and typed non-answer Rust
-seam. #955 remains blocked on a positive
+remains open. Do not tune or retry the C1-SB3, C1-SB4, or C1-SB5 mechanisms.
+#955 remains blocked on a positive
 correctness result, and #954's final source-free terminal remains blocked behind
 #973. Validation,
 test, and inference remain strictly causal and cannot fit on their future
@@ -217,6 +224,9 @@ development/product `NOT_RUN`;
 `35/63` sealed exact records, positive groups `126/126` and `63/63`, negative
 groups `394/478` and `197/239`, all 24 attention tensors changed with no
 non-attention change, and Rust/checkpoint/development/product `NOT_RUN`;
+#954 C1-SB5 paired-query binding, `56/56` fit and `14/28` sealed pairs,
+bit-exact row-swap equivariance, mean-query and attention-off `0/28`, products
+unopened, and checkpoint/head/Rust/development/product `NOT_RUN`; rung retired;
 resonance replacement `NOT_RUN` and parked; full-model recurrent and
 exact lowering parked. See
 [`helm_d_r4_softmax_decoder_973.md`](helm_d_r4_softmax_decoder_973.md) and
@@ -226,7 +236,8 @@ then [`r4_softmax_trace_student_973.md`](r4_softmax_trace_student_973.md) and
 followed by [`r4_softmax_quality_capacity_continuation_1017.md`](r4_softmax_quality_capacity_continuation_1017.md),
 [`r4_grounded_correctness_954.md`](r4_grounded_correctness_954.md), and
 [`r4_source_relation_head_954_raw.json`](r4_source_relation_head_954_raw.json),
-then [`r4_joint_candidate_margin_954_raw.json`](r4_joint_candidate_margin_954_raw.json).
+then [`r4_joint_candidate_margin_954_raw.json`](r4_joint_candidate_margin_954_raw.json)
+and [`r4_paired_query_binding_954_raw.json`](r4_paired_query_binding_954_raw.json).
 
 ## Current route-native target lifecycle
 
@@ -274,7 +285,7 @@ canonical text/corpus
     -> terminal-residual relation head [#954 C1-SB2; MATCHED-TRANSFER PREFLIGHT FAIL, NO FINAL HEAD]
     -> rank-8 all-layer Q/K/V/O relation adapter, fixed yes/no verbalizer, no head [#954 C1-SB3; BOUNDED TRANSFER, EXACT PREFLIGHT FAIL]
     -> joint-source candidate-set representation + record-level structured margin through attention [#954 C1-SB4; EXACT PREFLIGHT FAIL, NO RUST/ARTIFACT]
-    -> paired-query conditional binding over one exact source [#954; PROPOSED, REQUIRES INDEPENDENT FREEZE]
+    -> paired-query conditional binding over one exact source [#954 C1-SB5; FIT 56/56, SEALED 14/28, RETIRED, NO ARTIFACT]
     -> final source-free correctness terminal [#954; BLOCKED BEHIND #973]
     -> bounded reasoning [#955; BLOCKED ON POSITIVE CORRECTNESS]
     -> durable isolated CLI/HTTP chat + persisted hive memory (#962)
@@ -1660,9 +1671,9 @@ D3 on construction covariance, with diagnostic curved NLL worse than donor and
   full-source record-margin successor then failed at `70/126` fit and `35/63`
   sealed exact records despite exact positive-group recall; negative specificity
   was `394/478` and `197/239`. It stopped before Rust/checkpoint/development/
-  product and must not be retried. The active proposal is separately frozen
-  paired-query conditional binding over the same exact source, preserving the
-  exact-copy and typed non-answer Rust seam. CUDA and external GPU execution are out of scope.
+  product and must not be retried. C1-SB5 then fit `56/56` pairs but reached
+  `14/28` sealed and retired before checkpoint/head/Rust/development; products
+  remained unopened. CUDA and external GPU execution are out of scope.
   Further exposure and LR tuning of the 7.15M checkpoint are prohibited.
   Resonance substitutes, unrelated optimization, and release work
   remain parked. Lowering does not otherwise reactivate automatically on a

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -179,8 +179,15 @@ assumptions, or objectives rather than measured results.
 > specificity was `394/478` fit and `197/239` sealed; exact records were
 > `70/126` and `35/63`, and same-source query relocation was not exact. All 24
 > attention targets changed with no non-attention change. It stopped before
-> Rust/checkpoint/development/product and must not be retried. The next proposal
-> is separately frozen paired-query conditional binding over one exact source.
+> Rust/checkpoint/development/product and must not be retried. C1-SB5
+> `R4PairedQueryCandidateMatrixV1` then fit `56/56` paired records but reached
+> only `14/28` sealed. Row-swap equivariance was bit-exact; pair-mean-query and
+> attention-off controls were each `0/28`. The product population remained
+> unopened, no checkpoint or binding head was emitted, and Rust parity,
+> development, and product evaluation were `NOT_RUN`. Terminal
+> `FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` retires the rung without retry. This is
+> bounded source-backed attention evidence only; it does not establish
+> generation, reasoning, correctness, or a source-free runtime.
 > A question-ignoring ` is inside ` rule reproduces every published aggregate
 > count exactly; because per-row model scores were not retained, this is
 > aggregate-equivalent shortcut evidence rather than an internal-mechanism claim.
@@ -189,8 +196,9 @@ assumptions, or objectives rather than measured results.
 > blocked behind #973. CUDA and external GPU execution are out of scope. See
 > the [signed preflight/admission result](r4_softmax_parameter_capacity_preflight_1019_raw.json),
 > [#954 correctness campaign](r4_grounded_correctness_954.md),
-> [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json), and
-> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+> [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json),
+> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json), and
+> [C1-SB5 aggregate](r4_paired_query_binding_954_raw.json).
 > Offline floats, matrix
 > operations, and softmax remain allowed while establishing language quality;
 > the deployed destination remains exact and source-free. Resonance substitutes
@@ -204,8 +212,9 @@ assumptions, or objectives rather than measured results.
 > [#1014 end-to-end record](r4_softmax_end_to_end_attention_1014.md), then the
 > [#1017 continuation record](r4_softmax_quality_capacity_continuation_1017.md),
 > the [#954 campaign record](r4_grounded_correctness_954.md),
-> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json), and
-> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+> [C1-SB2 compact aggregate](r4_source_relation_head_954_raw.json),
+> [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json), and
+> [C1-SB5 aggregate](r4_paired_query_binding_954_raw.json).
 >
 > **Measured evidence status:** HELM-D pinned-source provenance `PASS`;
 > ordinary-donor reproduction `PASS`; transported-R4 parity, destructive
@@ -633,8 +642,9 @@ assumptions, or objectives rather than measured results.
 > BCE adapter. C1-SB4's full-source record-margin successor then failed at
 > `70/126` fit and `35/63` sealed exact records, with positive groups exact but
 > negative specificity only `394/478` and `197/239`. Rust/checkpoint/
-> development/product are `NOT_RUN`; do not retry it. The next proposal is
-> separately frozen paired-query conditional binding. CUDA
+> development/product are `NOT_RUN`; do not retry it. C1-SB5 later fit `56/56`
+> pairs but reached `14/28` sealed and retired before checkpoint/head/Rust/
+> development, with products unopened. CUDA
 > and external GPU execution are out of scope.
 > Intrinsic/readout alternatives,
 > resonance-based softmax replacement, whole-decoder recurrent lowering, and
@@ -1185,8 +1195,9 @@ then ran the independently frozen full-source, record-level structured-margin
 successor and failed at `70/126` fit and `35/63` sealed exact records. Positive
 groups were exact; negative specificity was `394/478` and `197/239`, and
 same-source query relocation was not exact. It stopped before Rust/checkpoint/
-development/product and must not be retried. The next proposal is separately
-frozen paired-query conditional binding over one exact source. #955 remains blocked, and #954's
+development/product and must not be retried. C1-SB5 later fit `56/56` pairs but
+reached `14/28` sealed and retired before checkpoint/head/Rust/development, with
+products unopened. #955 remains blocked, and #954's
 final source-free terminal remains behind #973.
 GI-1/#961 has made lexical payloads and the hierarchy identities reversible.
 GI-2/#952 A1.0 then established candidate/value reachability but found that the
@@ -1272,13 +1283,14 @@ probes are `NOT_RUN`. Do not tune or retry this independent-candidate BCE
 adapter. C1-SB4's independently frozen full-source record-margin successor then
 failed at `70/126` fit and `35/63` sealed exact records, despite exact positive
 groups; negative specificity was `394/478` and `197/239`. Rust/checkpoint/
-development/product remain `NOT_RUN`, and no retry is authorized. The next
-proposal is paired-query conditional binding over the same source under a new
-independent freeze, retaining deterministic exact copy and typed non-answer output.
+development/product remain `NOT_RUN`, and no retry is authorized. C1-SB5 then
+fit `56/56` pairs but reached `14/28` sealed and retired before checkpoint/head/
+Rust/development, with products unopened.
 #954 remains open; #955 remains blocked, and the final source-free #954 terminal
 remains behind #973. See the [campaign record](r4_grounded_correctness_954.md),
-[C1-SB2 aggregate](r4_source_relation_head_954_raw.json), and
-[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json),
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json), and
+[C1-SB5 aggregate](r4_paired_query_binding_954_raw.json).
 CUDA and external GPU execution remain out of scope. Fiber-preserving
 multi-resonance replacement, whole-decoder recurrent factorization, capacity
 expansion, and final source-free requalification are parked. Dependable broad
@@ -1905,13 +1917,14 @@ tune or retry that independent-candidate BCE adapter. C1-SB4's full-source
 record-margin successor then failed at `70/126` fit and `35/63` sealed exact
 records; positive groups were exact, but negative specificity was `394/478`
 and `197/239`. It stopped before Rust/checkpoint/development/product and must
-not be retried. The next proposal is separately frozen paired-query
-conditional binding while preserving exact-copy and typed non-answer Rust
-behavior. Its final source-free terminal remains blocked behind
+not be retried. C1-SB5 then fit `56/56` pairs but reached `14/28` sealed and
+retired before checkpoint/head/Rust/development, with products unopened. Its
+final source-free terminal remains blocked behind
 #973, and #955 remains blocked on a positive correctness result. See the
 [#954 campaign record](r4_grounded_correctness_954.md),
-[C1-SB2 aggregate](r4_source_relation_head_954_raw.json), and
-[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+[C1-SB2 aggregate](r4_source_relation_head_954_raw.json),
+[C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json), and
+[C1-SB5 aggregate](r4_paired_query_binding_954_raw.json).
 #955 invokes that accepted selector/
 #953/#973/#954 consumer; #962 integrates the accepted selector/#953/#973 path
 into product chat with persisted identity-scoped hive memory. #963 retains

--- a/docs/r4_grounded_correctness_954.md
+++ b/docs/r4_grounded_correctness_954.md
@@ -360,3 +360,106 @@ The compact aggregate is
 This negative does not revise #1014/#1017 ordinary-attention or bounded coherent
 generation evidence, establish intrinsic geometry, or unblock #955. #954's
 final source-free terminal remains separately blocked behind #973.
+
+## C1-SB5 paired-query conditional-binding result — 2026-08-31
+
+`R4PairedQueryCandidateMatrixV1` implemented the independently frozen response
+to C1-SB4's question-ignoring shortcut. Each first-class item held one exact
+source and two different subject questions. Both lanes used the input below,
+with no terminal newline:
+
+```text
+E:<exact full source>
+Q:<question>
+Bind:
+```
+
+The candidate columns were the final punctuation-token states of the earliest
+source occurrence of each distinct exact-text candidate group. The two lanes
+had bit-identical source prefixes, and the query row used the final `Bind:`
+colon after all six established R4/Spin ordinary causal-softmax layers. Rank-8,
+alpha-8, dropout-zero LoRA updated Q/K/V/O in every layer. A separate asymmetric
+rank-32 head scored `dot(Wq*hq,Wc*hc)/sqrt(32)+b`; only a score greater than zero
+marked a candidate supported. LoRA plus the three-tensor head exposed 129,025
+trainable parameters. The eight four-lane head blocks are bookkeeping, not an
+intrinsic-geometry claim.
+
+The fresh population began at world ordinal 162. It contained 56 fit pairs and
+28 independently sealed pairs across widths 2 through 8. Every pair included
+at least one candidate whose label flipped between its two questions. The fit
+matrix contained 112 query rows, 266 candidate groups, 532 cells, and 98 flip
+columns; sealed contained 56 rows, 133 groups, 266 cells, and 49 flips. Exact
+sentences and complete composite world items were disjoint from C1-SB3,
+C1-SB4, and the other partitions; primitive component vocabulary remained
+shared deliberately. All candidate anchors preceded `Q:`, paired source token
+prefixes reproduced exactly, and the longest fit/sealed input occupied 189/201
+of 256 positions including BOS. Four opaque product pair commitments were
+created during preparation and remained outside the training view.
+
+The sole MPS optimizer used seed 9545, one pair for each of seven widths per
+step, 120 steps, 15 complete epochs, and 7,980 matrix-cell presentations. The
+objective was mean margin-one row loss plus mean margin-two flip-column loss.
+Loss moved from `5.9824323654174805` to `0.0`. The step-eight ETA gate passed,
+and the optimizer completed inside its 300-second ceiling; exact elapsed timing
+was deliberately omitted from the content-addressed result.
+
+Fit was exact, but lexical transfer was not:
+
+| Frozen metric | Trained fit | Trained sealed | Requirement |
+| --- | ---: | ---: | ---: |
+| exact pairs | `56/56` | `14/28` | exact |
+| exact query rows | `112/112` | `37/56` | exact |
+| cell signs | `532/532` | `227/266` | exact |
+| flip columns | `98/98` | `38/49` | exact |
+| supported copies | `42/42` | `13/21` | exact |
+| duplicate pairs | `14/14` | `4/7` | exact |
+| answer outcomes | `42/42` | `13/21` | exact |
+| abstain outcomes | `42/42` | `14/21` | exact |
+| conflict outcomes | `28/28` | `10/14` | exact |
+
+Fit mean loss was `0.0`; sealed mean row-margin loss was
+`2.1721223763057163`, mean flip-margin loss was `0.34822897035248424`, and
+total mean loss was `2.5203513466582006`. The miss was not isolated to one
+pair construction: the four pair slots reached `3/7`, `4/7`, `3/7`, and
+`4/7`. The descriptive sealed width/world counts were `4/4`, `0/4`, `4/4`,
+`4/4`, `0/4`, `0/4`, and `2/4` for widths 2 through 8. Each width had exactly
+one sealed lexical world, so that pattern cannot identify a causal width
+effect.
+
+The causal controls sharpen the result without rescuing qualification.
+Corresponding candidate states were bit-identical in all `56/56` fit and
+`28/28` sealed pairs. Identity-aligned row swapping reproduced the complete
+matrix trace and aggregate exactly. Pair-mean query ablation produced identical
+rows in `28/28`, scored `0/28` exact pairs, and increased loss. Turning
+attention off also scored `0/28` and increased loss. Deterministic evaluation
+replay was exact. All 24 targeted attention tensors and all three binding-head
+tensors changed and remained finite; no non-attention base tensor changed.
+Thus distinct query states and active causal attention were load-bearing for
+the observed behavior, but the independently sealed semantics still failed.
+
+Terminal: **`FAIL_PAIRED_QUERY_BINDING_PREFLIGHT`**. The result is bound by:
+
+- result CID `blake3:076242ab2bd379083ae55a22a272b3a0943b350fa301f65909e1b0ecc0d72571`;
+- manifest CID `blake3:c4a7ec5e4926cc5ede144d7f3c013940d104bb77ce26f8e201aa63c524c6a119`;
+- tree CID `blake3:0c3b0d869c45fca9924c1d76af19c9b411d8529c6ac8f9f7bf9d641d788dc188`;
+- run-contract CID `blake3:992bc9bb61c3e7bb4481cee3b959db338aa68530ffe43e93ee0eac5c133d2103`.
+
+The training view recorded zero product or forbidden reads, and the result
+manifest contains no checkpoint or binding-head artifact. Product evaluation,
+Rust parity, development evaluation, and any larger fit are `NOT_RUN`.
+Per the independent freeze, C1-SB5 is retired without retry, parameter change,
+larger fit, checkpoint emission, or product reveal.
+
+This is a bounded causal-mechanism result and an exact-qualification negative:
+the architecture fit paired subject binding perfectly, and query/attention
+ablations destroyed its sealed behavior, but it did not transfer exact binding
+to fresh lexical worlds. It does not establish intrinsic geometry, source-free
+correctness, reasoning, transformerlessness, exact lowering, browser/WASM, or
+release readiness, and it does not revoke #1014/#1017 ordinary-attention or
+bounded-generation evidence. No C1-SB6 or other scientific run is authorized
+by this result. #973 remains parked and must be independently re-scoped before
+work on the source-free/geometric-attention blocker resumes; #955 reasoning
+remains downstream.
+
+The compact bound aggregate is
+[`r4_paired_query_binding_954_raw.json`](r4_paired_query_binding_954_raw.json).

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -120,11 +120,16 @@
   `blake3:82f83d865eaea24589cf8acdbcc4c83fd4714041c1d80e31a818d587664b7b84`;
   manifest CID
   `blake3:4872dd1b70cebbd7c2cf9930389e73df52e2325f809b0d0e27763a588a88b04f`.
-  #954 remains open. The next proposal is a separately frozen paired-query
-  conditional-binding objective: multiple questions share the same exact
-  source and the same candidate must change sign with the queried subject. It
-  is not a C1-SB4 seed, rank, threshold, schedule, or corpus retry. Retain the
-  exact-copy and typed non-answer Rust seam. #955 remains blocked, and #954's
+  C1-SB5 `R4PairedQueryCandidateMatrixV1` then executed that independently
+  frozen same-source paired-query contrast. Fit was `56/56`, but sealed exact
+  pairs were only `14/28`. Query-row-swap equivariance was bit-exact;
+  pair-mean-query and inference-time attention-off controls were each `0/28`.
+  The product population remained unopened, no checkpoint or binding-head
+  artifact was emitted, and Rust parity, development, and product evaluation
+  were `NOT_RUN`. Terminal `FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` retires C1-SB5
+  without retry. This remains bounded source-backed attention evidence and does
+  not establish generation, reasoning, correctness, or a source-free runtime.
+  #954 remains open. #955 remains blocked, and #954's
   final source-free terminal remains blocked behind #973.
   UOR's deployed
   architecture/runtime remains CPU-native;
@@ -152,7 +157,8 @@
   followed by the [#954 campaign record](r4_grounded_correctness_954.md), the
   [C1-SB2 aggregate](r4_source_relation_head_954_raw.json), the
   [corrected C1-SB3 aggregate](r4_attended_relation_adapter_954_raw.json), and
-  the [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json).
+  the [C1-SB4 aggregate](r4_joint_candidate_margin_954_raw.json), followed by the
+  [C1-SB5 aggregate](r4_paired_query_binding_954_raw.json).
   The intermediate
   [Geometric Causal Decoder Roadmap](geometric_causal_decoder_plan.md) records
   the superseded #948-#958 sequence.

--- a/docs/r4_paired_query_binding_954_raw.json
+++ b/docs/r4_paired_query_binding_954_raw.json
@@ -1,0 +1,230 @@
+{
+  "schema": "uor-r4.paired-query-binding-aggregate/1",
+  "issue": 954,
+  "policy": "R4PairedQueryCandidateMatrixV1",
+  "observed_at": "2026-08-31",
+  "terminal": "FAIL_PAIRED_QUERY_BINDING_PREFLIGHT",
+  "claim_scope": "one independently frozen same-source paired-query conditional-binding preflight through rank-8 Q/K/V/O adapters on all six established R4/Spin ordinary causal-softmax layers plus a separate asymmetric rank-32 binding head",
+  "frozen_identities": {
+    "predecessor_export_manifest_cid": "blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3",
+    "predecessor_weights_cid": "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d",
+    "predecessor_tokenizer_cid": "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc",
+    "dataset_cid": "blake3:b8d6b381eb856396b91ba1cc343b94f6abe99e3de9d54953e5071dfdb1d5bc3f",
+    "preflight_cid": "blake3:008a302b1e625a7568d04d26492c058ddcd26a7caaa23b63138e57871c4cf4c1",
+    "split_policy_cid": "blake3:3010b5bc37c1f8b9e5afb9adfab34abf98632df9449ba67f502a57c74555ab0c",
+    "census_cid": "blake3:95533608ebe3dae761d925667572cd6de6d2e1f7b94d3efa29374c0a29fe4307",
+    "tokenizer_census_cid": "blake3:bf4eebd5c35f09ce4452e86fe14823888d75d14dc82a025769c43c4801965271",
+    "training_view_manifest_cid": "blake3:2256e0ff59fbbd9a5efed6f9d8505e6f94910470e505238d9f6b485837782ad9",
+    "training_view_tree_cid": "blake3:b2211e95e1a3c08d735b17a0db502c42ad8d3fcede5608460fe1260168d35cf2",
+    "product_probes_cid": "blake3:5489089f7fc73906d07c27308e6a031a2dd373d016b610f09b26657d4238665e",
+    "product_manifest_cid": "blake3:7f03b47c3aecdb47c943eaafba3dea19c9798f83b938d40742b0bdcb7f9aa246",
+    "run_contract_cid": "blake3:992bc9bb61c3e7bb4481cee3b959db338aa68530ffe43e93ee0eac5c133d2103",
+    "implementation_tree_cid": "blake3:ca3b1f0804af779151baa9e0875973aba9542cb219f6e876c85512c3365b1a29",
+    "result_cid": "blake3:076242ab2bd379083ae55a22a272b3a0943b350fa301f65909e1b0ecc0d72571",
+    "manifest_cid": "blake3:c4a7ec5e4926cc5ede144d7f3c013940d104bb77ce26f8e201aa63c524c6a119",
+    "result_tree_cid": "blake3:0c3b0d869c45fca9924c1d76af19c9b411d8529c6ac8f9f7bf9d641d788dc188"
+  },
+  "product_probe_commitments": [
+    "blake3:6c0fa9773dcde75b5e07e3427d8554645d1093cde74aefd8b14a497647286630",
+    "blake3:c281c06533c3cf418a016e98cb0028e8e833a94f865451ffb1f69cede6112e34",
+    "blake3:07ee858c95e9da02b746625ed31e23d066680ebda60c48b081b48b47f1cfcaec",
+    "blake3:abce456fad476bed4d30c38f862df1ff432cca797b22bd46ebc231b13746f89a"
+  ],
+  "population": {
+    "fresh_world_ordinal_range": [162, 186],
+    "source_widths": [2, 3, 4, 5, 6, 7, 8],
+    "fit": {
+      "pairs": 56,
+      "query_rows": 112,
+      "candidate_groups": 266,
+      "matrix_cells": 532,
+      "positive_cells": 98,
+      "negative_cells": 434,
+      "required_flips": 98,
+      "duplicate_pairs": 14,
+      "outcomes": {"answer": 42, "abstain": 42, "conflict": 28},
+      "maximum_positions_including_bos": 189
+    },
+    "sealed": {
+      "pairs": 28,
+      "query_rows": 56,
+      "candidate_groups": 133,
+      "matrix_cells": 266,
+      "positive_cells": 49,
+      "negative_cells": 217,
+      "required_flips": 49,
+      "duplicate_pairs": 7,
+      "outcomes": {"answer": 21, "abstain": 21, "conflict": 14},
+      "maximum_positions_including_bos": 201
+    },
+    "product": {
+      "pairs": 4,
+      "query_rows": 8,
+      "commitments": 4,
+      "maximum_positions_including_bos": 81,
+      "text_status": "COMMITTED_UNOPENED_NOT_RUN"
+    },
+    "context_ceiling_including_bos": 256,
+    "no_prompt_truncated": true,
+    "candidate_states_before_query": true,
+    "paired_source_prefix_identity_exact": true,
+    "partition_disjointness": "exact sentences and complete composite world items are disjoint from C1-SB3, C1-SB4, and each other; primitive component vocabulary is deliberately shared"
+  },
+  "mechanism": {
+    "representation_update": "lora_qkvo_all_layers_plus_rank32_binding",
+    "input": "E:<exact full source>\\nQ:<question>\\nBind:",
+    "input_has_terminal_newline": false,
+    "query_state": "final Bind colon after all six layers",
+    "candidate_state": "final punctuation token of the earliest source occurrence of each distinct exact-text candidate group",
+    "duplicate_policy": "collapse exact-text groups and copy the earliest exact source occurrence",
+    "score": "dot(Wq*hq,Wc*hc)/sqrt(32)+b",
+    "decision": "supported iff score > 0",
+    "lora_rank": 8,
+    "lora_alpha": 8,
+    "lora_dropout": 0,
+    "attention_layers": 6,
+    "adapted_projections": ["q_proj", "k_proj", "v_proj", "o_proj"],
+    "binding_rank": 32,
+    "binding_blocks": 8,
+    "binding_head_parameters": 18433,
+    "lora_parameters": 110592,
+    "trainable_parameters": 129025,
+    "geometry_claim": "NONE; the eight four-lane binding blocks are bookkeeping"
+  },
+  "optimization": {
+    "objective": "mean margin-one row loss plus mean margin-two counterfactual flip-column loss over complete paired matrices",
+    "seed": 9545,
+    "optimizer": "AdamW",
+    "learning_rate": 0.001,
+    "betas": [0.9, 0.999],
+    "epsilon": 1e-8,
+    "weight_decay": 0,
+    "gradient_clip": 1.0,
+    "optimizer_steps": 120,
+    "steps_per_epoch": 8,
+    "epochs": 15,
+    "pairs_per_step": 7,
+    "pair_presentations": 840,
+    "row_presentations": 1680,
+    "cell_presentations": 7980,
+    "initial_loss": 5.9824323654174805,
+    "final_loss": 0.0,
+    "backend": "Apple MPS required; CPU fallback refused; no CUDA path",
+    "timing": {
+      "scope": "optimizer only",
+      "eta_probe_step": 8,
+      "wall_ceiling_seconds": 300.0,
+      "eta_probe_passed": true,
+      "completed_within_wall_ceiling": true,
+      "elapsed_seconds": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM"
+    }
+  },
+  "fit": {
+    "pair_exact": {"correct": 56, "total": 56},
+    "row_exact": {"correct": 112, "total": 112},
+    "cell_exact": {"correct": 532, "total": 532},
+    "flip_exact": {"correct": 98, "total": 98},
+    "candidate_copy_exact": {"correct": 42, "total": 42},
+    "duplicate_pair_exact": {"correct": 14, "total": 14},
+    "outcomes": {
+      "answer": {"correct": 42, "total": 42},
+      "abstain": {"correct": 42, "total": 42},
+      "conflict": {"correct": 28, "total": 28}
+    },
+    "candidate_state_bit_identity": {"correct": 56, "total": 56},
+    "mean_row_margin": 0.0,
+    "mean_flip_margin": 0.0,
+    "mean_loss": 0.0
+  },
+  "sealed": {
+    "pair_exact": {"correct": 14, "total": 28},
+    "row_exact": {"correct": 37, "total": 56},
+    "cell_exact": {"correct": 227, "total": 266},
+    "flip_exact": {"correct": 38, "total": 49},
+    "candidate_copy_exact": {"correct": 13, "total": 21},
+    "duplicate_pair_exact": {"correct": 4, "total": 7},
+    "outcomes": {
+      "answer": {"correct": 13, "total": 21},
+      "abstain": {"correct": 14, "total": 21},
+      "conflict": {"correct": 10, "total": 14}
+    },
+    "candidate_state_bit_identity": {"correct": 28, "total": 28},
+    "mean_row_margin": 2.1721223763057163,
+    "mean_flip_margin": 0.34822897035248424,
+    "mean_loss": 2.5203513466582006,
+    "pair_slot_breakdown": [
+      {"pair_slot": 0, "correct": 3, "total": 7},
+      {"pair_slot": 1, "correct": 4, "total": 7},
+      {"pair_slot": 2, "correct": 3, "total": 7},
+      {"pair_slot": 3, "correct": 4, "total": 7}
+    ],
+    "width_world_breakdown": [
+      {"source_width": 2, "correct": 4, "total": 4},
+      {"source_width": 3, "correct": 0, "total": 4},
+      {"source_width": 4, "correct": 4, "total": 4},
+      {"source_width": 5, "correct": 4, "total": 4},
+      {"source_width": 6, "correct": 0, "total": 4},
+      {"source_width": 7, "correct": 0, "total": 4},
+      {"source_width": 8, "correct": 2, "total": 4}
+    ],
+    "width_world_caveat": "each width has exactly one sealed lexical world, so this descriptive breakdown cannot identify a causal width effect"
+  },
+  "controls": {
+    "row_swap_equivariance": {
+      "record_order_exact": true,
+      "pair_trace_bit_exact": true,
+      "aggregate_bit_exact": true,
+      "identity_aligned_trace_cid": "blake3:d895009240ba4d4222f1640145157f3dbba85e1fe9ad8d27ca722a50a97f4d27",
+      "passed": true
+    },
+    "row_swap_combined_with_exact_sealed_semantics": false,
+    "mean_query_ablation": {
+      "paired_rows_identical": {"correct": 28, "total": 28},
+      "pair_exact": {"correct": 0, "total": 28},
+      "loss_higher_than_main": true,
+      "passed": true
+    },
+    "attention_off": {
+      "pair_exact": {"correct": 0, "total": 28},
+      "loss_higher_than_main": true,
+      "passed": true
+    },
+    "deterministic_replay_exact": true,
+    "all_controls_and_main_semantics_passed": false
+  },
+  "representation_audit": {
+    "changed_attention_tensors": 24,
+    "expected_attention_tensors": 24,
+    "all_changed_attention_tensors_finite": true,
+    "changed_nonattention_tensors": 0,
+    "changed_binding_head_tensors": 3,
+    "expected_binding_head_tensors": 3,
+    "all_binding_head_tensors_finite": true,
+    "passed": true
+  },
+  "access_and_artifact_policy": {
+    "training_view_artifacts": [
+      "paired-query-binding-census.json",
+      "paired-query-binding-dataset.json",
+      "paired-query-binding-preflight.json",
+      "paired-query-binding-tokenizer-census.json"
+    ],
+    "product_or_forbidden_reads": 0,
+    "product": "UNOPENED_NOT_RUN",
+    "rust_parity": "NOT_RUN",
+    "development": "NOT_RUN",
+    "research_checkpoint": "NOT_EMITTED",
+    "binding_head_artifact": "NOT_EMITTED",
+    "retry": "FORBIDDEN",
+    "rung_disposition": "RETIRED_NO_RETRY"
+  },
+  "falsifier": "The frozen mechanism required exact fit and sealed pairs, rows, cell signs, flips, copies, duplicate pairs, outcomes, causal candidate-state identity, controls, and tensor deltas. Fit and representation criteria passed, but sealed semantics reached only 14/28 exact pairs; therefore exact transferable paired-query binding was falsified for C1-SB5.",
+  "interpretation": "The architecture can fit the paired binding objective exactly, and the sealed behavior depends on distinct query states and active causal attention. It did not transfer exact subject-question binding to the independently sealed lexical worlds. The result is bounded causal mechanism evidence but a qualification negative, not an intrinsic-geometry result.",
+  "next_action": "Retire C1-SB5 without retry, Rust parity, a larger fit, development evaluation, checkpoint or head emission, or product reveal. No C1-SB6 or other scientific run is authorized by this result. #973 remains parked and must be independently re-scoped before source-free/geometric-attention work resumes; #955 reasoning remains downstream.",
+  "nonclaims": [
+    "No C1-SB5 checkpoint or binding-head artifact is qualified.",
+    "No product record was opened or evaluated.",
+    "This negative does not revoke #1014/#1017 ordinary causal-attention or bounded coherent-generation evidence.",
+    "No intrinsic geometry advantage, source-free correctness, reasoning, transformerlessness, exact lowering, browser, WASM, or release claim was established."
+  ]
+}

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -7,7 +7,7 @@ preflight-recorded [#1019](https://github.com/UOR-Foundation/uor-r4/issues/1019)
 parameter-capacity campaign, and the bounded [#954](https://github.com/UOR-Foundation/uor-r4/issues/954)
 grounding fine-tune, frozen source-span-pointer successor, and independently
 frozen source-relative relation-head, attended-relation, and joint-candidate
-successors. They train
+successors, followed by the frozen paired-query binding rung. They train
 and continue ordinary causal-softmax
 Llama-family models, export them in the existing Rust loaders' Hugging Face
 format, and freeze evidence before each sealed test is opened. They contain no
@@ -62,8 +62,15 @@ record-level structured-margin run: exact records were `70/126` fit and
 `35/63` sealed, with perfect positive-group recall and negative specificity
 `394/478` and `197/239`. It stopped before Rust/checkpoint/development/product
 and must not be retried. A question-ignoring ` is inside ` rule reproduces the
-entire published aggregate exactly. The next proposal is separately frozen
-paired-query conditional binding over one exact source. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
+entire published aggregate exactly. C1-SB5
+`R4PairedQueryCandidateMatrixV1` then fit all `56/56` paired records but reached
+only `14/28` sealed. Row-swap equivariance was bit-exact; pair-mean-query and
+attention-off controls were each `0/28`. Products remained unopened, no
+checkpoint or binding head was emitted, and Rust parity, development, and
+product evaluation were `NOT_RUN`. Terminal
+`FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` retires the rung without retry. This is
+bounded source-backed attention evidence only, not generation, reasoning,
+correctness, or a source-free runtime. UOR's deployed architecture/runtime remains CPU-native; Apple Accelerate/BLAS
 and MPS are local offline accelerators only; CUDA and external GPU execution
 are out of scope. The MPS stop is not a model-quality negative,
 leaves the full-scale capacity hypothesis untested, and does not revoke the
@@ -73,7 +80,8 @@ established attention result. See the
 its [observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 The #954 evidence is in the
 [#954 record](../../docs/r4_grounded_correctness_954.md) and
-[C1-SB4 aggregate](../../docs/r4_joint_candidate_margin_954_raw.json).
+[C1-SB4 aggregate](../../docs/r4_joint_candidate_margin_954_raw.json), followed
+by the [C1-SB5 aggregate](../../docs/r4_paired_query_binding_954_raw.json).
 
 For fast local #1017 inference on Apple Silicon, build the Rust CLI with
 `--features local-inference-accelerate`. The observed four-token comparison
@@ -352,8 +360,8 @@ Its signed MPS probe stopped `UNAVAILABLE_HARDWARE_BUDGET` because the
 terminal applies only to the frozen offline implementation. Full training,
 final parity, reveal, generation, and replay remain `NOT_RUN`. The subsequent
 fused-AdamW/deferred-logging fast path was slower (`4.485223` versus signed
-`3.491307 s/step`), so #1019 closed without a full run. #954's five bounded
-source-grounding mechanisms through C1-SB4 subsequently closed negative. CUDA
+`3.491307 s/step`), so #1019 closed without a full run. #954's six bounded
+source-grounding mechanisms through C1-SB5 subsequently closed negative. CUDA
 and external GPU execution are out of scope. See the
 [#1019 observed preflight](../../docs/r4_softmax_parameter_capacity_preflight_1019_raw.json).
 

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -41,6 +41,10 @@ from .joint_candidate_margin_campaign import (
     prepare_joint_candidate_margin_data,
     run_joint_candidate_margin_preflight,
 )
+from .paired_query_binding_campaign import (
+    prepare_paired_query_binding_data,
+    run_paired_query_binding_preflight,
+)
 from .paths import (
     default_attended_relation_adapter_root,
     default_capacity_root,
@@ -48,6 +52,7 @@ from .paths import (
     default_grounding_predecessor_root,
     default_grounding_root,
     default_joint_candidate_margin_root,
+    default_paired_query_binding_root,
     default_research_root,
     default_source_relation_head_root,
     default_source_span_pointer_root,
@@ -340,6 +345,32 @@ def parser() -> argparse.ArgumentParser:
         default=default_grounding_predecessor_root(),
         help="immutable completed #1017 Hugging Face export",
     )
+    prepare_paired = subcommands.add_parser(
+        "prepare-paired-query-binding",
+        help=(
+            "commit the C1-SB5 paired-query population and sealed product CIDs "
+            "without starting optimization"
+        ),
+    )
+    prepare_paired.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
+    train_paired = subcommands.add_parser(
+        "train-paired-query-binding-preflight",
+        help=(
+            "run the sole C1-SB5 optimizer under its 300-second ceiling, then "
+            "the mandatory controls; never opens product text"
+        ),
+    )
+    train_paired.add_argument(
+        "--predecessor",
+        type=_root,
+        default=default_grounding_predecessor_root(),
+        help="immutable completed #1017 Hugging Face export",
+    )
     return command
 
 
@@ -377,6 +408,10 @@ def main() -> None:
         "prepare-joint-candidate-margin",
         "train-joint-candidate-margin-preflight",
     }
+    paired_query_commands = {
+        "prepare-paired-query-binding",
+        "train-paired-query-binding-preflight",
+    }
     if arguments.root:
         root = arguments.root
     elif arguments.command in capacity_commands:
@@ -393,6 +428,8 @@ def main() -> None:
         root = default_attended_relation_adapter_root()
     elif arguments.command in joint_candidate_commands:
         root = default_joint_candidate_margin_root()
+    elif arguments.command in paired_query_commands:
+        root = default_paired_query_binding_root()
     else:
         root = default_research_root()
     if arguments.command == "download":
@@ -548,6 +585,20 @@ def main() -> None:
     if arguments.command == "train-joint-candidate-margin-preflight":
         _print_result(
             run_joint_candidate_margin_preflight(
+                root, predecessor=arguments.predecessor
+            )
+        )
+        return
+    if arguments.command == "prepare-paired-query-binding":
+        _print_result(
+            prepare_paired_query_binding_data(
+                root, predecessor=arguments.predecessor
+            )
+        )
+        return
+    if arguments.command == "train-paired-query-binding-preflight":
+        _print_result(
+            run_paired_query_binding_preflight(
                 root, predecessor=arguments.predecessor
             )
         )

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/export.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/export.py
@@ -25,8 +25,14 @@ def export_hugging_face_snapshot(
     split_policy_cid: str,
     run_contract_cid: str,
     selected_checkpoint_cid: str | None,
+    selected_checkpoint_identity: str | None = None,
 ) -> dict[str, Any]:
     """Export three standard files plus CID-bound provenance/result files."""
+    if (
+        selected_checkpoint_identity is not None
+        and not selected_checkpoint_identity.strip()
+    ):
+        raise ValueError("selected checkpoint identity must be nonempty when provided")
     output_dir.mkdir(parents=True, exist_ok=True)
     config_path = output_dir / "config.json"
     weights_path = output_dir / "model.safetensors"
@@ -45,6 +51,11 @@ def export_hugging_face_snapshot(
     atomic_write_json(result_path, training_result)
 
     weights_cid = cid_file(weights_path)
+    checkpoint_identity = selected_checkpoint_identity
+    if checkpoint_identity is None:
+        checkpoint_identity = (
+            "checkpoint artifact" if selected_checkpoint_cid else "exported smoke weights"
+        )
     payload: dict[str, Any] = {
         "schema": EXPORT_MANIFEST_SCHEMA,
         "dataset_manifest_cid": dataset_manifest_cid,
@@ -52,9 +63,7 @@ def export_hugging_face_snapshot(
         "split_policy_cid": split_policy_cid,
         "run_contract_cid": run_contract_cid,
         "selected_checkpoint_cid": selected_checkpoint_cid or weights_cid,
-        "selected_checkpoint_identity": (
-            "checkpoint artifact" if selected_checkpoint_cid else "exported smoke weights"
-        ),
+        "selected_checkpoint_identity": checkpoint_identity,
         "training_result_cid": training_result["result_cid"],
         "config_cid": cid_file(config_path),
         "tokenizer_cid": cid_file(exported_tokenizer_path),

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding.py
@@ -1,0 +1,1409 @@
+"""Paired-query conditional binding over the frozen #1017 attention model.
+
+This is the C1-SB5 mechanism core.  Two questions share the exact same source
+prefix and candidate groups.  Candidate states are read before either question,
+while each query state is read at the final ``Bind:`` colon.  A small asymmetric
+rank-32 biaffine head therefore scores the complete query-by-candidate matrix.
+
+The 32 binding coordinates may be viewed as eight four-lane bookkeeping blocks.
+That layout is not an intrinsic-geometry or geometry-advantage claim.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from .constants import BOS_TOKEN_ID, EOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .model import R4SoftmaxForCausalLM, expected_hf_tensor_names
+from .source_relation_adapter import (
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_RANK,
+    TRAINABLE_PARAMETER_COUNT as LORA_TRAINABLE_PARAMETER_COUNT,
+    LoRALinear,
+)
+from .train import require_mps
+
+
+POLICY = "R4PairedQueryCandidateMatrixV1"
+REPRESENTATION_UPDATE = "lora_qkvo_all_layers_plus_rank32_binding"
+SOURCE_WIDTHS = tuple(range(2, 9))
+TARGET_PROJECTIONS = ("q_proj", "k_proj", "v_proj", "o_proj")
+TARGET_LAYER_INDICES = tuple(range(FROZEN_MODEL_CONFIG.num_hidden_layers))
+BINDING_RANK = 32
+BINDING_BLOCK_WIDTH = 4
+BINDING_BLOCKS = BINDING_RANK // BINDING_BLOCK_WIDTH
+BINDING_HEAD_PARAMETER_COUNT = (
+    2 * FROZEN_MODEL_CONFIG.hidden_size * BINDING_RANK + 1
+)
+TRAINABLE_PARAMETER_COUNT = (
+    LORA_TRAINABLE_PARAMETER_COUNT + BINDING_HEAD_PARAMETER_COUNT
+)
+MARGIN = 1.0
+FLIP_MARGIN = 2.0
+FIT_SEED = 9_545
+PAIRED_RECORDS_PER_WIDTH = 8
+RECORDS_PER_STEP = len(SOURCE_WIDTHS)
+STEPS_PER_EPOCH = PAIRED_RECORDS_PER_WIDTH
+OPTIMIZER_STEPS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class PairedQueryBindingAdapterConfig:
+    """The one independently frozen C1-SB5 model contract."""
+
+    rank: int = LORA_RANK
+    alpha: int = LORA_ALPHA
+    dropout: float = LORA_DROPOUT
+    target_layer_indices: tuple[int, ...] = TARGET_LAYER_INDICES
+    target_projections: tuple[str, ...] = TARGET_PROJECTIONS
+    binding_rank: int = BINDING_RANK
+    initialization_seed: int = FIT_SEED
+
+    def validate(self) -> None:
+        if self != PairedQueryBindingAdapterConfig():
+            raise ValueError("paired-query binding exposes one frozen model contract")
+        if self.rank != 8 or self.alpha != 8 or self.dropout != 0.0:
+            raise AssertionError("paired-query LoRA shape drifted")
+        if self.target_layer_indices != tuple(range(6)):
+            raise AssertionError("paired-query binding must adapt all six layers")
+        if self.target_projections != TARGET_PROJECTIONS:
+            raise AssertionError("paired-query binding must adapt exactly Q/K/V/O")
+        if self.binding_rank != 32 or self.binding_rank % 4:
+            raise AssertionError("paired-query binding head must contain eight R4 blocks")
+        if self.initialization_seed != 9_545:
+            raise AssertionError("paired-query initialization seed drifted")
+
+    @property
+    def trainable_parameter_count(self) -> int:
+        self.validate()
+        return TRAINABLE_PARAMETER_COUNT
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        value = asdict(self)
+        value["target_layer_indices"] = list(self.target_layer_indices)
+        value["target_projections"] = list(self.target_projections)
+        value.update(
+            {
+                "representation_update": REPRESENTATION_UPDATE,
+                "lora_trainable_parameters": LORA_TRAINABLE_PARAMETER_COUNT,
+                "binding_head_trainable_parameters": BINDING_HEAD_PARAMETER_COUNT,
+                "trainable_parameter_count": TRAINABLE_PARAMETER_COUNT,
+                "binding_blocks": BINDING_BLOCKS,
+                "score": "dot(Wq*hq,Wc*hc)/sqrt(32)+b",
+                "decision": "supported iff score > +0.0",
+                "generic_lm_or_classification_head": False,
+                "geometry_claim": "NONE; eight four-lane blocks are bookkeeping",
+            }
+        )
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class PairedQueryBindingFitConfig:
+    """The sole bounded optimizer schedule; this is intentionally not a sweep."""
+
+    seed: int = FIT_SEED
+    optimizer_steps: int = OPTIMIZER_STEPS
+    records_per_step: int = RECORDS_PER_STEP
+    learning_rate: float = 0.001
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    adam_epsilon: float = 1e-8
+    weight_decay: float = 0.0
+    gradient_clip: float = 1.0
+    eta_probe_step: int = 8
+    wall_ceiling_seconds: float = 300.0
+    progress_interval: int = STEPS_PER_EPOCH
+
+    def validate(self) -> None:
+        if self != PairedQueryBindingFitConfig():
+            raise ValueError("paired-query binding exposes one frozen fit contract")
+        if (
+            self.seed != 9_545
+            or self.optimizer_steps != 120
+            or self.records_per_step != 7
+            or self.weight_decay != 0.0
+        ):
+            raise AssertionError("paired-query fit contract drifted")
+
+    def as_contract(self) -> dict[str, Any]:
+        self.validate()
+        value = asdict(self)
+        value.update(
+            {
+                "steps_per_epoch": STEPS_PER_EPOCH,
+                "epochs": self.optimizer_steps // STEPS_PER_EPOCH,
+                "row_margin": MARGIN,
+                "flip_margin": FLIP_MARGIN,
+                "schedule": (
+                    "eight steps per epoch; every step contains one complete "
+                    "paired record for each source width 2..8"
+                ),
+            }
+        )
+        return value
+
+
+class PairedQueryBindingWallBudgetExceeded(RuntimeError):
+    def __init__(
+        self,
+        *,
+        step: int,
+        elapsed_seconds: float,
+        projected_seconds_at_eta_probe: float | None,
+        wall_ceiling_seconds: float,
+    ) -> None:
+        super().__init__("UNAVAILABLE_PAIRED_QUERY_BINDING_WALL_BUDGET")
+        self.step = step
+        self.elapsed_seconds = elapsed_seconds
+        self.projected_seconds_at_eta_probe = projected_seconds_at_eta_probe
+        self.wall_ceiling_seconds = wall_ceiling_seconds
+
+    def as_result(self) -> dict[str, Any]:
+        return {
+            "status": "UNAVAILABLE_PAIRED_QUERY_BINDING_WALL_BUDGET",
+            "stopped_after_step": self.step,
+            "elapsed_seconds": self.elapsed_seconds,
+            "projected_seconds_at_eta_probe": self.projected_seconds_at_eta_probe,
+            "wall_ceiling_seconds": self.wall_ceiling_seconds,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedPairedQueryLane:
+    question: str
+    token_ids: tuple[int, ...]
+    query_terminal_index: int
+    candidate_terminal_indices: tuple[int, ...]
+    source_prefix_token_count: int
+    target_outcome: str
+    metadata: Mapping[str, Any] = field(default_factory=dict, repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedPairedCandidateGroup:
+    relation_group_cid: str
+    occurrence_indices: tuple[int, ...]
+    earliest_occurrence_index: int
+    text: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedPairedQueryRecord:
+    record_id: str
+    source_width: int
+    pair_slot: int
+    lexical_world: str
+    queries: tuple[EncodedPairedQueryLane, EncodedPairedQueryLane]
+    candidate_groups: tuple[EncodedPairedCandidateGroup, ...]
+    label_matrix: tuple[tuple[int, ...], tuple[int, ...]]
+    flip_group_indices: tuple[int, ...]
+    source_prefix_token_ids_cid: str
+    metadata: Mapping[str, Any] = field(default_factory=dict, repr=False, compare=False)
+
+
+@dataclass(slots=True)
+class PairedQueryTokenBatch:
+    """A padded batch of complete paired records and variable candidate groups."""
+
+    input_ids: Tensor
+    query_indices: Tensor
+    candidate_indices: Tensor
+    group_mask: Tensor
+    labels: Tensor
+    flip_mask: Tensor
+    source_prefix_lengths: Tensor
+    record_indices: tuple[int, ...]
+    group_identities: tuple[tuple[str, ...], ...]
+    validated: bool = False
+
+    def validate(self) -> None:
+        if self.input_ids.ndim != 3 or self.input_ids.shape[1] != 2:
+            raise ValueError("paired input_ids must have shape [pairs, 2, time]")
+        pairs, _, time_width = self.input_ids.shape
+        if self.input_ids.dtype != torch.long:
+            raise ValueError("paired input_ids must be int64")
+        if self.query_indices.shape != (pairs, 2):
+            raise ValueError("paired query indices must have shape [pairs, 2]")
+        if self.query_indices.dtype != torch.long:
+            raise ValueError("paired query indices must be int64")
+        if self.candidate_indices.ndim != 2 or self.candidate_indices.shape[0] != pairs:
+            raise ValueError("candidate indices must have shape [pairs, groups]")
+        groups = self.candidate_indices.shape[1]
+        if self.candidate_indices.dtype != torch.long:
+            raise ValueError("candidate indices must be int64")
+        if self.group_mask.shape != (pairs, groups) or self.group_mask.dtype != torch.bool:
+            raise ValueError("group mask must be bool [pairs, groups]")
+        if self.labels.shape != (pairs, 2, groups):
+            raise ValueError("label matrix must have shape [pairs, 2, groups]")
+        if self.labels.dtype not in (torch.float16, torch.float32, torch.float64):
+            raise ValueError("paired labels must be floating point")
+        if self.flip_mask.shape != (pairs, groups) or self.flip_mask.dtype != torch.bool:
+            raise ValueError("flip mask must be bool [pairs, groups]")
+        if self.source_prefix_lengths.shape != (pairs,):
+            raise ValueError("source-prefix lengths must have shape [pairs]")
+        if self.source_prefix_lengths.dtype != torch.long:
+            raise ValueError("source-prefix lengths must be int64")
+        if len(self.record_indices) != pairs or len(self.group_identities) != pairs:
+            raise ValueError("paired batch identities do not align with pair rows")
+        if groups < 1 or bool((~self.group_mask.any(dim=1)).any()):
+            raise ValueError("every paired record must contain a candidate group")
+        if bool((self.flip_mask & ~self.group_mask).any()):
+            raise ValueError("required flips must refer to admitted candidate groups")
+        if bool((~self.flip_mask.any(dim=1)).any()):
+            raise ValueError("every paired record must contain a required label flip")
+        active_labels = self.labels.masked_select(self.group_mask[:, None, :])
+        if bool(((active_labels != 0.0) & (active_labels != 1.0)).any()):
+            raise ValueError("paired labels must be binary on admitted groups")
+        inactive_labels = self.labels.masked_select(~self.group_mask[:, None, :])
+        if inactive_labels.numel() and bool((inactive_labels != 0.0).any()):
+            raise ValueError("padded paired labels must be zero")
+        flip_labels = self.labels.permute(0, 2, 1)[self.flip_mask]
+        if bool((flip_labels.sum(dim=1) != 1.0).any()):
+            raise ValueError("each required flip must contain one positive query row")
+        if bool(((self.source_prefix_lengths < 1) | (self.source_prefix_lengths > time_width)).any()):
+            raise ValueError("source-prefix length is outside the token sequence")
+        if bool(((self.query_indices < 0) | (self.query_indices >= time_width)).any()):
+            raise ValueError("query terminal index is outside the token sequence")
+        if bool((self.query_indices < self.source_prefix_lengths[:, None]).any()):
+            raise ValueError("query state must occur after the complete source prefix")
+        active_candidates = self.candidate_indices.masked_select(self.group_mask)
+        active_prefixes = self.source_prefix_lengths[:, None].expand_as(
+            self.candidate_indices
+        ).masked_select(self.group_mask)
+        if bool(((active_candidates < 0) | (active_candidates >= active_prefixes)).any()):
+            raise ValueError("candidate state must occur before the question")
+        for pair_index, prefix_length in enumerate(self.source_prefix_lengths.tolist()):
+            if not torch.equal(
+                self.input_ids[pair_index, 0, :prefix_length],
+                self.input_ids[pair_index, 1, :prefix_length],
+            ):
+                raise ValueError("paired source token prefixes are not bit-identical")
+            if len(self.group_identities[pair_index]) != int(
+                self.group_mask[pair_index].sum().item()
+            ):
+                raise ValueError("candidate group identities do not match the mask")
+        self.validated = True
+
+    def to(self, device: torch.device) -> "PairedQueryTokenBatch":
+        if not self.validated:
+            self.validate()
+        return PairedQueryTokenBatch(
+            input_ids=self.input_ids.to(device),
+            query_indices=self.query_indices.to(device),
+            candidate_indices=self.candidate_indices.to(device),
+            group_mask=self.group_mask.to(device),
+            labels=self.labels.to(device),
+            flip_mask=self.flip_mask.to(device),
+            source_prefix_lengths=self.source_prefix_lengths.to(device),
+            record_indices=self.record_indices,
+            group_identities=self.group_identities,
+            validated=True,
+        )
+
+    def swapped_query_rows(self) -> "PairedQueryTokenBatch":
+        swapped = PairedQueryTokenBatch(
+            input_ids=self.input_ids.flip(1),
+            query_indices=self.query_indices.flip(1),
+            candidate_indices=self.candidate_indices,
+            group_mask=self.group_mask,
+            labels=self.labels.flip(1),
+            flip_mask=self.flip_mask,
+            source_prefix_lengths=self.source_prefix_lengths,
+            record_indices=self.record_indices,
+            group_identities=self.group_identities,
+            validated=True,
+        )
+        return swapped
+
+
+@dataclass(frozen=True, slots=True)
+class PairedQueryBindingOutput:
+    scores: Tensor
+    query_states: Tensor
+    candidate_states: Tensor
+    candidate_states_by_lane: Tensor
+    paired_candidate_states_exact: bool | None
+    attention_off: bool
+    mean_query_ablation: bool
+
+    @property
+    def supported(self) -> Tensor:
+        return self.scores > 0.0
+
+
+class AsymmetricR4BindingHead(nn.Module):
+    """Bias-free asymmetric rank-32 projections plus one scalar threshold bias."""
+
+    def __init__(self, *, initialization_seed: int = FIT_SEED) -> None:
+        super().__init__()
+        self.query_weight = nn.Parameter(
+            torch.empty(BINDING_RANK, FROZEN_MODEL_CONFIG.hidden_size)
+        )
+        self.candidate_weight = nn.Parameter(
+            torch.empty(BINDING_RANK, FROZEN_MODEL_CONFIG.hidden_size)
+        )
+        self.bias = nn.Parameter(torch.zeros(()))
+        query_generator = torch.Generator(device="cpu")
+        candidate_generator = torch.Generator(device="cpu")
+        query_generator.manual_seed(initialization_seed + 24)
+        candidate_generator.manual_seed(initialization_seed + 25)
+        nn.init.xavier_uniform_(self.query_weight, generator=query_generator)
+        nn.init.xavier_uniform_(self.candidate_weight, generator=candidate_generator)
+        self.register_buffer(
+            "_initial_query_weight", self.query_weight.detach().clone(), persistent=False
+        )
+        self.register_buffer(
+            "_initial_candidate_weight",
+            self.candidate_weight.detach().clone(),
+            persistent=False,
+        )
+        self.register_buffer("_initial_bias", self.bias.detach().clone(), persistent=False)
+
+    def forward(self, query_states: Tensor, candidate_states: Tensor) -> Tensor:
+        if query_states.ndim != 3 or query_states.shape[-1] != FROZEN_MODEL_CONFIG.hidden_size:
+            raise ValueError("query states must have shape [pairs, 2, 288]")
+        if query_states.shape[1] != 2:
+            raise ValueError("binding head requires exactly two query rows")
+        if candidate_states.ndim != 3 or candidate_states.shape[-1] != FROZEN_MODEL_CONFIG.hidden_size:
+            raise ValueError("candidate states must have shape [pairs, groups, 288]")
+        if candidate_states.shape[0] != query_states.shape[0]:
+            raise ValueError("query and candidate pair counts differ")
+        query = F.linear(query_states.float(), self.query_weight.float())
+        candidate = F.linear(candidate_states.float(), self.candidate_weight.float())
+        return (
+            torch.matmul(query, candidate.transpose(-2, -1)) / math.sqrt(BINDING_RANK)
+            + self.bias.float()
+        )
+
+    def state_for_artifact(self) -> dict[str, Tensor]:
+        return {
+            "query_weight": self.query_weight.detach().float().cpu().contiguous(),
+            "candidate_weight": self.candidate_weight.detach().float().cpu().contiguous(),
+            "bias": self.bias.detach().float().cpu().contiguous(),
+        }
+
+    def audit(self) -> dict[str, Any]:
+        rows = (
+            ("query_weight", self.query_weight, self._initial_query_weight),
+            ("candidate_weight", self.candidate_weight, self._initial_candidate_weight),
+            ("bias", self.bias, self._initial_bias),
+        )
+        tensors = [
+            {
+                "name": name,
+                "parameter_count": parameter.numel(),
+                "finite": bool(torch.isfinite(parameter.detach()).all()),
+                "changed_from_initialization": not torch.equal(
+                    parameter.detach(), initial.detach()
+                ),
+                "l2_norm": float(torch.linalg.vector_norm(parameter.detach().float()).cpu()),
+            }
+            for name, parameter, initial in rows
+        ]
+        return {
+            "tensor_count": len(tensors),
+            "parameter_count": sum(int(row["parameter_count"]) for row in tensors),
+            "changed_tensor_count": sum(
+                bool(row["changed_from_initialization"]) for row in tensors
+            ),
+            "all_finite": all(bool(row["finite"]) for row in tensors),
+            "tensors": tensors,
+        }
+
+
+class R4PairedQueryCandidateMatrix(nn.Module):
+    """Six-layer Q/K/V/O LoRA representation plus the explicit binding head."""
+
+    def __init__(
+        self,
+        model: R4SoftmaxForCausalLM,
+        config: PairedQueryBindingAdapterConfig = PairedQueryBindingAdapterConfig(),
+    ) -> None:
+        super().__init__()
+        config.validate()
+        if model.config != FROZEN_MODEL_CONFIG:
+            raise ValueError("paired-query binding requires the exact #1017 architecture")
+        model.requires_grad_(False)
+        self.model = model
+        self.config = config
+        self._adapters: dict[str, LoRALinear] = {}
+        adapter_ordinal = 0
+        for layer_index in config.target_layer_indices:
+            attention = self.model.model.layers[layer_index].self_attn
+            for projection_name in config.target_projections:
+                projection = getattr(attention, projection_name)
+                if not isinstance(projection, nn.Linear):
+                    raise TypeError(
+                        f"layer {layer_index} {projection_name} is not an unwrapped linear"
+                    )
+                adapter = LoRALinear(
+                    projection,
+                    rank=config.rank,
+                    alpha=config.alpha,
+                    dropout=config.dropout,
+                    initialization_seed=config.initialization_seed + adapter_ordinal,
+                )
+                setattr(attention, projection_name, adapter)
+                self._adapters[
+                    self._projection_weight_path(layer_index, projection_name)
+                ] = adapter
+                adapter_ordinal += 1
+        self.binding_head = AsymmetricR4BindingHead(
+            initialization_seed=config.initialization_seed
+        )
+        observed = sum(
+            parameter.numel()
+            for parameter in self.parameters()
+            if parameter.requires_grad
+        )
+        if observed != config.trainable_parameter_count:
+            raise AssertionError(
+                f"paired-query binding has {observed} trainable parameters, "
+                f"expected {config.trainable_parameter_count}"
+            )
+
+    @staticmethod
+    def _projection_weight_path(layer_index: int, projection_name: str) -> str:
+        return f"model.layers.{layer_index}.self_attn.{projection_name}.weight"
+
+    def adapter_parameters(self) -> Iterable[nn.Parameter]:
+        return (parameter for parameter in self.parameters() if parameter.requires_grad)
+
+    def trainable_parameter_names(self) -> tuple[str, ...]:
+        return tuple(
+            name for name, parameter in self.named_parameters() if parameter.requires_grad
+        )
+
+    def binding_head_state_dict(self) -> dict[str, Tensor]:
+        return self.binding_head.state_for_artifact()
+
+    def forward(
+        self,
+        batch: PairedQueryTokenBatch,
+        *,
+        attention_off: bool = False,
+        mean_query_ablation: bool = False,
+        verify_candidate_state_identity: bool = True,
+    ) -> PairedQueryBindingOutput:
+        if not batch.validated:
+            batch.validate()
+        pairs, lanes, time_width = batch.input_ids.shape
+        hidden = self.model.model(
+            batch.input_ids.reshape(pairs * lanes, time_width),
+            attention_off=attention_off,
+        ).view(pairs, lanes, time_width, FROZEN_MODEL_CONFIG.hidden_size)
+        query_gather = batch.query_indices[:, :, None, None].expand(
+            pairs, lanes, 1, FROZEN_MODEL_CONFIG.hidden_size
+        )
+        query_states = torch.gather(hidden, 2, query_gather).squeeze(2)
+        groups = batch.candidate_indices.shape[1]
+        candidate_gather = batch.candidate_indices[:, None, :, None].expand(
+            pairs, lanes, groups, FROZEN_MODEL_CONFIG.hidden_size
+        )
+        candidate_states_by_lane = torch.gather(hidden, 2, candidate_gather)
+        candidate_states_exact: bool | None = None
+        if verify_candidate_state_identity:
+            active_state_mask = batch.group_mask[:, None, :, None].expand_as(
+                candidate_states_by_lane
+            )
+            left = candidate_states_by_lane[:, 0:1].expand_as(candidate_states_by_lane)
+            candidate_states_exact = torch.equal(
+                candidate_states_by_lane.masked_select(active_state_mask),
+                left.masked_select(active_state_mask),
+            )
+            if not candidate_states_exact:
+                raise RuntimeError(
+                    "paired candidate states differ despite an identical causal source prefix"
+                )
+        candidate_states = candidate_states_by_lane[:, 0]
+        if mean_query_ablation:
+            query_states = query_states.mean(dim=1, keepdim=True).expand_as(query_states)
+        scores = self.binding_head(query_states, candidate_states)
+        scores = torch.where(batch.group_mask[:, None, :], scores, torch.zeros_like(scores))
+        if mean_query_ablation and not torch.equal(scores[:, 0], scores[:, 1]):
+            raise RuntimeError("pair-mean query ablation did not produce identical rows")
+        return PairedQueryBindingOutput(
+            scores=scores,
+            query_states=query_states,
+            candidate_states=candidate_states,
+            candidate_states_by_lane=candidate_states_by_lane,
+            paired_candidate_states_exact=candidate_states_exact,
+            attention_off=attention_off,
+            mean_query_ablation=mean_query_ablation,
+        )
+
+    def merged_state_dict(self) -> dict[str, Tensor]:
+        wrapped_state = self.model.state_dict()
+        expected = expected_hf_tensor_names(self.model.config)
+        merged: dict[str, Tensor] = {}
+        for name in sorted(expected):
+            adapter = self._adapters.get(name)
+            if adapter is not None:
+                merged[name] = adapter.merged_weight()
+                continue
+            try:
+                value = wrapped_state[name]
+            except KeyError as error:
+                raise RuntimeError(f"paired-query wrapped model is missing {name}") from error
+            merged[name] = value.detach().float().cpu().contiguous()
+        if set(merged) != expected or len(self._adapters) != 24:
+            raise RuntimeError("paired-query merge did not cover 24 Q/K/V/O tensors")
+        return merged
+
+    def delta_audit(self) -> dict[str, Any]:
+        tensors: list[dict[str, Any]] = []
+        for name in sorted(self._adapters):
+            adapter = self._adapters[name]
+            delta = (
+                torch.matmul(
+                    adapter.lora_b.detach().float(), adapter.lora_a.detach().float()
+                )
+                * adapter.scaling
+            )
+            tensors.append(
+                {
+                    "name": name,
+                    "parameter_count": adapter.lora_a.numel()
+                    + adapter.lora_b.numel(),
+                    "nonzero": int(torch.count_nonzero(delta).item()),
+                    "changed": bool(torch.count_nonzero(delta).item()),
+                    "finite": bool(torch.isfinite(delta).all()),
+                    "l2_norm": float(torch.linalg.vector_norm(delta).cpu()),
+                    "initialization_seed": adapter.initialization_seed,
+                }
+            )
+        if len(tensors) != 24:
+            raise RuntimeError("paired-query delta census does not contain 24 tensors")
+        return {
+            "target_tensor_count": len(tensors),
+            "trainable_parameter_count": sum(
+                int(tensor["parameter_count"]) for tensor in tensors
+            ),
+            "changed_tensor_count": sum(bool(tensor["changed"]) for tensor in tensors),
+            "all_finite": all(bool(tensor["finite"]) for tensor in tensors),
+            "tensors": tensors,
+        }
+
+    def binding_head_audit(self) -> dict[str, Any]:
+        return self.binding_head.audit()
+
+    def representation_audit(
+        self, base_state: Mapping[str, Tensor]
+    ) -> dict[str, Any]:
+        """Compare the merged representation to its immutable predecessor."""
+        merged = self.merged_state_dict()
+        expected = expected_hf_tensor_names(self.model.config)
+        if set(base_state) != expected:
+            raise ValueError("paired-query base-state tensor names differ from #1017")
+        target_names = set(self._adapters)
+        changed_targets = sorted(
+            name for name in target_names if not torch.equal(merged[name], base_state[name])
+        )
+        changed_nontargets = sorted(
+            name
+            for name in expected - target_names
+            if not torch.equal(merged[name], base_state[name])
+        )
+        target_finite = all(
+            bool(torch.isfinite(merged[name]).all()) for name in target_names
+        )
+        head = self.binding_head_audit()
+        passed = (
+            len(changed_targets) == 24
+            and not changed_nontargets
+            and target_finite
+            and int(head["changed_tensor_count"]) == 3
+            and bool(head["all_finite"])
+        )
+        return {
+            "target_tensor_count": len(target_names),
+            "changed_target_tensor_count": len(changed_targets),
+            "changed_target_tensors": changed_targets,
+            "changed_nontarget_tensors": changed_nontargets,
+            "all_target_tensors_finite": target_finite,
+            "binding_head": head,
+            "passed": passed,
+        }
+
+    def merged_model(self) -> R4SoftmaxForCausalLM:
+        """Return an ordinary #1017 model with all 24 LoRA deltas folded."""
+        clean = R4SoftmaxForCausalLM(self.model.config)
+        clean.load_state_dict(self.merged_state_dict(), strict=True)
+        clean.eval()
+        return clean
+
+
+def _mapping_sequence(value: Any, *, field_name: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"paired-query {field_name} must be a sequence")
+    return value
+
+
+def _encoded_record(record: Mapping[str, Any], offset: int) -> EncodedPairedQueryRecord:
+    record_id = record.get("record_id", record.get("record_cid"))
+    if not isinstance(record_id, str) or not record_id:
+        raise ValueError(f"paired-query record {offset} has no stable identity")
+    source_width = record.get("source_width")
+    pair_slot = record.get("pair_slot")
+    lexical_world = record.get("lexical_world", record.get("world", ""))
+    if source_width not in SOURCE_WIDTHS:
+        raise ValueError(f"paired-query record {record_id} has width outside 2..8")
+    if not isinstance(pair_slot, int) or pair_slot not in range(4):
+        raise ValueError(f"paired-query record {record_id} has pair_slot outside 0..3")
+    if not isinstance(lexical_world, str) or not lexical_world:
+        raise ValueError(f"paired-query record {record_id} has no lexical world")
+    if record.get("source_prefix_identity_exact") is not True:
+        raise ValueError(f"paired-query record {record_id} lacks exact prefix identity")
+    prefix_cid = record.get("source_prefix_token_ids_cid")
+    if not isinstance(prefix_cid, str) or not prefix_cid:
+        raise ValueError(f"paired-query record {record_id} has no prefix token CID")
+
+    raw_groups = _mapping_sequence(
+        record.get("candidate_groups"), field_name="candidate_groups"
+    )
+    groups: list[EncodedPairedCandidateGroup] = []
+    for group_offset, raw_group in enumerate(raw_groups):
+        if not isinstance(raw_group, Mapping):
+            raise ValueError(f"paired-query record {record_id} has a nonmapping group")
+        group_cid = raw_group.get("relation_group_cid")
+        occurrences = _mapping_sequence(
+            raw_group.get("occurrence_indices"), field_name="occurrence_indices"
+        )
+        occurrence_indices = tuple(int(value) for value in occurrences)
+        if (
+            not isinstance(group_cid, str)
+            or not group_cid
+            or not occurrence_indices
+            or tuple(sorted(set(occurrence_indices))) != occurrence_indices
+        ):
+            raise ValueError(
+                f"paired-query record {record_id} group {group_offset} is noncanonical"
+            )
+        earliest = raw_group.get("earliest_occurrence_index", occurrence_indices[0])
+        if earliest != occurrence_indices[0]:
+            raise ValueError("paired-query group does not bind its earliest occurrence")
+        groups.append(
+            EncodedPairedCandidateGroup(
+                relation_group_cid=group_cid,
+                occurrence_indices=occurrence_indices,
+                earliest_occurrence_index=int(earliest),
+                text=str(raw_group.get("text", "")),
+            )
+        )
+    if not groups:
+        raise ValueError(f"paired-query record {record_id} has no candidate groups")
+
+    raw_labels = _mapping_sequence(record.get("label_matrix"), field_name="label_matrix")
+    if len(raw_labels) != 2:
+        raise ValueError("paired-query label matrix must contain exactly two rows")
+    label_matrix = tuple(
+        tuple(int(value) for value in _mapping_sequence(row, field_name="label row"))
+        for row in raw_labels
+    )
+    if any(len(row) != len(groups) for row in label_matrix):
+        raise ValueError("paired-query label rows do not align with candidate groups")
+    if any(value not in (0, 1) for row in label_matrix for value in row):
+        raise ValueError("paired-query label matrix is nonbinary")
+    flip_cids = set(
+        str(value)
+        for value in _mapping_sequence(
+            record.get("flip_group_cids"), field_name="flip_group_cids"
+        )
+    )
+    group_cids = [group.relation_group_cid for group in groups]
+    if not flip_cids or not flip_cids.issubset(group_cids):
+        raise ValueError("paired-query flips do not bind admitted candidate groups")
+    flip_indices = tuple(
+        index for index, group_cid in enumerate(group_cids) if group_cid in flip_cids
+    )
+    if any(label_matrix[0][index] + label_matrix[1][index] != 1 for index in flip_indices):
+        raise ValueError("paired-query required flip is not a complementary label column")
+
+    raw_queries = _mapping_sequence(record.get("queries"), field_name="queries")
+    if len(raw_queries) != 2:
+        raise ValueError("paired-query record must contain exactly two query lanes")
+    queries: list[EncodedPairedQueryLane] = []
+    for query_offset, raw_query in enumerate(raw_queries):
+        if not isinstance(raw_query, Mapping):
+            raise ValueError("paired-query lane must be a mapping")
+        question = raw_query.get("question")
+        token_ids = tuple(
+            int(value)
+            for value in _mapping_sequence(
+                raw_query.get("token_ids"), field_name="query token_ids"
+            )
+        )
+        terminal = raw_query.get("query_terminal_index")
+        candidate_terminals = tuple(
+            int(value)
+            for value in _mapping_sequence(
+                raw_query.get("candidate_terminal_indices"),
+                field_name="candidate terminal indices",
+            )
+        )
+        prefix_count = raw_query.get("source_prefix_token_count")
+        if not isinstance(question, str) or not question.endswith("?"):
+            raise ValueError("paired-query question is not canonical")
+        if not token_ids or any(value < 0 for value in token_ids):
+            raise ValueError("paired-query token IDs are empty or negative")
+        if terminal != len(token_ids):
+            raise ValueError("query terminal must be the final Bind colon including BOS")
+        if len(candidate_terminals) != len(groups):
+            raise ValueError("candidate terminal anchors do not align with groups")
+        if not isinstance(prefix_count, int) or not 1 <= prefix_count <= terminal:
+            raise ValueError("paired-query source-prefix token count is invalid")
+        if any(not 0 <= value < prefix_count for value in candidate_terminals):
+            raise ValueError("paired-query candidate terminal is not before Q")
+        positives = sum(label_matrix[query_offset])
+        derived_outcome = (
+            "abstain" if positives == 0 else "answer" if positives == 1 else "conflict"
+        )
+        target_outcome = str(raw_query.get("target_outcome", derived_outcome))
+        if target_outcome != derived_outcome:
+            raise ValueError("paired-query target outcome differs from its label row")
+        queries.append(
+            EncodedPairedQueryLane(
+                question=question,
+                token_ids=token_ids,
+                query_terminal_index=int(terminal),
+                candidate_terminal_indices=candidate_terminals,
+                source_prefix_token_count=prefix_count,
+                target_outcome=target_outcome,
+                metadata=dict(raw_query),
+            )
+        )
+    if queries[0].question == queries[1].question:
+        raise ValueError("paired-query questions must differ")
+    if queries[0].source_prefix_token_count != queries[1].source_prefix_token_count:
+        raise ValueError("paired-query source-prefix lengths differ")
+    if queries[0].candidate_terminal_indices != queries[1].candidate_terminal_indices:
+        raise ValueError("paired-query candidate anchors differ between lanes")
+    left = (BOS_TOKEN_ID, *queries[0].token_ids)
+    right = (BOS_TOKEN_ID, *queries[1].token_ids)
+    prefix_count = queries[0].source_prefix_token_count
+    if left[:prefix_count] != right[:prefix_count]:
+        raise ValueError("paired-query encoded source prefixes differ")
+    if max(len(left), len(right)) > FROZEN_MODEL_CONFIG.max_position_embeddings:
+        raise ValueError("paired-query input exceeds the 256-token context")
+
+    return EncodedPairedQueryRecord(
+        record_id=record_id,
+        source_width=int(source_width),
+        pair_slot=pair_slot,
+        lexical_world=lexical_world,
+        queries=(queries[0], queries[1]),
+        candidate_groups=tuple(groups),
+        label_matrix=(label_matrix[0], label_matrix[1]),
+        flip_group_indices=flip_indices,
+        source_prefix_token_ids_cid=prefix_cid,
+        metadata=dict(record),
+    )
+
+
+class EncodedPairedQueryBindingDataset:
+    """Tokenizer-bound pairs, variable candidate groups, and frozen fit schedule."""
+
+    def __init__(self, records: Sequence[Mapping[str, Any]]) -> None:
+        if not records:
+            raise ValueError("paired-query dataset is empty")
+        encoded = [_encoded_record(record, offset) for offset, record in enumerate(records)]
+        self.records = tuple(sorted(encoded, key=lambda record: record.record_id))
+        if len({record.record_id for record in self.records}) != len(self.records):
+            raise ValueError("paired-query record identities are not unique")
+        mutable: dict[int, list[int]] = defaultdict(list)
+        for index, record in enumerate(self.records):
+            mutable[record.source_width].append(index)
+        self._by_width = {
+            width: tuple(
+                sorted(
+                    indices,
+                    key=lambda index: (
+                        self.records[index].lexical_world,
+                        self.records[index].pair_slot,
+                        self.records[index].record_id,
+                    ),
+                )
+            )
+            for width, indices in mutable.items()
+        }
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def validate_fit_schedule(self) -> None:
+        if set(self._by_width) != set(SOURCE_WIDTHS):
+            raise ValueError("paired-query fit schedule lacks a source width")
+        if any(
+            len(self._by_width[width]) != PAIRED_RECORDS_PER_WIDTH
+            for width in SOURCE_WIDTHS
+        ):
+            raise ValueError("paired-query fit requires eight records per source width")
+        if len(self.records) != RECORDS_PER_STEP * STEPS_PER_EPOCH:
+            raise ValueError("paired-query fit requires exactly 56 paired records")
+        for step in range(1, STEPS_PER_EPOCH + 1):
+            selected = self.record_indices_for_step(step)
+            if len(selected) != RECORDS_PER_STEP or len(set(selected)) != len(selected):
+                raise RuntimeError("paired-query epoch schedule is not seven unique pairs")
+        observed = {
+            index
+            for step in range(1, STEPS_PER_EPOCH + 1)
+            for index in self.record_indices_for_step(step)
+        }
+        if observed != set(range(len(self.records))):
+            raise RuntimeError("paired-query schedule does not cover one exact epoch")
+
+    def record_indices_for_step(self, step: int) -> tuple[int, ...]:
+        if step < 1:
+            raise ValueError("paired-query schedule step must be positive")
+        within_epoch = (step - 1) % STEPS_PER_EPOCH
+        epoch = (step - 1) // STEPS_PER_EPOCH
+        selected = tuple(
+            self._by_width[width][
+                (within_epoch + epoch + width - SOURCE_WIDTHS[0])
+                % PAIRED_RECORDS_PER_WIDTH
+            ]
+            for width in SOURCE_WIDTHS
+        )
+        if len(selected) != RECORDS_PER_STEP:
+            raise RuntimeError("paired-query schedule did not select seven records")
+        return selected
+
+    def batch(
+        self, record_indices: Sequence[int], *, device: torch.device
+    ) -> PairedQueryTokenBatch:
+        if not record_indices or len(set(record_indices)) != len(record_indices):
+            raise ValueError("paired-query batch must contain unique records")
+        selected = [self.records[index] for index in record_indices]
+        time_width = max(
+            len(query.token_ids) + 1
+            for record in selected
+            for query in record.queries
+        )
+        groups = max(len(record.candidate_groups) for record in selected)
+        pairs = len(selected)
+        input_ids = torch.full(
+            (pairs, 2, time_width), EOS_TOKEN_ID, dtype=torch.long
+        )
+        query_indices = torch.empty((pairs, 2), dtype=torch.long)
+        candidate_indices = torch.zeros((pairs, groups), dtype=torch.long)
+        group_mask = torch.zeros((pairs, groups), dtype=torch.bool)
+        labels = torch.zeros((pairs, 2, groups), dtype=torch.float32)
+        flip_mask = torch.zeros((pairs, groups), dtype=torch.bool)
+        source_prefix_lengths = torch.empty(pairs, dtype=torch.long)
+        group_identities: list[tuple[str, ...]] = []
+        for pair_index, record in enumerate(selected):
+            group_count = len(record.candidate_groups)
+            group_mask[pair_index, :group_count] = True
+            labels[pair_index, :, :group_count] = torch.tensor(
+                record.label_matrix, dtype=torch.float32
+            )
+            flip_mask[pair_index, list(record.flip_group_indices)] = True
+            candidate_indices[pair_index, :group_count] = torch.tensor(
+                record.queries[0].candidate_terminal_indices, dtype=torch.long
+            )
+            source_prefix_lengths[pair_index] = (
+                record.queries[0].source_prefix_token_count
+            )
+            group_identities.append(
+                tuple(group.relation_group_cid for group in record.candidate_groups)
+            )
+            for query_index, query in enumerate(record.queries):
+                lane = torch.tensor(
+                    (BOS_TOKEN_ID, *query.token_ids), dtype=torch.long
+                )
+                input_ids[pair_index, query_index, : lane.numel()] = lane
+                query_indices[pair_index, query_index] = query.query_terminal_index
+        batch = PairedQueryTokenBatch(
+            input_ids=input_ids,
+            query_indices=query_indices,
+            candidate_indices=candidate_indices,
+            group_mask=group_mask,
+            labels=labels,
+            flip_mask=flip_mask,
+            source_prefix_lengths=source_prefix_lengths,
+            record_indices=tuple(record_indices),
+            group_identities=tuple(group_identities),
+        )
+        batch.validate()
+        return batch.to(device)
+
+
+@dataclass(frozen=True, slots=True)
+class PairedQueryLossTerms:
+    row_losses: Tensor
+    flip_losses: Tensor
+    mean_row_loss: Tensor
+    mean_flip_loss: Tensor
+    total: Tensor
+
+
+def paired_query_loss_terms(
+    scores: Tensor,
+    labels: Tensor,
+    group_mask: Tensor,
+    flip_mask: Tensor,
+) -> PairedQueryLossTerms:
+    """Return row-extrema and direct counterfactual-column margin terms."""
+    if scores.ndim != 3 or scores.shape[1] != 2:
+        raise ValueError("paired-query scores must have shape [pairs, 2, groups]")
+    if labels.shape != scores.shape:
+        raise ValueError("paired-query labels do not match the score matrix")
+    pairs, _, groups = scores.shape
+    if group_mask.shape != (pairs, groups) or group_mask.dtype != torch.bool:
+        raise ValueError("paired-query group mask shape or dtype differs")
+    if flip_mask.shape != (pairs, groups) or flip_mask.dtype != torch.bool:
+        raise ValueError("paired-query flip mask shape or dtype differs")
+    if labels.dtype not in (torch.float16, torch.float32, torch.float64):
+        raise ValueError("paired-query labels must be floating point")
+    if not (
+        scores.device == labels.device == group_mask.device == flip_mask.device
+    ):
+        raise ValueError("paired-query loss tensors must share one device")
+    # Content invariants are checked once on the CPU token-batch boundary.  Keep
+    # direct CPU calls fail-closed without introducing device synchronizations in
+    # every MPS optimizer step.
+    if scores.device.type == "cpu":
+        active_labels = labels.masked_select(group_mask[:, None, :])
+        if bool(((active_labels != 0.0) & (active_labels != 1.0)).any()):
+            raise ValueError("paired-query active labels must be binary")
+        if bool((flip_mask & ~group_mask).any()) or bool(
+            (~flip_mask.any(dim=1)).any()
+        ):
+            raise ValueError("every paired record requires an admitted flip column")
+        flip_labels = labels.permute(0, 2, 1)[flip_mask]
+        if bool((flip_labels.sum(dim=1) != 1.0).any()):
+            raise ValueError("flip column must contain one positive query row")
+
+    score_values = scores.float()
+    admitted = group_mask[:, None, :]
+    positive_mask = admitted & (labels == 1.0)
+    negative_mask = admitted & (labels == 0.0)
+    positive_minimum = score_values.masked_fill(~positive_mask, float("inf")).amin(
+        dim=-1
+    )
+    negative_maximum = score_values.masked_fill(~negative_mask, float("-inf")).amax(
+        dim=-1
+    )
+    positive_loss = torch.where(
+        positive_mask.any(dim=-1),
+        F.relu(score_values.new_tensor(MARGIN) - positive_minimum),
+        torch.zeros_like(positive_minimum),
+    )
+    negative_loss = torch.where(
+        negative_mask.any(dim=-1),
+        F.relu(score_values.new_tensor(MARGIN) + negative_maximum),
+        torch.zeros_like(negative_maximum),
+    )
+    row_tensor = (positive_loss + negative_loss).reshape(pairs * 2)
+
+    # Each required column contains exactly one positive row.  Orient the row
+    # difference so a correct pair always has ``positive - negative >= 2``.
+    orientation = labels[:, 0].float().mul(2.0).sub(1.0)
+    oriented_gap = (score_values[:, 0] - score_values[:, 1]) * orientation
+    flip_tensor = F.relu(
+        score_values.new_tensor(FLIP_MARGIN) - oriented_gap[flip_mask]
+    )
+    if not row_tensor.numel() or not flip_tensor.numel():
+        raise ValueError("paired-query loss has no admitted rows or flips")
+    mean_row = row_tensor.mean()
+    mean_flip = flip_tensor.mean()
+    return PairedQueryLossTerms(
+        row_losses=row_tensor,
+        flip_losses=flip_tensor,
+        mean_row_loss=mean_row,
+        mean_flip_loss=mean_flip,
+        total=mean_row + mean_flip,
+    )
+
+
+def paired_query_binding_loss(
+    scores: Tensor,
+    labels: Tensor,
+    group_mask: Tensor,
+    flip_mask: Tensor,
+) -> Tensor:
+    return paired_query_loss_terms(scores, labels, group_mask, flip_mask).total
+
+
+def _row_evaluation(
+    record: EncodedPairedQueryRecord,
+    *,
+    query_index: int,
+    scores: Sequence[float],
+    labels: Sequence[int],
+) -> dict[str, Any]:
+    supported = [index for index, score in enumerate(scores) if score > 0.0]
+    predicted_outcome = (
+        "abstain"
+        if not supported
+        else "answer"
+        if len(supported) == 1
+        else "conflict"
+    )
+    positive = [index for index, label in enumerate(labels) if label == 1]
+    target_outcome = record.queries[query_index].target_outcome
+    predicted_copy = (
+        record.candidate_groups[supported[0]].earliest_occurrence_index
+        if predicted_outcome == "answer"
+        else None
+    )
+    target_copy = (
+        record.candidate_groups[positive[0]].earliest_occurrence_index
+        if target_outcome == "answer"
+        else None
+    )
+    cells_exact = all((score > 0.0) == bool(label) for score, label in zip(scores, labels))
+    return {
+        "question": record.queries[query_index].question,
+        "target_outcome": target_outcome,
+        "predicted_outcome": predicted_outcome,
+        "outcome_exact": predicted_outcome == target_outcome,
+        "target_copy_candidate_index": target_copy,
+        "predicted_copy_candidate_index": predicted_copy,
+        "copy_exact": predicted_copy == target_copy,
+        "positive_group_indices": positive,
+        "predicted_positive_group_indices": supported,
+        "cells_exact": cells_exact,
+        "cells": [
+            {
+                "relation_group_cid": group.relation_group_cid,
+                "label": int(label),
+                "score": float(score),
+                "supported": bool(score > 0.0),
+            }
+            for group, label, score in zip(record.candidate_groups, labels, scores)
+        ],
+    }
+
+
+@torch.no_grad()
+def evaluate_paired_query_binding(
+    adapter: R4PairedQueryCandidateMatrix,
+    dataset: EncodedPairedQueryBindingDataset,
+    *,
+    device: torch.device,
+    pair_batch_size: int = RECORDS_PER_STEP,
+    attention_off: bool = False,
+    mean_query_ablation: bool = False,
+    row_swap: bool = False,
+) -> dict[str, Any]:
+    if pair_batch_size < 1:
+        raise ValueError("paired-query evaluation batch size must be positive")
+    adapter.eval()
+    evaluations: list[dict[str, Any]] = []
+    row_loss_sum = 0.0
+    row_loss_count = 0
+    flip_loss_sum = 0.0
+    flip_loss_count = 0
+    for base in range(0, len(dataset), pair_batch_size):
+        indices = tuple(range(base, min(base + pair_batch_size, len(dataset))))
+        batch = dataset.batch(indices, device=device)
+        if row_swap:
+            batch = batch.swapped_query_rows()
+        output = adapter(
+            batch,
+            attention_off=attention_off,
+            mean_query_ablation=mean_query_ablation,
+        )
+        terms = paired_query_loss_terms(
+            output.scores, batch.labels, batch.group_mask, batch.flip_mask
+        )
+        row_loss_sum += float(terms.row_losses.sum().cpu())
+        row_loss_count += terms.row_losses.numel()
+        flip_loss_sum += float(terms.flip_losses.sum().cpu())
+        flip_loss_count += terms.flip_losses.numel()
+        for lane, record_index in enumerate(indices):
+            record = dataset.records[record_index]
+            group_count = len(record.candidate_groups)
+            scores = output.scores[lane, :, :group_count].detach().float().cpu()
+            labels = batch.labels[lane, :, :group_count].detach().int().cpu()
+            query_order = (1, 0) if row_swap else (0, 1)
+            rows = [
+                _row_evaluation(
+                    record,
+                    query_index=source_query_index,
+                    scores=scores[output_query_index].tolist(),
+                    labels=labels[output_query_index].tolist(),
+                )
+                for output_query_index, source_query_index in enumerate(query_order)
+            ]
+            flip_columns = [
+                {
+                    "relation_group_cid": record.candidate_groups[
+                        group_index
+                    ].relation_group_cid,
+                    "exact": (
+                        rows[0]["cells"][group_index]["supported"]
+                        != rows[1]["cells"][group_index]["supported"]
+                        and rows[0]["cells"][group_index]["supported"]
+                        == bool(labels[0, group_index])
+                        and rows[1]["cells"][group_index]["supported"]
+                        == bool(labels[1, group_index])
+                    ),
+                }
+                for group_index in record.flip_group_indices
+            ]
+            flip_exact = all(bool(column["exact"]) for column in flip_columns)
+            paired_rows_identical = torch.equal(scores[0], scores[1])
+            evaluations.append(
+                {
+                    "record_id": record.record_id,
+                    "source_width": record.source_width,
+                    "pair_slot": record.pair_slot,
+                    "candidate_state_identity": output.paired_candidate_states_exact,
+                    "query_rows": rows,
+                    "flip_columns": flip_columns,
+                    "flip_exact": flip_exact,
+                    "paired_rows_identical": paired_rows_identical,
+                    "pair_exact": flip_exact
+                    and all(
+                        bool(row["cells_exact"])
+                        and bool(row["outcome_exact"])
+                        and bool(row["copy_exact"])
+                        for row in rows
+                    ),
+                }
+            )
+    mean_row = row_loss_sum / row_loss_count
+    mean_flip = flip_loss_sum / flip_loss_count
+    all_rows = [
+        row
+        for evaluation in evaluations
+        for row in evaluation["query_rows"]
+    ]
+    all_cells = [cell for row in all_rows for cell in row["cells"]]
+    all_flips = [
+        column
+        for evaluation in evaluations
+        for column in evaluation["flip_columns"]
+    ]
+    answer_rows = [row for row in all_rows if row["target_outcome"] == "answer"]
+    duplicate_pairs = [
+        evaluation for evaluation in evaluations if evaluation["pair_slot"] == 3
+    ]
+
+    def fraction(correct: int, total: int) -> dict[str, int]:
+        return {"correct": correct, "total": total}
+
+    outcome = {
+        target: fraction(
+            sum(
+                bool(row["outcome_exact"])
+                and bool(row["cells_exact"])
+                and bool(row["copy_exact"])
+                for row in all_rows
+                if row["target_outcome"] == target
+            ),
+            sum(row["target_outcome"] == target for row in all_rows),
+        )
+        for target in ("answer", "abstain", "conflict")
+    }
+    return {
+        "pairs": len(evaluations),
+        "query_rows": 2 * len(evaluations),
+        "matrix_cells": sum(
+            2 * len(dataset.records[index].candidate_groups)
+            for index in range(len(dataset))
+        ),
+        "flip_columns": sum(
+            len(dataset.records[index].flip_group_indices)
+            for index in range(len(dataset))
+        ),
+        "mean_row_margin": mean_row,
+        "mean_flip_margin": mean_flip,
+        "mean_total_loss": mean_row + mean_flip,
+        "mean_loss": mean_row + mean_flip,
+        "pair_exact": fraction(
+            sum(bool(row["pair_exact"]) for row in evaluations), len(evaluations)
+        ),
+        "row_exact": fraction(
+            sum(
+                bool(row["cells_exact"])
+                and bool(row["outcome_exact"])
+                and bool(row["copy_exact"])
+                for row in all_rows
+            ),
+            len(all_rows),
+        ),
+        "cell_exact": fraction(
+            sum(bool(cell["supported"]) == bool(cell["label"]) for cell in all_cells),
+            len(all_cells),
+        ),
+        "flip_exact": fraction(
+            sum(bool(column["exact"]) for column in all_flips), len(all_flips)
+        ),
+        "candidate_copy_exact": fraction(
+            sum(bool(row["copy_exact"]) for row in answer_rows), len(answer_rows)
+        ),
+        "duplicate_pair_exact": fraction(
+            sum(bool(row["pair_exact"]) for row in duplicate_pairs),
+            len(duplicate_pairs),
+        ),
+        "outcome": outcome,
+        "candidate_state_bit_identity": fraction(
+            sum(bool(row["candidate_state_identity"]) for row in evaluations),
+            len(evaluations),
+        ),
+        "paired_rows_identical": fraction(
+            sum(bool(row["paired_rows_identical"]) for row in evaluations),
+            len(evaluations),
+        ),
+        "attention_off": attention_off,
+        "mean_query_ablation": mean_query_ablation,
+        "row_swap": row_swap,
+        "candidate_state_identity_exact": all(
+            bool(row["candidate_state_identity"]) for row in evaluations
+        ),
+        "pair_evaluations": evaluations,
+    }
+
+
+def fit_paired_query_binding(
+    adapter: R4PairedQueryCandidateMatrix,
+    dataset: EncodedPairedQueryBindingDataset,
+    *,
+    config: PairedQueryBindingFitConfig = PairedQueryBindingFitConfig(),
+) -> dict[str, Any]:
+    """Run the sole 120-update MPS fit without reading sealed or product data."""
+    config.validate()
+    if config.seed != adapter.config.initialization_seed:
+        raise ValueError("paired-query fit seed differs from model initialization")
+    dataset.validate_fit_schedule()
+    device = require_mps(config.seed)
+    adapter.to(device)
+    adapter.train()
+    parameters = list(adapter.adapter_parameters())
+    if sum(parameter.numel() for parameter in parameters) != TRAINABLE_PARAMETER_COUNT:
+        raise RuntimeError("paired-query optimizer parameter census differs")
+    optimizer = torch.optim.AdamW(
+        parameters,
+        lr=config.learning_rate,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_epsilon,
+        weight_decay=config.weight_decay,
+    )
+    started = time.monotonic()
+    initial_loss: float | None = None
+    final_loss = math.nan
+    projected_seconds: float | None = None
+    elapsed_seconds = 0.0
+    for step in range(1, config.optimizer_steps + 1):
+        indices = dataset.record_indices_for_step(step)
+        batch = dataset.batch(indices, device=device)
+        optimizer.zero_grad(set_to_none=True)
+        # Exact causal candidate-state identity is established by the final
+        # fit/sealed evaluators.  Rechecking it here would turn every optimizer
+        # step into a device-to-host synchronization.
+        output = adapter(batch, verify_candidate_state_identity=False)
+        loss = paired_query_binding_loss(
+            output.scores, batch.labels, batch.group_mask, batch.flip_mask
+        )
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(parameters, config.gradient_clip)
+        optimizer.step()
+        synchronized_boundary = (
+            step == 1
+            or step % config.progress_interval == 0
+            or step == config.optimizer_steps
+        )
+        if synchronized_boundary:
+            if device.type == "mps":
+                torch.mps.synchronize()
+            final_loss = float(loss.detach().cpu())
+            if initial_loss is None:
+                initial_loss = final_loss
+            if not math.isfinite(final_loss):
+                raise RuntimeError("paired-query binding produced a nonfinite loss")
+            elapsed_seconds = time.monotonic() - started
+            if step == config.eta_probe_step:
+                projected_seconds = elapsed_seconds * config.optimizer_steps / step
+                print(
+                    f"paired_query_binding_eta_probe_step={step} "
+                    f"elapsed_seconds={elapsed_seconds:.3f} "
+                    f"projected_seconds={projected_seconds:.3f} "
+                    f"ceiling_seconds={config.wall_ceiling_seconds:.3f}",
+                    flush=True,
+                )
+                if projected_seconds > config.wall_ceiling_seconds:
+                    raise PairedQueryBindingWallBudgetExceeded(
+                        step=step,
+                        elapsed_seconds=elapsed_seconds,
+                        projected_seconds_at_eta_probe=projected_seconds,
+                        wall_ceiling_seconds=config.wall_ceiling_seconds,
+                    )
+            if elapsed_seconds > config.wall_ceiling_seconds:
+                raise PairedQueryBindingWallBudgetExceeded(
+                    step=step,
+                    elapsed_seconds=elapsed_seconds,
+                    projected_seconds_at_eta_probe=projected_seconds,
+                    wall_ceiling_seconds=config.wall_ceiling_seconds,
+                )
+            if step % config.progress_interval == 0 or step == config.optimizer_steps:
+                print(
+                    f"paired_query_binding_step={step}/{config.optimizer_steps} "
+                    f"loss={final_loss:.6f}",
+                    flush=True,
+                )
+        else:
+            # Host elapsed time above the ceiling is already sufficient to stop;
+            # below the ceiling it is not treated as device-completion timing.
+            dispatch_elapsed = time.monotonic() - started
+            if dispatch_elapsed > config.wall_ceiling_seconds:
+                raise PairedQueryBindingWallBudgetExceeded(
+                    step=step,
+                    elapsed_seconds=dispatch_elapsed,
+                    projected_seconds_at_eta_probe=projected_seconds,
+                    wall_ceiling_seconds=config.wall_ceiling_seconds,
+                )
+    return {
+        "optimizer_steps": config.optimizer_steps,
+        "paired_records_per_step": config.records_per_step,
+        "initial_loss": initial_loss,
+        "final_loss": final_loss,
+        "elapsed_seconds": elapsed_seconds,
+        "eta_probe_step": config.eta_probe_step,
+        "projected_seconds_at_eta_probe": projected_seconds,
+        "wall_ceiling_seconds": config.wall_ceiling_seconds,
+        "trainable_parameter_count": TRAINABLE_PARAMETER_COUNT,
+        "delta_audit": adapter.delta_audit(),
+        "binding_head_audit": adapter.binding_head_audit(),
+    }
+
+
+__all__ = [
+    "BINDING_BLOCKS",
+    "BINDING_HEAD_PARAMETER_COUNT",
+    "BINDING_RANK",
+    "FIT_SEED",
+    "FLIP_MARGIN",
+    "MARGIN",
+    "OPTIMIZER_STEPS",
+    "POLICY",
+    "RECORDS_PER_STEP",
+    "STEPS_PER_EPOCH",
+    "TRAINABLE_PARAMETER_COUNT",
+    "AsymmetricR4BindingHead",
+    "EncodedPairedQueryBindingDataset",
+    "PairedQueryBindingAdapterConfig",
+    "PairedQueryBindingFitConfig",
+    "PairedQueryBindingOutput",
+    "PairedQueryBindingWallBudgetExceeded",
+    "PairedQueryTokenBatch",
+    "R4PairedQueryCandidateMatrix",
+    "evaluate_paired_query_binding",
+    "fit_paired_query_binding",
+    "paired_query_binding_loss",
+    "paired_query_loss_terms",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding_campaign.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding_campaign.py
@@ -1,0 +1,1189 @@
+"""Prepared, one-shot C1-SB5 paired-query conditional-binding campaign.
+
+Preparation is the only phase allowed to construct the independently frozen
+population or open product records.  The optimizer consumes an explicit
+four-file training view and cannot rebuild or read the product envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+from safetensors.torch import save_file
+from tokenizers import Tokenizer
+
+from .constants import FROZEN_MODEL_CONFIG
+from .paired_query_binding import (
+    FIT_SEED,
+    EncodedPairedQueryBindingDataset,
+    PairedQueryBindingAdapterConfig,
+    PairedQueryBindingFitConfig,
+    PairedQueryBindingWallBudgetExceeded,
+    REPRESENTATION_UPDATE,
+    R4PairedQueryCandidateMatrix,
+    evaluate_paired_query_binding,
+    fit_paired_query_binding,
+)
+from .paired_query_binding_data import (
+    CENSUS_SCHEMA,
+    DATASET_SCHEMA,
+    POLICY,
+    PREFLIGHT_SCHEMA,
+    PRODUCT_SCHEMA,
+    TOKENIZER_CENSUS_SCHEMA,
+    build_paired_query_binding_population,
+)
+from .provenance import (
+    atomic_write_json,
+    canonical_json_bytes,
+    cid_bytes,
+    cid_file,
+    trainer_implementation_contract,
+    verify_artifact_subset,
+    verify_bound_manifest,
+    verify_manifest_envelope,
+    write_bound_manifest,
+)
+from .source_relation_adapter import (
+    export_merged_attended_relation_checkpoint,
+    validate_tokenizer_contract,
+)
+from .source_relation_adapter_campaign import (
+    EXPECTED_CONFIG_CID,
+    EXPECTED_TOKENIZER_CID,
+    EXPECTED_WEIGHTS_CID,
+    _load_base_model,
+    _rust_checkpoint_tree_binding,
+    _validate_roots,
+    _validated_predecessor,
+)
+from .train import require_mps
+
+
+ISSUE = 954
+EXPECTED_DATASET_CID = (
+    "blake3:b8d6b381eb856396b91ba1cc343b94f6abe99e3de9d54953e5071dfdb1d5bc3f"
+)
+EXPECTED_PREFLIGHT_CID = (
+    "blake3:008a302b1e625a7568d04d26492c058ddcd26a7caaa23b63138e57871c4cf4c1"
+)
+EXPECTED_CENSUS_CID = (
+    "blake3:95533608ebe3dae761d925667572cd6de6d2e1f7b94d3efa29374c0a29fe4307"
+)
+EXPECTED_TOKENIZER_CENSUS_CID = (
+    "blake3:bf4eebd5c35f09ce4452e86fe14823888d75d14dc82a025769c43c4801965271"
+)
+EXPECTED_PRODUCT_CID = (
+    "blake3:5489089f7fc73906d07c27308e6a031a2dd373d016b610f09b26657d4238665e"
+)
+EXPECTED_SPLIT_POLICY_CID = (
+    "blake3:3010b5bc37c1f8b9e5afb9adfab34abf98632df9449ba67f502a57c74555ab0c"
+)
+EXPECTED_PREDECESSOR_MANIFEST_CID = (
+    "blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3"
+)
+EXPECTED_PRODUCT_COMMITMENTS = (
+    "blake3:6c0fa9773dcde75b5e07e3427d8554645d1093cde74aefd8b14a497647286630",
+    "blake3:c281c06533c3cf418a016e98cb0028e8e833a94f865451ffb1f69cede6112e34",
+    "blake3:07ee858c95e9da02b746625ed31e23d066680ebda60c48b081b48b47f1cfcaec",
+    "blake3:abce456fad476bed4d30c38f862df1ff432cca797b22bd46ebc231b13746f89a",
+)
+DATA_MANIFEST_SCHEMA = "uor-r4.paired-query-binding-training-view-manifest/1"
+PRODUCT_MANIFEST_SCHEMA = "uor-r4.paired-query-binding-product-manifest/1"
+RUN_SCHEMA = "uor-r4.paired-query-binding-run/1"
+RESULT_SCHEMA = "uor-r4.paired-query-binding-preflight-result/1"
+RESULT_MANIFEST_SCHEMA = "uor-r4.paired-query-binding-preflight-manifest/1"
+ARTIFACT_SCHEMA = "uor-r4.paired-query-binding-adapter/1"
+HEAD_SCHEMA = "uor-r4.paired-query-binding-head/1"
+RESEARCH_ADMISSION = "research_only"
+
+DATASET_FILE = "paired-query-binding-dataset.json"
+PREFLIGHT_FILE = "paired-query-binding-preflight.json"
+STRUCTURAL_CENSUS_FILE = "paired-query-binding-census.json"
+TOKENIZER_CENSUS_FILE = "paired-query-binding-tokenizer-census.json"
+PRODUCT_FILE = "paired-query-binding-product-probes.json"
+PRODUCT_MANIFEST_FILE = "product-commitments-manifest.json"
+TRAINING_MANIFEST_FILE = "training-view-manifest.json"
+RUN_CONTRACT_FILE = "run-contract.json"
+STARTED_FILE = "preflight-started.json"
+RESULT_FILE = "preflight-result.json"
+RESULT_MANIFEST_FILE = "preflight-manifest.json"
+CHECKPOINT_DIRECTORY = "preflight-checkpoint"
+HEAD_DIRECTORY = "preflight-binding-head"
+HEAD_TENSORS_FILE = "binding-head.safetensors"
+HEAD_MANIFEST_FILE = "head-manifest.json"
+ADAPTER_ARTIFACT = "paired-query-binding-adapter.json"
+
+TRAINING_VIEW_ARTIFACTS = {
+    DATASET_FILE,
+    PREFLIGHT_FILE,
+    STRUCTURAL_CENSUS_FILE,
+    TOKENIZER_CENSUS_FILE,
+}
+
+FIT_PAIRS = 56
+SEALED_PAIRS = 28
+ROWS_PER_PAIR = 2
+WIDTHS = tuple(range(2, 9))
+STEPS_PER_EPOCH = 8
+OPTIMIZER_STEPS = 120
+EPOCHS = 15
+PAIRS_PER_STEP = len(WIDTHS)
+PAIR_PRESENTATIONS = OPTIMIZER_STEPS * PAIRS_PER_STEP
+ROW_PRESENTATIONS = PAIR_PRESENTATIONS * ROWS_PER_PAIR
+CELL_PRESENTATIONS = 7_980
+ETA_PROBE_STEP = 8
+WALL_CEILING_SECONDS = 300.0
+EXPECTED_PARTITION_METRICS = {
+    FIT_PAIRS: {
+        "query_rows": 112,
+        "matrix_cells": 532,
+        "flip_columns": 98,
+        "candidate_copies": 42,
+        "duplicate_pairs": 14,
+        "outcome": {"answer": 42, "abstain": 42, "conflict": 28},
+    },
+    SEALED_PAIRS: {
+        "query_rows": 56,
+        "matrix_cells": 266,
+        "flip_columns": 49,
+        "candidate_copies": 21,
+        "duplicate_pairs": 7,
+        "outcome": {"answer": 21, "abstain": 21, "conflict": 14},
+    },
+}
+
+
+def _canonical_with_cid(value: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _verify_self_cid(value: Mapping[str, Any], field: str) -> None:
+    unsigned = dict(value)
+    observed = unsigned.pop(field, None)
+    if not isinstance(observed, str):
+        raise ValueError(f"C1-SB5 value has no {field}")
+    if observed != cid_bytes(canonical_json_bytes(unsigned)):
+        raise ValueError(f"C1-SB5 {field} does not reproduce")
+
+
+def _write_or_verify(path: Path, value: Mapping[str, Any]) -> None:
+    encoded = canonical_json_bytes(value)
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ValueError(f"existing C1-SB5 artifact differs: {path}")
+        return
+    atomic_write_json(path, value)
+
+
+def _write_exclusive_started_marker(path: Path, value: Mapping[str, Any]) -> None:
+    """Claim the sole run atomically; any complete or partial marker is terminal."""
+    encoded = canonical_json_bytes(value)
+    try:
+        with path.open("xb") as target:
+            target.write(encoded)
+            target.flush()
+            os.fsync(target.fileno())
+    except FileExistsError as error:
+        raise FileExistsError(
+            "the sole C1-SB5 preflight was already started"
+        ) from error
+
+
+def _partition_pairs(preflight: Mapping[str, Any], name: str) -> list[dict[str, Any]]:
+    records = preflight.get(name)
+    if not isinstance(records, list) or not all(isinstance(row, dict) for row in records):
+        raise ValueError(f"C1-SB5 {name} partition is not a pair list")
+    expected = FIT_PAIRS if name == "fit" else SEALED_PAIRS
+    if len(records) != expected:
+        raise ValueError(f"C1-SB5 {name} requires exactly {expected} pairs")
+    return records
+
+
+def _validate_population(
+    dataset: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    products: Mapping[str, Any],
+    tokenizer_census: Mapping[str, Any],
+) -> None:
+    if dataset.get("schema") != DATASET_SCHEMA or dataset.get("policy") != POLICY:
+        raise ValueError("C1-SB5 dataset schema or policy drifted")
+    if preflight.get("schema") != PREFLIGHT_SCHEMA or preflight.get("policy") != POLICY:
+        raise ValueError("C1-SB5 preflight schema or policy drifted")
+    if tokenizer_census.get("schema") != TOKENIZER_CENSUS_SCHEMA:
+        raise ValueError("C1-SB5 tokenizer-census schema drifted")
+    if tokenizer_census.get("policy") != POLICY or not tokenizer_census.get("passed"):
+        raise ValueError("C1-SB5 tokenizer census is not positive")
+    if products.get("schema") != PRODUCT_SCHEMA or products.get("policy") != POLICY:
+        raise ValueError("C1-SB5 product schema or policy drifted")
+    census = dataset.get("census")
+    if (
+        not isinstance(census, Mapping)
+        or census.get("schema") != CENSUS_SCHEMA
+        or census.get("policy") != POLICY
+        or not census.get("passed")
+    ):
+        raise ValueError("C1-SB5 structural census is not positive")
+    fit = _partition_pairs(preflight, "fit")
+    sealed = _partition_pairs(preflight, "sealed")
+    widths = set(WIDTHS)
+    for name, records in (("fit", fit), ("sealed", sealed)):
+        observed_widths = {int(record.get("source_width", -1)) for record in records}
+        if observed_widths != widths:
+            raise ValueError(f"C1-SB5 {name} does not cover widths 2 through 8")
+        for record in records:
+            queries = record.get("queries")
+            matrix = record.get("label_matrix")
+            if not isinstance(queries, list) or len(queries) != ROWS_PER_PAIR:
+                raise ValueError("C1-SB5 pair must contain exactly two queries")
+            if not isinstance(matrix, list) or len(matrix) != ROWS_PER_PAIR:
+                raise ValueError("C1-SB5 label matrix must contain exactly two rows")
+    commitments = dataset.get("product_probe_commitments")
+    if (
+        not isinstance(commitments, list)
+        or not commitments
+        or len(set(commitments)) != len(commitments)
+    ):
+        raise ValueError("C1-SB5 product commitments are missing or duplicated")
+    if products.get("product_probe_commitments") not in (None, commitments):
+        raise ValueError("C1-SB5 product envelope commitments disagree")
+    for field, value in (
+        ("dataset_cid", dataset),
+        ("preflight_cid", preflight),
+        ("census_cid", census),
+        ("tokenizer_census_cid", tokenizer_census),
+        ("product_probes_cid", products),
+    ):
+        _verify_self_cid(value, field)
+    frozen = {
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "census_cid": census["census_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "product_probes_cid": products["product_probes_cid"],
+        "split_policy_cid": dataset.get("split_policy_cid"),
+        "product_probe_commitments": tuple(commitments),
+    }
+    expected = {
+        "dataset_cid": EXPECTED_DATASET_CID,
+        "preflight_cid": EXPECTED_PREFLIGHT_CID,
+        "census_cid": EXPECTED_CENSUS_CID,
+        "tokenizer_census_cid": EXPECTED_TOKENIZER_CENSUS_CID,
+        "product_probes_cid": EXPECTED_PRODUCT_CID,
+        "split_policy_cid": EXPECTED_SPLIT_POLICY_CID,
+        "product_probe_commitments": EXPECTED_PRODUCT_COMMITMENTS,
+    }
+    if frozen != expected:
+        raise ValueError("C1-SB5 population identities differ from the freeze")
+
+
+def prepare_paired_query_binding_data(
+    root: Path, *, predecessor: Path
+) -> dict[str, Any]:
+    """Commit the frozen population and opaque products without optimization."""
+    root, predecessor = _validate_roots(root, predecessor)
+    predecessor_manifest = _validated_predecessor(predecessor)
+    try:
+        tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+        validate_tokenizer_contract(tokenizer)
+        dataset, preflight, products = build_paired_query_binding_population(
+            tokenizer, tokenizer_cid=EXPECTED_TOKENIZER_CID
+        )
+        tokenizer_census = dataset.get("tokenizer_census")
+        if not isinstance(tokenizer_census, Mapping):
+            raise ValueError("C1-SB5 bound dataset omits its tokenizer census")
+        _validate_population(dataset, preflight, products, tokenizer_census)
+    except (RuntimeError, ValueError) as error:
+        # Population construction is a zero-training admission gate.  Keep the
+        # failure typed and in memory: no campaign root or partial training view
+        # may be created when the semantic/tokenizer frame is unavailable.
+        return {
+            "terminal": "UNAVAILABLE_FRAME_OR_POPULATION",
+            "issue": ISSUE,
+            "policy": POLICY,
+            "failure_stage": "POPULATION_BUILD_OR_VALIDATION",
+            "failure_type": type(error).__name__,
+            "failure": str(error),
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "population_root": "NOT_CREATED",
+            "training_view": "NOT_COMMITTED",
+            "artifacts": "NOT_EMITTED",
+            "training": "NOT_STARTED",
+            "optimizer_steps": 0,
+        }
+
+    # Do not expose a partially admitted population if any check above fails.
+    root.mkdir(parents=True, exist_ok=True)
+    _write_or_verify(root / DATASET_FILE, dataset)
+    _write_or_verify(root / PREFLIGHT_FILE, preflight)
+    _write_or_verify(root / STRUCTURAL_CENSUS_FILE, dataset["census"])
+    _write_or_verify(root / TOKENIZER_CENSUS_FILE, tokenizer_census)
+    _write_or_verify(root / PRODUCT_FILE, products)
+
+    product_manifest_path = root / PRODUCT_MANIFEST_FILE
+    if product_manifest_path.exists():
+        product_manifest = verify_bound_manifest(product_manifest_path, artifact_root=root)
+    else:
+        product_manifest = write_bound_manifest(
+            product_manifest_path,
+            {
+                "schema": PRODUCT_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "product_probes_cid": products["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "access_policy": "opaque to every optimizer and preflight evaluator",
+            },
+            artifact_root=root,
+            relative_paths=[PRODUCT_FILE],
+        )
+
+    training_manifest_path = root / TRAINING_MANIFEST_FILE
+    if training_manifest_path.exists():
+        training_manifest = verify_bound_manifest(training_manifest_path, artifact_root=root)
+    else:
+        training_manifest = write_bound_manifest(
+            training_manifest_path,
+            {
+                "schema": DATA_MANIFEST_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "dataset_cid": dataset["dataset_cid"],
+                "preflight_cid": preflight["preflight_cid"],
+                "split_policy_cid": dataset["split_policy_cid"],
+                "census_cid": dataset["census_cid"],
+                "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+                "product_probes_cid": products["product_probes_cid"],
+                "product_probe_commitments": dataset["product_probe_commitments"],
+                "product_probe_count": len(dataset["product_probe_commitments"]),
+                "product_manifest_cid": product_manifest["manifest_cid"],
+                "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+                "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+                "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+                "product_text_access": "DENIED_TO_TRAINING_VIEW",
+            },
+            artifact_root=root,
+            relative_paths=sorted(TRAINING_VIEW_ARTIFACTS),
+        )
+    artifact_paths = {str(record["path"]) for record in training_manifest["artifacts"]}
+    if artifact_paths != TRAINING_VIEW_ARTIFACTS:
+        raise ValueError("C1-SB5 training-view artifact whitelist drifted")
+    if PRODUCT_FILE in artifact_paths or PRODUCT_MANIFEST_FILE in artifact_paths:
+        raise ValueError("C1-SB5 training view contains product material")
+    return {
+        "terminal": "PAIRED_QUERY_BINDING_DATA_COMMITTED_NO_TRAINING",
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "census_cid": dataset["census_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "product_probes_cid": products["product_probes_cid"],
+        "product_probe_commitments": dataset["product_probe_commitments"],
+        "training_view_manifest_cid": training_manifest["manifest_cid"],
+        "product_manifest_cid": product_manifest["manifest_cid"],
+        "product_text_status": "COMMITTED_UNOPENED_BY_TRAINER",
+    }
+
+
+def _load_training_view(
+    root: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load only the four artifacts admitted to the optimizer view."""
+    manifest = verify_manifest_envelope(root / TRAINING_MANIFEST_FILE)
+    if manifest.get("schema") != DATA_MANIFEST_SCHEMA or manifest.get("policy") != POLICY:
+        raise ValueError("unexpected C1-SB5 training-view schema or policy")
+    records = manifest.get("artifacts")
+    paths = (
+        [record.get("path") for record in records]
+        if isinstance(records, list)
+        and all(isinstance(record, Mapping) for record in records)
+        else []
+    )
+    if (
+        len(paths) != len(TRAINING_VIEW_ARTIFACTS)
+        or any(not isinstance(path, str) for path in paths)
+        or set(paths) != TRAINING_VIEW_ARTIFACTS
+    ):
+        raise ValueError("C1-SB5 training-view artifact whitelist drifted")
+    verify_artifact_subset(
+        manifest,
+        artifact_root=root,
+        relative_paths=TRAINING_VIEW_ARTIFACTS,
+    )
+    dataset = json.loads((root / DATASET_FILE).read_text(encoding="utf-8"))
+    preflight = json.loads((root / PREFLIGHT_FILE).read_text(encoding="utf-8"))
+    structural = json.loads((root / STRUCTURAL_CENSUS_FILE).read_text(encoding="utf-8"))
+    tokenizer_census = json.loads((root / TOKENIZER_CENSUS_FILE).read_text(encoding="utf-8"))
+    _verify_self_cid(dataset, "dataset_cid")
+    _verify_self_cid(preflight, "preflight_cid")
+    _verify_self_cid(structural, "census_cid")
+    _verify_self_cid(tokenizer_census, "tokenizer_census_cid")
+    if dataset.get("census") != structural or not structural.get("passed"):
+        raise ValueError("C1-SB5 structural census differs or is not positive")
+    expected = {
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "split_policy_cid": dataset["split_policy_cid"],
+        "census_cid": structural["census_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "product_probes_cid": dataset["product_probes_cid"],
+        "product_probe_commitments": dataset["product_probe_commitments"],
+        "product_probe_count": len(dataset["product_probe_commitments"]),
+        "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+        "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+        "predecessor_export_manifest_cid": EXPECTED_PREDECESSOR_MANIFEST_CID,
+        "product_text_access": "DENIED_TO_TRAINING_VIEW",
+    }
+    if any(manifest.get(key) != value for key, value in expected.items()):
+        raise ValueError("C1-SB5 training view differs from its commitments")
+    frozen = {
+        "dataset_cid": EXPECTED_DATASET_CID,
+        "preflight_cid": EXPECTED_PREFLIGHT_CID,
+        "split_policy_cid": EXPECTED_SPLIT_POLICY_CID,
+        "census_cid": EXPECTED_CENSUS_CID,
+        "tokenizer_census_cid": EXPECTED_TOKENIZER_CENSUS_CID,
+        "product_probes_cid": EXPECTED_PRODUCT_CID,
+        "product_probe_commitments": list(EXPECTED_PRODUCT_COMMITMENTS),
+    }
+    if any(manifest.get(key) != value for key, value in frozen.items()):
+        raise ValueError("C1-SB5 training view does not bind the frozen population")
+    if (
+        dataset.get("schema") != DATASET_SCHEMA
+        or dataset.get("policy") != POLICY
+        or preflight.get("schema") != PREFLIGHT_SCHEMA
+        or preflight.get("policy") != POLICY
+        or tokenizer_census.get("schema") != TOKENIZER_CENSUS_SCHEMA
+        or tokenizer_census.get("policy") != POLICY
+        or not tokenizer_census.get("passed")
+    ):
+        raise ValueError("C1-SB5 loaded training identities or gates drifted")
+    _partition_pairs(preflight, "fit")
+    _partition_pairs(preflight, "sealed")
+    return dataset, preflight, tokenizer_census, manifest
+
+
+def _run_contract(
+    *,
+    predecessor_manifest: Mapping[str, Any],
+    dataset: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    tokenizer_census: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    fit_config = PairedQueryBindingFitConfig()
+    fit_contract = fit_config.as_contract()
+    frozen_schedule = {
+        "seed": FIT_SEED,
+        "widths": list(WIDTHS),
+        "pairs_per_step": PAIRS_PER_STEP,
+        "rows_per_pair": ROWS_PER_PAIR,
+        "steps_per_epoch": STEPS_PER_EPOCH,
+        "optimizer_steps": OPTIMIZER_STEPS,
+        "epochs": EPOCHS,
+        "pair_presentations": PAIR_PRESENTATIONS,
+        "row_presentations": ROW_PRESENTATIONS,
+        "cell_presentations": CELL_PRESENTATIONS,
+        "eta_probe_step": ETA_PROBE_STEP,
+        "wall_ceiling_seconds": WALL_CEILING_SECONDS,
+    }
+    if any(
+        fit_contract.get(key) != value
+        for key, value in frozen_schedule.items()
+        if key in fit_contract
+    ):
+        raise ValueError("C1-SB5 fit configuration differs from the frozen schedule")
+    return _canonical_with_cid(
+        {
+            "schema": RUN_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "predecessor_export_manifest_cid": predecessor_manifest["manifest_cid"],
+            "predecessor_weights_cid": EXPECTED_WEIGHTS_CID,
+            "predecessor_tokenizer_cid": EXPECTED_TOKENIZER_CID,
+            "model_contract": FROZEN_MODEL_CONFIG.as_contract(),
+            "adapter_contract": PairedQueryBindingAdapterConfig().as_contract(),
+            "optimizer_contract": fit_contract,
+            "frozen_schedule": frozen_schedule,
+            "dataset_cid": dataset["dataset_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "census_cid": dataset["census_cid"],
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "training_view_manifest_cid": training_manifest["manifest_cid"],
+            "product_probes_cid": dataset["product_probes_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+            "product_text_access": "DENIED_TO_PYTHON_TRAINER_AND_EVALUATOR",
+            "mechanism": (
+                "two query rows share one exact source/candidate encoding; an asymmetric "
+                "subject-binding head must make a candidate change sign with the query"
+            ),
+            "objective": (
+                "paired row/cell classification plus a columnwise counterfactual flip "
+                "margin over the complete candidate matrix"
+            ),
+            "execution_backend": (
+                "Apple MPS required; CPU fallback refused; no CUDA path"
+            ),
+            "reachability_ceiling": "84/84 fit+sealed pairs = 100%",
+            "preflight_gate": {
+                "fit_pairs": FIT_PAIRS,
+                "sealed_pairs": SEALED_PAIRS,
+                "main_semantics": (
+                    "all pairs, rows, cells, flips, copies, duplicates, and "
+                    "outcomes exact"
+                ),
+                "row_swap": (
+                    "28/28 sealed pairs exact and identity-aligned main/swapped "
+                    "traces bit-exact"
+                ),
+                "mean_query_ablation": "identical paired rows and 0/28 exact with higher loss",
+                "attention_off": "0/28 exact with higher loss",
+                "delta": (
+                    "24 LoRA plus 3 head tensors changed and finite; no base "
+                    "nontarget changed"
+                ),
+                "deterministic_replay": "exact",
+                "wall_ceiling_seconds": WALL_CEILING_SECONDS,
+            },
+            "if_positive": "emit one research-only merged checkpoint and separate binding head",
+            "if_negative": "emit no checkpoint or head and retire C1-SB5 without retry",
+            "implementation": trainer_implementation_contract(),
+        },
+        "run_contract_cid",
+    )
+
+
+def _counter(metrics: Mapping[str, Any], key: str) -> tuple[int, int]:
+    value = metrics.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"C1-SB5 metrics have no {key} counter")
+    correct = value.get("correct")
+    total = value.get("total")
+    if not isinstance(correct, int) or not isinstance(total, int) or not 0 <= correct <= total:
+        raise ValueError(f"C1-SB5 {key} counter is invalid")
+    return correct, total
+
+
+def _main_metrics_exact(metrics: Mapping[str, Any], *, expected_pairs: int) -> bool:
+    if metrics.get("pairs") != expected_pairs:
+        raise ValueError("C1-SB5 evaluation pair count drifted")
+    expected = EXPECTED_PARTITION_METRICS.get(expected_pairs)
+    if expected is None:
+        raise ValueError("C1-SB5 metrics requested an unknown partition")
+    if (
+        metrics.get("query_rows") != expected["query_rows"]
+        or metrics.get("matrix_cells") != expected["matrix_cells"]
+        or metrics.get("flip_columns") != expected["flip_columns"]
+    ):
+        raise ValueError("C1-SB5 row, cell, or flip denominator drifted")
+    required = {
+        "pair_exact": expected_pairs,
+        "row_exact": expected_pairs * ROWS_PER_PAIR,
+        "candidate_state_bit_identity": expected_pairs,
+    }
+    exact = True
+    for key, expected_total in required.items():
+        correct, total = _counter(metrics, key)
+        if total != expected_total:
+            raise ValueError(f"C1-SB5 {key} total drifted")
+        exact = exact and correct == total
+    exact_totals = {
+        "cell_exact": expected["matrix_cells"],
+        "flip_exact": expected["flip_columns"],
+        "candidate_copy_exact": expected["candidate_copies"],
+        "duplicate_pair_exact": expected["duplicate_pairs"],
+    }
+    for key, expected_total in exact_totals.items():
+        correct, total = _counter(metrics, key)
+        if total != expected_total:
+            raise ValueError(f"C1-SB5 {key} denominator drifted")
+        exact = exact and correct == total
+    outcomes = metrics.get("outcome")
+    if not isinstance(outcomes, Mapping) or set(outcomes) != {"answer", "abstain", "conflict"}:
+        raise ValueError("C1-SB5 outcome counters drifted")
+    for name, expected_total in expected["outcome"].items():
+        correct, total = _counter(outcomes, name)
+        if total != expected_total:
+            raise ValueError(f"C1-SB5 {name} outcome denominator drifted")
+        exact = exact and correct == total
+    return exact
+
+
+def _finite_loss(metrics: Mapping[str, Any]) -> float:
+    value = metrics.get("mean_loss")
+    if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+        raise ValueError("C1-SB5 mean loss is missing or nonfinite")
+    return float(value)
+
+
+def _row_swap_equivariance(
+    sealed: Mapping[str, Any], row_swap: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Compare sealed and row-swapped traces after restoring query identity."""
+    if sealed.get("row_swap") not in (None, False) or row_swap.get("row_swap") is not True:
+        raise ValueError("C1-SB5 row-swap trace flags are missing or inconsistent")
+    if any(
+        value.get(flag) not in (None, False)
+        for value in (sealed, row_swap)
+        for flag in ("attention_off", "mean_query_ablation")
+    ):
+        raise ValueError("C1-SB5 row-swap trace contains another active control")
+    sealed_evaluations = sealed.get("pair_evaluations")
+    swapped_evaluations = row_swap.get("pair_evaluations")
+    if not isinstance(sealed_evaluations, list) or not isinstance(
+        swapped_evaluations, list
+    ):
+        raise ValueError("C1-SB5 row-swap trace populations are missing")
+    if len(sealed_evaluations) != SEALED_PAIRS or len(swapped_evaluations) != SEALED_PAIRS:
+        raise ValueError("C1-SB5 row-swap trace cardinality drifted")
+
+    if not all(
+        isinstance(row, Mapping)
+        for row in (*sealed_evaluations, *swapped_evaluations)
+    ):
+        raise ValueError("C1-SB5 row-swap pair trace is not an object")
+    sealed_ids = [row.get("record_id") for row in sealed_evaluations]
+    swapped_ids = [row.get("record_id") for row in swapped_evaluations]
+    if not all(isinstance(record_id, str) for record_id in sealed_ids + swapped_ids):
+        raise ValueError("C1-SB5 row-swap traces contain an invalid record identity")
+    record_order_exact = sealed_ids == swapped_ids and len(set(sealed_ids)) == SEALED_PAIRS
+
+    sealed_pairs: list[dict[str, Any]] = []
+    aligned_swapped_pairs: list[dict[str, Any]] = []
+    for sealed_pair, swapped_pair in zip(sealed_evaluations, swapped_evaluations):
+        sealed_rows = sealed_pair.get("query_rows")
+        swapped_rows = swapped_pair.get("query_rows")
+        if (
+            not isinstance(sealed_rows, list)
+            or len(sealed_rows) != ROWS_PER_PAIR
+            or not isinstance(swapped_rows, list)
+            or len(swapped_rows) != ROWS_PER_PAIR
+        ):
+            raise ValueError("C1-SB5 row-swap pair does not contain two query rows")
+        sealed_value = dict(sealed_pair)
+        swapped_value = dict(swapped_pair)
+        swapped_value["query_rows"] = list(reversed(swapped_rows))
+        sealed_pairs.append(sealed_value)
+        aligned_swapped_pairs.append(swapped_value)
+
+    aggregate_keys = (
+        "pairs",
+        "query_rows",
+        "matrix_cells",
+        "flip_columns",
+        "mean_row_margin",
+        "mean_flip_margin",
+        "mean_total_loss",
+        "mean_loss",
+        "pair_exact",
+        "row_exact",
+        "cell_exact",
+        "flip_exact",
+        "candidate_copy_exact",
+        "duplicate_pair_exact",
+        "outcome",
+        "candidate_state_bit_identity",
+        "paired_rows_identical",
+        "candidate_state_identity_exact",
+    )
+    sealed_aggregate = {key: sealed.get(key) for key in aggregate_keys}
+    swapped_aggregate = {key: row_swap.get(key) for key in aggregate_keys}
+    pair_trace_exact = canonical_json_bytes(sealed_pairs) == canonical_json_bytes(
+        aligned_swapped_pairs
+    )
+    aggregate_exact = canonical_json_bytes(sealed_aggregate) == canonical_json_bytes(
+        swapped_aggregate
+    )
+    sealed_trace_cid = cid_bytes(canonical_json_bytes(sealed_pairs))
+    swapped_trace_cid = cid_bytes(canonical_json_bytes(aligned_swapped_pairs))
+    return {
+        "record_order_exact": record_order_exact,
+        "pair_trace_bit_exact": pair_trace_exact,
+        "aggregate_bit_exact": aggregate_exact,
+        "sealed_identity_aligned_trace_cid": sealed_trace_cid,
+        "swapped_identity_aligned_trace_cid": swapped_trace_cid,
+        "passed": record_order_exact
+        and pair_trace_exact
+        and aggregate_exact
+        and sealed_trace_cid == swapped_trace_cid,
+    }
+
+
+def _control_gate(
+    sealed: Mapping[str, Any],
+    row_swap: Mapping[str, Any],
+    mean_query: Mapping[str, Any],
+    attention_off: Mapping[str, Any],
+) -> dict[str, Any]:
+    sealed_loss = _finite_loss(sealed)
+    row_swap_semantic_exact = _main_metrics_exact(
+        row_swap, expected_pairs=SEALED_PAIRS
+    )
+    row_swap_equivariance = _row_swap_equivariance(sealed, row_swap)
+    row_swap_exact = row_swap_semantic_exact and row_swap_equivariance["passed"]
+    mean_correct, mean_total = _counter(mean_query, "paired_rows_identical")
+    mean_pair_correct, mean_pair_total = _counter(mean_query, "pair_exact")
+    off_pair_correct, off_pair_total = _counter(attention_off, "pair_exact")
+    mean_passed = (
+        mean_correct == mean_total == SEALED_PAIRS
+        and mean_pair_correct == 0
+        and mean_pair_total == SEALED_PAIRS
+        and _finite_loss(mean_query) > sealed_loss
+    )
+    attention_passed = (
+        off_pair_correct == 0
+        and off_pair_total == SEALED_PAIRS
+        and _finite_loss(attention_off) > sealed_loss
+    )
+    return {
+        "row_swap_exact": row_swap_exact,
+        "row_swap_equivariance": row_swap_equivariance,
+        "mean_query_ablation": {
+            "paired_rows_identical": {"correct": mean_correct, "total": mean_total},
+            "pair_exact": {"correct": mean_pair_correct, "total": mean_pair_total},
+            "loss_higher_than_main": _finite_loss(mean_query) > sealed_loss,
+            "passed": mean_passed,
+        },
+        "attention_off": {
+            "pair_exact": {"correct": off_pair_correct, "total": off_pair_total},
+            "loss_higher_than_main": _finite_loss(attention_off) > sealed_loss,
+            "passed": attention_passed,
+        },
+        "passed": row_swap_exact and mean_passed and attention_passed,
+    }
+
+
+def _delta_gate(delta: Mapping[str, Any]) -> bool:
+    head = delta.get("binding_head")
+    return bool(
+        delta.get("target_tensor_count") == 24
+        and delta.get("changed_target_tensor_count") == 24
+        and delta.get("all_target_tensors_finite") is True
+        and delta.get("changed_nontarget_tensors") == []
+        and isinstance(head, Mapping)
+        and head.get("tensor_count") == 3
+        and head.get("changed_tensor_count") == 3
+        and head.get("all_finite") is True
+        and delta.get("passed") is True
+    )
+
+
+def _sanitized_optimization(value: Mapping[str, Any]) -> dict[str, Any]:
+    result = {
+        key: item
+        for key, item in value.items()
+        if key not in {"elapsed_seconds", "projected_seconds_at_eta_probe"}
+    }
+    result["operational_budget_observation"] = {
+        "eta_probe_step": ETA_PROBE_STEP,
+        "wall_ceiling_seconds": WALL_CEILING_SECONDS,
+        "eta_probe_passed": True,
+        "completed_within_wall_ceiling": True,
+        "timing_values": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM",
+    }
+    return result
+
+
+def _sanitized_budget_failure(error: PairedQueryBindingWallBudgetExceeded) -> dict[str, Any]:
+    value = error.as_result()
+    for key in ("stopped_after_step", "elapsed_seconds", "projected_seconds_at_eta_probe"):
+        value.pop(key, None)
+    value.update(
+        {
+            "budget_gate_passed": False,
+            "timing_values": "OMITTED_FROM_CONTENT_ADDRESS_FOR_DETERMINISM",
+        }
+    )
+    return value
+
+
+def _schedule_observation(
+    value: Mapping[str, Any], dataset: EncodedPairedQueryBindingDataset
+) -> dict[str, int]:
+    dataset.validate_fit_schedule()
+    cell_presentations = 0
+    for step in range(1, OPTIMIZER_STEPS + 1):
+        for index in dataset.record_indices_for_step(step):
+            cell_presentations += ROWS_PER_PAIR * len(
+                dataset.records[index].candidate_groups
+            )
+    observation = {
+        "optimizer_steps": int(value.get("optimizer_steps", -1)),
+        "steps_per_epoch": STEPS_PER_EPOCH,
+        "epochs": EPOCHS,
+        "pairs_per_step": int(value.get("paired_records_per_step", -1)),
+        "pair_presentations": PAIR_PRESENTATIONS,
+        "row_presentations": ROW_PRESENTATIONS,
+        "cell_presentations": cell_presentations,
+    }
+    expected = {
+        "optimizer_steps": OPTIMIZER_STEPS,
+        "steps_per_epoch": STEPS_PER_EPOCH,
+        "epochs": EPOCHS,
+        "pairs_per_step": PAIRS_PER_STEP,
+        "pair_presentations": PAIR_PRESENTATIONS,
+        "row_presentations": ROW_PRESENTATIONS,
+        "cell_presentations": CELL_PRESENTATIONS,
+    }
+    if observation != expected:
+        raise ValueError("C1-SB5 optimizer did not execute the frozen schedule")
+    return observation
+
+
+def _write_positive_delivery(
+    root: Path,
+    *,
+    predecessor: Path,
+    adapter: R4PairedQueryCandidateMatrix,
+    result: Mapping[str, Any],
+    dataset: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+    run_contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    checkpoint = root / CHECKPOINT_DIRECTORY
+    head_root = root / HEAD_DIRECTORY
+    if checkpoint.exists() or head_root.exists():
+        raise FileExistsError("C1-SB5 positive artifacts already exist")
+    export_merged_attended_relation_checkpoint(
+        adapter,
+        output_dir=checkpoint,
+        tokenizer_path=predecessor / "tokenizer.json",
+        training_result=dict(result),
+        dataset_manifest_cid=str(dataset["dataset_cid"]),
+        training_view_manifest_cid=str(training_manifest["manifest_cid"]),
+        split_policy_cid=str(dataset["split_policy_cid"]),
+        run_contract_cid=str(run_contract["run_contract_cid"]),
+        selected_checkpoint_cid=None,
+        selected_checkpoint_identity="C1-SB5 merged LoRA training output",
+    )
+    checkpoint_manifest = verify_bound_manifest(
+        checkpoint / "export-manifest.json", artifact_root=checkpoint
+    )
+    if (
+        checkpoint_manifest.get("weights_cid") == EXPECTED_WEIGHTS_CID
+        or checkpoint_manifest.get("config_cid") != EXPECTED_CONFIG_CID
+        or checkpoint_manifest.get("tokenizer_cid") != EXPECTED_TOKENIZER_CID
+        or checkpoint_manifest.get("training_result_cid") != result["result_cid"]
+    ):
+        raise ValueError("C1-SB5 positive checkpoint identity drifted")
+
+    head_state = adapter.binding_head_state_dict()
+    if len(head_state) != 3 or any(
+        not torch.isfinite(tensor).all() for tensor in head_state.values()
+    ):
+        raise ValueError("C1-SB5 binding head is not exactly three finite tensors")
+    head_root.mkdir(parents=True)
+    head_path = head_root / HEAD_TENSORS_FILE
+    temporary = head_root / f".{HEAD_TENSORS_FILE}.part"
+    save_file(
+        {
+            name: tensor.detach().to(device="cpu").contiguous()
+            for name, tensor in sorted(head_state.items())
+        },
+        str(temporary),
+        metadata={"format": "pt"},
+    )
+    temporary.replace(head_path)
+    head_manifest = write_bound_manifest(
+        head_root / HEAD_MANIFEST_FILE,
+        {
+            "schema": HEAD_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "tensor_names": sorted(head_state),
+            "tensor_count": 3,
+            "head_weights_cid": cid_file(head_path),
+            "training_result_cid": result["result_cid"],
+            "run_contract_cid": run_contract["run_contract_cid"],
+        },
+        artifact_root=head_root,
+        relative_paths=[HEAD_TENSORS_FILE],
+    )
+    checkpoint_tree = _rust_checkpoint_tree_binding(checkpoint)
+    artifact = _canonical_with_cid(
+        {
+            "schema": ARTIFACT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "admission": RESEARCH_ADMISSION,
+            "representation_update": REPRESENTATION_UPDATE,
+            "predecessor_model_weights_cid": EXPECTED_WEIGHTS_CID,
+            "model_weights_cid": checkpoint_manifest["weights_cid"],
+            "checkpoint_tree_cid": checkpoint_tree["checkpoint_tree_cid"],
+            "binding_head_manifest_cid": head_manifest["manifest_cid"],
+            "binding_head_weights_cid": head_manifest["head_weights_cid"],
+            "config_cid": checkpoint_manifest["config_cid"],
+            "tokenizer_cid": checkpoint_manifest["tokenizer_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "split_policy_cid": dataset["split_policy_cid"],
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "training_result_cid": result["result_cid"],
+            "product_probe_commitments": dataset["product_probe_commitments"],
+        },
+        "artifact_cid",
+    )
+    _write_or_verify(root / ADAPTER_ARTIFACT, artifact)
+    relative_paths = [
+        *(
+            f"{CHECKPOINT_DIRECTORY}/{record['path']}"
+            for record in checkpoint_manifest["artifacts"]
+        ),
+        f"{CHECKPOINT_DIRECTORY}/export-manifest.json",
+        f"{HEAD_DIRECTORY}/{HEAD_TENSORS_FILE}",
+        f"{HEAD_DIRECTORY}/{HEAD_MANIFEST_FILE}",
+        ADAPTER_ARTIFACT,
+    ]
+    return {
+        "artifact": artifact,
+        "checkpoint_manifest": checkpoint_manifest,
+        "checkpoint_tree": checkpoint_tree,
+        "head_manifest": head_manifest,
+        "relative_paths": relative_paths,
+    }
+
+
+def _finalize_result(
+    root: Path,
+    *,
+    predecessor: Path,
+    adapter: R4PairedQueryCandidateMatrix | None,
+    result: dict[str, Any],
+    dataset: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    tokenizer_census: Mapping[str, Any],
+    training_manifest: Mapping[str, Any],
+    run_contract: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    delivery = None
+    if str(result["terminal"]).startswith("PASS_"):
+        if adapter is None:
+            raise ValueError("C1-SB5 passing result has no adapter")
+        delivery = _write_positive_delivery(
+            root,
+            predecessor=predecessor,
+            adapter=adapter,
+            result=result,
+            dataset=dataset,
+            training_manifest=training_manifest,
+            run_contract=run_contract,
+        )
+    atomic_write_json(root / RESULT_FILE, result)
+    relative_paths = [
+        DATASET_FILE,
+        PREFLIGHT_FILE,
+        STRUCTURAL_CENSUS_FILE,
+        TOKENIZER_CENSUS_FILE,
+        TRAINING_MANIFEST_FILE,
+        RUN_CONTRACT_FILE,
+        STARTED_FILE,
+        RESULT_FILE,
+    ]
+    payload: dict[str, Any] = {
+        "schema": RESULT_MANIFEST_SCHEMA,
+        "issue": ISSUE,
+        "policy": POLICY,
+        "terminal": result["terminal"],
+        "representation_update": REPRESENTATION_UPDATE,
+        "dataset_cid": dataset["dataset_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        "run_contract_cid": run_contract["run_contract_cid"],
+        "result_cid": result["result_cid"],
+        "product_status": "UNOPENED_NOT_RUN",
+    }
+    if delivery is not None:
+        payload.update(
+            {
+                "adapter_artifact_cid": delivery["artifact"]["artifact_cid"],
+                "checkpoint_tree_cid": delivery["checkpoint_tree"]["checkpoint_tree_cid"],
+                "binding_head_manifest_cid": delivery["head_manifest"]["manifest_cid"],
+            }
+        )
+        relative_paths.extend(delivery["relative_paths"])
+    manifest = write_bound_manifest(
+        root / RESULT_MANIFEST_FILE,
+        payload,
+        artifact_root=root,
+        relative_paths=relative_paths,
+    )
+    return manifest, delivery
+
+
+def run_paired_query_binding_preflight(
+    root: Path, *, predecessor: Path
+) -> dict[str, Any]:
+    """Run exactly one frozen C1-SB5 preflight without product access."""
+    root, predecessor = _validate_roots(root, predecessor)
+    predecessor_manifest = _validated_predecessor(predecessor)
+    dataset, preflight, tokenizer_census, training_manifest = _load_training_view(root)
+    if (root / STARTED_FILE).exists() or (root / RESULT_FILE).exists():
+        raise FileExistsError("the sole C1-SB5 preflight was already started")
+    run_contract = _run_contract(
+        predecessor_manifest=predecessor_manifest,
+        dataset=dataset,
+        preflight=preflight,
+        tokenizer_census=tokenizer_census,
+        training_manifest=training_manifest,
+    )
+    _write_or_verify(root / RUN_CONTRACT_FILE, run_contract)
+    _write_exclusive_started_marker(
+        root / STARTED_FILE,
+        {
+            "schema": RUN_SCHEMA,
+            "phase": "SOLE_C1_SB5_PREFLIGHT_STARTED",
+            "run_contract_cid": run_contract["run_contract_cid"],
+        },
+    )
+
+    device = require_mps(FIT_SEED)
+    tokenizer = Tokenizer.from_file(str(predecessor / "tokenizer.json"))
+    validate_tokenizer_contract(tokenizer)
+    fit_records = _partition_pairs(preflight, "fit")
+    sealed_records = _partition_pairs(preflight, "sealed")
+    fit_dataset = EncodedPairedQueryBindingDataset(fit_records)
+    sealed_dataset = EncodedPairedQueryBindingDataset(sealed_records)
+    model, base_state = _load_base_model(predecessor)
+    adapter = R4PairedQueryCandidateMatrix(model).to(device)
+
+    try:
+        optimization = fit_paired_query_binding(adapter, fit_dataset)
+    except PairedQueryBindingWallBudgetExceeded as error:
+        result = _canonical_with_cid(
+            {
+                "schema": RESULT_SCHEMA,
+                "issue": ISSUE,
+                "policy": POLICY,
+                "terminal": "UNAVAILABLE_PAIRED_QUERY_BINDING_BUDGET",
+                "representation_update": REPRESENTATION_UPDATE,
+                "run_contract_cid": run_contract["run_contract_cid"],
+                "dataset_cid": dataset["dataset_cid"],
+                "preflight_cid": preflight["preflight_cid"],
+                "operational_budget_observation": _sanitized_budget_failure(error),
+                "fit_metrics": "NOT_RUN",
+                "sealed_metrics": "NOT_RUN",
+                "controls": "NOT_RUN",
+                "delta_audit": adapter.representation_audit(base_state),
+                "deterministic_replay": "NOT_RUN",
+                "access_audit": {
+                    "training_view_artifacts": sorted(TRAINING_VIEW_ARTIFACTS),
+                    "product_or_forbidden_reads": 0,
+                    "product_status": "COMMITTED_UNOPENED",
+                },
+                "product": "UNOPENED_NOT_RUN",
+                "rust_parity": "NOT_RUN",
+                "development": "NOT_RUN",
+                "retry": "FORBIDDEN",
+                "rung_disposition": "RETIRED_UNAVAILABLE_NO_RETRY",
+            },
+            "result_cid",
+        )
+        manifest, _ = _finalize_result(
+            root,
+            predecessor=predecessor,
+            adapter=None,
+            result=result,
+            dataset=dataset,
+            preflight=preflight,
+            tokenizer_census=tokenizer_census,
+            training_manifest=training_manifest,
+            run_contract=run_contract,
+        )
+        return {**result, "preflight_manifest_cid": manifest["manifest_cid"]}
+
+    schedule_observation = _schedule_observation(optimization, fit_dataset)
+    fit_metrics = evaluate_paired_query_binding(adapter, fit_dataset, device=device)
+    sealed_metrics = evaluate_paired_query_binding(adapter, sealed_dataset, device=device)
+    replay_metrics = evaluate_paired_query_binding(adapter, sealed_dataset, device=device)
+    row_swap_metrics = evaluate_paired_query_binding(
+        adapter, sealed_dataset, device=device, row_swap=True
+    )
+    mean_query_metrics = evaluate_paired_query_binding(
+        adapter, sealed_dataset, device=device, mean_query_ablation=True
+    )
+    attention_off_metrics = evaluate_paired_query_binding(
+        adapter, sealed_dataset, device=device, attention_off=True
+    )
+    replay_exact = canonical_json_bytes(sealed_metrics) == canonical_json_bytes(replay_metrics)
+    controls = _control_gate(
+        sealed_metrics, row_swap_metrics, mean_query_metrics, attention_off_metrics
+    )
+    delta = adapter.representation_audit(base_state)
+    semantic_passed = _main_metrics_exact(
+        fit_metrics, expected_pairs=FIT_PAIRS
+    ) and _main_metrics_exact(sealed_metrics, expected_pairs=SEALED_PAIRS)
+    passed = semantic_passed and controls["passed"] and _delta_gate(delta) and replay_exact
+    terminal = (
+        "PASS_PAIRED_QUERY_BINDING_PREFLIGHT_RESEARCH_ONLY"
+        if passed
+        else "FAIL_PAIRED_QUERY_BINDING_PREFLIGHT"
+    )
+    result = _canonical_with_cid(
+        {
+            "schema": RESULT_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "terminal": terminal,
+            "representation_update": REPRESENTATION_UPDATE,
+            "run_contract_cid": run_contract["run_contract_cid"],
+            "dataset_cid": dataset["dataset_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "training_view_manifest_cid": training_manifest["manifest_cid"],
+            "optimization": {
+                **_sanitized_optimization(optimization),
+                "frozen_schedule_observation": schedule_observation,
+            },
+            "fit_metrics": fit_metrics,
+            "sealed_metrics": sealed_metrics,
+            "controls": controls,
+            "delta_audit": delta,
+            "deterministic_replay": {
+                "exact": replay_exact,
+                "timing_excluded": True,
+            },
+            "access_audit": {
+                "training_view_artifacts": sorted(TRAINING_VIEW_ARTIFACTS),
+                "product_or_forbidden_reads": 0,
+                "product_status": "COMMITTED_UNOPENED",
+            },
+            "product": "UNOPENED_NOT_RUN",
+            "rust_parity": "NOT_RUN",
+            "development": "NOT_RUN",
+            "retry": "FORBIDDEN",
+            "rung_disposition": (
+                "RESEARCH_CHECKPOINT_ONLY_AWAITING_SEPARATE_NEXT_DECISION"
+                if passed
+                else "RETIRED_NO_RETRY"
+            ),
+        },
+        "result_cid",
+    )
+    manifest, delivery = _finalize_result(
+        root,
+        predecessor=predecessor,
+        adapter=adapter if passed else None,
+        result=result,
+        dataset=dataset,
+        preflight=preflight,
+        tokenizer_census=tokenizer_census,
+        training_manifest=training_manifest,
+        run_contract=run_contract,
+    )
+    return {
+        **result,
+        "preflight_manifest_cid": manifest["manifest_cid"],
+        "research_checkpoint": (
+            delivery["checkpoint_manifest"]["weights_cid"] if delivery else "NOT_EMITTED"
+        ),
+        "binding_head": (
+            delivery["head_manifest"]["head_weights_cid"] if delivery else "NOT_EMITTED"
+        ),
+    }

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding_data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paired_query_binding_data.py
@@ -1,0 +1,1200 @@
+"""Fresh C1-SB5 paired-query candidate-matrix data.
+
+The unit of supervision in this module is one exact source with two questions
+and one shared, ordered set of exact-text candidate groups.  Every affirmative
+candidate is positive for exactly one question and negative for the other, so
+question-independent candidate syntax cannot satisfy a complete pair.
+
+Population construction is pure and deterministic.  Tokenizer binding is a
+separate, explicit step because the source-token anchors are part of the model
+contract and must be derived with the pinned #1017 tokenizer before training.
+Product text is returned in a separate envelope and is never named by the
+training-view whitelist.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+import json
+from pathlib import Path
+import struct
+from typing import Any
+
+from tokenizers import Tokenizer
+
+from .constants import BOS_TOKEN_ID, FROZEN_MODEL_CONFIG
+from .provenance import canonical_json_bytes, cid_bytes
+from .source_relation_adapter_data import (
+    ABSTAIN,
+    CONTRADICTION,
+    LexicalWorld,
+    SOURCE_WIDTHS,
+    _world,
+    _world_inventory,
+    _world_records,
+)
+from .source_relation_data import split_sentence_spans
+
+
+ISSUE = 954
+POLICY = "R4PairedQueryCandidateMatrixV1"
+
+PAIR_SCHEMA = "uor-r4.paired-query-binding-pair/1"
+QUERY_SCHEMA = "uor-r4.paired-query-binding-query/1"
+DATASET_SCHEMA = "uor-r4.paired-query-binding-dataset/1"
+PREFLIGHT_SCHEMA = "uor-r4.paired-query-binding-preflight/1"
+PRODUCT_SCHEMA = "uor-r4.paired-query-binding-products/1"
+CENSUS_SCHEMA = "uor-r4.paired-query-binding-census/1"
+SPLIT_SCHEMA = "uor-r4.paired-query-binding-split/1"
+TOKENIZER_CENSUS_SCHEMA = "uor-r4.paired-query-binding-tokenizer-census/1"
+
+DATASET_FILENAME = "paired-query-binding-dataset.json"
+PREFLIGHT_FILENAME = "paired-query-binding-preflight.json"
+CENSUS_FILENAME = "paired-query-binding-census.json"
+TOKENIZER_CENSUS_FILENAME = "paired-query-binding-tokenizer-census.json"
+PRODUCT_FILENAME = "paired-query-binding-product-probes.json"
+TRAINING_VIEW_MANIFEST_FILENAME = "training-view-manifest.json"
+PRODUCT_MANIFEST_FILENAME = "product-commitments-manifest.json"
+TRAINING_VIEW_FILENAMES = (
+    CENSUS_FILENAME,
+    DATASET_FILENAME,
+    PREFLIGHT_FILENAME,
+    TOKENIZER_CENSUS_FILENAME,
+)
+PRODUCT_DENIED_FILENAMES = (PRODUCT_FILENAME, PRODUCT_MANIFEST_FILENAME)
+
+INPUT_POLICY = (
+    "exact UTF-8 `E:<exact full source>\\nQ:<question>\\nBind:` with no "
+    "terminal newline; prepend one pinned BOS token; candidate states are the "
+    "terminal punctuation states of the earliest occurrence of each distinct "
+    "exact-text group and precede Q; the query state is the final Bind colon"
+)
+QUESTION_POLICY = "Where is the <subject>?"
+SENTENCE_POLICY = "exact .!? terminated UTF-8 byte spans"
+
+FRESH_WORLD_ORDINAL_START = 162
+PREFLIGHT_FIT_WORLDS_PER_WIDTH = 2
+PREFLIGHT_SEALED_WORLDS_PER_WIDTH = 1
+PAIRS_PER_WORLD = 4
+QUERIES_PER_PAIR = 2
+MAX_POSITIONS_INCLUDING_BOS = FROZEN_MODEL_CONFIG.max_position_embeddings
+
+PAIR_KINDS = (
+    "matched-primary-secondary-answers",
+    "primary-conflict-secondary-abstain",
+    "secondary-conflict-primary-abstain",
+    "duplicate-primary-agreement-secondary-abstain",
+)
+
+EXPECTED_COUNTS = {
+    "fit": {
+        "pairs": 56,
+        "query_rows": 112,
+        "candidate_groups": 266,
+        "query_candidate_cells": 532,
+        "positive_cells": 98,
+        "negative_cells": 434,
+        "required_flips": 98,
+        "outcomes": {"answer": 42, "abstain": 42, "conflict": 28},
+        "duplicate_pairs": 14,
+    },
+    "sealed": {
+        "pairs": 28,
+        "query_rows": 56,
+        "candidate_groups": 133,
+        "query_candidate_cells": 266,
+        "positive_cells": 49,
+        "negative_cells": 217,
+        "required_flips": 49,
+        "outcomes": {"answer": 21, "abstain": 21, "conflict": 14},
+        "duplicate_pairs": 7,
+    },
+    "product": {
+        "pairs": 4,
+        "query_rows": 8,
+        "candidate_groups": 11,
+        "query_candidate_cells": 22,
+        "positive_cells": 7,
+        "negative_cells": 15,
+        "required_flips": 7,
+        "outcomes": {"answer": 3, "abstain": 3, "conflict": 2},
+        "duplicate_pairs": 1,
+    },
+}
+
+
+def _canonical_with_cid(value: Mapping[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def artifact_bytes(value: Mapping[str, Any]) -> bytes:
+    """Return the one canonical JSON representation used by campaign manifests."""
+    return canonical_json_bytes(value)
+
+
+def verify_artifact_cid(value: Mapping[str, Any], field: str) -> str:
+    """Reproduce one self-CID and fail closed on schema/artifact drift."""
+    unsigned = dict(value)
+    expected = unsigned.pop(field, None)
+    if not isinstance(expected, str):
+        raise ValueError(f"artifact omits self-CID field {field}")
+    actual = cid_bytes(canonical_json_bytes(unsigned))
+    if actual != expected:
+        raise ValueError(f"artifact {field} does not reproduce")
+    return actual
+
+
+def load_artifact(path: Path, *, schema: str, cid_field: str) -> dict[str, Any]:
+    """Load a canonical JSON artifact with an exact schema and reproduced CID."""
+    raw = path.read_bytes()
+    value = json.loads(raw)
+    if not isinstance(value, dict) or value.get("schema") != schema:
+        raise ValueError(f"artifact schema differs at {path}")
+    if raw != canonical_json_bytes(value):
+        raise ValueError(f"artifact is not canonical JSON at {path}")
+    verify_artifact_cid(value, cid_field)
+    return value
+
+
+def render_paired_query_input(source: str, question: str) -> str:
+    """Render one lane; no candidate text is repeated after the source."""
+    if not source or source != source.strip():
+        raise ValueError("paired-query source must be nonempty and trimmed")
+    spans = split_sentence_spans(source)
+    if not spans or " ".join(str(span["text"]) for span in spans) != source:
+        raise ValueError("paired-query source must be exact terminated spans")
+    if (
+        not question.startswith("Where is the ")
+        or not question.endswith("?")
+        or question != question.strip()
+    ):
+        raise ValueError("paired-query question differs from the frozen policy")
+    value = f"E:{source}\nQ:{question}\nBind:"
+    if value.endswith("\n"):
+        raise AssertionError("paired-query renderer added a terminal newline")
+    return value
+
+
+def _candidate_subject(text: str, world: LexicalWorld) -> str:
+    matches = [subject for subject in world.subjects if text.startswith(f"The {subject} ")]
+    if len(matches) != 1:
+        raise ValueError("candidate sentence does not bind exactly one world subject")
+    return matches[0]
+
+
+def _candidate_groups(
+    record: Mapping[str, Any], world: LexicalWorld
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    source = str(record["source"])
+    source_bytes = source.encode("utf-8")
+    parsed = split_sentence_spans(source)
+    spans = list(record["sentence_spans"])
+    if len(parsed) != len(spans) or len(spans) != int(record["source_width"]):
+        raise ValueError("paired-query source width/span count differs")
+
+    occurrences: list[dict[str, Any]] = []
+    grouped: dict[str, dict[str, Any]] = {}
+    for expected_index, (parsed_span, inherited) in enumerate(zip(parsed, spans)):
+        text = str(inherited["text"])
+        byte_start = int(inherited["byte_start"])
+        byte_end = int(inherited["byte_end"])
+        text_cid = cid_bytes(text.encode("utf-8"))
+        if (
+            parsed_span["text"] != text
+            or int(parsed_span["byte_start"]) != byte_start
+            or int(parsed_span["byte_end"]) != byte_end
+            or source_bytes[byte_start:byte_end] != text.encode("utf-8")
+            or inherited["candidate_index"] != expected_index
+            or inherited["relation_group_cid"] != text_cid
+        ):
+            raise ValueError("paired-query inherited exact span differs")
+        subject = _candidate_subject(text, world)
+        semantic_kind = str(inherited["semantic_kind"])
+        occurrence = {
+            "candidate_index": expected_index,
+            "byte_start": byte_start,
+            "byte_end": byte_end,
+            "terminal_byte_end": byte_end,
+            "text": text,
+            "text_cid": text_cid,
+            "relation_group_cid": text_cid,
+            "role": str(inherited["role"]),
+            "semantic_kind": semantic_kind,
+            "candidate_subject": subject,
+            "candidate_subject_cid": cid_bytes(subject.encode("utf-8")),
+        }
+        occurrences.append(occurrence)
+        group = grouped.get(text_cid)
+        if group is None:
+            grouped[text_cid] = {
+                "relation_group_cid": text_cid,
+                "text": text,
+                "text_cid": text_cid,
+                "semantic_kind": semantic_kind,
+                "candidate_subject": subject,
+                "candidate_subject_cid": occurrence["candidate_subject_cid"],
+                "occurrence_indices": [expected_index],
+                "earliest_occurrence_index": expected_index,
+                "earliest_terminal_byte_end": byte_end,
+            }
+        else:
+            if (
+                group["text"] != text
+                or group["semantic_kind"] != semantic_kind
+                or group["candidate_subject"] != subject
+            ):
+                raise ValueError("duplicate exact-text candidate metadata disagrees")
+            group["occurrence_indices"].append(expected_index)
+
+    ordered = sorted(grouped.values(), key=lambda group: group["earliest_occurrence_index"])
+    for group_index, group in enumerate(ordered):
+        group["group_index"] = group_index
+        group["source_scoped_group_cid"] = cid_bytes(
+            canonical_json_bytes(
+                {
+                    "source_cid": record["source_cid"],
+                    "relation_group_cid": group["relation_group_cid"],
+                }
+            )
+        )
+    return occurrences, ordered
+
+
+def _query_row(
+    *,
+    source: str,
+    query_lane: int,
+    question: str,
+    subject: str,
+    groups: Sequence[Mapping[str, Any]],
+    inherited: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if question != f"Where is the {subject}?":
+        raise ValueError("paired-query question/subject binding differs")
+    labels = [
+        int(
+            group["semantic_kind"] == "locative"
+            and group["candidate_subject"] == subject
+        )
+        for group in groups
+    ]
+    positive_indices = [index for index, label in enumerate(labels) if label]
+    positive_group_cids = [
+        str(groups[index]["relation_group_cid"]) for index in positive_indices
+    ]
+    outcome = (
+        "abstain"
+        if not positive_indices
+        else "answer"
+        if len(positive_indices) == 1
+        else "conflict"
+    )
+    target_group_index = positive_indices[0] if outcome == "answer" else None
+    target_span_index = (
+        int(groups[target_group_index]["earliest_occurrence_index"])
+        if target_group_index is not None
+        else None
+    )
+    answer = (
+        str(groups[target_group_index]["text"])
+        if target_group_index is not None
+        else ABSTAIN
+        if outcome == "abstain"
+        else CONTRADICTION
+    )
+    positive_span_indices = [
+        int(occurrence)
+        for index in positive_indices
+        for occurrence in groups[index]["occurrence_indices"]
+    ]
+    relation_input = render_paired_query_input(source, question)
+    value: dict[str, Any] = {
+        "schema": QUERY_SCHEMA,
+        "query_lane": query_lane,
+        "question": question,
+        "question_cid": cid_bytes(question.encode("utf-8")),
+        "subject": subject,
+        "subject_cid": cid_bytes(subject.encode("utf-8")),
+        "relation_input": relation_input,
+        "relation_input_cid": cid_bytes(relation_input.encode("utf-8")),
+        "labels": labels,
+        "positive_relation_group_cids": positive_group_cids,
+        "positive_span_indices": positive_span_indices,
+        "target_outcome": outcome,
+        "target_group_index": target_group_index,
+        "target_group_cid": (
+            groups[target_group_index]["relation_group_cid"]
+            if target_group_index is not None
+            else None
+        ),
+        "target_span_index": target_span_index,
+        "answer": answer,
+        "duplicate_agreement": bool(
+            outcome == "answer"
+            and target_group_index is not None
+            and len(groups[target_group_index]["occurrence_indices"]) > 1
+        ),
+    }
+    if inherited is not None:
+        inherited_labels: dict[str, int] = {}
+        for span in inherited["sentence_spans"]:
+            group_cid = str(span["relation_group_cid"])
+            prior = inherited_labels.setdefault(group_cid, int(span["relation_label"]))
+            if prior != int(span["relation_label"]):
+                raise ValueError("inherited duplicate labels disagree")
+        expected_labels = [
+            inherited_labels[str(group["relation_group_cid"])] for group in groups
+        ]
+        if (
+            inherited["source"] != source
+            or inherited["question"] != question
+            or inherited["subject"] != subject
+            or inherited["target_outcome"] != outcome
+            or expected_labels != labels
+            or inherited["target_span_index"] != target_span_index
+            or inherited["answer"] != answer
+        ):
+            raise ValueError("fresh paired-query oracle differs from inherited row")
+        value["inherited_record_cid"] = inherited["record_cid"]
+    else:
+        value["inherited_record_cid"] = None
+        value["oracle"] = (
+            "affirmative exact locative candidate whose generated subject equals "
+            "the query subject"
+        )
+    return _canonical_with_cid(value, "query_row_cid")
+
+
+def _pair_from_world(
+    world: LexicalWorld, *, population: str, pair_slot: int
+) -> dict[str, Any]:
+    if pair_slot not in range(PAIRS_PER_WORLD):
+        raise ValueError("paired-query pair slot is outside 0..3")
+    rows = _world_records(world, population=population)
+    if len(rows) != 9:
+        raise RuntimeError("paired-query source world no longer has nine base rows")
+    inherited_rows: tuple[Mapping[str, Any] | None, Mapping[str, Any] | None]
+    if pair_slot == 0:
+        inherited_rows = (rows[0], rows[1])
+    elif pair_slot == 1:
+        inherited_rows = (rows[6], rows[4])
+    elif pair_slot == 2:
+        inherited_rows = (rows[5], rows[7])
+    else:
+        inherited_rows = (rows[2], None)
+
+    base = inherited_rows[0]
+    if base is None:
+        raise AssertionError("paired-query pair has no base source")
+    source = str(base["source"])
+    source_cid = cid_bytes(source.encode("utf-8"))
+    for inherited in inherited_rows:
+        if inherited is not None and (
+            inherited["source"] != source or inherited["source_cid"] != source_cid
+        ):
+            raise ValueError("paired-query inherited rows do not share exact source bytes")
+
+    occurrences, groups = _candidate_groups(base, world)
+    first = inherited_rows[0]
+    second = inherited_rows[1]
+    if first is None:
+        raise AssertionError("paired-query first query cannot be synthetic")
+    query_specs: tuple[tuple[str, str, Mapping[str, Any] | None], ...] = (
+        (str(first["question"]), str(first["subject"]), first),
+        (
+            str(second["question"])
+            if second is not None
+            else f"Where is the {world.subjects[1]}?",
+            str(second["subject"]) if second is not None else world.subjects[1],
+            second,
+        ),
+    )
+    queries = [
+        _query_row(
+            source=source,
+            query_lane=lane,
+            question=question,
+            subject=subject,
+            groups=groups,
+            inherited=inherited,
+        )
+        for lane, (question, subject, inherited) in enumerate(query_specs)
+    ]
+    if queries[0]["subject"] == queries[1]["subject"]:
+        raise ValueError("paired-query questions do not relocate the subject")
+    label_matrix = [list(query["labels"]) for query in queries]
+    flip_group_cids = [
+        str(group["relation_group_cid"])
+        for column, group in enumerate(groups)
+        if {label_matrix[0][column], label_matrix[1][column]} == {0, 1}
+    ]
+    positive_cells = sum(sum(row) for row in label_matrix)
+    if len(flip_group_cids) != positive_cells:
+        raise ValueError("every positive paired-query cell must own one required flip")
+
+    value = {
+        "schema": PAIR_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "population": population,
+        "lexical_world": world.name,
+        "world_ordinal": world.ordinal,
+        "world_lane": world.lane,
+        "source_width": world.width,
+        "pair_slot": pair_slot,
+        "pair_kind": PAIR_KINDS[pair_slot],
+        "source": source,
+        "source_cid": source_cid,
+        "sentence_spans": occurrences,
+        "candidate_groups": groups,
+        "queries": queries,
+        "label_matrix": label_matrix,
+        "flip_group_cids": flip_group_cids,
+        "required_flip_count": len(flip_group_cids),
+        "duplicate_pair": pair_slot == 3,
+        "candidate_group_count": len(groups),
+        "query_candidate_cell_count": QUERIES_PER_PAIR * len(groups),
+        "positive_cell_count": positive_cells,
+        "negative_cell_count": QUERIES_PER_PAIR * len(groups) - positive_cells,
+    }
+    return _canonical_with_cid(value, "record_cid")
+
+
+def _world_partition(
+    *, partition: str, worlds_per_width: int, ordinal_start: int
+) -> tuple[list[LexicalWorld], list[dict[str, Any]], int]:
+    worlds: list[LexicalWorld] = []
+    pairs: list[dict[str, Any]] = []
+    ordinal = ordinal_start
+    for width in SOURCE_WIDTHS:
+        for lane in range(worlds_per_width):
+            world = _world(
+                partition=partition, width=width, lane=lane, ordinal=ordinal
+            )
+            worlds.append(world)
+            pairs.extend(
+                _pair_from_world(world, population=partition, pair_slot=pair_slot)
+                for pair_slot in range(PAIRS_PER_WORLD)
+            )
+            ordinal += 1
+    return worlds, pairs, ordinal
+
+
+def _product_partition(
+    *, ordinal_start: int
+) -> tuple[list[LexicalWorld], dict[str, Any], int]:
+    worlds: list[LexicalWorld] = []
+    pairs: list[dict[str, Any]] = []
+    ordinal = ordinal_start
+    for lane, pair_slot in enumerate(range(PAIRS_PER_WORLD)):
+        world = _world(
+            partition="c1-sb5-product",
+            width=3,
+            lane=lane,
+            ordinal=ordinal,
+        )
+        worlds.append(world)
+        pairs.append(
+            _pair_from_world(world, population="product", pair_slot=pair_slot)
+        )
+        ordinal += 1
+    value = {
+        "schema": PRODUCT_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "access_policy": (
+            "commit this separate envelope before optimization; product text and "
+            "token-bound lanes are denied to every training/evaluation view until "
+            "all pre-product gates pass"
+        ),
+        "training_view_access": "DENIED",
+        "records": pairs,
+    }
+    return worlds, _canonical_with_cid(value, "product_probes_cid"), ordinal
+
+
+def _partition_counts(pairs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    outcomes = Counter(
+        str(query["target_outcome"])
+        for pair in pairs
+        for query in pair["queries"]
+    )
+    groups = sum(len(pair["candidate_groups"]) for pair in pairs)
+    cells = sum(int(pair["query_candidate_cell_count"]) for pair in pairs)
+    positives = sum(int(pair["positive_cell_count"]) for pair in pairs)
+    flips = sum(int(pair["required_flip_count"]) for pair in pairs)
+    return {
+        "pairs": len(pairs),
+        "query_rows": sum(len(pair["queries"]) for pair in pairs),
+        "candidate_groups": groups,
+        "query_candidate_cells": cells,
+        "positive_cells": positives,
+        "negative_cells": cells - positives,
+        "required_flips": flips,
+        "outcomes": {
+            outcome: outcomes[outcome] for outcome in ("answer", "abstain", "conflict")
+        },
+        "duplicate_pairs": sum(bool(pair["duplicate_pair"]) for pair in pairs),
+    }
+
+
+def _sentence_inventory(pairs: Sequence[Mapping[str, Any]]) -> set[str]:
+    return {
+        str(span["text"]) for pair in pairs for span in pair["sentence_spans"]
+    }
+
+
+def _old_sentence_inventory() -> set[str]:
+    """Generate a width-eight superset for all frozen SB3/SB4 ordinals 0..161."""
+    sentences: set[str] = set()
+    for ordinal in range(FRESH_WORLD_ORDINAL_START):
+        world = _world(partition="historical", width=8, lane=0, ordinal=ordinal)
+        sentences.update(
+            str(span["text"])
+            for record in _world_records(world, population="historical")
+            for span in record["sentence_spans"]
+        )
+    return sentences
+
+
+def _partition_contract(pairs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    exact = True
+    question_blind_exact_pairs = 0
+    query_order_counter = Counter()
+    slot_width = Counter()
+    for pair in pairs:
+        groups = list(pair["candidate_groups"])
+        matrix = list(pair["label_matrix"])
+        if (
+            len(pair["queries"]) != QUERIES_PER_PAIR
+            or len(matrix) != QUERIES_PER_PAIR
+            or any(len(row) != len(groups) for row in matrix)
+            or pair["candidate_group_count"] != len(groups)
+        ):
+            exact = False
+            continue
+        slot_width[(int(pair["source_width"]), int(pair["pair_slot"]))] += 1
+        query_order_counter[
+            tuple(str(query["target_outcome"]) for query in pair["queries"])
+        ] += 1
+        expected_flips = {
+            str(groups[column]["relation_group_cid"])
+            for column in range(len(groups))
+            if {int(matrix[0][column]), int(matrix[1][column])} == {0, 1}
+        }
+        declared_flips = {str(value) for value in pair["flip_group_cids"]}
+        expected_labels = [
+            [
+                int(
+                    group["semantic_kind"] == "locative"
+                    and group["candidate_subject"] == query["subject"]
+                )
+                for group in groups
+            ]
+            for query in pair["queries"]
+        ]
+        if (
+            matrix != expected_labels
+            or expected_flips != declared_flips
+            or len(expected_flips) != sum(sum(row) for row in matrix)
+        ):
+            exact = False
+        shortcut = [
+            [int(group["semantic_kind"] == "locative") for group in groups]
+            for _ in pair["queries"]
+        ]
+        question_blind_exact_pairs += int(shortcut == matrix)
+
+    widths_per_slot = {
+        str(width): {
+            str(pair_slot): slot_width[(width, pair_slot)]
+            for pair_slot in range(PAIRS_PER_WORLD)
+        }
+        for width in SOURCE_WIDTHS
+    }
+    return {
+        **_partition_counts(pairs),
+        "pair_oracle_and_flip_matrix_exact": exact,
+        "question_blind_affirmative_locative_exact_pairs": question_blind_exact_pairs,
+        "question_blind_shortcut_rejected": question_blind_exact_pairs == 0,
+        "width_pair_slot_counts": widths_per_slot,
+        "query_outcome_order_counts": {
+            "|".join(key): value for key, value in sorted(query_order_counter.items())
+        },
+    }
+
+
+def _population_census(
+    *,
+    fit_worlds: Sequence[LexicalWorld],
+    fit: Sequence[Mapping[str, Any]],
+    sealed_worlds: Sequence[LexicalWorld],
+    sealed: Sequence[Mapping[str, Any]],
+    product_worlds: Sequence[LexicalWorld],
+    products: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    partitions = {"fit": fit, "sealed": sealed, "product": products}
+    worlds = {
+        "fit": fit_worlds,
+        "sealed": sealed_worlds,
+        "product": product_worlds,
+    }
+    sentence_sets = {
+        name: _sentence_inventory(rows) for name, rows in partitions.items()
+    }
+    composite_sets = {
+        name: _world_inventory(rows) for name, rows in worlds.items()
+    }
+    names = tuple(partitions)
+    sentence_disjoint = all(
+        sentence_sets[left].isdisjoint(sentence_sets[right])
+        for left_index, left in enumerate(names)
+        for right in names[left_index + 1 :]
+    )
+    composite_disjoint = all(
+        composite_sets[left].isdisjoint(composite_sets[right])
+        for left_index, left in enumerate(names)
+        for right in names[left_index + 1 :]
+    )
+    historical_worlds = [
+        _world(partition="historical", width=8, lane=0, ordinal=ordinal)
+        for ordinal in range(FRESH_WORLD_ORDINAL_START)
+    ]
+    historical_composites = _world_inventory(historical_worlds)
+    historical_sentences = _old_sentence_inventory()
+    vs_historical = {
+        name: {
+            "subjects_locations_nonlocatives_disjoint": composite_sets[name].isdisjoint(
+                historical_composites
+            ),
+            "exact_sentences_disjoint": sentence_sets[name].isdisjoint(
+                historical_sentences
+            ),
+        }
+        for name in names
+    }
+    checks = {
+        name: _partition_contract(rows) for name, rows in partitions.items()
+    }
+    counts_exact = all(
+        {key: checks[name][key] for key in EXPECTED_COUNTS[name]}
+        == EXPECTED_COUNTS[name]
+        for name in names
+    )
+    ordinal_set = {
+        world.ordinal for rows in worlds.values() for world in rows
+    }
+    ordinal_contract = {
+        "historical_sb4_max_world_ordinal": FRESH_WORLD_ORDINAL_START - 1,
+        "sb5_min_world_ordinal": min(ordinal_set),
+        "sb5_max_world_ordinal": max(ordinal_set),
+        "starts_exactly_after_sb4": min(ordinal_set) == FRESH_WORLD_ORDINAL_START,
+        "ordinals_contiguous": ordinal_set
+        == set(range(FRESH_WORLD_ORDINAL_START, FRESH_WORLD_ORDINAL_START + 25)),
+    }
+    passed = (
+        counts_exact
+        and sentence_disjoint
+        and composite_disjoint
+        and all(
+            bool(value)
+            for comparison in vs_historical.values()
+            for value in comparison.values()
+        )
+        and all(
+            bool(check["pair_oracle_and_flip_matrix_exact"])
+            and bool(check["question_blind_shortcut_rejected"])
+            for check in checks.values()
+        )
+        and bool(ordinal_contract["starts_exactly_after_sb4"])
+        and bool(ordinal_contract["ordinals_contiguous"])
+    )
+    value = {
+        "schema": CENSUS_SCHEMA,
+        "policy": POLICY,
+        "fresh_world_ordinal_start": FRESH_WORLD_ORDINAL_START,
+        "partition_checks": checks,
+        "expected_counts": EXPECTED_COUNTS,
+        "counts_exact": counts_exact,
+        "new_sentence_partitions_pairwise_disjoint": sentence_disjoint,
+        "new_composite_world_partitions_pairwise_disjoint": composite_disjoint,
+        "new_vs_sb3_sb4": vs_historical,
+        "composite_world_item_definition": (
+            "complete generated subject phrases, complete generated location phrases, "
+            "and complete generated nonlocative phrases"
+        ),
+        "primitive_component_vocabulary": (
+            "DELIBERATELY_SHARED; only complete composite items and exact sentences "
+            "are disjoint"
+        ),
+        "ordinal_contract": ordinal_contract,
+        "passed": passed,
+    }
+    if not passed:
+        raise RuntimeError(f"C1-SB5 population census failed: {value}")
+    return _canonical_with_cid(value, "census_cid")
+
+
+def build_paired_query_binding_semantic_population(
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build fresh semantic pairs, split commitments, and opaque products."""
+    ordinal = FRESH_WORLD_ORDINAL_START
+    fit_worlds, fit, ordinal = _world_partition(
+        partition="c1-sb5-preflight-fit",
+        worlds_per_width=PREFLIGHT_FIT_WORLDS_PER_WIDTH,
+        ordinal_start=ordinal,
+    )
+    sealed_worlds, sealed, ordinal = _world_partition(
+        partition="c1-sb5-preflight-sealed",
+        worlds_per_width=PREFLIGHT_SEALED_WORLDS_PER_WIDTH,
+        ordinal_start=ordinal,
+    )
+    product_worlds, products, ordinal = _product_partition(ordinal_start=ordinal)
+    if ordinal != FRESH_WORLD_ORDINAL_START + 25:
+        raise RuntimeError("C1-SB5 lexical-world ordinal allocation drifted")
+
+    census = _population_census(
+        fit_worlds=fit_worlds,
+        fit=fit,
+        sealed_worlds=sealed_worlds,
+        sealed=sealed,
+        product_worlds=product_worlds,
+        products=products["records"],
+    )
+    preflight_value = {
+        "schema": PREFLIGHT_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "binding": "SEMANTIC_UNTOKENIZED",
+        "selection": (
+            "fresh ordinals 162..182; two fit and one sealed world per width "
+            "2..8; four exact same-source two-query pairs per world"
+        ),
+        "counts": {
+            "fit": EXPECTED_COUNTS["fit"],
+            "sealed": EXPECTED_COUNTS["sealed"],
+        },
+        "fit_world_names": [world.name for world in fit_worlds],
+        "sealed_world_names": [world.name for world in sealed_worlds],
+        "fit": fit,
+        "sealed": sealed,
+        "census_cid": census["census_cid"],
+    }
+    preflight = _canonical_with_cid(preflight_value, "preflight_cid")
+    split_policy = _canonical_with_cid(
+        {
+            "schema": SPLIT_SCHEMA,
+            "policy": POLICY,
+            "source_widths": list(SOURCE_WIDTHS),
+            "pair_kinds": list(PAIR_KINDS),
+            "worlds_per_width": {
+                "fit": PREFLIGHT_FIT_WORLDS_PER_WIDTH,
+                "sealed": PREFLIGHT_SEALED_WORLDS_PER_WIDTH,
+            },
+            "fresh_world_ordinal_start": FRESH_WORLD_ORDINAL_START,
+            "product_world_ordinals": [world.ordinal for world in product_worlds],
+            "product_policy": "four separately committed opaque two-query pairs",
+        },
+        "split_policy_cid",
+    )
+    dataset_value = {
+        "schema": DATASET_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "question_policy": QUESTION_POLICY,
+        "sentence_policy": SENTENCE_POLICY,
+        "input_policy": INPUT_POLICY,
+        "counts": EXPECTED_COUNTS,
+        "split_policy": split_policy,
+        "split_policy_cid": split_policy["split_policy_cid"],
+        "census": census,
+        "census_cid": census["census_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "product_probes_cid": products["product_probes_cid"],
+        "product_probe_commitments": [
+            record["record_cid"] for record in products["records"]
+        ],
+        "training_view": {
+            "allowed_filenames": list(TRAINING_VIEW_FILENAMES),
+            "denied_filenames": list(PRODUCT_DENIED_FILENAMES),
+            "product_text_access": "DENIED",
+        },
+    }
+    dataset = _canonical_with_cid(dataset_value, "dataset_cid")
+    return dataset, preflight, products
+
+
+def _token_ids_cid(token_ids: Sequence[int]) -> str:
+    material = bytearray(b"uor-r4-token-ids-u32be/1\x00")
+    for token_id in token_ids:
+        if not isinstance(token_id, int) or not 0 <= token_id <= 0xFFFF_FFFF:
+            raise ValueError("token ID is outside canonical u32")
+        material.extend(struct.pack(">I", token_id))
+    return cid_bytes(bytes(material))
+
+
+def _tokenizer_identity(tokenizer: Tokenizer, tokenizer_cid: str | None) -> str:
+    if tokenizer_cid is not None:
+        if not tokenizer_cid.startswith("blake3:"):
+            raise ValueError("tokenizer CID is not a BLAKE3 identifier")
+        return tokenizer_cid
+    return cid_bytes(tokenizer.to_str().encode("utf-8"))
+
+
+def _terminal_content_index(
+    *, text: str, offsets: Sequence[tuple[int, int]], byte_end: int, marker: str
+) -> int:
+    if not text.isascii():
+        raise ValueError("bounded paired-query token anchors require ASCII generated text")
+    matches = [
+        index
+        for index, (start, end) in enumerate(offsets)
+        if start < end and end == byte_end and text[start:end] == marker
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"paired-query terminal marker {marker!r} is not one exact token")
+    return matches[0]
+
+
+def encode_paired_query_pair(
+    pair: Mapping[str, Any],
+    tokenizer: Tokenizer,
+    *,
+    tokenizer_cid: str | None = None,
+) -> dict[str, Any]:
+    """Bind one semantic pair to exact token IDs and source/query state anchors."""
+    if pair.get("schema") != PAIR_SCHEMA or pair.get("policy") != POLICY:
+        raise ValueError("paired-query pair schema/policy differs")
+    verify_artifact_cid(pair, "record_cid")
+    tokenizer_identity = _tokenizer_identity(tokenizer, tokenizer_cid)
+    source = str(pair["source"])
+    if not source.isascii():
+        raise ValueError("bounded paired-query source must be ASCII for byte anchors")
+    source_prefix_end = 2 + len(source)
+    encoded_queries: list[dict[str, Any]] = []
+    shared_prefix_ids: list[int] | None = None
+    shared_candidate_indices: list[int] | None = None
+
+    spans_by_index = {
+        int(span["candidate_index"]): span for span in pair["sentence_spans"]
+    }
+    for semantic_query in pair["queries"]:
+        relation_input = render_paired_query_input(
+            source, str(semantic_query["question"])
+        )
+        if relation_input != semantic_query["relation_input"]:
+            raise ValueError("paired-query semantic lane renderer differs")
+        encoding = tokenizer.encode(relation_input, add_special_tokens=False)
+        token_ids = [int(token_id) for token_id in encoding.ids]
+        offsets = [(int(start), int(end)) for start, end in encoding.offsets]
+        if not token_ids or len(token_ids) != len(offsets):
+            raise ValueError("paired-query tokenizer returned an empty/malformed lane")
+        positions = len(token_ids) + 1
+        if positions > MAX_POSITIONS_INCLUDING_BOS:
+            raise ValueError(
+                "paired-query lane exceeds 256 positions including BOS; truncation forbidden"
+            )
+        terminal_content_index = _terminal_content_index(
+            text=relation_input,
+            offsets=offsets,
+            byte_end=len(relation_input),
+            marker=":",
+        )
+        if terminal_content_index != len(token_ids) - 1:
+            raise ValueError("paired-query Bind colon is not the final content token")
+
+        prefix_crossings = [
+            (start, end)
+            for start, end in offsets
+            if start < source_prefix_end < end
+        ]
+        if prefix_crossings:
+            raise ValueError("paired-query tokenizer merged across the source/Q boundary")
+        prefix_content_count = sum(
+            start < end and end <= source_prefix_end for start, end in offsets
+        )
+        prefix_ids = [BOS_TOKEN_ID, *token_ids[:prefix_content_count]]
+        source_prefix_token_count = len(prefix_ids)
+
+        candidate_terminal_indices: list[int] = []
+        candidate_terminal_anchors: list[dict[str, Any]] = []
+        for group in pair["candidate_groups"]:
+            occurrence_index = int(group["earliest_occurrence_index"])
+            occurrence = spans_by_index[occurrence_index]
+            terminal_byte_end = 2 + int(occurrence["terminal_byte_end"])
+            content_index = _terminal_content_index(
+                text=relation_input,
+                offsets=offsets,
+                byte_end=terminal_byte_end,
+                marker=str(occurrence["text"])[-1],
+            )
+            model_index = content_index + 1
+            if model_index >= source_prefix_token_count:
+                raise ValueError("candidate state is not strictly before Q")
+            candidate_terminal_indices.append(model_index)
+            candidate_terminal_anchors.append(
+                {
+                    "relation_group_cid": group["relation_group_cid"],
+                    "occurrence_index": occurrence_index,
+                    "content_token_index": content_index,
+                    "model_token_index_including_bos": model_index,
+                    "token_id": token_ids[content_index],
+                    "token_bit_offset_u32": model_index * 32,
+                    "terminal_byte_end_in_lane": terminal_byte_end,
+                }
+            )
+        query_terminal_index = terminal_content_index + 1
+        if query_terminal_index < source_prefix_token_count:
+            raise ValueError("query terminal state falls inside the source prefix")
+
+        if shared_prefix_ids is None:
+            shared_prefix_ids = prefix_ids
+            shared_candidate_indices = candidate_terminal_indices
+        elif (
+            shared_prefix_ids != prefix_ids
+            or shared_candidate_indices != candidate_terminal_indices
+        ):
+            raise ValueError("same-source paired lanes do not have identical source anchors")
+
+        unsigned_query = dict(semantic_query)
+        semantic_query_cid = unsigned_query.pop("query_row_cid")
+        unsigned_query.update(
+            {
+                "semantic_query_row_cid": semantic_query_cid,
+                "tokenizer_cid": tokenizer_identity,
+                "token_ids": token_ids,
+                "token_ids_cid": _token_ids_cid(token_ids),
+                "input_ids_including_bos_cid": _token_ids_cid(
+                    [BOS_TOKEN_ID, *token_ids]
+                ),
+                "positions_including_bos": positions,
+                "source_prefix_token_count": source_prefix_token_count,
+                "source_prefix_token_ids_cid": _token_ids_cid(prefix_ids),
+                "source_prefix_bit_range_u32": [0, source_prefix_token_count * 32],
+                "candidate_terminal_indices": candidate_terminal_indices,
+                "candidate_terminal_bit_offsets_u32": [
+                    index * 32 for index in candidate_terminal_indices
+                ],
+                "candidate_terminal_anchors": candidate_terminal_anchors,
+                "query_terminal_index": query_terminal_index,
+                "query_terminal_bit_offset_u32": query_terminal_index * 32,
+                "all_candidate_states_before_query": all(
+                    index < source_prefix_token_count
+                    for index in candidate_terminal_indices
+                ),
+                "truncation": "FORBIDDEN_NOT_USED",
+            }
+        )
+        encoded_queries.append(_canonical_with_cid(unsigned_query, "query_row_cid"))
+
+    if shared_prefix_ids is None or shared_candidate_indices is None:
+        raise RuntimeError("paired-query pair encoded no lanes")
+    unsigned_pair = deepcopy(dict(pair))
+    semantic_record_cid = unsigned_pair.pop("record_cid")
+    unsigned_pair["semantic_record_cid"] = semantic_record_cid
+    unsigned_pair["binding"] = "TOKENIZER_BOUND"
+    unsigned_pair["tokenizer_cid"] = tokenizer_identity
+    unsigned_pair["queries"] = encoded_queries
+    unsigned_pair["source_prefix_token_count"] = len(shared_prefix_ids)
+    unsigned_pair["source_prefix_token_ids_cid"] = _token_ids_cid(shared_prefix_ids)
+    unsigned_pair["source_prefix_identity_exact"] = True
+    unsigned_pair["candidate_terminal_indices"] = shared_candidate_indices
+    unsigned_pair["candidate_anchor_identity_exact"] = True
+    unsigned_pair["all_candidate_states_before_query"] = all(
+        query["all_candidate_states_before_query"] for query in encoded_queries
+    )
+    return _canonical_with_cid(unsigned_pair, "record_cid")
+
+
+def _tokenizer_partition(
+    pairs: Sequence[Mapping[str, Any]],
+    tokenizer: Tokenizer,
+    *,
+    tokenizer_cid: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    encoded = [
+        encode_paired_query_pair(pair, tokenizer, tokenizer_cid=tokenizer_cid)
+        for pair in pairs
+    ]
+    positions = [
+        int(query["positions_including_bos"])
+        for pair in encoded
+        for query in pair["queries"]
+    ]
+    value = {
+        "pairs": len(encoded),
+        "query_rows": len(positions),
+        "minimum_positions_including_bos": min(positions),
+        "maximum_positions_including_bos": max(positions),
+        "context_ceiling_including_bos": MAX_POSITIONS_INCLUDING_BOS,
+        "no_prompt_truncated": all(
+            query["truncation"] == "FORBIDDEN_NOT_USED"
+            for pair in encoded
+            for query in pair["queries"]
+        ),
+        "source_prefix_identity_exact": all(
+            pair["source_prefix_identity_exact"] for pair in encoded
+        ),
+        "candidate_anchor_identity_exact": all(
+            pair["candidate_anchor_identity_exact"] for pair in encoded
+        ),
+        "all_candidate_states_before_query": all(
+            pair["all_candidate_states_before_query"] for pair in encoded
+        ),
+        "passed": all(position <= MAX_POSITIONS_INCLUDING_BOS for position in positions),
+    }
+    return encoded, value
+
+
+def build_paired_query_tokenizer_census(
+    preflight: Mapping[str, Any],
+    products: Mapping[str, Any],
+    tokenizer: Tokenizer,
+    *,
+    tokenizer_cid: str | None = None,
+) -> dict[str, Any]:
+    """Bind every fit/sealed/product lane before optimization; never truncate."""
+    if preflight.get("schema") != PREFLIGHT_SCHEMA:
+        raise ValueError("paired-query preflight schema differs")
+    if products.get("schema") != PRODUCT_SCHEMA:
+        raise ValueError("paired-query product schema differs")
+    identity = _tokenizer_identity(tokenizer, tokenizer_cid)
+    partitions: dict[str, Any] = {}
+    for name, pairs in (
+        ("fit", preflight["fit"]),
+        ("sealed", preflight["sealed"]),
+        ("product", products["records"]),
+    ):
+        _, partitions[name] = _tokenizer_partition(
+            pairs, tokenizer, tokenizer_cid=identity
+        )
+    passed = all(
+        bool(partition["passed"])
+        and bool(partition["no_prompt_truncated"])
+        and bool(partition["source_prefix_identity_exact"])
+        and bool(partition["candidate_anchor_identity_exact"])
+        and bool(partition["all_candidate_states_before_query"])
+        for partition in partitions.values()
+    )
+    value = {
+        "schema": TOKENIZER_CENSUS_SCHEMA,
+        "policy": POLICY,
+        "issue": ISSUE,
+        "tokenizer_cid": identity,
+        "input_policy": INPUT_POLICY,
+        "partitions": partitions,
+        "product_text_access": "PREPARATION_ONLY_DENIED_TO_TRAINING_VIEW",
+        "passed": passed,
+    }
+    if not passed:
+        raise RuntimeError(f"C1-SB5 tokenizer census failed: {value}")
+    return _canonical_with_cid(value, "tokenizer_census_cid")
+
+
+def build_paired_query_binding_population(
+    tokenizer: Tokenizer | None = None,
+    *,
+    tokenizer_cid: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build semantic data, optionally returning a tokenizer-bound preflight."""
+    dataset, semantic_preflight, products = (
+        build_paired_query_binding_semantic_population()
+    )
+    if tokenizer is None:
+        if tokenizer_cid is not None:
+            raise ValueError("tokenizer CID was provided without a tokenizer")
+        return dataset, semantic_preflight, products
+
+    identity = _tokenizer_identity(tokenizer, tokenizer_cid)
+    encoded_fit, fit_census = _tokenizer_partition(
+        semantic_preflight["fit"], tokenizer, tokenizer_cid=identity
+    )
+    encoded_sealed, sealed_census = _tokenizer_partition(
+        semantic_preflight["sealed"], tokenizer, tokenizer_cid=identity
+    )
+    tokenizer_census = build_paired_query_tokenizer_census(
+        semantic_preflight,
+        products,
+        tokenizer,
+        tokenizer_cid=identity,
+    )
+    unsigned_preflight = {
+        key: deepcopy(value)
+        for key, value in semantic_preflight.items()
+        if key not in {"preflight_cid", "fit", "sealed", "binding"}
+    }
+    unsigned_preflight.update(
+        {
+            "binding": "TOKENIZER_BOUND",
+            "semantic_preflight_cid": semantic_preflight["preflight_cid"],
+            "tokenizer_cid": identity,
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "fit_tokenizer_census": fit_census,
+            "sealed_tokenizer_census": sealed_census,
+            "fit": encoded_fit,
+            "sealed": encoded_sealed,
+        }
+    )
+    preflight = _canonical_with_cid(unsigned_preflight, "preflight_cid")
+
+    unsigned_dataset = {
+        key: deepcopy(value)
+        for key, value in dataset.items()
+        if key not in {"dataset_cid", "preflight_cid"}
+    }
+    unsigned_dataset.update(
+        {
+            "binding": "TOKENIZER_BOUND",
+            "semantic_dataset_cid": dataset["dataset_cid"],
+            "semantic_preflight_cid": semantic_preflight["preflight_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "tokenizer_census": tokenizer_census,
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "tokenizer_cid": identity,
+        }
+    )
+    bound_dataset = _canonical_with_cid(unsigned_dataset, "dataset_cid")
+    return bound_dataset, preflight, products
+
+
+__all__ = [
+    "CENSUS_FILENAME",
+    "CENSUS_SCHEMA",
+    "DATASET_FILENAME",
+    "DATASET_SCHEMA",
+    "EXPECTED_COUNTS",
+    "FRESH_WORLD_ORDINAL_START",
+    "INPUT_POLICY",
+    "ISSUE",
+    "MAX_POSITIONS_INCLUDING_BOS",
+    "PAIR_KINDS",
+    "PAIR_SCHEMA",
+    "POLICY",
+    "PREFLIGHT_FILENAME",
+    "PREFLIGHT_SCHEMA",
+    "PRODUCT_DENIED_FILENAMES",
+    "PRODUCT_FILENAME",
+    "PRODUCT_MANIFEST_FILENAME",
+    "PRODUCT_SCHEMA",
+    "QUERY_SCHEMA",
+    "SENTENCE_POLICY",
+    "SPLIT_SCHEMA",
+    "TOKENIZER_CENSUS_FILENAME",
+    "TOKENIZER_CENSUS_SCHEMA",
+    "TRAINING_VIEW_FILENAMES",
+    "TRAINING_VIEW_MANIFEST_FILENAME",
+    "artifact_bytes",
+    "build_paired_query_binding_population",
+    "build_paired_query_binding_semantic_population",
+    "build_paired_query_tokenizer_census",
+    "encode_paired_query_pair",
+    "load_artifact",
+    "render_paired_query_input",
+    "verify_artifact_cid",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/paths.py
@@ -58,3 +58,7 @@ def default_attended_relation_adapter_root() -> Path:
 
 def default_joint_candidate_margin_root() -> Path:
     return model_store_root() / "research" / "issue-954" / "joint-candidate-margin"
+
+
+def default_paired_query_binding_root() -> Path:
+    return model_store_root() / "research" / "issue-954" / "paired-query-binding"

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_adapter.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/source_relation_adapter.py
@@ -750,6 +750,7 @@ def export_merged_attended_relation_checkpoint(
     split_policy_cid: str,
     run_contract_cid: str,
     selected_checkpoint_cid: str | None,
+    selected_checkpoint_identity: str | None = None,
 ) -> dict[str, Any]:
     """Merge LoRA and reuse the standard checkpoint format accepted by Rust."""
     clean = adapter.merged_model()
@@ -763,4 +764,5 @@ def export_merged_attended_relation_checkpoint(
         split_policy_cid=split_policy_cid,
         run_contract_cid=run_contract_cid,
         selected_checkpoint_cid=selected_checkpoint_cid,
+        selected_checkpoint_identity=selected_checkpoint_identity,
     )

--- a/tools/r4-softmax-trainer/tests/test_paired_query_binding.py
+++ b/tools/r4-softmax-trainer/tests/test_paired_query_binding.py
@@ -1,0 +1,503 @@
+"""Focused checks for C1-SB5 paired-query conditional binding."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import torch
+
+from r4_softmax_trainer.model import R4SoftmaxForCausalLM, expected_hf_tensor_names
+from r4_softmax_trainer.paired_query_binding import (
+    BINDING_BLOCKS,
+    BINDING_HEAD_PARAMETER_COUNT,
+    BINDING_RANK,
+    FIT_SEED,
+    FLIP_MARGIN,
+    MARGIN,
+    OPTIMIZER_STEPS,
+    POLICY,
+    RECORDS_PER_STEP,
+    STEPS_PER_EPOCH,
+    TRAINABLE_PARAMETER_COUNT,
+    EncodedPairedQueryBindingDataset,
+    PairedQueryBindingAdapterConfig,
+    PairedQueryBindingFitConfig,
+    PairedQueryBindingOutput,
+    PairedQueryTokenBatch,
+    R4PairedQueryCandidateMatrix,
+    evaluate_paired_query_binding,
+    fit_paired_query_binding,
+    paired_query_binding_loss,
+    paired_query_loss_terms,
+)
+from r4_softmax_trainer.source_relation_adapter import LoRALinear
+
+
+def _outcome(labels: list[int]) -> str:
+    positives = sum(labels)
+    return "abstain" if positives == 0 else "answer" if positives == 1 else "conflict"
+
+
+def _record(
+    record_id: str,
+    *,
+    width: int = 2,
+    pair_slot: int = 0,
+    world_lane: int = 0,
+    labels: tuple[list[int], list[int]] = ([1, 0], [0, 1]),
+    groups: int = 2,
+) -> dict[str, Any]:
+    if groups not in (1, 2):
+        raise ValueError("test fixture supports one or two candidate groups")
+    group_cids = [f"group-{record_id}-{index}" for index in range(groups)]
+    candidate_groups = [
+        {
+            "relation_group_cid": group_cid,
+            "text": f"Candidate {index}.",
+            "occurrence_indices": [index],
+            "earliest_occurrence_index": index,
+        }
+        for index, group_cid in enumerate(group_cids)
+    ]
+    candidate_indices = [2, 4][:groups]
+    token_lanes = ([10, 11, 12, 13, 20, 21], [10, 11, 12, 13, 30, 21])
+    queries = [
+        {
+            "question": f"Where is the subject {query_index}?",
+            "token_ids": list(token_lanes[query_index]),
+            "query_terminal_index": 6,
+            "candidate_terminal_indices": candidate_indices,
+            "source_prefix_token_count": 5,
+            "target_outcome": _outcome(labels[query_index][:groups]),
+        }
+        for query_index in range(2)
+    ]
+    flip_cids = [
+        group_cids[index]
+        for index in range(groups)
+        if labels[0][index] != labels[1][index]
+    ]
+    return {
+        "record_cid": record_id,
+        "source_width": width,
+        "pair_slot": pair_slot,
+        "lexical_world": f"world-w{width}-lane{world_lane}",
+        "source_prefix_identity_exact": True,
+        "source_prefix_token_ids_cid": f"prefix-{record_id}",
+        "candidate_groups": candidate_groups,
+        "label_matrix": [labels[0][:groups], labels[1][:groups]],
+        "flip_group_cids": flip_cids,
+        "queries": queries,
+    }
+
+
+def _complete_fit_records() -> list[dict[str, Any]]:
+    return [
+        _record(
+            f"record-w{width}-world{world_lane}-pair{pair_slot}",
+            width=width,
+            pair_slot=pair_slot,
+            world_lane=world_lane,
+        )
+        for width in range(2, 9)
+        for world_lane in range(2)
+        for pair_slot in range(4)
+    ]
+
+
+class _ExactScoreAdapter:
+    def eval(self) -> "_ExactScoreAdapter":
+        return self
+
+    def __call__(
+        self,
+        batch: PairedQueryTokenBatch,
+        *,
+        attention_off: bool,
+        mean_query_ablation: bool,
+    ) -> PairedQueryBindingOutput:
+        if mean_query_ablation:
+            scores = torch.zeros_like(batch.labels)
+        else:
+            scores = torch.where(
+                batch.labels == 1.0,
+                torch.full_like(batch.labels, 2.0),
+                torch.full_like(batch.labels, -2.0),
+            )
+        hidden_width = 288
+        query_states = torch.zeros(
+            batch.input_ids.shape[0], 2, hidden_width, device=batch.input_ids.device
+        )
+        candidates = torch.zeros(
+            batch.input_ids.shape[0],
+            batch.candidate_indices.shape[1],
+            hidden_width,
+            device=batch.input_ids.device,
+        )
+        return PairedQueryBindingOutput(
+            scores=scores,
+            query_states=query_states,
+            candidate_states=candidates,
+            candidate_states_by_lane=candidates[:, None].expand(-1, 2, -1, -1),
+            paired_candidate_states_exact=True,
+            attention_off=attention_off,
+            mean_query_ablation=mean_query_ablation,
+        )
+
+
+class PairedQueryBindingTests(unittest.TestCase):
+    def test_frozen_contract_shapes_parameters_and_deterministic_initialization(self) -> None:
+        self.assertEqual(POLICY, "R4PairedQueryCandidateMatrixV1")
+        self.assertEqual(BINDING_RANK, 32)
+        self.assertEqual(BINDING_BLOCKS, 8)
+        self.assertEqual(BINDING_HEAD_PARAMETER_COUNT, 18_433)
+        self.assertEqual(TRAINABLE_PARAMETER_COUNT, 129_025)
+        self.assertEqual(FIT_SEED, 9_545)
+        self.assertEqual(OPTIMIZER_STEPS, 120)
+        self.assertEqual(RECORDS_PER_STEP, 7)
+        self.assertEqual(STEPS_PER_EPOCH, 8)
+        self.assertEqual(MARGIN, 1.0)
+        self.assertEqual(FLIP_MARGIN, 2.0)
+
+        config = PairedQueryBindingAdapterConfig()
+        config.validate()
+        self.assertEqual(config.trainable_parameter_count, 129_025)
+        self.assertFalse(config.as_contract()["generic_lm_or_classification_head"])
+        with self.assertRaisesRegex(ValueError, "frozen"):
+            replace(config, binding_rank=16).validate()
+        fit = PairedQueryBindingFitConfig()
+        fit.validate()
+        self.assertEqual(fit.as_contract()["epochs"], 15)
+        with self.assertRaisesRegex(ValueError, "frozen"):
+            replace(fit, learning_rate=0.002).validate()
+
+        first = R4PairedQueryCandidateMatrix(R4SoftmaxForCausalLM())
+        second = R4PairedQueryCandidateMatrix(R4SoftmaxForCausalLM())
+        self.assertEqual(len(first.trainable_parameter_names()), 51)
+        self.assertEqual(
+            sum(parameter.numel() for parameter in first.adapter_parameters()),
+            129_025,
+        )
+        for name in first.binding_head_state_dict():
+            self.assertTrue(
+                torch.equal(
+                    first.binding_head_state_dict()[name],
+                    second.binding_head_state_dict()[name],
+                )
+            )
+        first_query = first.model.model.layers[0].self_attn.q_proj
+        second_query = second.model.model.layers[0].self_attn.q_proj
+        self.assertIsInstance(first_query, LoRALinear)
+        self.assertIsInstance(second_query, LoRALinear)
+        self.assertTrue(torch.equal(first_query.lora_a, second_query.lora_a))
+        self.assertEqual(set(first.binding_head_state_dict()), {"query_weight", "candidate_weight", "bias"})
+        self.assertTrue(
+            all(
+                tensor.device.type == "cpu" and tensor.is_contiguous()
+                for tensor in first.binding_head_state_dict().values()
+            )
+        )
+
+    def test_matrix_forward_enforces_causal_prefix_and_supports_controls(self) -> None:
+        dataset = EncodedPairedQueryBindingDataset([_record("pair")])
+        batch = dataset.batch([0], device=torch.device("cpu"))
+        adapter = R4PairedQueryCandidateMatrix(R4SoftmaxForCausalLM()).eval()
+        output = adapter(batch)
+        self.assertEqual(tuple(output.scores.shape), (1, 2, 2))
+        self.assertEqual(tuple(output.query_states.shape), (1, 2, 288))
+        self.assertEqual(tuple(output.candidate_states.shape), (1, 2, 288))
+        self.assertTrue(output.paired_candidate_states_exact)
+        self.assertTrue(
+            torch.equal(
+                output.candidate_states_by_lane[:, 0],
+                output.candidate_states_by_lane[:, 1],
+            )
+        )
+        unchecked = adapter(batch, verify_candidate_state_identity=False)
+        self.assertIsNone(unchecked.paired_candidate_states_exact)
+
+        ablated = adapter(batch, mean_query_ablation=True)
+        self.assertTrue(torch.equal(ablated.scores[:, 0], ablated.scores[:, 1]))
+        self.assertTrue(torch.equal(ablated.query_states[:, 0], ablated.query_states[:, 1]))
+        attention_off = adapter(batch, attention_off=True)
+        self.assertTrue(attention_off.attention_off)
+        self.assertEqual(tuple(attention_off.scores.shape), (1, 2, 2))
+
+        tampered_ids = batch.input_ids.clone()
+        tampered_ids[0, 1, 2] += 1
+        with self.assertRaisesRegex(ValueError, "prefixes"):
+            replace(batch, input_ids=tampered_ids).validate()
+        late_candidate = batch.candidate_indices.clone()
+        late_candidate[0, 0] = batch.source_prefix_lengths[0]
+        with self.assertRaisesRegex(ValueError, "before the question"):
+            replace(batch, candidate_indices=late_candidate).validate()
+
+    def test_loss_arithmetic_includes_abstain_and_direct_flip_margin(self) -> None:
+        labels = torch.tensor(
+            [
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+            ]
+        )
+        group_mask = torch.tensor([[True, True, True], [True, True, False]])
+        flip_mask = torch.tensor([[True, True, False], [True, True, False]])
+        exact_scores = torch.tensor(
+            [
+                [[1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]],
+                [[-1.0, -1.0, 0.0], [1.0, 1.0, 0.0]],
+            ]
+        )
+        exact = paired_query_loss_terms(
+            exact_scores, labels, group_mask, flip_mask
+        )
+        self.assertTrue(torch.equal(exact.row_losses, torch.zeros(4)))
+        self.assertTrue(torch.equal(exact.flip_losses, torch.zeros(4)))
+        self.assertEqual(float(exact.total), 0.0)
+
+        zeros = torch.zeros_like(exact_scores)
+        violated = paired_query_loss_terms(zeros, labels, group_mask, flip_mask)
+        self.assertTrue(
+            torch.equal(violated.row_losses, torch.tensor([2.0, 2.0, 1.0, 1.0]))
+        )
+        self.assertTrue(torch.equal(violated.flip_losses, torch.full((4,), 2.0)))
+        self.assertEqual(float(violated.mean_row_loss), 1.5)
+        self.assertEqual(float(violated.mean_flip_loss), 2.0)
+        self.assertEqual(float(paired_query_binding_loss(zeros, labels, group_mask, flip_mask)), 3.5)
+
+    def test_variable_groups_alignment_and_exact_eight_step_epoch(self) -> None:
+        records = list(reversed(_complete_fit_records()))
+        dataset = EncodedPairedQueryBindingDataset(records)
+        dataset.validate_fit_schedule()
+        selected = [
+            dataset.record_indices_for_step(step)
+            for step in range(1, STEPS_PER_EPOCH + 1)
+        ]
+        self.assertTrue(all(len(indices) == 7 for indices in selected))
+        self.assertEqual(
+            {
+                index
+                for indices in selected
+                for index in indices
+            },
+            set(range(56)),
+        )
+        self.assertEqual(
+            [dataset.records[index].source_width for index in selected[0]],
+            list(range(2, 9)),
+        )
+        self.assertNotEqual(
+            dataset.record_indices_for_step(1),
+            dataset.record_indices_for_step(1 + STEPS_PER_EPOCH),
+        )
+
+        variable = EncodedPairedQueryBindingDataset(
+            [
+                _record("pair-two", groups=2),
+                _record(
+                    "pair-one",
+                    groups=1,
+                    labels=([1, 0], [0, 0]),
+                ),
+            ]
+        )
+        batch = variable.batch([0, 1], device=torch.device("cpu"))
+        self.assertEqual(tuple(batch.input_ids.shape[:2]), (2, 2))
+        self.assertEqual(tuple(batch.group_mask.shape), (2, 2))
+        self.assertEqual(sorted(batch.group_mask.sum(dim=1).tolist()), [1, 2])
+        self.assertTrue(torch.equal(batch.input_ids[:, 0, :5], batch.input_ids[:, 1, :5]))
+        self.assertTrue(bool((batch.candidate_indices[batch.group_mask] < 5).all()))
+
+    def test_evaluator_preserves_pair_identity_and_exposes_binding_controls(self) -> None:
+        dataset = EncodedPairedQueryBindingDataset(
+            [
+                _record("pair-b", pair_slot=3),
+                _record("pair-a", pair_slot=0),
+            ]
+        )
+        exact = evaluate_paired_query_binding(
+            _ExactScoreAdapter(),  # type: ignore[arg-type]
+            dataset,
+            device=torch.device("cpu"),
+            pair_batch_size=2,
+        )
+        self.assertEqual(exact["pair_exact"], {"correct": 2, "total": 2})
+        self.assertEqual(exact["row_exact"], {"correct": 4, "total": 4})
+        self.assertEqual(exact["cell_exact"], {"correct": 8, "total": 8})
+        self.assertEqual(exact["flip_exact"], {"correct": 4, "total": 4})
+        self.assertEqual(exact["candidate_state_bit_identity"], {"correct": 2, "total": 2})
+        self.assertEqual(exact["mean_loss"], 0.0)
+        self.assertEqual(
+            [row["record_id"] for row in exact["pair_evaluations"]],
+            ["pair-a", "pair-b"],
+        )
+
+        swapped = evaluate_paired_query_binding(
+            _ExactScoreAdapter(),  # type: ignore[arg-type]
+            dataset,
+            device=torch.device("cpu"),
+            pair_batch_size=2,
+            row_swap=True,
+        )
+        self.assertEqual(swapped["pair_exact"], {"correct": 2, "total": 2})
+        ablated = evaluate_paired_query_binding(
+            _ExactScoreAdapter(),  # type: ignore[arg-type]
+            dataset,
+            device=torch.device("cpu"),
+            pair_batch_size=2,
+            mean_query_ablation=True,
+        )
+        self.assertEqual(ablated["paired_rows_identical"], {"correct": 2, "total": 2})
+        self.assertEqual(ablated["pair_exact"], {"correct": 0, "total": 2})
+        self.assertGreater(ablated["mean_loss"], exact["mean_loss"])
+
+    def test_changed_and_finite_tensor_census_covers_only_the_frozen_targets(self) -> None:
+        adapter = R4PairedQueryCandidateMatrix(R4SoftmaxForCausalLM())
+        # Wrapped projections have ``base.weight`` names, so bind the actual
+        # immutable ordinary tensors through the merge surface before mutation.
+        base_state = adapter.merged_state_dict()
+        self.assertEqual(adapter.delta_audit()["changed_tensor_count"], 0)
+        self.assertEqual(adapter.binding_head_audit()["changed_tensor_count"], 0)
+        with torch.no_grad():
+            for layer in adapter.model.model.layers:
+                for projection_name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                    projection = getattr(layer.self_attn, projection_name)
+                    self.assertIsInstance(projection, LoRALinear)
+                    projection.lora_b[0, 0] = 0.125
+            adapter.binding_head.query_weight[0, 0] += 0.25
+            adapter.binding_head.candidate_weight[0, 0] -= 0.25
+            adapter.binding_head.bias += 0.125
+        delta = adapter.delta_audit()
+        self.assertEqual(delta["target_tensor_count"], 24)
+        self.assertEqual(delta["changed_tensor_count"], 24)
+        self.assertTrue(delta["all_finite"])
+        head = adapter.binding_head_audit()
+        self.assertEqual(head["tensor_count"], 3)
+        self.assertEqual(head["changed_tensor_count"], 3)
+        self.assertTrue(head["all_finite"])
+        representation = adapter.representation_audit(base_state)
+        self.assertEqual(representation["changed_target_tensor_count"], 24)
+        self.assertEqual(representation["changed_nontarget_tensors"], [])
+        self.assertTrue(representation["passed"])
+        self.assertEqual(set(adapter.merged_state_dict()), expected_hf_tensor_names())
+        self.assertIsInstance(adapter.merged_model(), R4SoftmaxForCausalLM)
+
+    def test_fit_samples_host_loss_only_at_synchronized_boundaries(self) -> None:
+        class FakeParameter:
+            def numel(self) -> int:
+                return TRAINABLE_PARAMETER_COUNT
+
+        class FakeAdapter:
+            config = SimpleNamespace(initialization_seed=FIT_SEED)
+
+            def __init__(self) -> None:
+                self.verify_identity: list[bool] = []
+
+            def to(self, _device: torch.device) -> "FakeAdapter":
+                return self
+
+            def train(self) -> "FakeAdapter":
+                return self
+
+            def adapter_parameters(self) -> list[FakeParameter]:
+                return [FakeParameter()]
+
+            def __call__(
+                self,
+                _batch: object,
+                *,
+                verify_candidate_state_identity: bool,
+            ) -> SimpleNamespace:
+                self.verify_identity.append(verify_candidate_state_identity)
+                return SimpleNamespace(scores=object())
+
+            def delta_audit(self) -> dict[str, object]:
+                return {}
+
+            def binding_head_audit(self) -> dict[str, object]:
+                return {}
+
+        class FakeDataset:
+            def validate_fit_schedule(self) -> None:
+                return None
+
+            def record_indices_for_step(self, _step: int) -> tuple[int, ...]:
+                return tuple(range(RECORDS_PER_STEP))
+
+            def batch(self, _indices: object, *, device: torch.device) -> object:
+                self.device = device
+                return SimpleNamespace(
+                    labels=object(),
+                    group_mask=object(),
+                    flip_mask=object(),
+                )
+
+        class FakeOptimizer:
+            def zero_grad(self, *, set_to_none: bool) -> None:
+                self.set_to_none = set_to_none
+
+            def step(self) -> None:
+                return None
+
+        class FakeLoss:
+            def __init__(self, step: int) -> None:
+                self.step = step
+
+            def backward(self) -> None:
+                return None
+
+            def detach(self) -> "FakeLoss":
+                return self
+
+            def cpu(self) -> float:
+                host_loss_reads.append(self.step)
+                return 1.0
+
+        adapter = FakeAdapter()
+        dataset = FakeDataset()
+        host_loss_reads: list[int] = []
+        loss_step = 0
+
+        def fake_loss(*_args: object) -> FakeLoss:
+            nonlocal loss_step
+            loss_step += 1
+            return FakeLoss(loss_step)
+
+        with (
+            patch(
+                "r4_softmax_trainer.paired_query_binding.require_mps",
+                return_value=torch.device("mps"),
+            ),
+            patch(
+                "r4_softmax_trainer.paired_query_binding.torch.optim.AdamW",
+                return_value=FakeOptimizer(),
+            ),
+            patch(
+                "r4_softmax_trainer.paired_query_binding.torch.nn.utils.clip_grad_norm_"
+            ),
+            patch(
+                "r4_softmax_trainer.paired_query_binding.paired_query_binding_loss",
+                side_effect=fake_loss,
+            ),
+            patch(
+                "r4_softmax_trainer.paired_query_binding.torch.mps.synchronize"
+            ) as synchronize,
+        ):
+            result = fit_paired_query_binding(  # type: ignore[arg-type]
+                adapter,  # type: ignore[arg-type]
+                dataset,  # type: ignore[arg-type]
+            )
+
+        boundaries = [1, *range(STEPS_PER_EPOCH, OPTIMIZER_STEPS + 1, STEPS_PER_EPOCH)]
+        self.assertEqual(host_loss_reads, boundaries)
+        self.assertEqual(synchronize.call_count, len(boundaries))
+        self.assertEqual(adapter.verify_identity, [False] * OPTIMIZER_STEPS)
+        self.assertEqual(result["initial_loss"], 1.0)
+        self.assertEqual(result["final_loss"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_paired_query_binding_campaign.py
+++ b/tools/r4-softmax-trainer/tests/test_paired_query_binding_campaign.py
@@ -1,0 +1,739 @@
+"""Focused one-shot, provenance, schedule, and CLI checks for C1-SB5."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from contextlib import ExitStack, contextmanager
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from r4_softmax_trainer import cli
+from r4_softmax_trainer import paired_query_binding_campaign as campaign
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes, tree_cid
+
+
+def _with_cid(value: dict[str, object], field: str) -> dict[str, object]:
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _pairs(*, records_per_width: int) -> list[dict[str, object]]:
+    return [
+        {
+            "record_cid": cid_bytes(f"pair-{width}-{slot}".encode()),
+            "source_width": width,
+            "queries": [{"target_outcome": "answer"}, {"target_outcome": "abstain"}],
+            "candidate_groups": [{"relation_group_cid": cid_bytes(b"group")}],
+            "label_matrix": [[1], [0]],
+        }
+        for width in campaign.WIDTHS
+        for slot in range(records_per_width)
+    ]
+
+
+def _fake_population() -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    census = _with_cid(
+        {
+            "schema": campaign.CENSUS_SCHEMA,
+            "policy": campaign.POLICY,
+            "passed": True,
+        },
+        "census_cid",
+    )
+    tokenizer_census = _with_cid(
+        {
+            "schema": campaign.TOKENIZER_CENSUS_SCHEMA,
+            "policy": campaign.POLICY,
+            "tokenizer_cid": campaign.EXPECTED_TOKENIZER_CID,
+            "partitions": {
+                "fit": {"pairs": campaign.FIT_PAIRS, "passed": True},
+                "sealed": {"pairs": campaign.SEALED_PAIRS, "passed": True},
+                "product": {"pairs": 4, "passed": True},
+            },
+            "passed": True,
+        },
+        "tokenizer_census_cid",
+    )
+    preflight = _with_cid(
+        {
+            "schema": campaign.PREFLIGHT_SCHEMA,
+            "policy": campaign.POLICY,
+            "fit": _pairs(records_per_width=8),
+            "sealed": _pairs(records_per_width=4),
+            "census_cid": census["census_cid"],
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+        },
+        "preflight_cid",
+    )
+    commitments = [cid_bytes(f"product-{index}".encode()) for index in range(4)]
+    products = _with_cid(
+        {
+            "schema": "uor-r4.paired-query-binding-products/1",
+            "policy": campaign.POLICY,
+            "records": [{"record_cid": commitment} for commitment in commitments],
+        },
+        "product_probes_cid",
+    )
+    split_policy_cid = cid_bytes(b"paired-query-split")
+    dataset = _with_cid(
+        {
+            "schema": campaign.DATASET_SCHEMA,
+            "policy": campaign.POLICY,
+            "split_policy_cid": split_policy_cid,
+            "census": census,
+            "census_cid": census["census_cid"],
+            "preflight_cid": preflight["preflight_cid"],
+            "tokenizer_census": tokenizer_census,
+            "tokenizer_census_cid": tokenizer_census["tokenizer_census_cid"],
+            "product_probes_cid": products["product_probes_cid"],
+            "product_probe_commitments": commitments,
+        },
+        "dataset_cid",
+    )
+    return dataset, preflight, products
+
+
+@contextmanager
+def _patched_freeze(
+    dataset: dict[str, object],
+    preflight: dict[str, object],
+    products: dict[str, object],
+):
+    with ExitStack() as stack:
+        values = {
+            "EXPECTED_DATASET_CID": dataset["dataset_cid"],
+            "EXPECTED_PREFLIGHT_CID": preflight["preflight_cid"],
+            "EXPECTED_CENSUS_CID": dataset["census_cid"],
+            "EXPECTED_TOKENIZER_CENSUS_CID": dataset["tokenizer_census_cid"],
+            "EXPECTED_PRODUCT_CID": products["product_probes_cid"],
+            "EXPECTED_SPLIT_POLICY_CID": dataset["split_policy_cid"],
+            "EXPECTED_PRODUCT_COMMITMENTS": tuple(
+                dataset["product_probe_commitments"]  # type: ignore[arg-type]
+            ),
+            "EXPECTED_PREDECESSOR_MANIFEST_CID": cid_bytes(
+                b"predecessor-manifest"
+            ),
+        }
+        for name, value in values.items():
+            stack.enter_context(patch.object(campaign, name, value))
+        yield
+
+
+def _metrics(
+    *, pairs: int, exact: bool, mean_loss: float, identical_rows: bool = False
+) -> dict[str, object]:
+    if pairs == campaign.FIT_PAIRS:
+        cells, flips, copies, duplicates = 532, 98, 42, 14
+        outcomes = {"answer": 42, "abstain": 42, "conflict": 28}
+    else:
+        cells, flips, copies, duplicates = 266, 49, 21, 7
+        outcomes = {"answer": 21, "abstain": 21, "conflict": 14}
+    pair_correct = pairs if exact else 0
+    pair_evaluations = []
+    for index in range(pairs):
+        group_cid = cid_bytes(f"group-{index}".encode())
+        answer_supported = exact
+        pair_evaluations.append(
+            {
+                "record_id": f"record-{index:02d}",
+                "source_width": campaign.WIDTHS[index % len(campaign.WIDTHS)],
+                "pair_slot": index % 4,
+                "candidate_state_identity": True,
+                "query_rows": [
+                    {
+                        "question": f"Where is subject-a-{index}?",
+                        "target_outcome": "answer",
+                        "predicted_outcome": "answer" if exact else "abstain",
+                        "outcome_exact": exact,
+                        "target_copy_candidate_index": 0,
+                        "predicted_copy_candidate_index": 0 if exact else None,
+                        "copy_exact": exact,
+                        "positive_group_indices": [0],
+                        "predicted_positive_group_indices": [0] if exact else [],
+                        "cells_exact": exact,
+                        "cells": [
+                            {
+                                "relation_group_cid": group_cid,
+                                "label": 1,
+                                "score": 2.0 if answer_supported else -2.0,
+                                "supported": answer_supported,
+                            }
+                        ],
+                    },
+                    {
+                        "question": f"Where is subject-b-{index}?",
+                        "target_outcome": "abstain",
+                        "predicted_outcome": "abstain",
+                        "outcome_exact": True,
+                        "target_copy_candidate_index": None,
+                        "predicted_copy_candidate_index": None,
+                        "copy_exact": True,
+                        "positive_group_indices": [],
+                        "predicted_positive_group_indices": [],
+                        "cells_exact": True,
+                        "cells": [
+                            {
+                                "relation_group_cid": group_cid,
+                                "label": 0,
+                                "score": -2.0,
+                                "supported": False,
+                            }
+                        ],
+                    },
+                ],
+                "flip_columns": [
+                    {"relation_group_cid": group_cid, "exact": exact}
+                ],
+                "flip_exact": exact,
+                "paired_rows_identical": identical_rows,
+                "pair_exact": exact,
+            }
+        )
+    return {
+        "pairs": pairs,
+        "query_rows": 2 * pairs,
+        "matrix_cells": cells,
+        "flip_columns": flips,
+        "mean_row_margin": mean_loss / 2.0,
+        "mean_flip_margin": mean_loss / 2.0,
+        "mean_total_loss": mean_loss,
+        "pair_exact": {"correct": pair_correct, "total": pairs},
+        "row_exact": {"correct": 2 * pairs if exact else 0, "total": 2 * pairs},
+        "cell_exact": {"correct": cells if exact else 0, "total": cells},
+        "flip_exact": {"correct": flips if exact else 0, "total": flips},
+        "candidate_copy_exact": {
+            "correct": copies if exact else 0,
+            "total": copies,
+        },
+        "duplicate_pair_exact": {
+            "correct": duplicates if exact else 0,
+            "total": duplicates,
+        },
+        "outcome": {
+            name: {"correct": total if exact else 0, "total": total}
+            for name, total in outcomes.items()
+        },
+        "candidate_state_bit_identity": {"correct": pairs, "total": pairs},
+        "paired_rows_identical": {
+            "correct": pairs if identical_rows else 0,
+            "total": pairs,
+        },
+        "mean_loss": mean_loss,
+        "attention_off": False,
+        "mean_query_ablation": False,
+        "row_swap": False,
+        "candidate_state_identity_exact": True,
+        "pair_evaluations": pair_evaluations,
+    }
+
+
+def _swapped_metrics(metrics: dict[str, object]) -> dict[str, object]:
+    swapped = deepcopy(metrics)
+    swapped["row_swap"] = True
+    for pair in swapped["pair_evaluations"]:  # type: ignore[union-attr]
+        pair["query_rows"] = list(reversed(pair["query_rows"]))
+    return swapped
+
+
+def _positive_delta() -> dict[str, object]:
+    return {
+        "target_tensor_count": 24,
+        "changed_target_tensor_count": 24,
+        "changed_target_tensors": [f"target-{index}" for index in range(24)],
+        "changed_nontarget_tensors": [],
+        "all_target_tensors_finite": True,
+        "binding_head": {
+            "tensor_count": 3,
+            "changed_tensor_count": 3,
+            "all_finite": True,
+        },
+        "passed": True,
+    }
+
+
+class _ScheduleDataset:
+    def __init__(self, _records: object = None) -> None:
+        group_counts = [5] * 42 + [4] * 14
+        self.records = [
+            SimpleNamespace(candidate_groups=[object()] * count)
+            for count in group_counts
+        ]
+
+    def validate_fit_schedule(self) -> None:
+        if len(self.records) != 56:
+            raise ValueError("bad fixture schedule")
+
+    def record_indices_for_step(self, step: int) -> tuple[int, ...]:
+        base = ((step - 1) % campaign.STEPS_PER_EPOCH) * campaign.PAIRS_PER_STEP
+        return tuple(range(base, base + campaign.PAIRS_PER_STEP))
+
+
+class PairedQueryBindingCampaignTests(unittest.TestCase):
+    def test_cli_registers_prepare_and_one_shot_train_commands(self) -> None:
+        parser = cli.parser()
+        prepare = parser.parse_args(["prepare-paired-query-binding"])
+        train = parser.parse_args(["train-paired-query-binding-preflight"])
+        self.assertEqual(prepare.command, "prepare-paired-query-binding")
+        self.assertEqual(train.command, "train-paired-query-binding-preflight")
+        help_text = parser.format_help()
+        self.assertIn("optimizer under its 300-second", help_text)
+        self.assertIn("ceiling, then the mandatory controls", help_text)
+        self.assertNotIn("<=5 minute C1-SB5", help_text)
+        self.assertEqual(
+            campaign.CELL_PRESENTATIONS,
+            campaign.EPOCHS * 532,
+        )
+
+    def test_one_shot_marker_is_exclusive_and_partial_marker_fails_closed(self) -> None:
+        payload = {
+            "schema": campaign.RUN_SCHEMA,
+            "phase": "SOLE_C1_SB5_PREFLIGHT_STARTED",
+            "run_contract_cid": cid_bytes(b"run-contract"),
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            marker = root / campaign.STARTED_FILE
+            campaign._write_exclusive_started_marker(marker, payload)
+            committed = marker.read_bytes()
+            with self.assertRaisesRegex(FileExistsError, "already started"):
+                campaign._write_exclusive_started_marker(marker, payload)
+            self.assertEqual(marker.read_bytes(), committed)
+
+            partial = root / "partial-started.json"
+            partial.write_bytes(b"{")
+            with self.assertRaisesRegex(FileExistsError, "already started"):
+                campaign._write_exclusive_started_marker(partial, payload)
+            self.assertEqual(partial.read_bytes(), b"{")
+
+    def test_schedule_arithmetic_is_exact_and_drift_fails_closed(self) -> None:
+        dataset = _ScheduleDataset()
+        observation = campaign._schedule_observation(
+            {"optimizer_steps": 120, "paired_records_per_step": 7}, dataset
+        )
+        self.assertEqual(observation["pair_presentations"], 840)
+        self.assertEqual(observation["row_presentations"], 1_680)
+        self.assertEqual(observation["cell_presentations"], 7_980)
+        with self.assertRaisesRegex(ValueError, "frozen schedule"):
+            campaign._schedule_observation(
+                {"optimizer_steps": 119, "paired_records_per_step": 7}, dataset
+            )
+
+    def test_semantic_gate_binds_every_frozen_denominator(self) -> None:
+        sealed = _metrics(pairs=28, exact=True, mean_loss=0.1)
+        self.assertTrue(campaign._main_metrics_exact(sealed, expected_pairs=28))
+        sealed["matrix_cells"] = 265
+        with self.assertRaisesRegex(ValueError, "denominator drifted"):
+            campaign._main_metrics_exact(sealed, expected_pairs=28)
+
+    def test_population_failure_is_typed_and_leaves_no_partial_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            predecessor_manifest = {
+                "manifest_cid": cid_bytes(b"predecessor-manifest"),
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            with (
+                patch.object(
+                    campaign,
+                    "_validated_predecessor",
+                    return_value=predecessor_manifest,
+                ),
+                patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                patch.object(campaign, "validate_tokenizer_contract"),
+                patch.object(
+                    campaign,
+                    "build_paired_query_binding_population",
+                    side_effect=ValueError("tokenizer census failed"),
+                ),
+                patch.object(campaign, "atomic_write_json") as write_json,
+                patch.object(campaign, "write_bound_manifest") as write_manifest,
+            ):
+                result = campaign.prepare_paired_query_binding_data(
+                    root, predecessor=predecessor
+                )
+            self.assertEqual(result["terminal"], "UNAVAILABLE_FRAME_OR_POPULATION")
+            self.assertEqual(result["optimizer_steps"], 0)
+            self.assertEqual(result["training"], "NOT_STARTED")
+            self.assertEqual(result["artifacts"], "NOT_EMITTED")
+            self.assertFalse(root.exists())
+            write_json.assert_not_called()
+            write_manifest.assert_not_called()
+
+    def test_row_swap_requires_bit_exact_identity_aligned_trace(self) -> None:
+        sealed = _metrics(pairs=28, exact=True, mean_loss=0.1)
+        row_swap = _swapped_metrics(sealed)
+        mean_query = _metrics(
+            pairs=28, exact=False, mean_loss=1.0, identical_rows=True
+        )
+        mean_query["mean_query_ablation"] = True
+        attention_off = _metrics(pairs=28, exact=False, mean_loss=1.1)
+        attention_off["attention_off"] = True
+
+        exact_gate = campaign._control_gate(
+            sealed, row_swap, mean_query, attention_off
+        )
+        self.assertTrue(exact_gate["passed"])
+        self.assertTrue(exact_gate["row_swap_equivariance"]["passed"])
+
+        mutated = deepcopy(row_swap)
+        # The raw swapped trace keeps query B in row zero and query A in row one.
+        # Move query A's positive score without crossing zero: aggregate semantic
+        # accuracy is unchanged, but exact row-swap equivariance must now fail.
+        mutated["pair_evaluations"][0]["query_rows"][1]["cells"][0][  # type: ignore[index]
+            "score"
+        ] = 2.25
+        self.assertTrue(
+            campaign._main_metrics_exact(mutated, expected_pairs=campaign.SEALED_PAIRS)
+        )
+        mutated_gate = campaign._control_gate(
+            sealed, mutated, mean_query, attention_off
+        )
+        self.assertFalse(mutated_gate["row_swap_exact"])
+        self.assertFalse(mutated_gate["row_swap_equivariance"]["pair_trace_bit_exact"])
+        self.assertFalse(mutated_gate["passed"])
+
+    def test_training_view_rejects_product_path_before_binary_open(self) -> None:
+        dataset, preflight, products = _fake_population()
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            predecessor_manifest = {
+                "manifest_cid": cid_bytes(b"predecessor-manifest"),
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            with _patched_freeze(dataset, preflight, products):
+                with (
+                    patch.object(
+                        campaign,
+                        "_validated_predecessor",
+                        return_value=predecessor_manifest,
+                    ),
+                    patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                    patch.object(campaign, "validate_tokenizer_contract"),
+                    patch.object(
+                        campaign,
+                        "build_paired_query_binding_population",
+                        return_value=(dataset, preflight, products),
+                    ),
+                ):
+                    campaign.prepare_paired_query_binding_data(
+                        root, predecessor=predecessor
+                    )
+
+            manifest_path = root / campaign.TRAINING_MANIFEST_FILE
+            manifest = campaign.verify_manifest_envelope(manifest_path)
+            product_path = root / campaign.PRODUCT_FILE
+            manifest["artifacts"].append(
+                {
+                    "bytes": product_path.stat().st_size,
+                    "cid": campaign.cid_file(product_path),
+                    "path": campaign.PRODUCT_FILE,
+                }
+            )
+            manifest["artifacts"].sort(key=lambda record: str(record["path"]))
+            manifest["tree_cid"] = tree_cid(manifest["artifacts"])
+            unsigned = dict(manifest)
+            unsigned.pop("manifest_cid")
+            manifest["manifest_cid"] = cid_bytes(canonical_json_bytes(unsigned))
+            campaign.atomic_write_json(manifest_path, manifest)
+
+            original_open = Path.open
+
+            def guarded_open(
+                path: Path, mode: str = "r", *args: object, **kwargs: object
+            ) -> object:
+                if path.name == campaign.PRODUCT_FILE and mode == "rb":
+                    raise AssertionError("trainer opened product bytes before rejection")
+                return original_open(path, mode, *args, **kwargs)
+
+            with (
+                patch.object(Path, "open", guarded_open),
+                self.assertRaisesRegex(ValueError, "artifact whitelist drifted"),
+            ):
+                campaign._load_training_view(root)
+
+    def test_positive_export_names_sb5_output_and_selects_exported_weights(self) -> None:
+        class FixtureConfig:
+            def validate(self) -> None:
+                return None
+
+            def as_hugging_face_config(self) -> dict[str, object]:
+                return {"model_type": "c1-sb5-fixture"}
+
+            def as_contract(self) -> dict[str, object]:
+                return {"fixture": "c1-sb5"}
+
+        class FixtureModel:
+            config = FixtureConfig()
+
+        class FixtureAdapter:
+            def merged_model(self) -> FixtureModel:
+                return FixtureModel()
+
+            def binding_head_state_dict(self) -> dict[str, torch.Tensor]:
+                return {
+                    "bias": torch.tensor([0.0]),
+                    "candidate_weight": torch.tensor([[1.0]]),
+                    "query_weight": torch.tensor([[1.0]]),
+                }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            tokenizer_bytes = b"fixture tokenizer bytes\n"
+            (predecessor / "tokenizer.json").write_bytes(tokenizer_bytes)
+            config_bytes = canonical_json_bytes({"model_type": "c1-sb5-fixture"})
+            predecessor_weights_cid = cid_bytes(b"immutable predecessor weights")
+            result = {"result_cid": cid_bytes(b"passing result")}
+            dataset = {
+                "dataset_cid": cid_bytes(b"dataset"),
+                "split_policy_cid": cid_bytes(b"split"),
+                "product_probe_commitments": [
+                    cid_bytes(f"product-{index}".encode()) for index in range(4)
+                ],
+            }
+            training_manifest = {"manifest_cid": cid_bytes(b"training manifest")}
+            run_contract = {"run_contract_cid": cid_bytes(b"run contract")}
+            with (
+                patch(
+                    "r4_softmax_trainer.export.export_state_dict",
+                    return_value={"fixture.weight": torch.tensor([[2.0]])},
+                ),
+                patch.multiple(
+                    campaign,
+                    EXPECTED_CONFIG_CID=cid_bytes(config_bytes),
+                    EXPECTED_TOKENIZER_CID=cid_bytes(tokenizer_bytes),
+                    EXPECTED_WEIGHTS_CID=predecessor_weights_cid,
+                ),
+            ):
+                delivery = campaign._write_positive_delivery(
+                    root,
+                    predecessor=predecessor,
+                    adapter=FixtureAdapter(),  # type: ignore[arg-type]
+                    result=result,
+                    dataset=dataset,
+                    training_manifest=training_manifest,
+                    run_contract=run_contract,
+                )
+            checkpoint_manifest = delivery["checkpoint_manifest"]
+            self.assertEqual(
+                checkpoint_manifest["selected_checkpoint_identity"],
+                "C1-SB5 merged LoRA training output",
+            )
+            self.assertEqual(
+                checkpoint_manifest["selected_checkpoint_cid"],
+                checkpoint_manifest["weights_cid"],
+            )
+
+    def test_prepare_and_negative_one_shot_never_read_or_emit_product(self) -> None:
+        dataset, preflight, products = _fake_population()
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "run"
+            predecessor = base / "predecessor"
+            predecessor.mkdir()
+            predecessor_manifest = {
+                "manifest_cid": cid_bytes(b"predecessor-manifest"),
+                "model_contract": campaign.FROZEN_MODEL_CONFIG.as_contract(),
+            }
+            with _patched_freeze(dataset, preflight, products):
+                with (
+                    patch.object(
+                        campaign,
+                        "_validated_predecessor",
+                        return_value=predecessor_manifest,
+                    ),
+                    patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                    patch.object(campaign, "validate_tokenizer_contract"),
+                    patch.object(
+                        campaign,
+                        "build_paired_query_binding_population",
+                        return_value=(dataset, preflight, products),
+                    ),
+                ):
+                    prepared = campaign.prepare_paired_query_binding_data(
+                        root, predecessor=predecessor
+                    )
+            self.assertEqual(
+                prepared["terminal"],
+                "PAIRED_QUERY_BINDING_DATA_COMMITTED_NO_TRAINING",
+            )
+            with _patched_freeze(dataset, preflight, products):
+                manifest_paths = {
+                    row["path"]
+                    for row in campaign._load_training_view(root)[3]["artifacts"]
+                }
+            self.assertEqual(manifest_paths, campaign.TRAINING_VIEW_ARTIFACTS)
+            self.assertNotIn(campaign.PRODUCT_FILE, manifest_paths)
+
+            original_read_text = Path.read_text
+
+            def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+                if path.name in {campaign.PRODUCT_FILE, campaign.PRODUCT_MANIFEST_FILE}:
+                    raise AssertionError("optimizer opened product material")
+                return original_read_text(path, *args, **kwargs)
+
+            fit = _metrics(pairs=56, exact=True, mean_loss=0.1)
+            sealed_negative = _metrics(pairs=28, exact=False, mean_loss=0.2)
+            row_swap = _swapped_metrics(
+                _metrics(pairs=28, exact=True, mean_loss=0.2)
+            )
+            mean_query = _metrics(
+                pairs=28, exact=False, mean_loss=1.0, identical_rows=True
+            )
+            mean_query["mean_query_ablation"] = True
+            attention_off = _metrics(pairs=28, exact=False, mean_loss=1.1)
+            attention_off["attention_off"] = True
+            evaluations = [
+                fit,
+                sealed_negative,
+                sealed_negative,
+                row_swap,
+                mean_query,
+                attention_off,
+            ]
+
+            class FakeAdapter:
+                def to(self, _device: torch.device) -> "FakeAdapter":
+                    return self
+
+                def representation_audit(self, _base: object) -> dict[str, object]:
+                    return _positive_delta()
+
+            with _patched_freeze(dataset, preflight, products):
+                with (
+                    patch.object(Path, "read_text", guarded_read_text),
+                    patch.object(
+                        campaign,
+                        "build_paired_query_binding_population",
+                        side_effect=AssertionError("optimizer rebuilt product data"),
+                    ),
+                    patch.object(
+                        campaign,
+                        "_validated_predecessor",
+                        return_value=predecessor_manifest,
+                    ),
+                    patch.object(campaign, "_run_contract") as run_contract,
+                    patch.object(campaign, "require_mps", return_value=torch.device("cpu")),
+                    patch.object(campaign.Tokenizer, "from_file", return_value=object()),
+                    patch.object(campaign, "validate_tokenizer_contract"),
+                    patch.object(
+                        campaign,
+                        "EncodedPairedQueryBindingDataset",
+                        side_effect=lambda records: _ScheduleDataset(records),
+                    ),
+                    patch.object(campaign, "_load_base_model", return_value=(object(), {})),
+                    patch.object(
+                        campaign,
+                        "R4PairedQueryCandidateMatrix",
+                        return_value=FakeAdapter(),
+                    ),
+                    patch.object(
+                        campaign,
+                        "fit_paired_query_binding",
+                        return_value={
+                            "optimizer_steps": 120,
+                            "paired_records_per_step": 7,
+                            "initial_loss": 3.0,
+                            "final_loss": 0.1,
+                        },
+                    ),
+                    patch.object(
+                        campaign,
+                        "evaluate_paired_query_binding",
+                        side_effect=evaluations,
+                    ),
+                ):
+                    run_contract.return_value = _with_cid(
+                        {"schema": campaign.RUN_SCHEMA}, "run_contract_cid"
+                    )
+                    result = campaign.run_paired_query_binding_preflight(
+                        root, predecessor=predecessor
+                    )
+            self.assertEqual(
+                result["terminal"], "FAIL_PAIRED_QUERY_BINDING_PREFLIGHT"
+            )
+            self.assertEqual(result["research_checkpoint"], "NOT_EMITTED")
+            self.assertEqual(result["binding_head"], "NOT_EMITTED")
+            self.assertFalse((root / campaign.CHECKPOINT_DIRECTORY).exists())
+            self.assertFalse((root / campaign.HEAD_DIRECTORY).exists())
+            with self.assertRaisesRegex(FileExistsError, "already started"):
+                with _patched_freeze(dataset, preflight, products):
+                    with (
+                        patch.object(
+                            campaign,
+                            "_validated_predecessor",
+                            return_value=predecessor_manifest,
+                        ),
+                        patch.object(campaign, "_run_contract"),
+                    ):
+                        campaign.run_paired_query_binding_preflight(
+                            root, predecessor=predecessor
+                        )
+
+    def test_positive_only_invokes_checkpoint_and_head_delivery(self) -> None:
+        root = Path("/unused")
+        common = {
+            "predecessor": Path("/predecessor"),
+            "dataset": {"dataset_cid": "dataset"},
+            "preflight": {"preflight_cid": "preflight"},
+            "tokenizer_census": {"tokenizer_census_cid": "tokenizer"},
+            "training_manifest": {"manifest_cid": "training"},
+            "run_contract": {"run_contract_cid": "run"},
+        }
+        passing = {"terminal": "PASS_PAIRED_QUERY_BINDING_PREFLIGHT_RESEARCH_ONLY"}
+        negative = {"terminal": "FAIL_PAIRED_QUERY_BINDING_PREFLIGHT"}
+        for value in (passing, negative):
+            value["result_cid"] = cid_bytes(canonical_json_bytes(value))
+
+        delivery = {
+            "artifact": {"artifact_cid": "artifact"},
+            "checkpoint_manifest": {"weights_cid": "weights"},
+            "checkpoint_tree": {"checkpoint_tree_cid": "tree"},
+            "head_manifest": {
+                "manifest_cid": "head-manifest",
+                "head_weights_cid": "head-weights",
+            },
+            "relative_paths": [],
+        }
+        with (
+            patch.object(campaign, "_write_positive_delivery", return_value=delivery) as emit,
+            patch.object(campaign, "atomic_write_json"),
+            patch.object(
+                campaign,
+                "write_bound_manifest",
+                return_value={"manifest_cid": "manifest"},
+            ),
+        ):
+            campaign._finalize_result(
+                root,
+                adapter=object(),
+                result=passing,
+                **common,
+            )
+            emit.assert_called_once()
+            emit.reset_mock()
+            campaign._finalize_result(
+                root,
+                adapter=None,
+                result=negative,
+                **common,
+            )
+            emit.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_paired_query_binding_data.py
+++ b/tools/r4-softmax-trainer/tests/test_paired_query_binding_data.py
@@ -1,0 +1,347 @@
+"""Focused contracts for the fresh C1-SB5 paired-query population."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from copy import deepcopy
+from pathlib import Path
+import tempfile
+import unittest
+
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+
+from r4_softmax_trainer.constants import BOS_TOKEN_ID
+from r4_softmax_trainer.paired_query_binding_data import (
+    DATASET_SCHEMA,
+    EXPECTED_COUNTS,
+    FRESH_WORLD_ORDINAL_START,
+    MAX_POSITIONS_INCLUDING_BOS,
+    PAIR_KINDS,
+    POLICY,
+    PREFLIGHT_SCHEMA,
+    PRODUCT_DENIED_FILENAMES,
+    PRODUCT_FILENAME,
+    PRODUCT_MANIFEST_FILENAME,
+    PRODUCT_SCHEMA,
+    TOKENIZER_CENSUS_SCHEMA,
+    TRAINING_VIEW_FILENAMES,
+    artifact_bytes,
+    build_paired_query_binding_population,
+    build_paired_query_binding_semantic_population,
+    load_artifact,
+    render_paired_query_input,
+    verify_artifact_cid,
+)
+from r4_softmax_trainer.provenance import canonical_json_bytes, cid_bytes
+
+
+def _toy_tokenizer() -> Tokenizer:
+    tokenizer = Tokenizer(
+        WordLevel(
+            {
+                "[UNK]": 0,
+                ".": 1,
+                "?": 2,
+                ":": 3,
+            },
+            unk_token="[UNK]",
+        )
+    )
+    tokenizer.pre_tokenizer = Whitespace()
+    return tokenizer
+
+
+class PairedQueryRendererTests(unittest.TestCase):
+    def test_exact_lane_contains_source_once_and_ends_at_bind_colon(self) -> None:
+        source = "The coral alder compass is inside the brass cabinet."
+        question = "Where is the coral alder compass?"
+        rendered = render_paired_query_input(source, question)
+        self.assertEqual(rendered, f"E:{source}\nQ:{question}\nBind:")
+        self.assertEqual(rendered.count(source), 1)
+        self.assertTrue(rendered.endswith("Bind:"))
+        self.assertFalse(rendered.endswith("\n"))
+
+    def test_renderer_rejects_noncanonical_source_or_question(self) -> None:
+        rejected = (
+            ("unterminated", "Where is the coral alder compass?"),
+            (" trailing. ", "Where is the coral alder compass?"),
+            ("The coral alder compass is listed.", "where is it?"),
+        )
+        for source, question in rejected:
+            with self.subTest(source=source, question=question):
+                with self.assertRaises(ValueError):
+                    render_paired_query_input(source, question)
+
+
+class PairedQuerySemanticPopulationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset, cls.preflight, cls.products = (
+            build_paired_query_binding_semantic_population()
+        )
+
+    def test_exact_partition_counts_worlds_and_outcomes(self) -> None:
+        self.assertEqual(self.dataset["schema"], DATASET_SCHEMA)
+        self.assertEqual(self.preflight["schema"], PREFLIGHT_SCHEMA)
+        self.assertEqual(self.products["schema"], PRODUCT_SCHEMA)
+        self.assertEqual(self.dataset["policy"], POLICY)
+        self.assertEqual(self.dataset["counts"], EXPECTED_COUNTS)
+        self.assertEqual(self.preflight["counts"]["fit"], EXPECTED_COUNTS["fit"])
+        self.assertEqual(
+            self.preflight["counts"]["sealed"], EXPECTED_COUNTS["sealed"]
+        )
+
+        for partition, worlds_per_width in (("fit", 2), ("sealed", 1)):
+            pairs = self.preflight[partition]
+            self.assertEqual(
+                Counter((pair["source_width"], pair["pair_slot"]) for pair in pairs),
+                Counter(
+                    {
+                        (width, pair_slot): worlds_per_width
+                        for width in range(2, 9)
+                        for pair_slot in range(4)
+                    }
+                ),
+            )
+            by_world: dict[str, list[dict[str, object]]] = defaultdict(list)
+            for pair in pairs:
+                by_world[str(pair["lexical_world"])].append(pair)
+            for world_pairs in by_world.values():
+                self.assertEqual({pair["pair_slot"] for pair in world_pairs}, set(range(4)))
+                self.assertEqual(
+                    {pair["pair_kind"] for pair in world_pairs}, set(PAIR_KINDS)
+                )
+
+        fit_ordinals = {pair["world_ordinal"] for pair in self.preflight["fit"]}
+        sealed_ordinals = {pair["world_ordinal"] for pair in self.preflight["sealed"]}
+        product_ordinals = {pair["world_ordinal"] for pair in self.products["records"]}
+        self.assertEqual(fit_ordinals, set(range(162, 176)))
+        self.assertEqual(sealed_ordinals, set(range(176, 183)))
+        self.assertEqual(product_ordinals, set(range(183, 187)))
+        self.assertEqual(min(fit_ordinals), FRESH_WORLD_ORDINAL_START)
+
+    def test_every_pair_is_an_exact_shared_source_counterfactual_matrix(self) -> None:
+        pairs = [
+            *self.preflight["fit"],
+            *self.preflight["sealed"],
+            *self.products["records"],
+        ]
+        for pair in pairs:
+            self.assertEqual(len(pair["queries"]), 2)
+            self.assertNotEqual(
+                pair["queries"][0]["question"], pair["queries"][1]["question"]
+            )
+            self.assertEqual(
+                {query["relation_input"].split("\nQ:", 1)[0] for query in pair["queries"]},
+                {f'E:{pair["source"]}'},
+            )
+            groups = pair["candidate_groups"]
+            matrix = pair["label_matrix"]
+            self.assertEqual([query["labels"] for query in pair["queries"]], matrix)
+            self.assertEqual(len(matrix), 2)
+            self.assertTrue(all(len(row) == len(groups) for row in matrix))
+            expected_flips = {
+                group["relation_group_cid"]
+                for index, group in enumerate(groups)
+                if {matrix[0][index], matrix[1][index]} == {0, 1}
+            }
+            self.assertEqual(set(pair["flip_group_cids"]), expected_flips)
+            self.assertEqual(len(expected_flips), sum(sum(row) for row in matrix))
+            for query, row in zip(pair["queries"], matrix):
+                positives = sum(row)
+                expected_outcome = (
+                    "abstain" if positives == 0 else "answer" if positives == 1 else "conflict"
+                )
+                self.assertEqual(query["target_outcome"], expected_outcome)
+            for group in groups:
+                self.assertEqual(
+                    group["relation_group_cid"],
+                    cid_bytes(group["text"].encode("utf-8")),
+                )
+                self.assertEqual(
+                    group["earliest_occurrence_index"],
+                    min(group["occurrence_indices"]),
+                )
+
+    def test_duplicate_pair_collapses_exact_text_and_uses_fresh_b_query(self) -> None:
+        duplicate_pairs = [
+            pair
+            for pair in [*self.preflight["fit"], *self.preflight["sealed"]]
+            if pair["pair_slot"] == 3
+        ]
+        self.assertEqual(len(duplicate_pairs), 21)
+        for pair in duplicate_pairs:
+            left, right = pair["queries"]
+            self.assertEqual(left["target_outcome"], "answer")
+            self.assertTrue(left["duplicate_agreement"])
+            self.assertEqual(right["target_outcome"], "abstain")
+            self.assertIsNone(right["inherited_record_cid"])
+            supported_group = pair["candidate_groups"][left["target_group_index"]]
+            self.assertEqual(len(supported_group["occurrence_indices"]), 2)
+            self.assertEqual(
+                left["target_span_index"], min(supported_group["occurrence_indices"])
+            )
+
+    def test_freshness_shortcut_and_product_isolation_census_is_positive(self) -> None:
+        census = self.dataset["census"]
+        self.assertTrue(census["passed"])
+        self.assertTrue(census["counts_exact"])
+        self.assertTrue(census["new_sentence_partitions_pairwise_disjoint"])
+        self.assertTrue(census["new_composite_world_partitions_pairwise_disjoint"])
+        for checks in census["new_vs_sb3_sb4"].values():
+            self.assertTrue(checks["subjects_locations_nonlocatives_disjoint"])
+            self.assertTrue(checks["exact_sentences_disjoint"])
+        for checks in census["partition_checks"].values():
+            self.assertTrue(checks["pair_oracle_and_flip_matrix_exact"])
+            self.assertTrue(checks["question_blind_shortcut_rejected"])
+            self.assertEqual(checks["question_blind_affirmative_locative_exact_pairs"], 0)
+
+        training_view = self.dataset["training_view"]
+        self.assertEqual(
+            set(training_view["allowed_filenames"]), set(TRAINING_VIEW_FILENAMES)
+        )
+        self.assertEqual(
+            set(training_view["denied_filenames"]), set(PRODUCT_DENIED_FILENAMES)
+        )
+        self.assertNotIn(PRODUCT_FILENAME, TRAINING_VIEW_FILENAMES)
+        self.assertNotIn(PRODUCT_MANIFEST_FILENAME, TRAINING_VIEW_FILENAMES)
+        self.assertEqual(self.products["training_view_access"], "DENIED")
+        self.assertEqual(
+            self.dataset["product_probe_commitments"],
+            [record["record_cid"] for record in self.products["records"]],
+        )
+        training_sources = {
+            pair["source"]
+            for pair in [*self.preflight["fit"], *self.preflight["sealed"]]
+        }
+        self.assertTrue(
+            training_sources.isdisjoint(
+                {pair["source"] for pair in self.products["records"]}
+            )
+        )
+
+    def test_all_semantic_cids_reproduce_and_population_is_deterministic(self) -> None:
+        verify_artifact_cid(self.dataset, "dataset_cid")
+        verify_artifact_cid(self.preflight, "preflight_cid")
+        verify_artifact_cid(self.products, "product_probes_cid")
+        verify_artifact_cid(self.dataset["census"], "census_cid")
+        for pair in [
+            *self.preflight["fit"],
+            *self.preflight["sealed"],
+            *self.products["records"],
+        ]:
+            verify_artifact_cid(pair, "record_cid")
+            for query in pair["queries"]:
+                verify_artifact_cid(query, "query_row_cid")
+        rebuilt = build_paired_query_binding_semantic_population()
+        self.assertEqual(
+            tuple(artifact_bytes(value) for value in rebuilt),
+            tuple(
+                artifact_bytes(value)
+                for value in (self.dataset, self.preflight, self.products)
+            ),
+        )
+
+    def test_canonical_artifact_loader_reproduces_and_rejects_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "dataset.json"
+            path.write_bytes(artifact_bytes(self.dataset))
+            loaded = load_artifact(
+                path, schema=DATASET_SCHEMA, cid_field="dataset_cid"
+            )
+            self.assertEqual(loaded, self.dataset)
+
+            corrupt = deepcopy(self.dataset)
+            corrupt["policy"] = "drifted"
+            path.write_bytes(canonical_json_bytes(corrupt))
+            with self.assertRaises(ValueError):
+                load_artifact(path, schema=DATASET_SCHEMA, cid_field="dataset_cid")
+
+
+class PairedQueryTokenizerBindingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tokenizer = _toy_tokenizer()
+        cls.tokenizer_cid = cid_bytes(cls.tokenizer.to_str().encode("utf-8"))
+        cls.dataset, cls.preflight, cls.products = build_paired_query_binding_population(
+            cls.tokenizer, tokenizer_cid=cls.tokenizer_cid
+        )
+
+    def test_bound_population_exposes_the_mechanism_interface(self) -> None:
+        self.assertEqual(self.dataset["binding"], "TOKENIZER_BOUND")
+        self.assertEqual(self.preflight["binding"], "TOKENIZER_BOUND")
+        census = self.dataset["tokenizer_census"]
+        self.assertEqual(census["schema"], TOKENIZER_CENSUS_SCHEMA)
+        self.assertTrue(census["passed"])
+        self.assertEqual(census["tokenizer_cid"], self.tokenizer_cid)
+
+        for partition in ("fit", "sealed"):
+            for pair in self.preflight[partition]:
+                verify_artifact_cid(pair, "record_cid")
+                self.assertTrue(pair["source_prefix_identity_exact"])
+                self.assertTrue(pair["candidate_anchor_identity_exact"])
+                self.assertTrue(pair["all_candidate_states_before_query"])
+                self.assertEqual(len(pair["queries"]), 2)
+                self.assertEqual(len(pair["label_matrix"]), 2)
+                left_ids = [BOS_TOKEN_ID, *pair["queries"][0]["token_ids"]]
+                right_ids = [BOS_TOKEN_ID, *pair["queries"][1]["token_ids"]]
+                prefix_count = pair["source_prefix_token_count"]
+                self.assertEqual(left_ids[:prefix_count], right_ids[:prefix_count])
+                self.assertEqual(
+                    pair["candidate_terminal_indices"],
+                    pair["queries"][0]["candidate_terminal_indices"],
+                )
+                self.assertEqual(
+                    pair["candidate_terminal_indices"],
+                    pair["queries"][1]["candidate_terminal_indices"],
+                )
+                self.assertEqual(
+                    len(pair["candidate_terminal_indices"]),
+                    len(pair["candidate_groups"]),
+                )
+                for query in pair["queries"]:
+                    verify_artifact_cid(query, "query_row_cid")
+                    self.assertEqual(
+                        query["query_terminal_index"], len(query["token_ids"])
+                    )
+                    self.assertLessEqual(
+                        query["positions_including_bos"],
+                        MAX_POSITIONS_INCLUDING_BOS,
+                    )
+                    self.assertEqual(query["truncation"], "FORBIDDEN_NOT_USED")
+                    self.assertGreaterEqual(
+                        query["query_terminal_index"],
+                        query["source_prefix_token_count"],
+                    )
+                    self.assertTrue(
+                        all(
+                            index < query["source_prefix_token_count"]
+                            for index in query["candidate_terminal_indices"]
+                        )
+                    )
+                    self.assertEqual(
+                        query["candidate_terminal_bit_offsets_u32"],
+                        [index * 32 for index in query["candidate_terminal_indices"]],
+                    )
+                    self.assertEqual(
+                        query["query_terminal_bit_offset_u32"],
+                        query["query_terminal_index"] * 32,
+                    )
+
+    def test_products_remain_separate_and_unbound_in_training_return(self) -> None:
+        self.assertEqual(self.products["schema"], PRODUCT_SCHEMA)
+        self.assertEqual(self.products["training_view_access"], "DENIED")
+        for pair in self.products["records"]:
+            self.assertNotIn("tokenizer_cid", pair)
+            self.assertNotIn("token_ids", pair["queries"][0])
+        self.assertIn("product", self.dataset["tokenizer_census"]["partitions"])
+        self.assertEqual(
+            self.dataset["tokenizer_census"]["product_text_access"],
+            "PREPARATION_ONLY_DENIED_TO_TRAINING_VIEW",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Implements and executes the independently frozen C1-SB5 `R4PairedQueryCandidateMatrixV1` rung for #954, then records its predeclared negative branch.

The sole MPS run fit all `56/56` construction pairs but transferred only `14/28` independently sealed pairs (`37/56` rows, `227/266` cells, `38/49` flips). It therefore terminates `FAIL_PAIRED_QUERY_BINDING_PREFLIGHT` and retires this rung without retry.

References #954

## What changed

- adds the paired-query construction/sealed/product population builder and tokenizer census;
- adds the all-layer rank-8 Q/K/V/O LoRA mechanism plus asymmetric rank-32 query/candidate binding head;
- adds deterministic one-shot preparation, immutable run contracts, exact training-view allowlists, exclusive start markers, MPS-only training, controls, replay, delta audits, and negative artifact suppression;
- adds focused mechanism/data/campaign tests;
- appends the C1-SB5 result and compact bound aggregate;
- updates the current project/roadmap/lifecycle/contributor surfaces to remove the stale paired-query proposal and preserve the source-free claim boundary.

## Frozen evidence

- implementation commit: `bd06cfaf761cfc4b2e61b38efaadc76e2c72c7c4`
- implementation tree CID: `blake3:ca3b1f0804af779151baa9e0875973aba9542cb219f6e876c85512c3365b1a29`
- run-contract CID: `blake3:992bc9bb61c3e7bb4481cee3b959db338aa68530ffe43e93ee0eac5c133d2103`
- result CID: `blake3:076242ab2bd379083ae55a22a272b3a0943b350fa301f65909e1b0ecc0d72571`
- result manifest CID: `blake3:c4a7ec5e4926cc5ede144d7f3c013940d104bb77ce26f8e201aa63c524c6a119`
- result tree CID: `blake3:0c3b0d869c45fca9924c1d76af19c9b411d8529c6ac8f9f7bf9d641d788dc188`

Controls remain informative but do not rescue qualification:

- identity-aligned row-swap trace and aggregates: bit-exact;
- mean-query ablation: `0/28`, paired rows identical `28/28`, higher loss;
- attention disabled: `0/28`, higher loss;
- deterministic replay: exact;
- intended parameter changes: 24/24 LoRA tensors and 3/3 head tensors, finite, zero non-target changes.

Product or forbidden reads were `0`. The four product pairs remain committed and unopened. No checkpoint, binding-head artifact, Rust parity, development expansion, product evaluation, or retry was emitted/run.

## Focused verification

- native unittest runner: `41/41` passed in 2.364 s;
- compact aggregate versus frozen result: `16/16` selected fields matched;
- Python compileall: passed;
- JSON parse: passed;
- diff whitespace check: passed;
- claim-wording gate: passed.

No broad workspace suite or corpus-scale run was launched. Queue CI remains the binding transport verification.

## Claim boundary

This preserves bounded evidence that ordinary source-backed causal softmax attention is query-sensitive: both query destruction and attention removal collapse the sealed score. It does not establish exact transferable binding, intrinsic geometry, a source-free runtime, transformerlessness, general generation, correctness, reasoning, browser/WASM readiness, or release readiness. #954 remains open behind #973; #955 remains blocked.
