### PR TITLE
Expose bounded #1017 loopback generation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > transformerlessness, correctness, reasoning, frontier quality, browser/WASM
 > readiness, or release readiness.
 >
+> [#1039](https://github.com/UOR-Foundation/uor-r4/issues/1039) now exposes
+> that exact frozen checkpoint as a **bounded local generation prototype**. A
+> predeclared fresh prompt produced 24 non-looping tokens in `0.22 s` and
+> `0.17 s` on the project M1's CPU-native Apple Accelerate backend; removing
+> timing made the fixed-seed reports byte-identical. Decision/output/audit/state
+> CIDs were respectively
+> `blake3:86ce45d07684f8abead1e4faca2346024ef7b01e99f9b0e3b51188deafcde61b`,
+> `blake3:87150ebc68ed1e3902f6e0c9937f7a642f234ac2a3644cc33262cb081715ae49`,
+> `blake3:3e7d642eb20c9e1d05c385df2802d120becb91ba88df16a9b61cf2569caec010`,
+> and
+> `blake3:ff69922ed27437e308852b053f3b3b15baebeb1e5a51c27c704f18f1ba423793`.
+> The new endpoint is an opt-in, loopback-only, single-flight wrapper around the
+> existing generator. It does not revise #973's V5 negative or implement #962's
+> source-free chat product. See the
+> [#1039 result and interface record](docs/r4_softmax_local_reference_surface_1039.md).
+>
 > The completed
 > `R4SoftmaxTraceStudentV1` then compiled construction-side teacher traces into
 > a source-free Q16 suffix artifact and showed bounded distillation relative to
@@ -698,6 +714,47 @@ that local export and is a bounded #1017 prototype: provider-free at execution,
 but still source-backed, floating-point/matmul/softmax, and below the strict
 `<1.50` NLL target. #1019 was closed without another capacity run; it is not a
 prerequisite for using or productizing this path.
+
+To expose that same frozen checkpoint through its dedicated native reference
+seam, build the Apple Silicon CPU-Accelerate binary and opt in on loopback:
+
+```bash
+cargo build --release --offline --features local-inference-accelerate --bin r4
+target/release/r4 --host 127.0.0.1 --port 8000 serve \
+  --enable-r4-softmax-local \
+  --r4-softmax-local-model .uor-models/research/issue-1017/export \
+  --r4-softmax-local-workers 4
+```
+
+The server never downloads the export. The path must contain the immutable
+#1017 `export-manifest.json`, `config.json`, `model.safetensors`,
+`tokenizer.json`, and `training-result.json`; invalid or missing state fails
+closed, and additional loader files such as a Safetensors shard index are
+rejected. The exact-executor default is up to four workers, capped by the
+process's available parallelism, and the resulting count is fixed at startup.
+Apple Accelerate/BLAS remains CPU-native and owns its internal CPU scheduling;
+the worker flag is not a BLAS thread cap. This surface has no CUDA or external
+GPU path.
+
+In another terminal, request one raw continuation:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8000/uor/v1/r4-softmax-local/generate \
+  -H 'content-type: application/json' \
+  --data '{"prompt":"Mira found a small brass key beneath the old pear tree.","max_tokens":8}'
+```
+
+`max_tokens` defaults to 8 and is capped at 32. The
+`uor-r4.r4-softmax-local-http/1` response reports text, generated token IDs,
+stop reason, model identity/shape, content-addressed decisions and audits, and
+backend/timing provenance without reflecting the prompt, prompt token IDs,
+local model path, or filenames. `GET /api/sysinfo` reports
+`r4_softmax_local.checkpoint_preflight_ready`. Requests are single-flight and
+cannot override the model, backend, or exact-executor workers. This dedicated raw single-turn
+endpoint is not `/v1/chat/completions`, the default serving engine, or #962's
+source-free multi-turn product. The native-served dashboard may offer it as a
+raw-completion choice only after preflight passes; it sends no chat history or
+chat template. Static/WASM sessions cannot use it.
 
 The bounded `answer` interface now admits only an exact
 `Where is the <subject>?` question and punctuation-terminated source spans:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,22 @@ The earlier
 preserved #948–#958 sequencing record. Measured, refuted, and frozen research
 remains in [docs/RESEARCH.md](docs/RESEARCH.md).
 
+**Bounded local reference surface (2026-09-01):** #1039 productizes only the
+already-frozen #1017 checkpoint. Its predeclared fresh-prompt gate passed: one
+24-token continuation was nonempty UTF-8, avoided an immediate short cycle, and
+replayed byte-identically after removing timing; measured Apple Accelerate CPU
+wall times were `0.22 s` and `0.17 s`. The immutable export is bound to manifest
+CID `blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3`
+and tree CID
+`blake3:4819f8cbb6e673c4124eaa61e319b42adc54b1de178969916df035aad65a4000`.
+The resulting product slice is an opt-in, loopback-only, single-flight raw
+generation endpoint over the existing implementation, not a new model or
+inference path. Call it a **bounded local generation prototype**. It does not
+change the active V5 negative below, unblock #954, or implement #962's
+source-free multi-turn chat stage. CUDA and external GPU execution remain out
+of scope. See the
+[#1039 result and interface record](docs/r4_softmax_local_reference_surface_1039.md).
+
 **Active correction (2026-09-01):** #973's V5 predictive write/binding campaign
 is independently verified at `PREDICTIVE_BINDING_NO_TERMINAL_CAPACITY` (result
 CID `blake3:6c67544d675eafcb8eb9c0dabb93617e3f6c3295af812e8acbb687107c010a74`;
@@ -783,6 +799,9 @@ feasibility boundary remains in the
    contract that binds evidence provenance #970 → #969 → #983 → #986 plus the
    actual accepted selector → #953 → #973 path (#964);
    then activate only the release QA needed to qualify that exact path (#965).
+   The #1039 loopback surface is explicitly outside this source-free sequence:
+   it is a useful source-backed #1017 reference harness, not partial completion
+   of #962 and not an unblocker for #954.
 
 The live issue bodies and native dependencies now mirror this sequence. #961
 is closed. #952's terminal negative evidence is preserved in
@@ -813,7 +832,10 @@ generalization criterion not satisfied, and no H4 separation → qualified
 data-supported language-path decoder plus ordinary matched non-geometric
 control → rejected paired-H4/direct/layerwise/learned-associative capacity
 seams → terminal V5 predictive write/binding
-`PREDICTIVE_BINDING_NO_TERMINAL_CAPACITY` → `STOP_WITHOUT_GENERATION` →
+`PREDICTIVE_BINDING_NO_TERMINAL_CAPACITY` → `STOP_WITHOUT_GENERATION`; in a
+separate source-backed reference lane, #1039 wraps the frozen #1017 checkpoint
+in a dedicated bounded loopback endpoint without changing any model or
+source-free claim →
 blocked #954 → #955 →
 #962–#965. #973 continues to
 block #954.

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -7,6 +7,29 @@
 > architecture and claim boundaries live in the
 > [Geometric Intelligence Programme](geometric_intelligence_programme.md).
 
+> **Bounded #1017 reference-surface lifecycle (2026-09-01):** #1039 leaves the
+> frozen 7.15M checkpoint, sampler, attention, and training unchanged. Its
+> predeclared fresh-prompt gate generated 24 non-looping tokens twice with seed
+> `1039`; both outputs were valid UTF-8 and the full reports replayed
+> byte-identically after timing removal. Apple Accelerate CPU wall times were
+> `0.22 s` and `0.17 s`. Manifest/tree CIDs are
+> `blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3`
+> and
+> `blake3:4819f8cbb6e673c4124eaa61e319b42adc54b1de178969916df035aad65a4000`;
+> decision/output/audit/state CIDs are
+> `blake3:86ce45d07684f8abead1e4faca2346024ef7b01e99f9b0e3b51188deafcde61b`,
+> `blake3:87150ebc68ed1e3902f6e0c9937f7a642f234ac2a3644cc33262cb081715ae49`,
+> `blake3:3e7d642eb20c9e1d05c385df2802d120becb91ba88df16a9b61cf2569caec010`,
+> and
+> `blake3:ff69922ed27437e308852b053f3b3b15baebeb1e5a51c27c704f18f1ba423793`.
+> The positive transition adds an explicit loopback-only, single-flight raw
+> HTTP reference seam over the existing generator. The required export remains
+> local and operator-supplied; invalid readiness fails closed. This is a
+> **bounded local generation prototype**, not a new model, the source-free #962
+> chat lifecycle, or an unblocker for #954. CUDA and external GPU execution are
+> out of scope. See the
+> [#1039 result and interface record](r4_softmax_local_reference_surface_1039.md).
+
 > **Latest #973 lifecycle (2026-09-01):** the independently frozen
 > [`R4PredictiveBlockDeltaPromptCapacityV5`](r4_predictive_block_delta_binding_prompt_capacity_973.md)
 > terminal is complete and independently verified at
@@ -239,6 +262,12 @@ The #1017 export remains the current working 7.15M coherent-generation
 prototype. `r4 generate --prompt "..."` defaults to
 `.uor-models/research/issue-1017/export`. #1019 is an optional quality-capacity
 improvement and does not block using or productizing that bounded path. The
+same generator is now available through the opt-in raw
+`POST /uor/v1/r4-softmax-local/generate` #1039 reference endpoint. It remains
+disabled by default, loopback-only, single-flight, capped at 32 generated
+tokens, and bound at startup to the operator-supplied local export and
+exact-executor worker count. Accelerate owns its internal CPU scheduling. It is
+not `/v1/chat/completions` and does not implement chat state. The
 prototype remains source-backed, floating-point/matmul/softmax, and below the
 strict NLL target; it does not establish geometry advantage,
 transformerlessness, correctness, reasoning, frontier quality, browser/WASM

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,34 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
+> **Bounded source-backed product/reference result (2026-09-01).** #1039
+> exercised the immutable #1017 export on a predeclared fresh narrative prompt
+> with 24 generated tokens, seed `1039`, four exact-executor workers, and Apple Accelerate on
+> the CPU. Both runs returned nonempty valid UTF-8 with no immediate short
+> cycle; after removing timing, their complete JSON reports were byte-identical.
+> Wall times were `0.22 s` and `0.17 s`. All six layers were selected, the
+> causal/projection/R4/policy audits passed, and future, provider, and Ollama
+> reads were zero.
+>
+> The export manifest/tree CIDs are
+> `blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3`
+> and
+> `blake3:4819f8cbb6e673c4124eaa61e319b42adc54b1de178969916df035aad65a4000`;
+> decision/output/audit/persistent-state CIDs are
+> `blake3:86ce45d07684f8abead1e4faca2346024ef7b01e99f9b0e3b51188deafcde61b`,
+> `blake3:87150ebc68ed1e3902f6e0c9937f7a642f234ac2a3644cc33262cb081715ae49`,
+> `blake3:3e7d642eb20c9e1d05c385df2802d120becb91ba88df16a9b61cf2569caec010`,
+> and
+> `blake3:ff69922ed27437e308852b053f3b3b15baebeb1e5a51c27c704f18f1ba423793`.
+> The positive binding action is a disabled-by-default, loopback-only,
+> single-flight raw generation endpoint over the same implementation. This is a
+> **bounded local generation prototype**, not #962's source-free multi-turn chat
+> stage. It does not revise the #973 V5 terminal below, unblock #954, or establish
+> geometry advantage, transformerlessness, correctness, reasoning, standalone
+> browser/WASM operation, release, or frontier quality. Apple Accelerate/BLAS
+> is CPU-native here; CUDA and external GPU execution remain out of scope. See the
+> [#1039 result and interface record](r4_softmax_local_reference_surface_1039.md).
+
 > **Current forward decision (2026-09-01).** The independently frozen
 > `R4PredictiveBlockDeltaBindingV1` V5 campaign completed
 > `PREDICTIVE_BINDING_NO_TERMINAL_CAPACITY`. The geometric arm reached prompt

--- a/docs/r4_softmax_local_reference_surface_1039.md
+++ b/docs/r4_softmax_local_reference_surface_1039.md
@@ -1,0 +1,180 @@
+# #1039 bounded local generation reference surface
+
+- **Issue:** [#1039](https://github.com/UOR-Foundation/uor-r4/issues/1039)
+- **Date:** 2026-09-01
+- **Scope:** frozen #1017 checkpoint; native CPU execution; raw single-turn
+  local generation
+- **Result:** `POSITIVE_REFERENCE_SURFACE_GATE`
+
+This record adds a small access surface around the already-qualified #1017
+generator. It does not change the checkpoint, sampler, attention mechanism,
+training, or geometric programme. The model remains a bounded local generation
+prototype rather than the source-free route-native product planned in #962.
+
+## Frozen decision gate
+
+The fresh prompt was committed before execution and was not one of #1017's five
+qualification prompts:
+
+> Mira found a small brass key beneath the old pear tree.
+
+The invocation requested 24 new tokens with stable seed `1039`, attention
+enabled, four exact-executor workers, and the opt-in Apple Accelerate release backend. The
+gate required nonempty valid UTF-8, no immediate period-one through period-four
+cycle, exact fixed-seed output/token/audit replay, all-layer attention auditing,
+zero future reads, and zero provider or Ollama calls.
+
+The two runs decoded the same continuation:
+
+> She picked it up and said, “I believe it can be a big tree!”
+> Mira and her mommy
+
+Measured wall times were `0.22 s` and `0.17 s`. After removing timing, the two
+complete JSON reports were byte-identical. The bounded gate therefore passed
+and authorized only the dedicated loopback reference seam described below.
+
+## Evidence identities
+
+The immutable local export supplied to both runs was:
+
+- export-manifest CID:
+  `blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3`
+- export-tree CID:
+  `blake3:4819f8cbb6e673c4124eaa61e319b42adc54b1de178969916df035aad65a4000`
+- weights CID:
+  `blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d`
+- tokenizer CID:
+  `blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc`
+- config CID:
+  `blake3:1f1ddb6de22f5c81c04d3093eeff8e0991d63b79ee33bc8ff3cf7c68ef0a9497`
+- training-result CID:
+  `blake3:7d8e859d30729971c6428a11fdbc4db07890c663a13a1425ae9998efad56ef69`
+
+The replayed generation evidence was:
+
+- decision CID:
+  `blake3:86ce45d07684f8abead1e4faca2346024ef7b01e99f9b0e3b51188deafcde61b`
+- output CID:
+  `blake3:87150ebc68ed1e3902f6e0c9937f7a642f234ac2a3644cc33262cb081715ae49`
+- attention-audit CID:
+  `blake3:3e7d642eb20c9e1d05c385df2802d120becb91ba88df16a9b61cf2569caec010`
+- persistent-state CID:
+  `blake3:ff69922ed27437e308852b053f3b3b15baebeb1e5a51c27c704f18f1ba423793`
+
+All six layers were selected. The causal, projection, R4, policy, and
+source-read audits passed; future, provider, and Ollama reads were zero. The
+selected backend was Apple Accelerate and the effective exact-executor worker
+count was four. Accelerate is a CPU-native local inference backend here and
+owns its internal CPU scheduling; the worker setting is not a BLAS thread cap.
+CUDA and external GPU execution are not part of this surface.
+
+## Native HTTP reference seam
+
+The dedicated endpoint is disabled by default and must bind to a loopback host.
+It uses the existing #1017 generation implementation under a process-wide
+single-flight reservation; it is not a second inference engine.
+
+The required local export is not downloaded or reconstructed by the server. An
+operator supplies it explicitly and owns the fixed exact-executor worker count
+(defaulting to up to four, capped by the process's available parallelism).
+Preflight admits
+exactly the five frozen export files; additional loader inputs, including a
+Safetensors shard index, fail closed:
+
+```bash
+cargo build --release --offline --features local-inference-accelerate --bin r4
+target/release/r4 --host 127.0.0.1 --port 8000 serve \
+  --enable-r4-softmax-local \
+  --r4-softmax-local-model .uor-models/research/issue-1017/export \
+  --r4-softmax-local-workers 4
+```
+
+Generate one bounded raw continuation:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8000/uor/v1/r4-softmax-local/generate \
+  -H 'content-type: application/json' \
+  --data '{"prompt":"Mira found a small brass key beneath the old pear tree.","max_tokens":8}'
+```
+
+`max_tokens` defaults to 8 and is capped at 32. Requests cannot select a model,
+backend, or exact-executor worker count. The response schema is
+`uor-r4.r4-softmax-local-http/1`. A successful response contains `schema`,
+`generator`, `claim_scope`, checkpoint identities and exact-backend provenance,
+`model_shape`, `input_tokens`, `generated_token_ids`, `response_text`,
+`stop_reason`, decision/generation-policy/output/audit/persistent-state CIDs,
+compact attention/output-policy/decode/source-read audits, `execution`,
+`timing`, and `nonclaims`. It does not reflect the prompt, prompt token IDs,
+local model path, or filenames. `GET /api/sysinfo` reports
+`r4_softmax_local.checkpoint_preflight_ready`. Errors use
+`{"error":{"type":"r4_softmax_local_error","code":"...","message":"..."}}`.
+
+This is a dedicated raw single-turn research endpoint. It is not
+`/v1/chat/completions`, does not implement chat history, and does not replace the
+default server engine, the older pinned-source reference bridge, the dashboard,
+or the WASM path. The native-served dashboard may invoke this endpoint only
+after `checkpoint_preflight_ready`; it sends the current prompt as a raw request
+without a chat template or prior turns. Static/WASM sessions cannot invoke it.
+Missing or invalid local export state fails closed.
+
+## Implemented endpoint qualification
+
+The release binary was rebuilt from the #1039 implementation with
+`local-inference-accelerate`, then started on `127.0.0.1` with the frozen
+export and four operator-owned exact-executor workers. `GET /api/sysinfo` reported the bridge
+enabled, `checkpoint_preflight_ready=true`, attention enabled, greedy decoding,
+an eight-token default, a 32-token maximum, and `static_wasm=false`.
+
+The documented request was then sent through the real HTTP listener with an
+eight-token cap. It returned in `0.16 s` wall time:
+
+> She was so excited to see what it
+
+The report measured `0.036683167 s` generation time and `0.126289625 s` total
+time. Its endpoint-specific evidence identities were:
+
+- decision CID:
+  `blake3:87d8e9689132584a1437a244bab4e97e03af9d2609905ae6c74db0fa792c2522`
+- output CID:
+  `blake3:aef50423770f79714247e2e496d7f49381423893cbb8c636a31276ff9a5aa885`
+- audit CID:
+  `blake3:6ba5f8d8073748f57692e92a10291d507ef6963251e42069fa42256f56072ffc`
+- persistent-state CID:
+  `blake3:0a837266df1c81d2cc2d54e32c41d6b4e6f0476dfe2bcf04103576278e995390`
+- loader checkpoint-tree CID:
+  `blake3:66ee347b23e818f1816682f0b942737c88f1eca831cd6d4f00b3d14fc00aaa37`
+
+The loader checkpoint-tree CID covers its admitted local tree and is distinct
+from the export manifest's artifact-array tree CID recorded above. Weights and
+tokenizer CIDs remained unchanged. Apple Accelerate was selected, all causal,
+projection, R4, output-policy, all-layer, and zero-future-read audits passed,
+and provider/Ollama calls remained zero. A second HTTP request produced the
+same response and complete report after timing was removed. A raw-response scan
+also confirmed that prompt text, prompt-token fields, the local model path, and
+checkpoint filenames were absent.
+
+Independent review then closed two boundary defects before delivery: preflight
+now rejects every file outside the exact five-file export (preventing an
+uncommitted shard index from changing loader selection), and the shared
+single-flight reservation no longer carries the private checkpoint path. A
+post-hardening Accelerate rerun returned the same text and evidence CIDs in
+`0.20 s` wall time with the same audit and response-scrubbing predicates.
+
+## Claim boundary and next decision
+
+This positive result establishes only that the frozen #1017 generator can
+produce and exactly replay one bounded fresh continuation and can be exposed
+through a constrained CPU-native loopback reference seam.
+
+It does **not** establish geometry advantage, transformerlessness,
+source-free/table-native/multiply-free execution, broad coherence, correctness,
+reasoning, instruction following, chat quality, browser/WASM readiness, release
+quality, or frontier capability beyond the explicitly bounded native-dashboard
+wiring above. #973's V5 terminal remains
+`PREDICTIVE_BINDING_NO_TERMINAL_CAPACITY` with action
+`STOP_WITHOUT_GENERATION`. This reference lane does not close or unblock #954,
+and it does not implement #962's source-free multi-turn CLI/HTTP chat stage.
+
+The next product decision must be based on actual use of this bounded surface.
+No additional training campaign or geometry mechanism is authorized by this
+record.

--- a/index.html
+++ b/index.html
@@ -996,7 +996,7 @@
                 <span class="config-val" id="engineVal" style="color: var(--cyan); font-weight: bold;">Geometric</span>
             </div>
             <div class="config-row" style="margin-bottom: 0.75rem; font-size: 0.75rem; color: #888;">
-                <span>↳ Exploratory route-conditioned continuation</span>
+                <span id="engineScopeVal">↳ Exploratory route-conditioned continuation</span>
             </div>
 
             <div class="identity-label">Routing Identity (UOR, address, or text)</div>
@@ -1007,6 +1007,7 @@
                 <optgroup label="Current interactive surface">
                     <option value="geometric" selected>Geometric Router Research Demo</option>
                     <option value="r4-softmax-reference" id="r4SoftmaxReferenceOption" hidden disabled>R4/Spin Softmax Reference — native source-backed</option>
+                    <option value="r4-softmax-local" id="r4SoftmaxLocalOption" hidden disabled>R4/Spin Local #1017 — bounded raw completion</option>
                 </optgroup>
                 <optgroup label="Preserved artifact experiments (setup required)">
                     <option value="r4g1">Historical R4G1 Runtime — requires admitted bundle</option>
@@ -1016,6 +1017,9 @@
             </select>
             <div id="r4SoftmaxReferenceNote" hidden style="font-size:0.64rem; margin-top:-0.45rem; margin-bottom:0.75rem; color:var(--amber); line-height:1.35;">
                 Native research reference: ordinary causal softmax in coherent R4/Spin frames. One local decode may take several minutes; this is not the source-free runtime.
+            </div>
+            <div id="r4SoftmaxLocalNote" hidden style="font-size:0.64rem; margin-top:-0.45rem; margin-bottom:0.75rem; color:var(--amber); line-height:1.35;">
+                Frozen source-backed #1017 CPU reference: bounded single-turn raw completion with fixed greedy decoding. Only the current prompt and token cap are sent; routing identity, temperature, state decay, and chat memory do not apply. This is not source-free, transformerless, or a WASM/static engine.
             </div>
 
             <div class="section-label">Manifold Database & Indexing</div>
@@ -1380,8 +1384,11 @@ const tempVal     = document.getElementById("tempVal");
 const tokensVal   = document.getElementById("tokensVal");
 const gammaVal    = document.getElementById("gammaVal");
 const engineVal   = document.getElementById("engineVal");
+const engineScopeVal = document.getElementById("engineScopeVal");
 const r4SoftmaxReferenceOption = document.getElementById("r4SoftmaxReferenceOption");
 const r4SoftmaxReferenceNote = document.getElementById("r4SoftmaxReferenceNote");
+const r4SoftmaxLocalOption = document.getElementById("r4SoftmaxLocalOption");
+const r4SoftmaxLocalNote = document.getElementById("r4SoftmaxLocalNote");
 
 const kbTextarea  = document.getElementById("kbTextarea");
 const indexBtn    = document.getElementById("indexBtn");
@@ -1504,6 +1511,13 @@ let localWasmMode = false;
 let serverResearchDemo = false;
 let serverR4g1Ready = false;
 let serverR4SoftmaxReferenceReady = false;
+let serverR4SoftmaxLocalReady = false;
+const R4_SOFTMAX_LOCAL_ENDPOINT = "/uor/v1/r4-softmax-local/generate";
+const R4_SOFTMAX_LOCAL_UI_DEFAULT_TOKENS = 8;
+const R4_SOFTMAX_LOCAL_UI_MAX_TOKENS = 32;
+let serverR4SoftmaxLocalEndpoint = R4_SOFTMAX_LOCAL_ENDPOINT;
+let serverR4SoftmaxLocalDefaultTokens = R4_SOFTMAX_LOCAL_UI_DEFAULT_TOKENS;
+let serverR4SoftmaxLocalMaxTokens = R4_SOFTMAX_LOCAL_UI_MAX_TOKENS;
 let r4g1ProductionInstalled = false;
 let r4g1InstallError = "schema-2 production bundle has not been installed";
 
@@ -1665,6 +1679,41 @@ function syncR4SoftmaxReferenceAvailability(info) {
         r4SoftmaxReferenceNote.hidden = !serverR4SoftmaxReferenceReady;
     }
     if (!serverR4SoftmaxReferenceReady && engineSelect?.value === "r4-softmax-reference") {
+        engineSelect.value = "geometric";
+    }
+}
+
+function syncR4SoftmaxLocalAvailability(info) {
+    const status = info?.r4_softmax_local || {};
+    serverR4SoftmaxLocalReady = !localWasmMode
+        && Boolean(status.enabled)
+        && Boolean(status.checkpoint_preflight_ready)
+        && status.attention_on === true
+        && status.greedy === true
+        && status.static_wasm === false;
+    serverR4SoftmaxLocalEndpoint = status.endpoint === R4_SOFTMAX_LOCAL_ENDPOINT
+        ? status.endpoint
+        : R4_SOFTMAX_LOCAL_ENDPOINT;
+    const reportedLimit = Number(
+        status.maximum_max_tokens
+            ?? status.limits?.max_tokens
+            ?? status.limits?.max_new_tokens
+    );
+    serverR4SoftmaxLocalMaxTokens = Number.isInteger(reportedLimit) && reportedLimit > 0
+        ? Math.min(reportedLimit, R4_SOFTMAX_LOCAL_UI_MAX_TOKENS)
+        : R4_SOFTMAX_LOCAL_UI_MAX_TOKENS;
+    const reportedDefault = Number(status.default_max_tokens);
+    serverR4SoftmaxLocalDefaultTokens = Number.isInteger(reportedDefault) && reportedDefault > 0
+        ? Math.min(reportedDefault, serverR4SoftmaxLocalMaxTokens)
+        : Math.min(R4_SOFTMAX_LOCAL_UI_DEFAULT_TOKENS, serverR4SoftmaxLocalMaxTokens);
+    if (r4SoftmaxLocalOption) {
+        r4SoftmaxLocalOption.hidden = !serverR4SoftmaxLocalReady;
+        r4SoftmaxLocalOption.disabled = !serverR4SoftmaxLocalReady;
+    }
+    if (r4SoftmaxLocalNote) {
+        r4SoftmaxLocalNote.hidden = !serverR4SoftmaxLocalReady;
+    }
+    if (!serverR4SoftmaxLocalReady && engineSelect?.value === "r4-softmax-local") {
         engineSelect.value = "geometric";
     }
 }
@@ -2866,6 +2915,9 @@ async function runLocalChat(text, identity) {
     if (engineSelect?.value === "r4-softmax-reference") {
         throw new Error("The R4/Spin softmax reference is native-only and was not exposed by this static/WASM session");
     }
+    if (engineSelect?.value === "r4-softmax-local") {
+        throw new Error("R4/Spin Local #1017 is native-only and was not exposed by this static/WASM session");
+    }
     if (!router) {
         const ok = await tryInitLocalWasm();
         if (!ok || !router) {
@@ -3000,32 +3052,70 @@ async function sendQuery(text) {
     if (!text.trim()) return;
     const selectedEngineMode = engineSelect?.value || "geometric";
     const referenceRequest = selectedEngineMode === "r4-softmax-reference";
+    const localCheckpointRequest = selectedEngineMode === "r4-softmax-local";
+    const nativeReferenceRequest = referenceRequest || localCheckpointRequest;
+    const referenceModelLabel = referenceRequest ? "R4/Spin Softmax Reference" : null;
+    const localCheckpointModelLabel = localCheckpointRequest ? "R4/Spin Local #1017" : null;
+    const responseModelLabel = localCheckpointModelLabel || referenceModelLabel;
+    const localCheckpointMaxTokens = Math.min(
+        serverR4SoftmaxLocalDefaultTokens,
+        serverR4SoftmaxLocalMaxTokens,
+        R4_SOFTMAX_LOCAL_UI_MAX_TOKENS
+    );
     addMessage("user", text);
     chatInput.value = "";
     chatInput.disabled = true;
     sendBtn.disabled = true;
 
     const loadMsg = document.createElement("div"); loadMsg.className = "message model";
-    loadMsg.innerHTML = referenceRequest
-        ? `<div class="avatar">R4</div><div class="message-content"><div class="message-sender">R4/Spin Softmax Reference</div><div class="message-bubble" style="padding:0.75rem 1rem"><span class="reference-wait">Running one exact local decode · elapsed 0:00</span></div></div>`
+    const nativeWaitLabel = localCheckpointRequest
+        ? `Running source-backed #1017 raw completion · ${localCheckpointMaxTokens}-token cap`
+        : "Running one exact local decode";
+    loadMsg.innerHTML = nativeReferenceRequest
+        ? `<div class="avatar">R4</div><div class="message-content"><div class="message-sender">${responseModelLabel}</div><div class="message-bubble" style="padding:0.75rem 1rem"><span class="reference-wait">${nativeWaitLabel} · elapsed 0:00</span></div></div>`
         : `<div class="avatar">R4</div><div class="message-content"><div class="message-sender">R4 Prime Router</div><div class="message-bubble" style="padding:0.75rem 1rem"><div class="loading-dots"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div></div></div>`;
     chatLogInner.appendChild(loadMsg);
     scrollToBottom();
 
     const referenceStarted = Date.now();
     const referenceWait = loadMsg.querySelector(".reference-wait");
-    const referenceTicker = referenceRequest ? window.setInterval(() => {
+    const referenceTicker = nativeReferenceRequest ? window.setInterval(() => {
         const elapsed = Math.floor((Date.now() - referenceStarted) / 1000);
         const minutes = Math.floor(elapsed / 60);
         const seconds = String(elapsed % 60).padStart(2, "0");
-        if (referenceWait) referenceWait.textContent = `Running one exact local decode · elapsed ${minutes}:${seconds}`;
+        if (referenceWait) referenceWait.textContent = `${nativeWaitLabel} · elapsed ${minutes}:${seconds}`;
     }, 1000) : null;
 
     const identity = document.getElementById("identityInput")?.value.trim() || "null_dev_00";
     try {
         let data;
-        if (localWasmMode) {
-            data = await runLocalChat(text, identity);
+        if (localCheckpointRequest) {
+            if (localWasmMode || !serverR4SoftmaxLocalReady) {
+                throw new Error("The source-backed #1017 checkpoint did not pass native server preflight; it is unavailable in this session");
+            }
+            const response = await fetch(serverR4SoftmaxLocalEndpoint, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                // Deliberately raw and single-turn: no identity, history, or chat envelope.
+                body: JSON.stringify({ prompt: text, max_tokens: localCheckpointMaxTokens })
+            });
+            if (!response.ok) {
+                const raw = await response.text();
+                let detail = null;
+                try { detail = JSON.parse(raw); } catch (_) { /* plain-text error */ }
+                const message = detail?.error?.message || detail?.error || detail?.message || raw
+                    || `HTTP error: ${response.status}`;
+                throw new Error(message);
+            }
+            const localCheckpoint = await response.json();
+            if (typeof localCheckpoint.response_text !== "string"
+                || !localCheckpoint.response_text.trim()) {
+                throw new Error("The #1017 endpoint returned no nonempty response_text");
+            }
+            data = {
+                description: localCheckpoint.response_text,
+                localCheckpoint
+            };
         } else if (referenceRequest) {
             if (!serverR4SoftmaxReferenceReady) {
                 throw new Error("The native R4/Spin softmax reference bridge is not enabled and source-ready");
@@ -3046,6 +3136,8 @@ async function sendQuery(text) {
                 description: reference.response_text,
                 reference
             };
+        } else if (localWasmMode) {
+            data = await runLocalChat(text, identity);
         } else {
             const payload = {
                 text: text,
@@ -3076,10 +3168,61 @@ async function sendQuery(text) {
             "model",
             data.description,
             true,
-            referenceRequest ? "R4/Spin Softmax Reference" : null
+            responseModelLabel
         );
 
-        if (referenceRequest) {
+        if (localCheckpointRequest) {
+            const localCheckpoint = data.localCheckpoint;
+            const audit = localCheckpoint.audit || {};
+            const attentionAudit = audit.attention || {};
+            const outputPolicyAudit = audit.attention_output_policy || {};
+            const decodeAudit = audit.decode || {};
+            const sourceReadAudit = audit.source_read || {};
+            const attentionExact = attentionAudit.causal_audit_exact === true
+                && attentionAudit.projection_audit_exact === true
+                && attentionAudit.r4_audit_exact === true
+                && attentionAudit.all_layers_selected === true
+                && attentionAudit.zero_future_reads === true
+                && outputPolicyAudit.exact === true;
+            const decodeQualified = decodeAudit.utf8_decodable === true
+                && decodeAudit.short_cycle_period === null;
+            const generatedTokens = Array.isArray(localCheckpoint.generated_token_ids)
+                ? localCheckpoint.generated_token_ids.length
+                : null;
+            const generationSeconds = Number(localCheckpoint.timing?.generation_seconds);
+            const stopReason = typeof localCheckpoint.stop_reason === "string"
+                ? localCheckpoint.stop_reason
+                : Number.isInteger(localCheckpoint.stop_reason?.short_cycle?.period)
+                    ? `short_cycle(${localCheckpoint.stop_reason.short_cycle.period})`
+                    : "unavailable";
+            const timingParts = [];
+            if (Number.isFinite(generationSeconds)) {
+                timingParts.push(`${generationSeconds.toFixed(1)}s`);
+            }
+            timingParts.push(generatedTokens === null ? "bounded output" : `${generatedTokens} tokens`);
+            timingParts.push(decodeQualified ? "UTF-8 · no short cycle" : "decode audit incomplete");
+            safeSetTextContent("output-timing", timingParts.join(" · "));
+            const output = document.getElementById("console-output");
+            if (output) {
+                output.textContent = [
+                    localCheckpoint.generator || "R4SoftmaxLocalGeneratorV1",
+                    "source-backed #1017 bounded raw completion · single turn · no chat memory",
+                    `checkpoint tree ${localCheckpoint.checkpoint?.checkpoint_tree_cid || "unavailable"}`,
+                    `weights ${localCheckpoint.checkpoint?.weights_cid || "unavailable"}`,
+                    `tokenizer ${localCheckpoint.checkpoint?.tokenizer_cid || "unavailable"}`,
+                    `decision ${localCheckpoint.decision_cid || "unavailable"}`,
+                    `output ${localCheckpoint.output_cid || "unavailable"}`,
+                    `audit ${localCheckpoint.audit_cid || "unavailable"}`,
+                    `state ${localCheckpoint.persistent_state_cid || "unavailable"}`,
+                    `layers ${localCheckpoint.model_shape?.layers ?? "?"} · ${attentionExact ? "attention audits exact" : "attention audit incomplete"}`,
+                    `decode ${decodeQualified ? "UTF-8 / no short cycle" : "qualification incomplete"} · stop ${stopReason}`,
+                    `source calls provider ${sourceReadAudit.provider_calls ?? "?"} · Ollama ${sourceReadAudit.ollama_calls ?? "?"}`,
+                    `exact-executor workers ${localCheckpoint.execution?.effective_workers ?? localCheckpoint.execution?.requested_workers ?? "?"} · Accelerate schedules its own CPU work`,
+                    "Not source-free, transformerless, broad chat, reasoning, or WASM/static inference."
+                ].join("\n");
+            }
+            updateSelectedEngineValue();
+        } else if (referenceRequest) {
             const reference = data.reference;
             const audit = reference.audit || {};
             const exact = audit.causal_audit_exact
@@ -3113,11 +3256,16 @@ async function sendQuery(text) {
     } catch (err) {
         console.error("Chat request failed:", err);
         chatLogInner.removeChild(loadMsg);
+        const errorPrefix = localCheckpointRequest
+            ? "R4/Spin Local #1017 error"
+            : referenceRequest
+                ? "R4/Spin reference error"
+                : "Error contacting Prime Router";
         addMessage(
             "model",
-            `${referenceRequest ? "R4/Spin reference error" : "Error contacting Prime Router"}: ${err.message}`,
+            `${errorPrefix}: ${err.message}`,
             true,
-            referenceRequest ? "R4/Spin Softmax Reference" : null
+            responseModelLabel
         );
     } finally {
         if (referenceTicker !== null) window.clearInterval(referenceTicker);
@@ -3311,6 +3459,7 @@ function selectedEngineLabel(engine) {
         "attention": "Full Attention Llama",
         "r4-attention": "Experimental R4 Attention",
         "r4-softmax-reference": "R4/Spin Softmax Reference",
+        "r4-softmax-local": "R4/Spin Local #1017",
         "geometric": "Geometric Research Demo"
     }[engine] || "R4G1 Graph";
 }
@@ -3318,10 +3467,19 @@ function selectedEngineLabel(engine) {
 function updateSelectedEngineValue() {
     if (!engineVal) return;
     engineVal.textContent = selectedEngineLabel(engineSelect?.value || "geometric");
+    if (engineScopeVal) {
+        engineScopeVal.textContent = engineSelect?.value === "r4-softmax-local"
+            ? "↳ Source-backed #1017 raw single-turn completion"
+            : engineSelect?.value === "r4-softmax-reference"
+                ? "↳ Native source-backed softmax attention reference"
+                : "↳ Exploratory route-conditioned continuation";
+    }
     if (engineSelect?.value === "r4g1") {
         engineVal.style.color = serverR4g1Ready ? "var(--emerald)" : "var(--amber)";
     } else if (engineSelect?.value === "r4-softmax-reference") {
         engineVal.style.color = serverR4SoftmaxReferenceReady ? "var(--purple)" : "var(--amber)";
+    } else if (engineSelect?.value === "r4-softmax-local") {
+        engineVal.style.color = serverR4SoftmaxLocalReady ? "var(--purple)" : "var(--amber)";
     } else {
         engineVal.style.color = "var(--cyan)";
     }
@@ -3697,6 +3855,7 @@ function pollSysinfo() {
                 localWasmMode = false;
                 serverResearchDemo = Boolean(info && info.research_demo);
                 syncR4SoftmaxReferenceAvailability(info);
+                syncR4SoftmaxLocalAvailability(info);
                 if (serverResearchDemo && engineSelect) engineSelect.value = "geometric";
                 updateConnectionStatusUI();
                 if (info && info.sentences_indexed !== undefined) {
@@ -3718,6 +3877,7 @@ function pollSysinfo() {
                 localWasmMode = true;
                 serverResearchDemo = true;
                 syncR4SoftmaxReferenceAvailability(null);
+                syncR4SoftmaxLocalAvailability(null);
                 if (engineSelect) engineSelect.value = "geometric";
                 updateConnectionStatusUI();
                 if (window.wasm_module && typeof router !== 'undefined') {
@@ -3912,7 +4072,9 @@ async function restoreSessionFromLocalStorage() {
                 const restoredEngine = session.engineSelect || "geometric";
                 const referenceUnavailable = restoredEngine === "r4-softmax-reference"
                     && !serverR4SoftmaxReferenceReady;
-                engineSelect.value = (localWasmMode || serverResearchDemo || referenceUnavailable)
+                const localCheckpointUnavailable = restoredEngine === "r4-softmax-local"
+                    && !serverR4SoftmaxLocalReady;
+                engineSelect.value = (localWasmMode || serverResearchDemo || referenceUnavailable || localCheckpointUnavailable)
                     ? "geometric"
                     : restoredEngine;
             }
@@ -3973,7 +4135,11 @@ function updateConnectionStatusUI() {
         const isR4g1Unavailable = selected === "r4g1" && !serverR4g1Ready;
         const isReferenceUnavailable = selected === "r4-softmax-reference"
             && !serverR4SoftmaxReferenceReady;
-        const selectedUnavailable = isR4g1Unavailable || isReferenceUnavailable;
+        const isLocalCheckpointUnavailable = selected === "r4-softmax-local"
+            && !serverR4SoftmaxLocalReady;
+        const selectedUnavailable = isR4g1Unavailable
+            || isReferenceUnavailable
+            || isLocalCheckpointUnavailable;
         if (dot) {
             dot.style.background = selectedUnavailable ? "var(--amber)" : "var(--emerald)";
             dot.style.boxShadow = selectedUnavailable
@@ -3987,6 +4153,12 @@ function updateConnectionStatusUI() {
             } else if (isReferenceUnavailable) {
                 route.textContent = "🟠 Server online · R4/Spin reference unavailable";
                 route.style.color = "var(--amber)";
+            } else if (isLocalCheckpointUnavailable) {
+                route.textContent = "🟠 Server online · #1017 checkpoint preflight unavailable";
+                route.style.color = "var(--amber)";
+            } else if (selected === "r4-softmax-local") {
+                route.textContent = "🟢 Local native · #1017 bounded raw completion (no chat memory)";
+                route.style.color = "var(--emerald)";
             } else {
                 route.textContent = `🟢 Connected · ${selectedEngineLabel(selected)}`;
                 route.style.color = "var(--emerald)";
@@ -4009,6 +4181,7 @@ async function startApp() {
                 localWasmMode = false;
                 serverResearchDemo = Boolean(info && info.research_demo);
                 syncR4SoftmaxReferenceAvailability(info);
+                syncR4SoftmaxLocalAvailability(info);
                 if (serverResearchDemo && engineSelect) engineSelect.value = "geometric";
                 updateConnectionStatusUI();
                 console.log("[+] Server detected, using backend routing.");
@@ -4020,6 +4193,7 @@ async function startApp() {
             localWasmMode = true;
             serverResearchDemo = true;
             syncR4SoftmaxReferenceAvailability(null);
+            syncR4SoftmaxLocalAvailability(null);
             if (engineSelect) engineSelect.value = "geometric";
             updateConnectionStatusUI();
             await tryInitLocalWasm();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ mod facade_smoke_tests {
     }
 
     #[test]
-    fn static_wasm_cannot_masquerade_as_the_native_r4_softmax_reference() {
+    fn static_wasm_cannot_masquerade_as_native_r4_softmax_engines() {
         let dashboard = include_str!("../index.html");
         let worker = include_str!("../r4_worker.js");
         assert!(dashboard.contains("id=\"r4SoftmaxReferenceOption\" hidden disabled"));
@@ -299,5 +299,20 @@ mod facade_smoke_tests {
         assert!(dashboard.contains("fetch(\"/uor/v1/r4-softmax-reference/generate\""));
         assert!(dashboard.contains("referenceRequest ? \"R4/Spin Softmax Reference\" : null"));
         assert!(!worker.contains("r4-softmax-reference"));
+
+        assert!(dashboard.contains("id=\"r4SoftmaxLocalOption\" hidden disabled"));
+        assert!(dashboard.contains("serverR4SoftmaxLocalReady = !localWasmMode"));
+        assert!(dashboard.contains("Boolean(status.checkpoint_preflight_ready)"));
+        assert!(dashboard.contains("status.attention_on === true"));
+        assert!(dashboard.contains("status.greedy === true"));
+        assert!(dashboard.contains("status.static_wasm === false"));
+        assert!(dashboard.contains(
+            "R4/Spin Local #1017 is native-only and was not exposed by this static/WASM session"
+        ));
+        assert!(dashboard.contains(
+            "body: JSON.stringify({ prompt: text, max_tokens: localCheckpointMaxTokens })"
+        ));
+        assert!(dashboard.contains("fetch(serverR4SoftmaxLocalEndpoint"));
+        assert!(!worker.contains("r4-softmax-local"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,6 +1019,15 @@ struct ServeArgs {
     /// Operator-owned projection workers (defaults to up to 8, capped by process parallelism).
     #[arg(long, requires = "enable_r4_softmax_reference")]
     r4_softmax_workers: Option<usize>,
+    /// Explicitly expose the frozen #1017 learned checkpoint on a local-only route.
+    #[arg(long)]
+    enable_r4_softmax_local: bool,
+    /// Exact frozen #1017 export used only by the opt-in local reference route.
+    #[arg(long, requires = "enable_r4_softmax_local")]
+    r4_softmax_local_model: Option<PathBuf>,
+    /// Exact-executor workers (defaults to up to 4, capped by process parallelism).
+    #[arg(long, requires = "enable_r4_softmax_local")]
+    r4_softmax_local_workers: Option<usize>,
 }
 
 #[derive(Args, Debug)]
@@ -1091,6 +1100,7 @@ impl Cli {
             tless_corpus_recs: self.tless_corpus_recs.clone(),
             geometric_demo: false,
             r4_softmax_reference: None,
+            r4_softmax_local: None,
         }
     }
 
@@ -1116,6 +1126,24 @@ fn resolve_r4_softmax_reference_workers(
     if workers.get() > available {
         return Err(format!(
             "--r4-softmax-workers={} exceeds the {available} workers available to this process",
+            workers.get()
+        ));
+    }
+    Ok(workers)
+}
+
+fn resolve_r4_softmax_local_workers(
+    requested: Option<usize>,
+) -> Result<std::num::NonZeroUsize, String> {
+    let available = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+    let workers = requested.unwrap_or(server::R4_SOFTMAX_LOCAL_HTTP_DEFAULT_WORKERS.min(available));
+    let workers = std::num::NonZeroUsize::new(workers)
+        .ok_or_else(|| "--r4-softmax-local-workers must be greater than zero".to_owned())?;
+    if workers.get() > available {
+        return Err(format!(
+            "--r4-softmax-local-workers={} exceeds the {available} workers available to this process",
             workers.get()
         ));
     }
@@ -2517,7 +2545,9 @@ fn print_research_tools() {
     println!("  deployed-quality, certify, compare, compare-report, scenarios");
     println!();
     println!("Run `r4 <command> --help` for an individual preserved command.");
-    println!("These paths are retained research infrastructure, not the active route-native intelligence sequence.");
+    println!(
+        "These paths are retained research infrastructure, not the active route-native intelligence sequence."
+    );
 }
 
 /// Default location of the reference teacher checkpoint used by `certify`/`compare`.
@@ -2535,7 +2565,7 @@ fn resolve_r4_softmax_local_model(configured: &Path) -> Result<PathBuf, RunError
     };
     if !model.join("model.safetensors").is_file() {
         return Err(RunError::Command(format!(
-            "no local #1017 model found at {}; set UOR_MODEL_STORE or pass --model",
+            "no local #1017 model found at {}; set UOR_MODEL_STORE or pass --model/--r4-softmax-local-model",
             model.display()
         )));
     }
@@ -2594,7 +2624,9 @@ fn run(cli: &Cli) -> Result<(), RunError> {
             config.geometric_demo = true;
             println!("UOR-R4 geometric router research demo");
             println!("Open http://{}:{} in a browser.", config.host, config.port);
-            println!("This demonstrates routing, retrieval, and geometry telemetry; it is not yet the source-free intelligence engine.");
+            println!(
+                "This demonstrates routing, retrieval, and geometry telemetry; it is not yet the source-free intelligence engine."
+            );
             server::run_server(Arc::new(config));
             Ok(())
         }
@@ -3108,9 +3140,24 @@ fn run(cli: &Cli) -> Result<(), RunError> {
                     workers,
                 });
             }
+            if args.enable_r4_softmax_local {
+                let configured_model = args
+                    .r4_softmax_local_model
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new(DEFAULT_R4_SOFTMAX_LOCAL_MODEL));
+                let model = resolve_r4_softmax_local_model(configured_model)?;
+                let workers = resolve_r4_softmax_local_workers(args.r4_softmax_local_workers)
+                    .map_err(RunError::Command)?;
+                config.r4_softmax_local = Some(server::R4SoftmaxLocalHttpConfig { model, workers });
+            }
             server::validate_r4_softmax_reference_http_startup(
                 &config.host,
                 config.r4_softmax_reference.as_ref(),
+            )
+            .map_err(RunError::Command)?;
+            server::validate_r4_softmax_local_http_startup(
+                &config.host,
+                config.r4_softmax_local.as_ref(),
             )
             .map_err(RunError::Command)?;
             server::run_server(Arc::new(config));
@@ -4983,6 +5030,9 @@ mod tests {
         assert!(!args.enable_r4_softmax_reference);
         assert!(args.r4_softmax_source.is_none());
         assert!(args.r4_softmax_workers.is_none());
+        assert!(!args.enable_r4_softmax_local);
+        assert!(args.r4_softmax_local_model.is_none());
+        assert!(args.r4_softmax_local_workers.is_none());
 
         let cli = Cli::try_parse_from([
             "r4",
@@ -5005,6 +5055,49 @@ mod tests {
         assert_eq!(args.r4_softmax_workers, Some(8));
 
         assert!(Cli::try_parse_from(["r4", "serve", "--r4-softmax-workers", "8"]).is_err());
+    }
+
+    #[test]
+    fn serve_keeps_r4_softmax_local_disabled_and_operator_owned() {
+        let cli = Cli::try_parse_from([
+            "r4",
+            "serve",
+            "--enable-r4-softmax-local",
+            "--r4-softmax-local-model",
+            "/models/issue-1017/export",
+            "--r4-softmax-local-workers",
+            "4",
+        ])
+        .unwrap();
+        let Some(Command::Serve(args)) = cli.command else {
+            panic!("expected serve")
+        };
+        assert!(args.enable_r4_softmax_local);
+        assert_eq!(
+            args.r4_softmax_local_model,
+            Some(PathBuf::from("/models/issue-1017/export"))
+        );
+        assert_eq!(args.r4_softmax_local_workers, Some(4));
+
+        assert!(Cli::try_parse_from([
+            "r4",
+            "serve",
+            "--r4-softmax-local-model",
+            "/models/issue-1017/export",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from(["r4", "serve", "--r4-softmax-local-workers", "4",]).is_err());
+        let available = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1);
+        assert_eq!(
+            super::resolve_r4_softmax_local_workers(None)
+                .expect("bounded default")
+                .get(),
+            4.min(available)
+        );
+        assert!(super::resolve_r4_softmax_local_workers(Some(0)).is_err());
+        assert!(super::resolve_r4_softmax_local_workers(Some(available + 1)).is_err());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,12 @@ use uor_r4_router::fallback::{
 };
 
 use crate::geometric_decoder::{validate_source, PINNED_SOURCE_REVISION};
+use crate::r4_softmax_local_generation::{
+    run_r4_softmax_local_generation, AttentionOutputPolicyAuditRecord, LocalDecodeAudit,
+    R4SoftmaxLocalGenerationError, R4SoftmaxLocalGenerationReport, R4SoftmaxLocalGeneratorConfig,
+    SourceReadAudit, TimingReport as R4SoftmaxLocalTimingReport,
+    POLICY_SCHEMA as R4_SOFTMAX_LOCAL_POLICY_SCHEMA,
+};
 use crate::r4_softmax_reference_generation::{
     run_r4_softmax_reference_generation, AttentionAuditEvidence, CausalAttentionAuditRecord,
     GenerationStopReason, ModelShape, ProjectionAuditRecord, R4SoftmaxReferenceGenerationError,
@@ -69,6 +75,33 @@ const R4_SOFTMAX_REFERENCE_HTTP_MAX_BODY_BYTES: usize = 16 * 1024;
 /// Frozen single-request worker default established by the native canary.
 pub const R4_SOFTMAX_REFERENCE_HTTP_DEFAULT_WORKERS: usize = 8;
 
+const R4_SOFTMAX_LOCAL_HTTP_PATH: &str = "/uor/v1/r4-softmax-local/generate";
+const R4_SOFTMAX_LOCAL_HTTP_SCHEMA: &str = "uor-r4.r4-softmax-local-http/1";
+const R4_SOFTMAX_LOCAL_HTTP_DEFAULT_MAX_TOKENS: usize = 8;
+const R4_SOFTMAX_LOCAL_HTTP_MAX_TOKENS: usize = 32;
+const R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES: usize = 16 * 1024;
+/// Operator-owned exact-executor worker default for the frozen #1017 reference model.
+pub const R4_SOFTMAX_LOCAL_HTTP_DEFAULT_WORKERS: usize = 4;
+const R4_SOFTMAX_LOCAL_ISSUE_1017_EXPORT_MANIFEST_CID: &str =
+    "blake3:77d5735ccfb4f2ac8a89f2f42a7ad8663b96770ea23a0b4bfae87b3daea7d8f3";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_EXPORT_TREE_CID: &str =
+    "blake3:4819f8cbb6e673c4124eaa61e319b42adc54b1de178969916df035aad65a4000";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_WEIGHTS_CID: &str =
+    "blake3:c5bf31aa97a567b3aaad4461ce2fac9cebc12b0a38becb6d02d21b43b493bf5d";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_TOKENIZER_CID: &str =
+    "blake3:3f42bcfce7728512076549c63b88387e13c8156fe35c0f91d9b112439f3739cc";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_CONFIG_CID: &str =
+    "blake3:1f1ddb6de22f5c81c04d3093eeff8e0991d63b79ee33bc8ff3cf7c68ef0a9497";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_LOADER_TREE_CID: &str =
+    "blake3:66ee347b23e818f1816682f0b942737c88f1eca831cd6d4f00b3d14fc00aaa37";
+const R4_SOFTMAX_LOCAL_ISSUE_1017_CHECKPOINT_ENTRIES: [&str; 5] = [
+    "config.json",
+    "export-manifest.json",
+    "model.safetensors",
+    "tokenizer.json",
+    "training-result.json",
+];
+
 /// Explicit native-server opt-in for the source-backed R4/Spin reference.
 ///
 /// This is deliberately separate from every default serving engine and from
@@ -77,6 +110,18 @@ pub const R4_SOFTMAX_REFERENCE_HTTP_DEFAULT_WORKERS: usize = 8;
 #[derive(Debug, Clone)]
 pub struct R4SoftmaxReferenceHttpConfig {
     pub source: PathBuf,
+    pub workers: NonZeroUsize,
+}
+
+/// Explicit native-server opt-in for the frozen #1017 learned checkpoint.
+///
+/// Requests cannot select a model, exact-executor worker count, attention
+/// intervention, or sampler. The operator owns the immutable checkpoint and
+/// worker bound; attention stays on and decoding is greedy. An accelerated
+/// BLAS backend owns its own internal CPU scheduling separately.
+#[derive(Debug, Clone)]
+pub struct R4SoftmaxLocalHttpConfig {
+    pub model: PathBuf,
     pub workers: NonZeroUsize,
 }
 
@@ -97,6 +142,8 @@ pub struct ServerConfig {
     pub geometric_demo: bool,
     /// `None` keeps the source-backed R4/Spin reference endpoint absent.
     pub r4_softmax_reference: Option<R4SoftmaxReferenceHttpConfig>,
+    /// `None` keeps the frozen #1017 learned reference endpoint absent.
+    pub r4_softmax_local: Option<R4SoftmaxLocalHttpConfig>,
 }
 
 pub use uor_r4_api::{InferenceRequest, InferenceResponse, InferenceWitness};
@@ -189,6 +236,120 @@ impl From<R4SoftmaxReferenceGenerationReport> for R4SoftmaxReferenceHttpResponse
             timing: report.timing,
             nonclaims: report.nonclaims,
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct R4SoftmaxLocalHttpRequest {
+    prompt: String,
+    #[serde(default)]
+    max_tokens: Option<usize>,
+}
+
+#[derive(Debug)]
+struct ValidatedR4SoftmaxLocalHttpRequest {
+    prompt: String,
+    max_tokens: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct R4SoftmaxLocalHttpCheckpoint {
+    checkpoint_tree_cid: String,
+    config_cid: String,
+    tokenizer_cid: String,
+    weights_cid: String,
+    weights_cid_scope: String,
+    exact_backend: uor_r4_model_source::ExactBackendReport,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct R4SoftmaxLocalHttpAudit {
+    attention: R4SoftmaxReferenceHttpAudit,
+    attention_output_policy: AttentionOutputPolicyAuditRecord,
+    decode: LocalDecodeAudit,
+    source_read: SourceReadAudit,
+}
+
+/// Compact product-facing view of the complete local-generation report.
+///
+/// Prompt text, prompt token ids, checkpoint paths, and checkpoint file paths
+/// are deliberately absent. Content identities and execution/audit provenance
+/// remain visible so the response stays independently attributable.
+#[derive(Debug, serde::Serialize)]
+struct R4SoftmaxLocalHttpResponse {
+    schema: &'static str,
+    generator: &'static str,
+    claim_scope: String,
+    checkpoint: R4SoftmaxLocalHttpCheckpoint,
+    model_shape: ModelShape,
+    input_tokens: usize,
+    generated_token_ids: Vec<u32>,
+    response_text: String,
+    stop_reason: GenerationStopReason,
+    decision_cid: String,
+    generation_policy_cid: String,
+    output_cid: String,
+    audit_cid: String,
+    persistent_state_cid: String,
+    audit: R4SoftmaxLocalHttpAudit,
+    execution: uor_r4_model_source::TeacherExecutionSnapshot,
+    timing: R4SoftmaxLocalTimingReport,
+    nonclaims: Vec<String>,
+}
+
+impl TryFrom<R4SoftmaxLocalGenerationReport> for R4SoftmaxLocalHttpResponse {
+    type Error = R4SoftmaxLocalGenerationError;
+
+    fn try_from(report: R4SoftmaxLocalGenerationReport) -> Result<Self, Self::Error> {
+        if report.checkpoint.checkpoint_tree_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_LOADER_TREE_CID
+            || report.checkpoint.config_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_CONFIG_CID
+            || report.checkpoint.tokenizer_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_TOKENIZER_CID
+            || report.checkpoint.weights_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_WEIGHTS_CID
+        {
+            return Err(R4SoftmaxLocalGenerationError::Audit(
+                "local generation report is not bound to the frozen #1017 checkpoint".to_owned(),
+            ));
+        }
+        if !report.source_read_audit.tree_unchanged_across_execution {
+            return Err(R4SoftmaxLocalGenerationError::Audit(
+                "local checkpoint tree changed during generation".to_owned(),
+            ));
+        }
+        let checkpoint = R4SoftmaxLocalHttpCheckpoint {
+            checkpoint_tree_cid: report.checkpoint.checkpoint_tree_cid.clone(),
+            config_cid: report.checkpoint.config_cid.clone(),
+            tokenizer_cid: report.checkpoint.tokenizer_cid.clone(),
+            weights_cid: report.checkpoint.weights_cid.clone(),
+            weights_cid_scope: report.checkpoint.weights_cid_scope.clone(),
+            exact_backend: report.checkpoint.exact_backend.clone(),
+        };
+        let audit = R4SoftmaxLocalHttpAudit {
+            attention: compact_r4_softmax_reference_http_audit(&report.attention_audit),
+            attention_output_policy: report.attention_output_policy_audit,
+            decode: report.decode_audit,
+            source_read: report.source_read_audit,
+        };
+        Ok(Self {
+            schema: R4_SOFTMAX_LOCAL_HTTP_SCHEMA,
+            generator: R4_SOFTMAX_LOCAL_POLICY_SCHEMA,
+            claim_scope: report.claim_scope,
+            checkpoint,
+            model_shape: report.model_shape,
+            input_tokens: report.prompt_token_ids.len(),
+            generated_token_ids: report.transcript.generated_token_ids,
+            response_text: report.transcript.response_text,
+            stop_reason: report.stop_reason,
+            decision_cid: report.decision_cid,
+            generation_policy_cid: report.generation_policy_cid,
+            output_cid: report.output_cid,
+            audit_cid: report.audit_cid,
+            persistent_state_cid: report.persistent_state_cid,
+            audit,
+            execution: report.execution,
+            timing: report.timing,
+            nonclaims: report.nonclaims,
+        })
     }
 }
 
@@ -521,6 +682,7 @@ enum SourceCacheOperationKind {
     Compile,
     Reload,
     R4SoftmaxReferenceGeneration,
+    R4SoftmaxLocalGeneration,
 }
 
 impl SourceCacheOperationKind {
@@ -530,6 +692,7 @@ impl SourceCacheOperationKind {
             Self::Compile => "compile",
             Self::Reload => "reload",
             Self::R4SoftmaxReferenceGeneration => "R4 softmax reference generation",
+            Self::R4SoftmaxLocalGeneration => "R4 softmax local generation",
         }
     }
 }
@@ -814,6 +977,418 @@ fn r4_softmax_reference_http_status(cli: &ServerConfig) -> serde_json::Value {
     })
 }
 
+/// Validate the frozen #1017 endpoint before the listener starts.
+///
+/// This performs no model load. It does verify the immutable export envelope,
+/// every committed artifact byte string, and the frozen #1017 identities. The
+/// request path repeats the same preflight under the single-flight reservation
+/// before invoking the existing generator.
+pub fn validate_r4_softmax_local_http_startup(
+    host: &str,
+    config: Option<&R4SoftmaxLocalHttpConfig>,
+) -> Result<(), String> {
+    let Some(config) = config else {
+        return Ok(());
+    };
+    if !r4_softmax_reference_loopback_host(host) {
+        return Err(
+            "the R4 softmax local HTTP bridge is local-only; bind to localhost, 127.0.0.1, or ::1"
+                .to_owned(),
+        );
+    }
+    validate_r4_softmax_local_checkpoint_preflight(&config.model)
+}
+
+fn r4_softmax_local_raw_cid(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn r4_softmax_local_json_string<'a>(
+    value: &'a serde_json::Value,
+    field: &str,
+) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|text| !text.is_empty())
+        .ok_or_else(|| format!("export manifest has no nonempty {field}"))
+}
+
+fn verify_r4_softmax_local_embedded_cid(
+    bytes: &[u8],
+    field: &str,
+    expected: &str,
+) -> Result<(), String> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|error| format!("export manifest is not UTF-8 JSON: {error}"))?;
+    let needle = format!("\"{field}\":\"{expected}\"");
+    let start = text
+        .find(&needle)
+        .ok_or_else(|| format!("export manifest does not contain its canonical {field}"))?;
+    if text[start + needle.len()..].contains(&needle) {
+        return Err(format!("export manifest contains duplicate {field} values"));
+    }
+    let mut unsigned = bytes.to_vec();
+    let end = start + needle.len();
+    if start > 0 && unsigned[start - 1] == b',' {
+        unsigned.drain(start - 1..end);
+    } else if unsigned.get(end) == Some(&b',') {
+        unsigned.drain(start..=end);
+    } else {
+        return Err(format!(
+            "export manifest {field} is not one field of a canonical JSON object"
+        ));
+    }
+    if r4_softmax_local_raw_cid(&unsigned) != expected {
+        return Err(format!("export manifest {field} does not reproduce"));
+    }
+    Ok(())
+}
+
+fn read_r4_softmax_local_regular_file(path: &Path, label: &str) -> Result<Vec<u8>, String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("cannot inspect {label} {}: {error}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        return Err(format!(
+            "{label} {} is not a regular non-symlink file",
+            path.display()
+        ));
+    }
+    fs::read(path).map_err(|error| format!("cannot read {label} {}: {error}", path.display()))
+}
+
+fn validate_r4_softmax_local_checkpoint_entry_names(
+    mut observed: Vec<String>,
+) -> Result<(), String> {
+    observed.sort();
+    let expected = R4_SOFTMAX_LOCAL_ISSUE_1017_CHECKPOINT_ENTRIES
+        .iter()
+        .map(|entry| (*entry).to_owned())
+        .collect::<Vec<_>>();
+    if observed != expected {
+        return Err(format!(
+            "checkpoint entries differ from the frozen #1017 loader tree: observed {observed:?}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_r4_softmax_local_checkpoint_preflight(model: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(model)
+        .map_err(|error| format!("cannot inspect checkpoint {}: {error}", model.display()))?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "checkpoint {} is not a regular non-symlink directory",
+            model.display()
+        ));
+    }
+
+    let mut observed_entries = Vec::new();
+    for entry in fs::read_dir(model)
+        .map_err(|error| format!("cannot enumerate checkpoint {}: {error}", model.display()))?
+    {
+        let entry = entry
+            .map_err(|error| format!("cannot enumerate checkpoint {}: {error}", model.display()))?;
+        let file_type = entry.file_type().map_err(|error| {
+            format!(
+                "cannot inspect checkpoint entry {}: {error}",
+                entry.path().display()
+            )
+        })?;
+        if !file_type.is_file() {
+            return Err(format!(
+                "checkpoint entry {} is not a regular non-symlink file",
+                entry.path().display()
+            ));
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            format!(
+                "checkpoint entry {} is not valid UTF-8",
+                entry.path().display()
+            )
+        })?;
+        observed_entries.push(name);
+    }
+    validate_r4_softmax_local_checkpoint_entry_names(observed_entries)?;
+
+    let manifest_bytes =
+        read_r4_softmax_local_regular_file(&model.join("export-manifest.json"), "export manifest")?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)
+        .map_err(|error| format!("invalid export manifest JSON: {error}"))?;
+    if r4_softmax_local_json_string(&manifest, "schema")? != "uor-r4-softmax-trainer-export/1" {
+        return Err("unexpected local softmax export manifest schema".to_owned());
+    }
+    let manifest_cid = r4_softmax_local_json_string(&manifest, "manifest_cid")?;
+    if manifest_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_EXPORT_MANIFEST_CID {
+        return Err("checkpoint is not the frozen #1017 export manifest".to_owned());
+    }
+    verify_r4_softmax_local_embedded_cid(&manifest_bytes, "manifest_cid", manifest_cid)?;
+
+    let artifacts = manifest
+        .get("artifacts")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "export manifest has no artifact array".to_owned())?;
+    let mut sorted = artifacts.clone();
+    sorted.sort_by(|left, right| {
+        left.get("path")
+            .and_then(serde_json::Value::as_str)
+            .cmp(&right.get("path").and_then(serde_json::Value::as_str))
+    });
+    if sorted != *artifacts {
+        return Err("export manifest artifacts are not in canonical path order".to_owned());
+    }
+    let mut tree_bytes = serde_json::to_vec(&serde_json::Value::Array(sorted))
+        .map_err(|error| format!("cannot serialize export artifact identity: {error}"))?;
+    tree_bytes.push(b'\n');
+    let tree_cid = r4_softmax_local_json_string(&manifest, "tree_cid")?;
+    if tree_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_EXPORT_TREE_CID
+        || r4_softmax_local_raw_cid(&tree_bytes) != tree_cid
+    {
+        return Err("frozen #1017 export tree CID does not reproduce".to_owned());
+    }
+
+    let mut seen_paths = Vec::with_capacity(artifacts.len());
+    let mut config_cid = None;
+    let mut tokenizer_cid = None;
+    let mut weights_cid = None;
+    for record in artifacts {
+        let relative = r4_softmax_local_json_string(record, "path")?;
+        let relative_path = Path::new(relative);
+        if relative_path.is_absolute()
+            || relative_path
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(format!(
+                "export artifact path {relative:?} is not a safe relative path"
+            ));
+        }
+        if seen_paths.iter().any(|seen| seen == relative) {
+            return Err(format!("duplicate export artifact path {relative:?}"));
+        }
+        seen_paths.push(relative.to_owned());
+        let bytes =
+            read_r4_softmax_local_regular_file(&model.join(relative_path), "export artifact")?;
+        let expected_bytes = record
+            .get("bytes")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| format!("export artifact {relative:?} has no byte length"))?;
+        let expected_cid = r4_softmax_local_json_string(record, "cid")?;
+        if u64::try_from(bytes.len()).ok() != Some(expected_bytes)
+            || r4_softmax_local_raw_cid(&bytes) != expected_cid
+        {
+            return Err(format!("export artifact {relative:?} does not reproduce"));
+        }
+        match relative {
+            "config.json" => config_cid = Some(expected_cid),
+            "tokenizer.json" => tokenizer_cid = Some(expected_cid),
+            "model.safetensors" => weights_cid = Some(expected_cid),
+            _ => {}
+        }
+    }
+    let config_cid = config_cid.ok_or_else(|| "export does not commit config.json".to_owned())?;
+    let tokenizer_cid =
+        tokenizer_cid.ok_or_else(|| "export does not commit tokenizer.json".to_owned())?;
+    let weights_cid =
+        weights_cid.ok_or_else(|| "export does not commit model.safetensors".to_owned())?;
+    if r4_softmax_local_json_string(&manifest, "config_cid")? != config_cid
+        || r4_softmax_local_json_string(&manifest, "tokenizer_cid")? != tokenizer_cid
+        || r4_softmax_local_json_string(&manifest, "weights_cid")? != weights_cid
+    {
+        return Err("export top-level artifact CIDs do not match artifact records".to_owned());
+    }
+    if tokenizer_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_TOKENIZER_CID
+        || weights_cid != R4_SOFTMAX_LOCAL_ISSUE_1017_WEIGHTS_CID
+    {
+        return Err("checkpoint is not the frozen #1017 tokenizer/weights pair".to_owned());
+    }
+    Ok(())
+}
+
+fn is_r4_softmax_local_http_path(path: &str) -> bool {
+    path == R4_SOFTMAX_LOCAL_HTTP_PATH
+}
+
+fn parse_r4_softmax_local_http_request(
+    body: &[u8],
+) -> Result<ValidatedR4SoftmaxLocalHttpRequest, String> {
+    if body.len() > R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES {
+        return Err(format!(
+            "request body exceeds the {}-byte R4 softmax local limit",
+            R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES
+        ));
+    }
+    let request: R4SoftmaxLocalHttpRequest =
+        serde_json::from_slice(body).map_err(|error| format!("invalid request body: {error}"))?;
+    if request.prompt.is_empty() {
+        return Err("prompt must not be empty".to_owned());
+    }
+    let max_tokens = request
+        .max_tokens
+        .unwrap_or(R4_SOFTMAX_LOCAL_HTTP_DEFAULT_MAX_TOKENS);
+    if max_tokens == 0 || max_tokens > R4_SOFTMAX_LOCAL_HTTP_MAX_TOKENS {
+        return Err(format!(
+            "max_tokens must be in 1..={R4_SOFTMAX_LOCAL_HTTP_MAX_TOKENS}"
+        ));
+    }
+    Ok(ValidatedR4SoftmaxLocalHttpRequest {
+        prompt: request.prompt,
+        max_tokens,
+    })
+}
+
+fn r4_softmax_local_http_error(
+    status: u16,
+    code: &'static str,
+    message: impl Into<String>,
+) -> (u16, serde_json::Value) {
+    (
+        status,
+        serde_json::json!({
+            "error": {
+                "type": "r4_softmax_local_error",
+                "code": code,
+                "message": message.into(),
+            }
+        }),
+    )
+}
+
+fn r4_softmax_local_generation_error(
+    error: R4SoftmaxLocalGenerationError,
+) -> (u16, serde_json::Value) {
+    let (status, message) = match &error {
+        R4SoftmaxLocalGenerationError::InvalidRequest(_) => {
+            (400, "the local generation request was rejected")
+        }
+        R4SoftmaxLocalGenerationError::InvalidCheckpoint(_)
+        | R4SoftmaxLocalGenerationError::Tokenizer(_)
+        | R4SoftmaxLocalGenerationError::Source(_)
+        | R4SoftmaxLocalGenerationError::Io(_) => {
+            (503, "the frozen #1017 checkpoint is unavailable")
+        }
+        R4SoftmaxLocalGenerationError::Attention(_) | R4SoftmaxLocalGenerationError::Audit(_) => {
+            (500, "local generation failed its internal audit")
+        }
+    };
+    tracing::error!(error = %error, status, "R4 softmax local generation failed");
+    r4_softmax_local_http_error(status, "generation_failed", message)
+}
+
+fn execute_r4_softmax_local_http_request<P, F>(
+    bridge: Option<&R4SoftmaxLocalHttpConfig>,
+    body: &[u8],
+    source_cache_operations: &SharedSourceCacheOperations,
+    preflight: P,
+    runner: F,
+) -> (u16, serde_json::Value)
+where
+    P: FnOnce(&Path) -> Result<(), String>,
+    F: FnOnce(
+        &R4SoftmaxLocalGeneratorConfig,
+    ) -> Result<R4SoftmaxLocalHttpResponse, R4SoftmaxLocalGenerationError>,
+{
+    let Some(bridge) = bridge else {
+        return r4_softmax_local_http_error(
+            404,
+            "bridge_disabled",
+            "the native R4 softmax local bridge was not enabled at server startup",
+        );
+    };
+    let request = match parse_r4_softmax_local_http_request(body) {
+        Ok(request) => request,
+        Err(error) => return r4_softmax_local_http_error(400, "invalid_request", error),
+    };
+    let _reservation = match try_reserve_source_cache_operation(
+        source_cache_operations,
+        SourceCacheOperationKind::R4SoftmaxLocalGeneration,
+        "frozen #1017 local checkpoint",
+    ) {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            tracing::warn!(error = %error, "R4 softmax local single-flight reservation failed");
+            return r4_softmax_local_http_error(
+                409,
+                "bridge_busy",
+                "another source-cache operation or reference generation is already active",
+            );
+        }
+    };
+    if let Err(error) = preflight(&bridge.model) {
+        tracing::warn!(
+            error = %error,
+            model = %bridge.model.display(),
+            "R4 softmax local checkpoint preflight failed"
+        );
+        return r4_softmax_local_http_error(
+            503,
+            "checkpoint_unavailable",
+            "the frozen #1017 checkpoint is unavailable",
+        );
+    }
+    let config = R4SoftmaxLocalGeneratorConfig {
+        model: bridge.model.clone(),
+        prompt: request.prompt,
+        max_new_tokens: request.max_tokens,
+        workers: bridge.workers,
+        attention_off: false,
+        seed: None,
+    };
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| runner(&config)));
+    match outcome {
+        Err(payload) => {
+            tracing::error!(
+                panic = %panic_payload_message(&*payload),
+                "R4 softmax local generation panicked"
+            );
+            r4_softmax_local_http_error(
+                500,
+                "generation_panicked",
+                "R4 softmax local generation failed unexpectedly",
+            )
+        }
+        Ok(Err(error)) => r4_softmax_local_generation_error(error),
+        Ok(Ok(response)) => match serde_json::to_value(response) {
+            Ok(body) => (200, body),
+            Err(error) => {
+                tracing::error!(error = %error, "R4 softmax local response serialization failed");
+                r4_softmax_local_http_error(
+                    500,
+                    "response_serialization_failed",
+                    "the local reference response could not be serialized",
+                )
+            }
+        },
+    }
+}
+
+fn r4_softmax_local_http_status(cli: &ServerConfig) -> serde_json::Value {
+    let Some(config) = cli.r4_softmax_local.as_ref() else {
+        return serde_json::json!({
+            "enabled": false,
+            "checkpoint_preflight_ready": false,
+            "attention_on": true,
+            "greedy": true,
+            "static_wasm": false,
+        });
+    };
+    serde_json::json!({
+        "enabled": true,
+        // Enabled configuration reached this listener only after the exact
+        // startup preflight passed. Avoid re-hashing the 28.6 MB checkpoint on
+        // dashboard polls; every generation repeats the exact preflight under
+        // the single-flight reservation before loading any model bytes.
+        "checkpoint_preflight_ready": true,
+        "endpoint": R4_SOFTMAX_LOCAL_HTTP_PATH,
+        "default_max_tokens": R4_SOFTMAX_LOCAL_HTTP_DEFAULT_MAX_TOKENS,
+        "maximum_max_tokens": R4_SOFTMAX_LOCAL_HTTP_MAX_TOKENS,
+        "workers": config.workers.get(),
+        "attention_on": true,
+        "greedy": true,
+        "static_wasm": false,
+    })
+}
+
 fn r4_softmax_reference_allowed_origin(cli: &ServerConfig) -> String {
     r4_softmax_reference_allowed_origin_for(&cli.host, cli.port)
 }
@@ -1027,6 +1602,12 @@ pub fn run_server(cli: Arc<ServerConfig>) {
         validate_r4_softmax_reference_http_startup(&cli.host, cli.r4_softmax_reference.as_ref())
     {
         tracing::error!(error = %error, "refusing invalid R4 softmax reference server configuration");
+        return;
+    }
+    if let Err(error) =
+        validate_r4_softmax_local_http_startup(&cli.host, cli.r4_softmax_local.as_ref())
+    {
+        tracing::error!(error = %error, "refusing invalid R4 softmax local server configuration");
         return;
     }
     tracing::info!(
@@ -15924,6 +16505,20 @@ fn handle_connection(
         send_json_response(stream, 413, &body.to_string());
         return;
     }
+    if is_r4_softmax_local_http_path(clean_path)
+        && content_length > R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES
+    {
+        let (_, body) = r4_softmax_local_http_error(
+            413,
+            "request_too_large",
+            format!(
+                "request body exceeds the {}-byte R4 softmax local limit",
+                R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES
+            ),
+        );
+        send_json_response(stream, 413, &body.to_string());
+        return;
+    }
 
     let mut body = vec![0; content_length];
     if content_length > 0 && buf_reader.read_exact(&mut body).is_err() {
@@ -15965,6 +16560,46 @@ fn handle_connection(
             |config| {
                 run_r4_softmax_reference_generation(config)
                     .map(R4SoftmaxReferenceHttpResponse::from)
+            },
+        );
+        send_json_response(stream, status, &response.to_string());
+        return;
+    }
+
+    // Frozen #1017 learned reference endpoint. It is isolated from the
+    // default engine cascade, OpenAI-compatible routes, and static/WASM app.
+    if is_r4_softmax_local_http_path(clean_path) {
+        if method != "POST" {
+            let (_, body) = r4_softmax_local_http_error(
+                405,
+                "method_not_allowed",
+                "the R4 softmax local endpoint accepts POST only",
+            );
+            send_json_response(stream, 405, &body.to_string());
+            return;
+        }
+        if let Some(origin) = request_origin.as_deref() {
+            let allowed = r4_softmax_reference_allowed_origin(&cli);
+            if origin != allowed {
+                let (_, body) = r4_softmax_local_http_error(
+                    403,
+                    "origin_forbidden",
+                    format!(
+                        "browser Origin {origin:?} does not match the local server origin {allowed:?}"
+                    ),
+                );
+                send_json_response(stream, 403, &body.to_string());
+                return;
+            }
+        }
+        let (status, response) = execute_r4_softmax_local_http_request(
+            cli.r4_softmax_local.as_ref(),
+            &body,
+            &source_cache_operations,
+            validate_r4_softmax_local_checkpoint_preflight,
+            |config| {
+                run_r4_softmax_local_generation(config)
+                    .and_then(R4SoftmaxLocalHttpResponse::try_from)
             },
         );
         send_json_response(stream, status, &response.to_string());
@@ -18274,6 +18909,7 @@ fn handle_connection(
             "otel_available": false,
             "r4g1_ready": r4g1_ready,
             "r4_softmax_reference": r4_softmax_reference_http_status(&cli),
+            "r4_softmax_local": r4_softmax_local_http_status(&cli),
             "research_demo": cli.geometric_demo,
             "model_format": if cli.geometric_demo {
                 "geometric router research demo"
@@ -26576,7 +27212,7 @@ mod tests {
     #[test]
     fn source_cache_reservation_closes_download_compile_reload_and_reference_races() {
         use super::SourceCacheOperationKind::{
-            Compile, Download, R4SoftmaxReferenceGeneration, Reload,
+            Compile, Download, R4SoftmaxLocalGeneration, R4SoftmaxReferenceGeneration, Reload,
         };
 
         assert_source_cache_reservation_conflict(Compile, Download);
@@ -26589,6 +27225,20 @@ mod tests {
         assert_source_cache_reservation_conflict(
             R4SoftmaxReferenceGeneration,
             R4SoftmaxReferenceGeneration,
+        );
+        assert_source_cache_reservation_conflict(R4SoftmaxLocalGeneration, Download);
+        assert_source_cache_reservation_conflict(Download, R4SoftmaxLocalGeneration);
+        assert_source_cache_reservation_conflict(
+            R4SoftmaxLocalGeneration,
+            R4SoftmaxReferenceGeneration,
+        );
+        assert_source_cache_reservation_conflict(
+            R4SoftmaxReferenceGeneration,
+            R4SoftmaxLocalGeneration,
+        );
+        assert_source_cache_reservation_conflict(
+            R4SoftmaxLocalGeneration,
+            R4SoftmaxLocalGeneration,
         );
     }
 
@@ -26873,6 +27523,300 @@ mod tests {
         assert!(!body["error"]["message"]
             .as_str()
             .is_some_and(|message| message.contains("synthetic runner panic")));
+        assert!(operations.lock().expect("operation state").active.is_none());
+    }
+
+    fn r4_softmax_local_http_test_response() -> super::R4SoftmaxLocalHttpResponse {
+        let reference = r4_softmax_reference_http_test_response();
+        super::R4SoftmaxLocalHttpResponse {
+            schema: super::R4_SOFTMAX_LOCAL_HTTP_SCHEMA,
+            generator: crate::r4_softmax_local_generation::POLICY_SCHEMA,
+            claim_scope: "frozen #1017 bounded source-backed reference model".to_owned(),
+            checkpoint: super::R4SoftmaxLocalHttpCheckpoint {
+                checkpoint_tree_cid: "checkpoint-tree-cid".to_owned(),
+                config_cid: "config-cid".to_owned(),
+                tokenizer_cid: super::R4_SOFTMAX_LOCAL_ISSUE_1017_TOKENIZER_CID.to_owned(),
+                weights_cid: super::R4_SOFTMAX_LOCAL_ISSUE_1017_WEIGHTS_CID.to_owned(),
+                weights_cid_scope: "canonical Safetensors shard bytes".to_owned(),
+                exact_backend: uor_r4_model_source::ExactBackendReport {
+                    arithmetic_owner: "Apple Accelerate CPU BLAS".to_owned(),
+                    std_runtime_detection_enabled: true,
+                    target_arch: "aarch64".to_owned(),
+                    target_os: "macos".to_owned(),
+                    uor_matmul_revision: "matmul-revision".to_owned(),
+                    available_backends: vec!["portable".to_owned()],
+                    selected_backend: Some("Apple Accelerate".to_owned()),
+                    selection_status: "AVAILABLE".to_owned(),
+                },
+            },
+            model_shape: crate::r4_softmax_reference_generation::ModelShape {
+                dimension: 288,
+                hidden_dimension: 768,
+                layers: 6,
+                query_heads: 6,
+                key_value_heads: 6,
+                head_size: 48,
+                vocabulary: 4_096,
+                sequence_capacity: 24,
+            },
+            input_tokens: 16,
+            generated_token_ids: vec![11, 12],
+            response_text: "bounded local response".to_owned(),
+            stop_reason:
+                crate::r4_softmax_reference_generation::GenerationStopReason::MaximumNewTokens,
+            decision_cid: "decision-cid".to_owned(),
+            generation_policy_cid: "policy-cid".to_owned(),
+            output_cid: "output-cid".to_owned(),
+            audit_cid: "audit-cid".to_owned(),
+            persistent_state_cid: "state-cid".to_owned(),
+            audit: super::R4SoftmaxLocalHttpAudit {
+                attention: reference.audit,
+                attention_output_policy:
+                    crate::r4_softmax_local_generation::AttentionOutputPolicyAuditRecord {
+                        policy: "enabled".to_owned(),
+                        applications: 96,
+                        enabled_applications: 96,
+                        zeroed_applications: 0,
+                        output_lanes: 27_648,
+                        nonzero_lanes_before_policy: 10,
+                        nonzero_lanes_after_policy: 10,
+                        applications_by_layer: vec![16; 6],
+                        maximum_query_position: Some(15),
+                        exact: true,
+                    },
+                decode: crate::r4_softmax_local_generation::LocalDecodeAudit {
+                    selection: "greedy argmax over local checkpoint logits".to_owned(),
+                    deterministic_greedy: true,
+                    exact_tie_break: "lower token id wins".to_owned(),
+                    sampler_policy: crate::r4_softmax_local_generation::GREEDY_SAMPLER_POLICY
+                        .to_owned(),
+                    seed: None,
+                    bos_policy: "one BOS".to_owned(),
+                    bos_insertions: 1,
+                    utf8_decodable: true,
+                    short_cycle_period: None,
+                    cycles_checked: vec![1, 2, 3, 4],
+                },
+                source_read: crate::r4_softmax_local_generation::SourceReadAudit {
+                    checkpoint_tree_scans: 2,
+                    checkpoint_tree_file_reads: 8,
+                    tokenizer_loads: 1,
+                    oracle_loads: 1,
+                    local_checkpoint_forward_steps: 16,
+                    provider_calls: 0,
+                    ollama_calls: 0,
+                    prior_trace_reads: 0,
+                    tree_unchanged_across_execution: true,
+                },
+            },
+            execution: uor_r4_model_source::TeacherExecutionSnapshot {
+                requested_workers: 4,
+                effective_workers: 4,
+                ..Default::default()
+            },
+            timing: crate::r4_softmax_local_generation::TimingReport {
+                source_load_seconds: 1.0,
+                generation_seconds: 2.0,
+                total_seconds: 3.0,
+            },
+            nonclaims: vec!["not transformerless".to_owned()],
+        }
+    }
+
+    #[test]
+    fn r4_softmax_local_http_parser_is_strict_exact_and_bounded() {
+        let defaulted = super::parse_r4_softmax_local_http_request(
+            br#"{"prompt":"  preserve exact prompt  "}"#,
+        )
+        .expect("default request");
+        assert_eq!(defaulted.prompt, "  preserve exact prompt  ");
+        assert_eq!(
+            defaulted.max_tokens,
+            super::R4_SOFTMAX_LOCAL_HTTP_DEFAULT_MAX_TOKENS
+        );
+
+        let maximum =
+            super::parse_r4_softmax_local_http_request(br#"{"prompt":"bounded","max_tokens":32}"#)
+                .expect("maximum request");
+        assert_eq!(maximum.max_tokens, super::R4_SOFTMAX_LOCAL_HTTP_MAX_TOKENS);
+
+        for invalid in [
+            br#"{"prompt":""}"#.as_slice(),
+            br#"{"prompt":"x","max_tokens":0}"#.as_slice(),
+            br#"{"prompt":"x","max_tokens":33}"#.as_slice(),
+            br#"{"prompt":"x","workers":4}"#.as_slice(),
+            br#"{"prompt":"x","model":"/tmp/model"}"#.as_slice(),
+            br#"{"prompt":"x","attention_off":true}"#.as_slice(),
+            br#"{"prompt":"x","seed":7}"#.as_slice(),
+        ] {
+            assert!(
+                super::parse_r4_softmax_local_http_request(invalid).is_err(),
+                "accepted invalid request: {}",
+                String::from_utf8_lossy(invalid)
+            );
+        }
+        let oversized = vec![b' '; super::R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES + 1];
+        assert!(super::parse_r4_softmax_local_http_request(&oversized).is_err());
+        assert!(super::is_r4_softmax_local_http_path(
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH
+        ));
+        assert!(!super::is_r4_softmax_local_http_path(
+            "/uor/v1/r4-softmax-local"
+        ));
+        assert!(!super::is_r4_softmax_local_http_path(
+            "/v1/chat/completions"
+        ));
+
+        assert!(super::validate_r4_softmax_local_http_startup("0.0.0.0", None).is_ok());
+        let bridge = super::R4SoftmaxLocalHttpConfig {
+            model: "/definitely/not/a/checkpoint".into(),
+            workers: std::num::NonZeroUsize::new(4).expect("nonzero"),
+        };
+        let error = super::validate_r4_softmax_local_http_startup("0.0.0.0", Some(&bridge))
+            .expect_err("enabled bridge cannot bind remotely");
+        assert!(error.contains("local-only"), "{error}");
+    }
+
+    #[test]
+    fn r4_softmax_local_checkpoint_entry_set_rejects_loader_override() {
+        let exact = super::R4_SOFTMAX_LOCAL_ISSUE_1017_CHECKPOINT_ENTRIES
+            .iter()
+            .map(|entry| (*entry).to_owned())
+            .collect();
+        assert!(super::validate_r4_softmax_local_checkpoint_entry_names(exact).is_ok());
+
+        let mut with_index = super::R4_SOFTMAX_LOCAL_ISSUE_1017_CHECKPOINT_ENTRIES
+            .iter()
+            .map(|entry| (*entry).to_owned())
+            .collect::<Vec<_>>();
+        with_index.push("model.safetensors.index.json".to_owned());
+        let error = super::validate_r4_softmax_local_checkpoint_entry_names(with_index)
+            .expect_err("an uncommitted shard index could override the frozen single-file model");
+        assert!(error.contains("entries differ"));
+        assert!(error.contains("model.safetensors.index.json"));
+    }
+
+    #[test]
+    fn r4_softmax_local_http_success_is_scrubbed_greedy_and_operator_bounded() {
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        let bridge = super::R4SoftmaxLocalHttpConfig {
+            model: "/private/operator/issue-1017-export".into(),
+            workers: std::num::NonZeroUsize::new(4).expect("nonzero"),
+        };
+        let (status, body) = super::execute_r4_softmax_local_http_request(
+            Some(&bridge),
+            br#"{"prompt":"exact private prompt","max_tokens":9}"#,
+            &operations,
+            |_| Ok(()),
+            |config| {
+                assert_eq!(config.model, bridge.model);
+                assert_eq!(config.prompt, "exact private prompt");
+                assert_eq!(config.max_new_tokens, 9);
+                assert_eq!(config.workers.get(), 4);
+                assert!(!config.attention_off);
+                assert_eq!(config.seed, None);
+                let conflict = match super::try_reserve_source_cache_operation(
+                    &operations,
+                    super::SourceCacheOperationKind::Download,
+                    "dashboard download",
+                ) {
+                    Err(error) => error,
+                    Ok(_) => panic!("the generation reservation must block a concurrent download"),
+                };
+                assert!(!conflict.contains("/private/operator"));
+                assert!(conflict.contains("frozen #1017 local checkpoint"));
+                Ok(r4_softmax_local_http_test_response())
+            },
+        );
+        assert_eq!(status, 200);
+        assert_eq!(body["response_text"], "bounded local response");
+        assert_eq!(body["generated_token_ids"], serde_json::json!([11, 12]));
+        assert_eq!(body["audit"]["source_read"]["provider_calls"], 0);
+        assert_eq!(body["audit"]["source_read"]["ollama_calls"], 0);
+        assert_eq!(body["audit"]["decode"]["deterministic_greedy"], true);
+        assert_eq!(body["execution"]["requested_workers"], 4);
+        assert_eq!(
+            body["checkpoint"]["exact_backend"]["arithmetic_owner"],
+            "Apple Accelerate CPU BLAS"
+        );
+        assert!(body.get("prompt").is_none());
+        assert!(body.get("prompt_token_ids").is_none());
+        assert!(body["checkpoint"].get("model_path").is_none());
+        assert!(body["checkpoint"].get("files").is_none());
+        let encoded = body.to_string();
+        assert!(!encoded.contains("/private/operator/issue-1017-export"));
+        assert!(!encoded.contains("exact private prompt"));
+        assert!(operations.lock().expect("operation state").active.is_none());
+    }
+
+    #[test]
+    fn r4_softmax_local_http_is_single_flight_and_releases_on_every_terminal() {
+        let operations = std::sync::Arc::new(std::sync::Mutex::new(
+            super::SourceCacheOperationState::default(),
+        ));
+        let bridge = super::R4SoftmaxLocalHttpConfig {
+            model: "/private/operator/issue-1017-export".into(),
+            workers: std::num::NonZeroUsize::new(4).expect("nonzero"),
+        };
+        let held = super::try_reserve_source_cache_operation(
+            &operations,
+            super::SourceCacheOperationKind::R4SoftmaxLocalGeneration,
+            "first request",
+        )
+        .expect("first reservation");
+        let (status, body) = super::execute_r4_softmax_local_http_request(
+            Some(&bridge),
+            br#"{"prompt":"second request"}"#,
+            &operations,
+            |_| panic!("preflight must not run while busy"),
+            |_| panic!("runner must not run while busy"),
+        );
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "bridge_busy");
+        drop(held);
+
+        let (status, body) = super::execute_r4_softmax_local_http_request(
+            Some(&bridge),
+            br#"{"prompt":"preflight failure"}"#,
+            &operations,
+            |_| Err("/private/operator/issue-1017-export is incomplete".to_owned()),
+            |_| panic!("runner must not run after failed preflight"),
+        );
+        assert_eq!(status, 503);
+        assert_eq!(body["error"]["code"], "checkpoint_unavailable");
+        assert!(!body.to_string().contains("/private/operator"));
+        assert!(operations.lock().expect("operation state").active.is_none());
+
+        let (status, body) = super::execute_r4_softmax_local_http_request(
+            Some(&bridge),
+            br#"{"prompt":"generation failure"}"#,
+            &operations,
+            |_| Ok(()),
+            |_| {
+                Err(
+                    crate::r4_softmax_local_generation::R4SoftmaxLocalGenerationError::InvalidCheckpoint(
+                        "/private/operator/issue-1017-export is unavailable".to_owned(),
+                    ),
+                )
+            },
+        );
+        assert_eq!(status, 503);
+        assert_eq!(body["error"]["code"], "generation_failed");
+        assert!(!body.to_string().contains("/private/operator"));
+        assert!(operations.lock().expect("operation state").active.is_none());
+
+        let (status, body) = super::execute_r4_softmax_local_http_request(
+            Some(&bridge),
+            br#"{"prompt":"panic containment"}"#,
+            &operations,
+            |_| Ok(()),
+            |_| panic!("synthetic local runner panic"),
+        );
+        assert_eq!(status, 500);
+        assert_eq!(body["error"]["code"], "generation_panicked");
+        assert!(!body.to_string().contains("synthetic local runner panic"));
         assert!(operations.lock().expect("operation state").active.is_none());
     }
 
@@ -29523,6 +30467,7 @@ mod tests {
             tless_corpus_recs: None,
             geometric_demo: false,
             r4_softmax_reference: None,
+            r4_softmax_local: None,
         });
 
         client.write_all(request.as_bytes()).expect("send request");
@@ -29608,6 +30553,54 @@ mod tests {
             "POST {} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
             super::R4_SOFTMAX_REFERENCE_HTTP_PATH,
             super::R4_SOFTMAX_REFERENCE_HTTP_MAX_BODY_BYTES + 1
+        ));
+        assert!(
+            status.contains("413 PAYLOAD TOO LARGE"),
+            "{status}: {response}"
+        );
+        assert!(response.contains(r#""code":"request_too_large""#));
+    }
+
+    #[test]
+    fn r4_softmax_local_http_route_fails_closed_before_checkpoint_work() {
+        let (status, response) = g4_post(
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH,
+            r#"{"prompt":"disabled"}"#,
+        );
+        assert!(status.contains("404 NOT FOUND"), "{status}: {response}");
+        assert!(response.contains(r#""code":"bridge_disabled""#));
+
+        let (status, response) = g4_drive(&format!(
+            "GET {} HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH
+        ));
+        assert!(
+            status.contains("405 METHOD NOT ALLOWED"),
+            "{status}: {response}"
+        );
+        assert!(response.contains(r#""code":"method_not_allowed""#));
+
+        let body = r#"{"prompt":"browser"}"#;
+        let (status, response) = g4_drive(&format!(
+            "POST {} HTTP/1.1\r\nHost: localhost\r\nOrigin: https://foreign.example\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH,
+            body.len()
+        ));
+        assert!(status.contains("403 FORBIDDEN"), "{status}: {response}");
+        assert!(response.contains(r#""code":"origin_forbidden""#));
+
+        let (status, response) = g4_drive(&format!(
+            "POST {} HTTP/1.1\r\nHost: localhost\r\nOrigin: http://127.0.0.1:0\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH,
+            body.len()
+        ));
+        assert!(status.contains("404 NOT FOUND"), "{status}: {response}");
+        assert!(response.contains(r#""code":"bridge_disabled""#));
+
+        let (status, response) = g4_drive(&format!(
+            "POST {} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
+            super::R4_SOFTMAX_LOCAL_HTTP_PATH,
+            super::R4_SOFTMAX_LOCAL_HTTP_MAX_BODY_BYTES + 1
         ));
         assert!(
             status.contains("413 PAYLOAD TOO LARGE"),


### PR DESCRIPTION
## Outcome

Productizes the existing frozen #1017 generator as a bounded local reference surface without changing the model or inference implementation.

- Adds disabled-by-default POST /uor/v1/r4-softmax-local/generate.
- Requires loopback startup and same-origin browser requests.
- Admits only prompt plus an 8-default/32-maximum token cap.
- Keeps attention enabled, greedy decoding, model selection, and exact-executor workers under operator policy.
- Reuses run_r4_softmax_local_generation; no second inference engine.
- Exposes a native-dashboard option only after exact checkpoint readiness.
- Keeps static/WASM, the default cascade, and /v1/chat/completions separate.
- Documents this strictly as a source-backed bounded local generation prototype.

## Real behavior evidence

The predeclared fresh-prompt CLI gate produced a non-looping 24-token continuation and replayed exactly after timing removal at 0.22s/0.17s on Apple Accelerate.

The implemented HTTP endpoint then returned HTTP 200 with an eight-token continuation in 0.16s. A post-review hardened rerun returned the same text and decision/output/audit/state CIDs in 0.20s.

- decision: blake3:87d8e9689132584a1437a244bab4e97e03af9d2609905ae6c74db0fa792c2522
- output: blake3:aef50423770f79714247e2e496d7f49381423893cbb8c636a31276ff9a5aa885
- audit: blake3:6ba5f8d8073748f57692e92a10291d507ef6963251e42069fa42256f56072ffc
- persistent state: blake3:0a837266df1c81d2cc2d54e32c41d6b4e6f0476dfe2bcf04103576278e995390
- loader tree: blake3:66ee347b23e818f1816682f0b942737c88f1eca831cd6d4f00b3d14fc00aaa37
- backend: Apple Accelerate CPU
- attention/decode/source-read audits: exact
- future/provider/Ollama reads: zero
- replay: exact after timing removal
- compact response: prompt/path/file fields absent

## Review hardening

Independent pre-commit review found and resolved:

1. A loader override through an extra Safetensors shard index. Preflight now admits exactly the frozen five-file export and the completed report must reproduce the frozen loader-tree/config/tokenizer/weights identities before HTTP 200.
2. A private checkpoint-path disclosure through the shared reservation subject. The subject is now non-sensitive and cross-operation scrubbing is asserted.
3. Worker wording now distinguishes the exact-executor bound from Accelerate's internal CPU scheduling.

Independent re-review found no remaining blocking issues.

## Focused verification

- 5 endpoint/server tests passed.
- CLI ownership/default test passed.
- Static/WASM masquerade guard passed.
- Real exact-export startup and release Accelerate HTTP generation passed.
- Targeted clippy with warnings denied passed.
- Rust formatting, claim wording, JavaScript syntax, and diff whitespace passed.

The protected merge queue remains the authoritative full integration ladder.

## Claim boundary

This does not establish geometry advantage, transformerlessness, source-free/table-native/multiply-free execution, broad coherence, correctness, reasoning, instruction following, chat quality, browser/WASM inference, release quality, or frontier capability. It does not change #973's V5 terminal, unblock #954, or implement #962.

Closes #1039
