### PR TITLE
A1Q-H8: add credited Zoology causal-softmax MQAR control

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,23 @@ local hardware. The project is testing whether language context, inference,
 and reasoning can emerge from routes through a canonical geometric memory. The
 target serving engine uses no Ollama, hosted model, or source-model weights.
 
-> **Latest open role-tagged associative result (2026-09-02):** #1045
+> **Latest copied-attention control result (2026-09-02):** #1047 ported and
+> credited the released ICLR24 Zoology one-head, width-64 causal-softmax cell
+> and MQAR loader. Literal-source loader/model goldens, initialization replay,
+> causal-prefix/query-only parity, and a 32-row `128/128` overfit all passed.
+> The long run was correctly `NOT_RUN_PREFLIGHT`: the fastest frozen plan used
+> all eight CPU cores but projected `959.212581 s` after the required `1.25`
+> safety factor, above the 900-second wall. C1, C2, binding permutation, and
+> artifacts therefore did not run; there is no scientific verdict about the
+> copied cell. Result CID is
+> `blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+> The next action preserves the exact cell/data/training contract and widens
+> only the CPU execution wall on a fresh issue. Modulo-256 remains the intended
+> substrate for discrete roles, wheel/table operations, and later lowering;
+> it is not continuous softmax normalization. See the
+> [#1047 record](docs/r4_zoology_mqar_control_1047.md).
+
+> **Predecessor open role-tagged associative result (2026-09-02):** #1045
 > completed the full 64-epoch R1 cap and stopped at
 > `OPEN_MQAR_NOT_LEARNED`. Training reached `65,500/65,536`
 > (`99.945068%`), but the assignment-disjoint development population reached
@@ -39,9 +55,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 > #1045 borrowed Zoology's associative-first curriculum and optimizer shape,
 > but it was not a stock Zoology replication: the role embedding, inherited
 > decoder, population loader, projection path, and other mechanics materially
-> differ. The next action is a new issue integrating the exact released ICLR24
-> Zoology causal-softmax cell and loader as a matched control, not tuning or
-> retrying #1045. Modulo-256 remains relevant to discrete role identities,
+> differ. #1047 subsequently integrated the released ICLR24 Zoology
+> causal-softmax cell and loader as a matched control and stopped at its CPU
+> admission wall, as reported above. Modulo-256 remains relevant to discrete role identities,
 > tables, and later lowering; it is not a substitute for continuous probability
 > normalization. See the
 > [#1045 record](docs/r4_role_tagged_associative_curriculum_1045.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,21 @@ The earlier
 preserved #948–#958 sequencing record. Measured, refuted, and frozen research
 remains in [docs/RESEARCH.md](docs/RESEARCH.md).
 
-**Current open associative-learning boundary (2026-09-02):** #1045 completed
+**Current copied-attention control boundary (2026-09-02):** #1047 integrated
+and credited the released ICLR24 Zoology one-head, width-64 causal-softmax cell
+and MQAR loader. C0 passed literal-source loader/model goldens, deterministic
+initialization, causal/query-only parity, and `128/128` open overfit. The
+scientific run is `NOT_RUN_PREFLIGHT`: the all-core 8-thread plan was fastest
+but projected `959.212581 s` after the frozen `1.25` safety factor, above the
+900-second wall. C1, C2, binding permutation, and artifacts did not run, so
+this is a resource-admission result rather than a finding about attention,
+geometry, or assignment-disjoint generalization. Result CID is
+`blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+Continue on a fresh issue with the identical scientific cell/data/training
+contract and a minimally widened CPU wall; do not tune #1047. See the
+[#1047 record](docs/r4_zoology_mqar_control_1047.md).
+
+**Predecessor open associative-learning boundary (2026-09-02):** #1045 completed
 all 64 permitted R1 epochs and stopped `OPEN_MQAR_NOT_LEARNED`. Training reached
 `65,500/65,536` (`99.945068%`), while assignment-disjoint development finished
 at `7,137/8,192` (`87.121582%`) with NLL `1.1712778`; the best development
@@ -28,9 +42,9 @@ coherent-R4 comparison, and generation do not run. This establishes no new
 attention attribution: #1045 used plain ordinary causal softmax and is neither
 geometric-attention nor generation evidence. It borrowed Zoology's curriculum
 and optimizer shape but materially differed from the released Zoology cell,
-loader, model, role path, and projection mechanics. The next bounded action is
-a new issue integrating the exact released ICLR24 Zoology causal-softmax cell
-and loader as an integration control, not tuning #1045. Modulo-256 remains a
+loader, model, role path, and projection mechanics. #1047 performed that
+released-cell integration and stopped at CPU admission, as reported above.
+Modulo-256 remains a
 discrete role/table/lowering substrate, not continuous softmax normalization.
 See the
 [#1045 record](docs/r4_role_tagged_associative_curriculum_1045.md).

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,7 +14,21 @@ Measurements retain their pre-declared exit rule and durable issue/record
 reference; design targets remain explicitly labeled as definitions,
 assumptions, or objectives rather than measured results.
 
-> **Open role-tagged associative-learning result (2026-09-02).** #1045
+> **Copied Zoology attention-control result (2026-09-02).** #1047 ported and
+> credited the released ICLR24 one-head, width-64 causal-softmax cell and MQAR
+> loader. C0 passed literal-source loader/model goldens, deterministic
+> initialization, causal-prefix/query-only parity, and `128/128` top-1 on the
+> disposable 32-row overfit. The long run is `NOT_RUN_PREFLIGHT`: all CPU plans
+> passed replay and memory checks, but the fastest plan used all eight host
+> cores and projected `959.212581 s` after the frozen safety factor, above the
+> 900-second admission wall. Thus C1, C2, binding permutation, and artifacts
+> did not run, and there is no scientific verdict about the cell. Result CID is
+> `blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+> Continue with the same scientific contract and a minimally widened CPU wall
+> in a fresh issue; do not tune or rerun #1047. See the
+> [#1047 record](r4_zoology_mqar_control_1047.md).
+
+> **Predecessor role-tagged associative-learning result (2026-09-02).** #1045
 > completed its full 64-epoch R1 cap and stopped
 > `OPEN_MQAR_NOT_LEARNED`. Training reached `65,500/65,536`
 > (`99.945068%`), but final assignment-disjoint development was only
@@ -39,9 +53,9 @@ assumptions, or objectives rather than measured results.
 > #1045 borrowed the associative-first curriculum and optimizer shape from
 > Zoology, but it was not a stock Zoology replication: its role-tagged wrapper,
 > inherited decoder, data loader, and query-only projection mechanics
-> materially differ. The divergent next action is a new issue integrating the
-> exact released ICLR24 Zoology causal-softmax cell and loader as a matched
-> integration control. Do not tune or retry #1045. Modulo-256 remains relevant
+> materially differ. #1047 performed that released-cell integration and
+> stopped at CPU admission, as reported above. Do not tune or retry #1045.
+> Modulo-256 remains relevant
 > to categorical roles, discrete tables, and later lowering, not continuous
 > probability normalization. See the
 > [#1045 record](r4_role_tagged_associative_curriculum_1045.md).

--- a/docs/r4_intelligence_completion_plan.md
+++ b/docs/r4_intelligence_completion_plan.md
@@ -4,7 +4,18 @@
   readable mirror of programme root #820 (stages S0–S7 plus cross-cutting F0).
   The [Geometric Intelligence Programme](geometric_intelligence_programme.md)
   is its current architecture and claim-boundary companion.
-  The newest open associative-learning result is #1045's
+  The newest copied-attention control is #1047's
+  [`ZoologyMQARControlV1`](r4_zoology_mqar_control_1047.md). It integrated and
+  credited the released ICLR24 one-head, width-64 causal-softmax cell and MQAR
+  loader. Literal-source mechanics and the 32-row `128/128` overfit passed, but
+  the long run is `NOT_RUN_PREFLIGHT`: the all-core 8-thread plan projected
+  `959.212581 s` after the frozen safety factor, above the 900-second wall.
+  C1, C2, binding permutation, and artifacts did not run; no scientific
+  attention or transfer verdict exists. Result CID is
+  `blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+  Continue with the identical scientific contract and a minimally widened CPU
+  wall in a fresh issue, not a #1047 tune or rerun.
+  The predecessor open associative-learning result is #1045's
   [`R4RoleTaggedAssociativeCurriculumV1`](r4_role_tagged_associative_curriculum_1045.md).
   It completed all 64 R1 epochs and `4,194,304` presentations in `966.7488 s`,
   reaching `65,500/65,536` (`99.945068%`) training accuracy but only
@@ -24,9 +35,9 @@
   used plain ordinary causal softmax; it does not establish geometric
   attention, attention attribution, or generation. It borrowed Zoology's
   curriculum and optimizer shape but materially differed from the released
-  cell, loader, model, role path, and projection mechanics. The next action is
-  a new issue integrating the exact released ICLR24 Zoology causal-softmax cell
-  and loader as a matched integration control, not tuning #1045. Modulo-256 is
+  cell, loader, model, role path, and projection mechanics. #1047 performed
+  that released-cell integration and stopped at CPU admission, as reported
+  above. Modulo-256 is
   retained for discrete roles, tables, and later lowering, not continuous
   probability normalization.
   The newest bounded source-free binding campaign is #1043's

--- a/docs/r4_zoology_mqar_control_1047.md
+++ b/docs/r4_zoology_mqar_control_1047.md
@@ -1,0 +1,321 @@
+# Released Zoology MQAR integration control (#1047)
+
+- **Execution status:** preflight complete; C1/C2 `NOT_RUN_PREFLIGHT`
+- **Policy:** `ZoologyMQARControlV1`
+- **Authority:** [issue #1047](https://github.com/UOR-Foundation/uor-r4/issues/1047),
+  child of #973 and successor to #1045
+- **Source oracle:** HazyResearch/Zoology ICLR24 release
+  [`de4e258784224e09909c257ff3ea040f089ed660`](https://github.com/HazyResearch/zoology/tree/de4e258784224e09909c257ff3ea040f089ed660),
+  Apache-2.0
+- **Provenance-only source:** later Zoology commit
+  [`1ad20d193b6113cae1e8f3c655c300d7b4b3f4bb`](https://github.com/HazyResearch/zoology/tree/1ad20d193b6113cae1e8f3c655c300d7b4b3f4bb)
+- **Claim boundary:** an open, CPU-only control of ordinary one-head causal
+  softmax on MQAR; no R4, geometric-attention, English, generation, reasoning,
+  recurrence, quantization, exact-lowering, browser/WASM, product, or release
+  claim
+
+This document preserves the frozen control and appends its execution evidence.
+The runner stops at the first missed rung. At contract publication, the CPU
+preflight and C0, C1, C2, and binding-permuted control were all `NOT_RUN`; the
+publication ledger below retains that state. The executed preflight result is
+appended after it. The frozen issue made #1045's landing through PR #1046 a
+prerequisite.
+
+## Decision and inherited evidence
+
+#1045 measured near-perfect fit of seen assignments in its inherited ordinary
+four-head causal-softmax cell but missed assignment-disjoint development:
+
+- construction: `65,500/65,536` (`99.945068%`);
+- final development: `7,137/8,192` (`87.121582%`);
+- frozen result CID:
+  `blake3:d920ad7b7f373c55cb564e27b3ddb1af8949a20c432e0d7cd2b39f1f69999557`;
+- fitted-artifact CID, recorded for provenance and forbidden as #1047 model
+  input:
+  `blake3:92bb13caf71c9ef44885a9da39023d080de075118b5902b716d2ca9b0f61f611`;
+- assignment-disjoint split CID:
+  `blake3:d36937f974e5e96dc697b219db8a7eb448dff7192abdf88bf6b21000f58b1f48`.
+
+An independent, no-write replay localized `893/1,055` development errors to a
+different value already admitted in the same row. In `739/893` of those
+errors, two second-layer heads both selected the wrongly predicted value slot.
+The diagnostic record is
+`blake3:ce11698f62561afb6d8ee5e8f816474df389802559d5e6519bff498c735b7736`.
+This is diagnostic localization, not an attention or geometry attribution.
+
+#1047 therefore asks one question: does the released Zoology one-head
+causal-softmax cell generalize on the exact open #1045 bytes where the inherited
+four-head cell missed? The control copies and credits the released mechanism
+before any further UOR-specific model change.
+
+## Source authority and attribution
+
+The executable oracle is the ICLR24 release at `de4e258...`:
+
+- [Figure 2 configuration](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/experiments/paper/figure2.py)
+- [MQAR loader](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/data/associative_recall.py)
+- [data-loader mechanics](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/data/utils.py)
+- [causal attention](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/mixers/attention.py)
+- [block, model, and initialization](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/model.py)
+- [trainer](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/zoology/train.py)
+- [Apache License 2.0](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/LICENSE.md)
+
+The later `1ad20d1...` commit cited by #1045 is bound only as provenance. It is
+not the executable oracle: that later tree changed batching and hard-coded CUDA
+in token-embedding construction. Source-derived files belong under
+`r4_softmax_trainer/zoology_control/` and are covered by that directory's
+`NOTICE.md`. Every adaptation is named below. This is neither a byte-identical
+port nor a reproduction of the full published Figure 2 sweep.
+
+## Modulo-256 boundary
+
+Modulo-256 semantics remain appropriate for discrete role codes, byte tables,
+and possible later lowering. They do not implement continuous probability
+normalization: `Z/256Z` has no general division and cannot represent even every
+elementary normalized distribution. This control therefore retains the
+released real-valued, numerically ordinary softmax.
+
+The #1045 categorical `uint8` role bytes are validated only to prove that C2
+loaded the intended rows. They are never embedded or passed to the Zoology
+cell. H4 frames and all other geometric sidecars are also excluded. A positive
+result would concern this ordinary causal-softmax control only.
+
+## Frozen cell and training mechanics
+
+The nested implementation copies the released discrete equations and
+initialization with this one fixed configuration:
+
+- fresh model/training seed `123`;
+- model width `64` and two released `TransformerBlock`s;
+- one attention head of dimension `64`;
+- learned absolute position embeddings;
+- biased combined Q/K/V projection and biased output projection;
+- the released pre-norm residual flow, final residual merge, and final
+  LayerNorm;
+- identity state mixer and no MLP;
+- attention dropout `0.1`, embedding dropout `0.1`, residual dropout `0`, and
+  no stochastic-depth drop;
+- tied token and vocabulary-output embeddings;
+- the released normal initialization, including the second model-level
+  `apply` and its residual-output rescaling;
+- AdamW defaults with weight decay `0.1` and learning rate exactly
+  `0.0004641588833612782` (the second released Figure 2 learning rate);
+- no gradient clipping;
+- a 64-epoch cosine schedule to zero.
+
+The copied attention computes the combined Q/K/V projection, reshapes to one
+head, scales by the inverse square root of head width, adds the released causal
+upper-triangular mask, applies softmax and training-only attention dropout,
+aggregates values, and applies the output projection. C0 binds these equations
+and the released block/model initialization to source-generated golden values;
+this prose is not a substitute for parity.
+
+### Declared adaptations
+
+Only these integration adaptations are permitted:
+
+1. Construct and run on CPU without the released CUDA-only device assumption;
+   CUDA and MPS remain forbidden.
+2. Gather hidden states at labelled query positions before the tied vocabulary
+   projection. This gives the same labelled logits and query-only
+   cross-entropy as projecting every position and masking all unlabelled logits,
+   while bounding CPU memory.
+3. Use a deterministic form of the release's shuffled data-loader order so a
+   repeated open run has a bound ordering.
+4. Use create-once UOR provenance and result containers to bind inputs, plans,
+   reads, work, artifacts, and decisions.
+
+C1 is deliberately scaled from the published experiment, and C2 deliberately
+substitutes the exact #1045 open serialization. Batch 64, the two-consecutive
+gate, query-only scoring, the CPU timing gate, and create-once records are
+control-contract choices. They must not be described as the full published
+100,000/3,000 Figure 2 run.
+
+## Ordered open controls
+
+The controls run in order and stop at the first miss. There is one learning
+arm per rung and no learning-rate, width, head-count, or other hyperparameter
+sweep.
+
+### C0 — source and mechanics
+
+Bind golden loader and model outputs generated from the `de4e258...` release.
+Require:
+
+- exact integer parity for released loader examples, labels, and selected query
+  positions;
+- scale-aware floating-point parity for the attention, residual block, model,
+  and initialization equations; and
+- `100%` query top-1 while overfitting 32 open rows within at most 256 updates.
+
+Any miss is `INVALID_CONTROL_PORT`. Repair only source parity; the miss permits
+no scientific inference and C1 does not start.
+
+### C1 — scaled source-native calibration
+
+Use the released `_mqar` serialization and distribution with:
+
+- zero filler (`random_non_queries=False`);
+- construction seed `0` and development seed `10`;
+- `input_seq_len=64`, four K/V pairs, power parameter `0.01`, and vocabulary
+  `8,192`;
+- 8,192 construction rows and 1,024 development rows;
+- batch 64 and at most 64 epochs.
+
+Require two consecutive evaluations in which construction query top-1 is
+`>=99.5%` and development query top-1 is `>=99%`. This is a scaled
+source-native calibration, not the published 100,000-construction/3,000-test
+experiment. A miss is `SCALED_SOURCE_CALIBRATION_MISS`: stop before
+interpreting the UOR bytes and do not modify R4. Outside this issue, the next
+decision is whether the full released calibration is worth its measured cost.
+
+### C2 — exact #1045 open bytes
+
+Load #1045's exact 8,192 construction and 1,024 assignment-disjoint
+development row identities, token bytes, selected query positions, and
+targets. Validate the role bytes for provenance, then exclude roles, H4 frames,
+and the failed #1045 fitted artifact from the model. Freeze context at `120`,
+vocabulary at `4,096`, and every other cell/optimizer setting above.
+
+Train with batch 64 for at most 64 epochs, capped at `4,194,304` query
+presentations. Require two consecutive evaluations in which construction query
+top-1 is `>=99.5%` and assignment-disjoint development query top-1 is `>=99%`.
+
+Only after the primary C2 development gate passes, run the existing data-level
+binding-permuted control. It must reduce development top-1 by at least 50
+percentage points. Do not invent current-only, cache, transport, or
+attention-off interventions absent from the copied cell.
+
+## Frozen decisions
+
+| Observation | Verdict | Binding next action |
+| --- | --- | --- |
+| C0 misses any parity or overfit gate | `INVALID_CONTROL_PORT` | Repair source parity only; make no scientific inference. |
+| C1 misses its two-consecutive calibration gate | `SCALED_SOURCE_CALIBRATION_MISS` | Stop before C2; do not modify R4. Decide in a separate issue whether the full 100,000-row release calibration merits its measured cost. |
+| C2 misses construction or the two-consecutive qualification | `STOCK_CELL_EXACT_QUALIFICATION_MISS` | Make no assignment-disjoint transfer inference. Isolate exact-byte fit or qualification mechanics only in a new frozen contract. |
+| C2 passes construction but misses assignment-disjoint development | `STOCK_CELL_TRANSFER_MISS` | The copied positive does not cover the assignment-disjoint/random-filler/reduced-population contract. Do not change R4; isolate source serialization versus assignment-disjointness in one new frozen contract. |
+| C2 development passes, binding-permuted drop `<50pp` | `NONASSOCIATIVE_SHORTCUT` | Do not accept the primary score as attention evidence. |
+| C2 development passes, binding-permuted drop `>=50pp` | `STOCK_CELL_PASSES_EXACT_BYTES` | Localize the #1045 miss to inherited model/integration mechanics; next align the R4 cell to the demonstrated one-head, width-64 addressing boundary before English transfer. |
+
+No branch authorizes tuning or rerunning #1047. The final row specifies a
+future engineering direction; it is not itself an R4 or geometric-attention
+result.
+
+## CPU run contract
+
+    metric to move:       #1045 exact-byte assignment-disjoint dev top-1, 87.121582% -> >=99%
+    reachability ceiling: every query has one physically admitted source K/V; 100% reaches attention
+    cheap instrument:     source parity + C0 + measured 1/4/8-thread batch-64 timing
+    proceed only if:      C0 passes; projected C1+C2 <=900s; peak RSS <=8GiB
+    if positive:          require binding-permutation drop, then align R4 addressing width/head shape
+    if negative:          use the exact stop code above; do not tune this issue
+    cost estimate:        timing proxy projects C2 about 317s; C1+C2 hard wall 900s
+
+Run one create-once preflight. Measure at least 32 timed training batches and a
+full development evaluation for each 1-, 4-, and 8-intra-op-thread batch-64
+plan. Apply a `1.25` safety factor for final scoring, export, and fsync. Select
+the fastest plan that projects C1+C2 within 900 seconds and holds peak RSS at
+or below 8 GiB. If none is eligible, do not launch. The combined C1+C2
+execution has a 900-second hard wall and receives no same-issue budget
+extension. Use CPU only, one worker/arm as frozen by the implementation, and at
+most one run for each reached rung.
+
+## Provenance, ledger, and forbidden inputs
+
+The create-once records must bind:
+
+- the recursive #1047 implementation tree;
+- authoritative Zoology hash `de4e258...` and provenance-only hash
+  `1ad20d1...`;
+- the #1045 result and assignment-disjoint split identities above;
+- every generated C0/C1/C2 population and selected query/target sequence;
+- the measured 1/4/8-thread plans and selected CPU plan;
+- the read/work ledger; and
+- the eventual artifact and result CIDs.
+
+The package is invoked as:
+
+```text
+python -m r4_softmax_trainer.zoology_control
+```
+
+Forbidden inputs and actions are the #1045 fitted artifact as model input; any
+sealed payload; future tokens or labels as inputs; teachers, providers,
+Ollama, or Gemma; CUDA or MPS; any hyperparameter/width sweep; and R4/geometry,
+English, generation, reasoning, recurrence, quantization, exact lowering,
+browser/WASM, product, or release work. The #1045 top-level implementation and
+immutable evidence remain untouched.
+
+## Definition of done
+
+- Source-derived code is credited and passes the frozen source-parity checks.
+- One create-once CPU preflight and at most one run per reached rung are
+  recorded.
+- Exact metrics, CIDs, source/read/work ledger, controls, and stop decision are
+  recorded in-tree and on #1047.
+- Focused tests and the repository claim-language check pass.
+- The result lands through a PR and the protected merge queue.
+- The successor follows the frozen decision branch; no same-issue tuning occurs.
+
+## Publication ledger
+
+| Item | State at contract publication |
+| --- | --- |
+| Source/license review | bound to `de4e258...`; later `1ad20d1...` is provenance only |
+| #1045 diagnostic | independently reproduced; CID and counts recorded above |
+| CPU preflight | `NOT_RUN` |
+| C0 source/mechanics | `NOT_RUN` |
+| C1 scaled source-native calibration | `NOT_RUN` |
+| C2 exact #1045 bytes | `NOT_RUN` |
+| Binding-permuted control | `NOT_RUN` (conditional on C2 primary pass) |
+| #1047 artifact/result | not created |
+
+## Executed result — 2026-09-02
+
+The create-once preflight completed correctly and stopped before C1 because no
+frozen CPU plan met the 900-second admission policy. This is
+`NOT_RUN_PREFLIGHT`, with no scientific verdict. It neither supports nor
+falsifies the copied attention cell.
+
+C0 passed every source/integration gate:
+
+- the literal `de4e258...` loader inputs and labels were byte-exact;
+- model parameters and selected logits were byte-exact, with scale-aware
+  parity also passing;
+- initialization replay, causal-prefix parity, and query-only projection
+  parity passed; and
+- the 32-row open overfit reached `128/128` query top-1 in 87 updates
+  (`11,136` query presentations).
+
+The preflight measured each arm under every frozen plan and applied the
+predeclared `1.25` safety factor:
+
+| CPU plan | Projected C1+C2 | Peak RSS | Admission |
+| --- | ---: | ---: | --- |
+| 1 thread, batch 64 | `1,522.035465 s` | `529,629,184` bytes | over wall |
+| 4 threads, batch 64 | `1,036.667109 s` | `567,345,152` bytes | over wall |
+| 8 threads, batch 64 | `959.212581 s` | `546,619,392` bytes | over wall |
+
+The 8-thread plan used all eight physical/logical cores reported by the host
+(four performance and four efficiency cores), but still projected `59.212581`
+seconds above the frozen wall. Memory, deterministic replay, both-arm timing,
+and full-development timing all passed. The selected plan is therefore `null`;
+C1, C2, binding permutation, and model artifacts are `NOT_RUN_PREFLIGHT`.
+
+The immutable identities are:
+
+- implementation tree:
+  `blake3:c848c05ae53bc3adc0a8f7099ceed43657b6348e4e00fe3aaef5cf1368cc38de`;
+- preparation:
+  `blake3:560dd6e9abbabbeccbb32b2dbec6b815b5f7842bbb30c387af79177bd32a98f8`;
+- preflight:
+  `blake3:78158700e632d303bf674ed544f997a0e14eb89947470f5032e6acc75c830c9b`;
+- result:
+  `blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+
+All forbidden, sealed, future-value, role-model-input, H4-model-input,
+provider, teacher, cache, and transport reads were zero. The binding action is
+a fresh issue that preserves the exact cell, source/data identities, batch 64,
+optimizer, gates, and CPU-only scope while widening only the execution wall
+enough to admit the already measured all-core plan. That is a resource-policy
+continuation, not tuning or rerunning #1047.

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -84,6 +84,32 @@ The executed R1 stopped `OPEN_MQAR_NOT_LEARNED`: construction reached
 released Zoology cell and loader, not a #1045 retry; exact evidence and CIDs are
 in the canonical record above.
 
+## #1047 released Zoology MQAR control
+
+The credited source port and frozen contract are documented in
+[`docs/r4_zoology_mqar_control_1047.md`](../../docs/r4_zoology_mqar_control_1047.md).
+Its create-once lifecycle is exposed as a module:
+
+```bash
+TRAINER="$(git rev-parse --show-toplevel)/tools/r4-softmax-trainer"
+cd "$TRAINER"
+PYTHONPATH=src .venv/bin/python -m r4_softmax_trainer.zoology_control prepare \
+  /absolute/run/root --source-root /absolute/1043/root \
+  --predecessor-root /absolute/1045/root
+PYTHONPATH=src .venv/bin/python -m r4_softmax_trainer.zoology_control preflight \
+  /absolute/run/root
+PYTHONPATH=src .venv/bin/python -m r4_softmax_trainer.zoology_control run \
+  /absolute/run/root
+PYTHONPATH=src .venv/bin/python -m r4_softmax_trainer.zoology_control verify \
+  /absolute/run/root
+```
+
+The executed C0 passed exact source goldens and disposable overfit, but no
+frozen CPU plan met the 900-second admission wall: the all-core 8-thread plan
+projected `959.212581 s`. The immutable result is `NOT_RUN_PREFLIGHT`, CID
+`blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`.
+No training artifact or scientific attention verdict was produced.
+
 ## Terminal #973 group-retention and decoder paths
 
 The canonical contract and evidence log are

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/LICENSE-APACHE-2.0.md
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/LICENSE-APACHE-2.0.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 The Meerkat Team.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/NOTICE.md
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/NOTICE.md
@@ -1,0 +1,63 @@
+# Zoology source attribution and modification notice
+
+Portions of this directory are adapted from
+[HazyResearch/Zoology](https://github.com/HazyResearch/zoology) at the ICLR24
+release commit
+[`de4e258784224e09909c257ff3ea040f089ed660`](https://github.com/HazyResearch/zoology/tree/de4e258784224e09909c257ff3ea040f089ed660).
+The upstream work is licensed under the
+[Apache License, Version 2.0](https://github.com/HazyResearch/zoology/blob/de4e258784224e09909c257ff3ea040f089ed660/LICENSE.md).
+The complete upstream license is redistributed beside this notice as
+[`LICENSE-APACHE-2.0.md`](LICENSE-APACHE-2.0.md).
+
+Copyright 2021 The Meerkat Team.
+
+The pinned upstream tree contains `LICENSE.md` and no separate upstream NOTICE
+file. Redistribution of source-derived code remains subject to Apache-2.0,
+including retention of applicable copyright, patent, trademark, and
+attribution notices. The upstream work is provided without warranties or
+conditions except as stated in that license. Reference to Zoology identifies
+origin and does not imply endorsement.
+
+## Upstream material adapted
+
+- `zoology/mixers/attention.py`: combined biased Q/K/V projection, one-head
+  scaled causal softmax, attention dropout, value aggregation, and biased
+  output projection.
+- `zoology/model.py`: learned token/absolute-position embeddings, released
+  `TransformerBlock` residual and LayerNorm flow, identity state mixer, tied
+  output embedding, and released initialization including the second
+  model-level initialization pass.
+- `zoology/data/associative_recall.py`: `_mqar` key/value serialization,
+  power-law query placement, shifted labels, zero-filler option, and seed
+  separation.
+- `zoology/data/utils.py` and `zoology/train.py`: shuffled tensor loading,
+  AdamW defaults, query-masked cross-entropy/accuracy, and cosine scheduling.
+- `zoology/experiments/paper/figure2.py`: the selected attention configuration,
+  width, learning rate, dropout, layer count, sequence length, vocabulary, and
+  K/V-pair settings.
+
+The later Zoology commit
+[`1ad20d193b6113cae1e8f3c655c300d7b4b3f4bb`](https://github.com/HazyResearch/zoology/tree/1ad20d193b6113cae1e8f3c655c300d7b4b3f4bb)
+is recorded for #1045 provenance only. It is not the executable source oracle.
+
+## UOR-R4 modifications
+
+The files in this directory are changed/adapted for the bounded
+`ZoologyMQARControlV1` experiment. The declared changes are:
+
+- device-neutral, CPU-only construction and execution in place of CUDA device
+  assumptions;
+- vocabulary projection only at labelled query positions, preserving the
+  labelled logits and masked query loss while bounding CPU memory;
+- deterministic release-style shuffled ordering;
+- create-once UOR provenance, work-ledger, artifact, and result containers;
+- a scaled 8,192/1,024 source-native calibration with batch 64 rather than the
+  published 100,000/3,000 Figure 2 experiment; and
+- a second control using #1045's exact open token rows and query targets, with
+  categorical role bytes checked only for provenance and never supplied to the
+  copied model.
+
+These adaptations are not represented as byte-identical Zoology code or as a
+full reproduction of the published Figure 2 sweep. Source-derived Python files
+in this directory must retain a prominent pointer to this notice and the
+upstream Apache-2.0 license.

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/__init__.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/__init__.py
@@ -1,0 +1,51 @@
+"""Credited, source-faithful Zoology MQAR integration control for #1047."""
+
+from .data import (
+    ZoologyMQARBatch,
+    ZoologyMQARPopulation,
+    ZoologyMQARRow,
+    batch_rows,
+    build_source_calibration,
+    deterministic_epoch_order,
+    load_exact_1045_population,
+    permute_exact_bindings,
+)
+from .development import (
+    ExecutionPlan,
+    decide_zoology_control,
+    execute_zoology_control,
+    prepare_zoology_control,
+    preflight_zoology_control,
+    run_zoology_control,
+    select_execution_plan,
+    verify_zoology_control,
+)
+from .model import (
+    ZoologyFigure2Config,
+    ZoologyFigure2Model,
+    ZoologyModelOutput,
+    set_zoology_seed,
+)
+
+__all__ = [
+    "ExecutionPlan",
+    "ZoologyFigure2Config",
+    "ZoologyFigure2Model",
+    "ZoologyMQARBatch",
+    "ZoologyMQARPopulation",
+    "ZoologyMQARRow",
+    "ZoologyModelOutput",
+    "batch_rows",
+    "build_source_calibration",
+    "decide_zoology_control",
+    "deterministic_epoch_order",
+    "execute_zoology_control",
+    "load_exact_1045_population",
+    "permute_exact_bindings",
+    "prepare_zoology_control",
+    "preflight_zoology_control",
+    "run_zoology_control",
+    "select_execution_plan",
+    "set_zoology_seed",
+    "verify_zoology_control",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/__main__.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/__main__.py
@@ -1,0 +1,77 @@
+"""Command-line lifecycle for ``python -m r4_softmax_trainer.zoology_control``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .development import (
+    execute_zoology_control,
+    prepare_zoology_control,
+    preflight_zoology_control,
+    run_zoology_control,
+    verify_zoology_control,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m r4_softmax_trainer.zoology_control",
+        description="Create-once CPU lifecycle for the frozen #1047 Zoology control.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare = commands.add_parser("prepare", help="bind open inputs and provenance")
+    prepare.add_argument("root", type=Path)
+    prepare.add_argument("--source-root", type=Path, required=True)
+    prepare.add_argument("--predecessor-root", type=Path, required=True)
+
+    for name, help_text in (
+        ("preflight", "run C0 and measured CPU admission"),
+        ("run", "execute the reached C1/C2 rungs once"),
+        ("verify", "verify structure and CIDs without a long rescore"),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument("root", type=Path)
+
+    execute = commands.add_parser("execute", help="prepare, preflight, run, verify")
+    execute.add_argument("root", type=Path)
+    execute.add_argument("--source-root", type=Path, required=True)
+    execute.add_argument("--predecessor-root", type=Path, required=True)
+    return parser
+
+
+def _print(value: Mapping[str, Any]) -> None:
+    print(json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+
+def main(argv: list[str] | None = None) -> None:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "prepare":
+        result = prepare_zoology_control(
+            arguments.root,
+            source_root=arguments.source_root,
+            predecessor_root=arguments.predecessor_root,
+        )
+    elif arguments.command == "preflight":
+        result = preflight_zoology_control(arguments.root)
+    elif arguments.command == "run":
+        result = run_zoology_control(arguments.root)
+    elif arguments.command == "verify":
+        result = verify_zoology_control(arguments.root)
+    elif arguments.command == "execute":
+        result = execute_zoology_control(
+            arguments.root,
+            source_root=arguments.source_root,
+            predecessor_root=arguments.predecessor_root,
+        )
+    else:  # pragma: no cover - argparse makes this unreachable.
+        raise AssertionError(f"unknown command: {arguments.command}")
+    _print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/data.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/data.py
@@ -1,0 +1,610 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from HazyResearch/Zoology; Copyright 2021 The Meerkat Team.
+"""MQAR data for the bounded Zoology integration control in issue #1047.
+
+The source-native generator is a bounded-memory adaptation of Zoology's
+ICLR24 ``_mqar`` implementation at revision
+``de4e258784224e09909c257ff3ea040f089ed660``.  It retains the released
+legacy NumPy RNG stream, integer layout, power-law gap sampling, shifted label
+alignment, and zero fillers used by this control.  See ``NOTICE.md`` and
+``LICENSE-APACHE-2.0.md`` in this directory for attribution and license terms.
+
+The exact-#1045 adapter keeps the already-open input, position, and target
+bytes unchanged.  Its categorical role sidecar is re-derived and validated,
+but :class:`ZoologyMQARBatch` deliberately has no role tensor, so roles cannot
+be supplied to the copied model through this data boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from blake3 import blake3
+from torch import Tensor
+
+from ..position_kv_binding_data import (
+    CONTEXT as EXACT_1045_CONTEXT,
+    MQAR_QUERIES as EXACT_1045_QUERIES,
+    MQAR_RECORDS as EXACT_1045_RECORDS,
+    VOCAB_SIZE as EXACT_1045_VOCAB_SIZE,
+)
+from ..provenance import canonical_json_bytes, cid_bytes
+from ..role_tagged_associative_data import (
+    MQAR_DEVELOPMENT_ROWS as EXACT_1045_DEVELOPMENT_ROWS,
+    MQAR_TRAIN_ROWS as EXACT_1045_TRAIN_ROWS,
+    RoleCode,
+    derive_mqar_role_ids,
+    load_role_tagged_construction,
+)
+from .provenance import ZOOLOGY_RELEASE_REVISION
+
+
+SOURCE_NATIVE_VOCAB_SIZE = 8_192
+SOURCE_NATIVE_INPUT_SEQ_LEN = 64
+SOURCE_NATIVE_KV_PAIRS = 4
+SOURCE_NATIVE_TRAIN_ROWS = 8_192
+SOURCE_NATIVE_DEVELOPMENT_ROWS = 1_024
+SOURCE_NATIVE_TRAIN_SEED = 0
+SOURCE_NATIVE_DEVELOPMENT_SEED = 10
+SOURCE_NATIVE_POWER_A = 0.01
+
+SOURCE_ROW_NAMESPACE = b"uor-r4/1047/zoology/source-native-row/v1\0"
+PERMUTED_ROW_NAMESPACE = b"uor-r4/1047/zoology/exact-binding-permutation/v1\0"
+SHUFFLE_NAMESPACE = b"uor-r4/1047/zoology/release-style-shuffle/v1\0"
+
+
+def _is_cid(value: object) -> bool:
+    if not isinstance(value, str) or not value.startswith("blake3:"):
+        return False
+    digest = value.removeprefix("blake3:")
+    return len(digest) == 64 and all(character in "0123456789abcdef" for character in digest)
+
+
+def _integer_tuple(values: Sequence[int], *, label: str) -> tuple[int, ...]:
+    result = tuple(values)
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in result):
+        raise ValueError(f"{label} must contain only integers")
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class ZoologyMQARRow:
+    """One fixed-width MQAR row with only query positions supervised."""
+
+    input_ids: tuple[int, ...]
+    selected_positions: tuple[int, ...]
+    targets: tuple[int, ...]
+    stable_id: str
+    role_ids: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        inputs = _integer_tuple(self.input_ids, label="input IDs")
+        positions = _integer_tuple(self.selected_positions, label="selected positions")
+        targets = _integer_tuple(self.targets, label="targets")
+        if inputs != self.input_ids or positions != self.selected_positions or targets != self.targets:
+            raise ValueError("MQAR row fields must be canonical tuples")
+        if not inputs or any(token < 0 for token in inputs):
+            raise ValueError("MQAR input IDs must be nonnegative and nonempty")
+        if (
+            not positions
+            or positions != tuple(sorted(positions))
+            or len(set(positions)) != len(positions)
+            or any(position < 0 or position >= len(inputs) for position in positions)
+        ):
+            raise ValueError("MQAR selected positions must be unique, ordered, and in bounds")
+        if len(targets) != len(positions) or any(target < 0 for target in targets):
+            raise ValueError("MQAR targets must align with selected positions")
+        if not _is_cid(self.stable_id):
+            raise ValueError("MQAR stable ID is malformed")
+        if self.role_ids is not None:
+            roles = _integer_tuple(self.role_ids, label="role IDs")
+            if roles != self.role_ids or len(roles) != len(inputs) or any(
+                role < int(RoleCode.TEXT) or role > int(RoleCode.QUERY) for role in roles
+            ):
+                raise ValueError("MQAR role sidecar is malformed")
+
+    def record(self) -> dict[str, Any]:
+        return {
+            "input_ids": list(self.input_ids),
+            "selected_positions": list(self.selected_positions),
+            "targets": list(self.targets),
+            "stable_id": self.stable_id,
+            "role_ids": None if self.role_ids is None else list(self.role_ids),
+        }
+
+    @property
+    def row_cid(self) -> str:
+        """Commit the complete row, including its inherited stable identity."""
+
+        return cid_bytes(canonical_json_bytes(self.record()))
+
+
+def _population_body(
+    *,
+    train: Sequence[ZoologyMQARRow],
+    development: Sequence[ZoologyMQARRow],
+    name: str,
+    vocab_size: int,
+    input_seq_len: int,
+    num_kv_pairs: int,
+    train_seed: int | None,
+    development_seed: int | None,
+    source_split_cid: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema": "uor-r4/zoology-mqar-population/v1",
+        "zoology_release_oracle_revision": ZOOLOGY_RELEASE_REVISION,
+        "name": name,
+        "vocab_size": vocab_size,
+        "input_seq_len": input_seq_len,
+        "num_kv_pairs": num_kv_pairs,
+        "train_seed": train_seed,
+        "development_seed": development_seed,
+        "source_split_cid": source_split_cid,
+        "train_row_cids": [row.row_cid for row in train],
+        "development_row_cids": [row.row_cid for row in development],
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ZoologyMQARPopulation:
+    """One create-once train/development population and its exact commitment."""
+
+    train: tuple[ZoologyMQARRow, ...]
+    development: tuple[ZoologyMQARRow, ...]
+    population_cid: str
+    name: str
+    vocab_size: int
+    input_seq_len: int
+    num_kv_pairs: int
+    train_seed: int | None = None
+    development_seed: int | None = None
+    source_split_cid: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.train or not self.development:
+            raise ValueError("MQAR population requires nonempty train and development rows")
+        if (
+            not self.name
+            or isinstance(self.vocab_size, bool)
+            or not isinstance(self.vocab_size, int)
+            or self.vocab_size < 2
+            or isinstance(self.input_seq_len, bool)
+            or not isinstance(self.input_seq_len, int)
+            or self.input_seq_len < 1
+            or isinstance(self.num_kv_pairs, bool)
+            or not isinstance(self.num_kv_pairs, int)
+            or self.num_kv_pairs < 1
+        ):
+            raise ValueError("MQAR population dimensions are invalid")
+        for seed in (self.train_seed, self.development_seed):
+            if seed is not None and (
+                isinstance(seed, bool) or not isinstance(seed, int) or seed < 0
+            ):
+                raise ValueError("MQAR population seed must be a nonnegative integer")
+        if self.source_split_cid is not None and not _is_cid(self.source_split_cid):
+            raise ValueError("MQAR source split CID is malformed")
+
+        all_rows = self.train + self.development
+        if any(
+            len(row.input_ids) != self.input_seq_len
+            or len(row.selected_positions) != self.num_kv_pairs
+            or any(token >= self.vocab_size for token in (*row.input_ids, *row.targets))
+            for row in all_rows
+        ):
+            raise ValueError("MQAR row differs from its population dimensions")
+        stable_ids = [row.stable_id for row in all_rows]
+        row_cids = [row.row_cid for row in all_rows]
+        if len(set(stable_ids)) != len(stable_ids) or len(set(row_cids)) != len(row_cids):
+            raise ValueError("MQAR rows repeat within or across population splits")
+
+        expected = cid_bytes(canonical_json_bytes(self._unsigned_record()))
+        if self.population_cid != expected:
+            raise ValueError("MQAR population CID does not reproduce")
+
+    def _unsigned_record(self) -> dict[str, Any]:
+        return _population_body(
+            train=self.train,
+            development=self.development,
+            name=self.name,
+            vocab_size=self.vocab_size,
+            input_seq_len=self.input_seq_len,
+            num_kv_pairs=self.num_kv_pairs,
+            train_seed=self.train_seed,
+            development_seed=self.development_seed,
+            source_split_cid=self.source_split_cid,
+        )
+
+    def record(self) -> dict[str, Any]:
+        return {**self._unsigned_record(), "population_cid": self.population_cid}
+
+
+@dataclass(frozen=True, slots=True)
+class ZoologyMQARBatch:
+    """The complete model-facing data ABI; role IDs are intentionally absent."""
+
+    input_ids: Tensor
+    selected_positions: Tensor
+    targets: Tensor
+
+    def __post_init__(self) -> None:
+        if (
+            self.input_ids.dtype != torch.long
+            or self.selected_positions.dtype != torch.long
+            or self.targets.dtype != torch.long
+            or self.input_ids.ndim != 2
+            or self.selected_positions.ndim != 2
+            or self.targets.shape != self.selected_positions.shape
+            or self.selected_positions.shape[0] != self.input_ids.shape[0]
+        ):
+            raise ValueError("Zoology MQAR batch tensor contract differs")
+        if len({self.input_ids.device, self.selected_positions.device, self.targets.device}) != 1:
+            raise ValueError("Zoology MQAR batch tensors are on different devices")
+        if bool(
+            (
+                (self.selected_positions < 0)
+                | (self.selected_positions >= self.input_ids.shape[1])
+            ).any()
+        ):
+            raise ValueError("Zoology MQAR selected position is outside its row")
+        if any(
+            tuple(sorted(int(value) for value in row.tolist()))
+            != tuple(int(value) for value in row.tolist())
+            or len(set(int(value) for value in row.tolist())) != row.numel()
+            for row in self.selected_positions.detach().cpu()
+        ):
+            raise ValueError("Zoology MQAR selected positions must be ordered and unique")
+
+
+def _released_mqar(
+    *,
+    vocab_size: int,
+    num_examples: int,
+    input_seq_len: int,
+    seed: int,
+    power_a: float = SOURCE_NATIVE_POWER_A,
+    num_kv_pairs: int = 8,
+) -> tuple[Tensor, Tensor]:
+    """Reproduce released ``_mqar(..., random_non_queries=False)`` integers.
+
+    Zoology tiles each choice vocabulary once per row before applying legacy
+    ``np.random.choice``.  The row arrays are read-only choice populations, so
+    sampling them sequentially from a local ``RandomState`` preserves the
+    exact released RNG calls while avoiding both large tiled intermediates.
+    """
+
+    if (
+        isinstance(vocab_size, bool)
+        or not isinstance(vocab_size, int)
+        or isinstance(num_examples, bool)
+        or not isinstance(num_examples, int)
+        or isinstance(input_seq_len, bool)
+        or not isinstance(input_seq_len, int)
+        or isinstance(seed, bool)
+        or not isinstance(seed, int)
+        or isinstance(num_kv_pairs, bool)
+        or not isinstance(num_kv_pairs, int)
+        or num_examples < 1
+        or seed < 0
+        or input_seq_len % 2 != 0
+        or vocab_size <= input_seq_len
+        or num_kv_pairs < 1
+        or num_kv_pairs * 4 > input_seq_len
+        or not np.isfinite(power_a)
+        or power_a <= 0.0
+    ):
+        raise ValueError("released MQAR dimensions or power law are invalid")
+
+    rng = np.random.RandomState(seed)
+    key_vocab_size = vocab_size // 2
+    key_choices = np.arange(1, key_vocab_size)
+    value_choices = np.arange(key_vocab_size, vocab_size)
+
+    keys = np.empty((num_examples, num_kv_pairs), dtype=np.int64)
+    values = np.empty_like(keys)
+    for row_index in range(num_examples):
+        keys[row_index] = rng.choice(key_choices, replace=False, size=num_kv_pairs)
+    for row_index in range(num_examples):
+        values[row_index] = rng.choice(value_choices, replace=False, size=num_kv_pairs)
+
+    context_size = num_kv_pairs * 2
+    space = (input_seq_len - context_size) // 2
+    gap_choices = np.arange(space, dtype=int)
+    probabilities = power_a * np.arange(1, space + 1) ** (power_a - 1)
+    probabilities = probabilities / probabilities.sum()
+    gaps = np.empty_like(keys)
+    for row_index in range(num_examples):
+        gaps[row_index] = rng.choice(
+            gap_choices,
+            replace=False,
+            p=probabilities,
+            size=num_kv_pairs,
+        )
+
+    inputs = np.zeros((num_examples, input_seq_len), dtype=np.int64)
+    labels = np.full((num_examples, input_seq_len), -100, dtype=np.int64)
+    inputs[:, :context_size:2] = keys
+    inputs[:, 1:context_size:2] = values
+    query_positions = context_size + gaps * 2
+    np.put_along_axis(inputs, query_positions, values=keys, axis=1)
+    np.put_along_axis(labels, query_positions, values=values, axis=1)
+    return torch.from_numpy(inputs), torch.from_numpy(labels)
+
+
+def _source_rows(
+    *,
+    split: str,
+    count: int,
+    seed: int,
+) -> tuple[ZoologyMQARRow, ...]:
+    inputs, labels = _released_mqar(
+        vocab_size=SOURCE_NATIVE_VOCAB_SIZE,
+        num_examples=count,
+        input_seq_len=SOURCE_NATIVE_INPUT_SEQ_LEN,
+        seed=seed,
+        num_kv_pairs=SOURCE_NATIVE_KV_PAIRS,
+    )
+    result: list[ZoologyMQARRow] = []
+    for row_index in range(count):
+        input_ids = tuple(int(value) for value in inputs[row_index].tolist())
+        label_ids = tuple(int(value) for value in labels[row_index].tolist())
+        selected = tuple(index for index, label in enumerate(label_ids) if label != -100)
+        targets = tuple(label_ids[index] for index in selected)
+        identity = {
+            "source_revision": ZOOLOGY_RELEASE_REVISION,
+            "split": split,
+            "seed": seed,
+            "row_index": row_index,
+            "input_ids": list(input_ids),
+            "selected_positions": list(selected),
+            "targets": list(targets),
+        }
+        stable_id = cid_bytes(SOURCE_ROW_NAMESPACE + canonical_json_bytes(identity))
+        result.append(
+            ZoologyMQARRow(
+                input_ids=input_ids,
+                selected_positions=selected,
+                targets=targets,
+                stable_id=stable_id,
+            )
+        )
+    return tuple(result)
+
+
+def _make_population(
+    *,
+    train: Sequence[ZoologyMQARRow],
+    development: Sequence[ZoologyMQARRow],
+    name: str,
+    vocab_size: int,
+    input_seq_len: int,
+    num_kv_pairs: int,
+    train_seed: int | None = None,
+    development_seed: int | None = None,
+    source_split_cid: str | None = None,
+) -> ZoologyMQARPopulation:
+    train_tuple = tuple(train)
+    development_tuple = tuple(development)
+    body = _population_body(
+        train=train_tuple,
+        development=development_tuple,
+        name=name,
+        vocab_size=vocab_size,
+        input_seq_len=input_seq_len,
+        num_kv_pairs=num_kv_pairs,
+        train_seed=train_seed,
+        development_seed=development_seed,
+        source_split_cid=source_split_cid,
+    )
+    return ZoologyMQARPopulation(
+        train=train_tuple,
+        development=development_tuple,
+        population_cid=cid_bytes(canonical_json_bytes(body)),
+        name=name,
+        vocab_size=vocab_size,
+        input_seq_len=input_seq_len,
+        num_kv_pairs=num_kv_pairs,
+        train_seed=train_seed,
+        development_seed=development_seed,
+        source_split_cid=source_split_cid,
+    )
+
+
+def build_source_calibration() -> ZoologyMQARPopulation:
+    """Build the declared scaled source-native train/development population."""
+
+    return _make_population(
+        train=_source_rows(
+            split="train",
+            count=SOURCE_NATIVE_TRAIN_ROWS,
+            seed=SOURCE_NATIVE_TRAIN_SEED,
+        ),
+        development=_source_rows(
+            split="development",
+            count=SOURCE_NATIVE_DEVELOPMENT_ROWS,
+            seed=SOURCE_NATIVE_DEVELOPMENT_SEED,
+        ),
+        name="scaled_source_native",
+        vocab_size=SOURCE_NATIVE_VOCAB_SIZE,
+        input_seq_len=SOURCE_NATIVE_INPUT_SEQ_LEN,
+        num_kv_pairs=SOURCE_NATIVE_KV_PAIRS,
+        train_seed=SOURCE_NATIVE_TRAIN_SEED,
+        development_seed=SOURCE_NATIVE_DEVELOPMENT_SEED,
+    )
+
+
+def _adapt_exact_row(tagged: Any) -> ZoologyMQARRow:
+    input_ids = tuple(int(value) for value in tagged.input_ids)
+    role_ids = tuple(int(value) for value in tagged.role_ids)
+    if derive_mqar_role_ids(input_ids) != role_ids:
+        raise ValueError("#1045 role bytes do not reproduce from exact input bytes")
+    selected = tuple(int(value) for value in tagged.source.query_positions)
+    targets = tuple(int(value) for value in tagged.source.answers)
+    label_ids = tuple(int(value) for value in tagged.label_ids)
+    active = tuple(index for index, label in enumerate(label_ids) if label != -100)
+    if (
+        active != selected
+        or tuple(label_ids[index] for index in selected) != targets
+        or tuple(input_ids[index] for index in selected)
+        != tuple(int(value) for value in tagged.source.query_keys)
+    ):
+        raise ValueError("#1045 query positions or targets do not reproduce")
+    return ZoologyMQARRow(
+        input_ids=input_ids,
+        selected_positions=selected,
+        targets=targets,
+        stable_id=str(tagged.stable_id),
+        role_ids=role_ids,
+    )
+
+
+def load_exact_1045_population(source_root: Path) -> ZoologyMQARPopulation:
+    """Adapt only #1045's open 8,192/1,024 split without changing row bytes."""
+
+    construction = load_role_tagged_construction(source_root)
+    if (
+        len(construction.mqar_train) != EXACT_1045_TRAIN_ROWS
+        or len(construction.mqar_development) != EXACT_1045_DEVELOPMENT_ROWS
+    ):
+        raise ValueError("#1045 open train/development split counts differ")
+    train = tuple(_adapt_exact_row(row) for row in construction.mqar_train)
+    development = tuple(_adapt_exact_row(row) for row in construction.mqar_development)
+    return _make_population(
+        train=train,
+        development=development,
+        name="exact_1045_open_bytes",
+        vocab_size=EXACT_1045_VOCAB_SIZE,
+        input_seq_len=EXACT_1045_CONTEXT,
+        num_kv_pairs=EXACT_1045_QUERIES,
+        source_split_cid=str(construction.split_cid),
+    )
+
+
+def batch_rows(
+    rows: Sequence[ZoologyMQARRow],
+    device: torch.device | str | None = None,
+) -> ZoologyMQARBatch:
+    """Create the complete three-tensor model ABI from uniform MQAR rows."""
+
+    if not rows:
+        raise ValueError("Zoology MQAR batch cannot be empty")
+    widths = {len(row.input_ids) for row in rows}
+    query_counts = {len(row.selected_positions) for row in rows}
+    if len(widths) != 1 or len(query_counts) != 1:
+        raise ValueError("one Zoology MQAR batch requires uniform row dimensions")
+    return ZoologyMQARBatch(
+        input_ids=torch.tensor([row.input_ids for row in rows], dtype=torch.long, device=device),
+        selected_positions=torch.tensor(
+            [row.selected_positions for row in rows], dtype=torch.long, device=device
+        ),
+        targets=torch.tensor([row.targets for row in rows], dtype=torch.long, device=device),
+    )
+
+
+def deterministic_epoch_order(
+    rows: Sequence[ZoologyMQARRow],
+    epoch: int,
+    namespace: str | bytes,
+) -> tuple[ZoologyMQARRow, ...]:
+    """Return an explicit, replayable ``torch.randperm`` release-style order."""
+
+    if not rows:
+        raise ValueError("release-style shuffle cannot order an empty population")
+    if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 0:
+        raise ValueError("shuffle epoch must be a nonnegative integer")
+    if isinstance(namespace, str):
+        namespace_bytes = namespace.encode("utf-8")
+    elif isinstance(namespace, bytes):
+        namespace_bytes = namespace
+    else:
+        raise TypeError("shuffle namespace must be str or bytes")
+    if not namespace_bytes:
+        raise ValueError("shuffle namespace cannot be empty")
+    stable_ids = [row.stable_id for row in rows]
+    if len(set(stable_ids)) != len(stable_ids):
+        raise ValueError("release-style shuffle requires unique stable row IDs")
+
+    digest = blake3(
+        SHUFFLE_NAMESPACE
+        + namespace_bytes
+        + b"\0"
+        + epoch.to_bytes(8, "big")
+        + canonical_json_bytes(stable_ids)
+    ).digest()
+    seed = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    order = torch.randperm(len(rows), generator=generator).tolist()
+    return tuple(rows[index] for index in order)
+
+
+def permute_exact_bindings(
+    rows: Sequence[ZoologyMQARRow],
+) -> tuple[ZoologyMQARRow, ...]:
+    """Rotate serialized #1045 values while retaining queries and targets.
+
+    This is a data-level intervention.  It intentionally makes the physical
+    bindings disagree with the retained labels, and it never exposes roles in
+    :func:`batch_rows`.
+    """
+
+    if not rows:
+        raise ValueError("exact binding permutation cannot be empty")
+    controls: list[ZoologyMQARRow] = []
+    for row in rows:
+        if row.role_ids is None or derive_mqar_role_ids(row.input_ids) != row.role_ids:
+            raise ValueError("exact binding permutation requires valid #1045 role bytes")
+        value_positions = tuple(
+            index for index, role in enumerate(row.role_ids) if role == int(RoleCode.VALUE)
+        )
+        if len(value_positions) != EXACT_1045_RECORDS:
+            raise ValueError("exact binding permutation requires every physical value slot")
+        native_values = tuple(row.input_ids[index] for index in value_positions)
+        permuted_values = native_values[1:] + native_values[:1]
+        if len(set(native_values)) != len(native_values) or any(
+            native == permuted
+            for native, permuted in zip(native_values, permuted_values, strict=True)
+        ):
+            raise ValueError("exact binding permutation is not a derangement")
+
+        changed = list(row.input_ids)
+        for position, value in zip(value_positions, permuted_values, strict=True):
+            changed[position] = value
+        changed_inputs = tuple(changed)
+        if derive_mqar_role_ids(changed_inputs) != row.role_ids:
+            raise ValueError("binding permutation changed the categorical role serialization")
+        identity = {
+            "intervention": "rotate_physical_values_left_one",
+            "source_stable_id": row.stable_id,
+            "input_ids": list(changed_inputs),
+            "selected_positions": list(row.selected_positions),
+            "targets": list(row.targets),
+            "role_ids": list(row.role_ids),
+        }
+        controls.append(
+            ZoologyMQARRow(
+                input_ids=changed_inputs,
+                selected_positions=row.selected_positions,
+                targets=row.targets,
+                stable_id=cid_bytes(PERMUTED_ROW_NAMESPACE + canonical_json_bytes(identity)),
+                role_ids=row.role_ids,
+            )
+        )
+    return tuple(controls)
+
+
+__all__ = [
+    "ZoologyMQARBatch",
+    "ZoologyMQARPopulation",
+    "ZoologyMQARRow",
+    "batch_rows",
+    "build_source_calibration",
+    "deterministic_epoch_order",
+    "load_exact_1045_population",
+    "permute_exact_bindings",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/development.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/development.py
@@ -1,0 +1,2264 @@
+"""Create-once CPU lifecycle for the credited Zoology MQAR control (#1047).
+
+Source-derived mechanics are attributed in :mod:`.provenance` and NOTICE.md.
+This runner never opens a fitted #1045 artifact or a sealed population.  It
+uses the exact open #1045 row loader, projects only selected query positions,
+and stops at the first frozen control miss.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import multiprocessing as mp
+import os
+import platform
+import queue as queue_module
+import resource
+import time
+import traceback
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+from blake3 import blake3
+from safetensors.torch import load as load_safetensors
+from safetensors.torch import save as save_safetensors
+from torch import Tensor
+from torch.nn import functional as F
+
+from ..provenance import canonical_json_bytes, cid_bytes
+from . import data as zoology_data
+from .data import (
+    ZoologyMQARBatch,
+    ZoologyMQARPopulation,
+    ZoologyMQARRow,
+    batch_rows,
+    build_source_calibration,
+    deterministic_epoch_order,
+    load_exact_1045_population,
+    permute_exact_bindings,
+)
+from .model import (
+    ZoologyFigure2Config,
+    ZoologyFigure2Model,
+    set_zoology_seed,
+)
+from .provenance import (
+    zoology_control_implementation_contract,
+    zoology_source_attribution,
+)
+
+
+ISSUE = 1047
+POLICY = "ZoologyMQARControlV1"
+SOURCE_MODEL_SEED = 123
+
+SOURCE_TRAIN_ROWS = 8_192
+SOURCE_DEVELOPMENT_ROWS = 1_024
+EXACT_TRAIN_ROWS = 8_192
+EXACT_DEVELOPMENT_ROWS = 1_024
+OVERFIT_ROWS = 32
+OVERFIT_UPDATES = 256
+MAXIMUM_EPOCHS = 64
+BATCH_SIZE = 64
+
+LEARNING_RATE = 0.0004641588833612782
+WEIGHT_DECAY = 0.1
+TRAIN_REQUIRED_RATE = 0.995
+DEVELOPMENT_REQUIRED_RATE = 0.99
+CONTROL_REQUIRED_DROP = 0.50
+REQUIRED_CONSECUTIVE_PASSES = 2
+MAXIMUM_C2_QUERY_PRESENTATIONS = 4_194_304
+
+ELIGIBLE_THREADS = (1, 4, 8)
+TIMED_TRAINING_BATCHES = 32
+PROJECTION_SAFETY_FACTOR = 1.25
+HARD_WALL_SECONDS = 900.0
+MEMORY_CEILING_BYTES = 8 * 1024**3
+PROBE_TIMEOUT_SECONDS = 300.0
+
+EXPECTED_1045_RESULT_CID = (
+    "blake3:d920ad7b7f373c55cb564e27b3ddb1af8949a20c432e0d7cd2b39f1f69999557"
+)
+EXPECTED_1045_SPLIT_CID = (
+    "blake3:d36937f974e5e96dc697b219db8a7eb448dff7192abdf88bf6b21000f58b1f48"
+)
+EXPECTED_1045_DIAGNOSTIC_CID = (
+    "blake3:ce11698f62561afb6d8ee5e8f816474df389802559d5e6519bff498c735b7736"
+)
+FORBIDDEN_1045_ARTIFACT_CID = (
+    "blake3:92bb13caf71c9ef44885a9da39023d080de075118b5902b716d2ca9b0f61f611"
+)
+
+PREPARATION_RELATIVE_PATH = "zoology-control-preparation.json"
+PREFLIGHT_STARTED_RELATIVE_PATH = "preflight/zoology-control-started.json"
+PREFLIGHT_RELATIVE_PATH = "preflight/zoology-control-preflight.json"
+RUN_STARTED_RELATIVE_PATH = "run/zoology-control-started.json"
+RESULT_RELATIVE_PATH = "run/zoology-control-result.json"
+C1_ARTIFACT_RELATIVE_PATH = "artifact/c1-source-calibration.safetensors"
+C2_ARTIFACT_RELATIVE_PATH = "artifact/c2-exact-1045.safetensors"
+PREDECESSOR_PREFLIGHT_RELATIVE_PATH = (
+    "preflight/role-tagged-associative-preflight.json"
+)
+PREDECESSOR_RESULT_RELATIVE_PATH = "run/role-tagged-associative-result.json"
+
+PREPARATION_SCHEMA = "uor-r4.zoology-control-preparation/1"
+PREFLIGHT_SCHEMA = "uor-r4.zoology-control-preflight/1"
+STARTED_SCHEMA = "uor-r4.zoology-control-started/1"
+RESULT_SCHEMA = "uor-r4.zoology-control-result/1"
+
+_SOURCE_GOLDEN_INPUTS = (
+    (2, 29, 7, 22, 2, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    (3, 21, 5, 16, 3, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    (5, 17, 13, 18, 13, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0),
+)
+_SOURCE_GOLDEN_LABELS = (
+    (-100, -100, -100, -100, 29, -100, 22, -100, -100, -100, -100, -100, -100, -100, -100, -100),
+    (-100, -100, -100, -100, 21, -100, 16, -100, -100, -100, -100, -100, -100, -100, -100, -100),
+    (-100, -100, -100, -100, 18, -100, -100, -100, 17, -100, -100, -100, -100, -100, -100, -100),
+)
+_SOURCE_GOLDEN_WORD = (
+    0.01682600937783718,
+    0.007630460895597935,
+    0.03871878609061241,
+    0.004360933322459459,
+)
+_SOURCE_GOLDEN_POSITION = (
+    0.002722495701164007,
+    -0.0014288985403254628,
+    -0.004648478236049414,
+    -0.01643170788884163,
+)
+_SOURCE_GOLDEN_WQKV = (
+    0.03611164167523384,
+    -0.02012898586690426,
+    0.003164451103657484,
+    0.00013401817705016583,
+)
+_SOURCE_GOLDEN_LOGITS = (
+    -0.03831605240702629,
+    -0.05481904745101929,
+    -0.031969670206308365,
+    0.005645290017127991,
+    0.10721376538276672,
+    -0.07025852799415588,
+)
+
+Verdict = Literal[
+    "INVALID_CONTROL_PORT",
+    "SCALED_SOURCE_CALIBRATION_MISS",
+    "STOCK_CELL_EXACT_QUALIFICATION_MISS",
+    "STOCK_CELL_TRANSFER_MISS",
+    "NONASSOCIATIVE_SHORTCUT",
+    "STOCK_CELL_PASSES_EXACT_BYTES",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionPlan:
+    """One frozen CPU-only batch-64 plan."""
+
+    threads: int
+    batch_size: int = BATCH_SIZE
+
+    def __post_init__(self) -> None:
+        if self.threads not in ELIGIBLE_THREADS:
+            raise ValueError("threads are outside the frozen #1047 plans")
+        if self.batch_size != BATCH_SIZE:
+            raise ValueError("#1047 admits only batch 64")
+
+    def record(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "name": f"cpu-{self.threads}t-b{self.batch_size}",
+            "device": "cpu",
+            "threads": self.threads,
+            "workers": 1,
+            "batch_size": self.batch_size,
+            "cuda": "FORBIDDEN",
+            "mps": "FORBIDDEN",
+        }
+        body["plan_cid"] = cid_bytes(canonical_json_bytes(body))
+        return body
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreResult:
+    """One query-only population score and its causal/work ledger."""
+
+    decisions: int
+    correct: int
+    loss_sum: float
+    selected_logits_cid: str
+    work: dict[str, int]
+
+    @property
+    def rate(self) -> float:
+        return self.correct / self.decisions
+
+    @property
+    def nll_nats(self) -> float:
+        return self.loss_sum / self.decisions
+
+    def record(self) -> dict[str, Any]:
+        return {
+            "decisions": self.decisions,
+            "top1_correct": self.correct,
+            "top1_rate": self.rate,
+            "nll_nats": self.nll_nats,
+            "selected_logits_cid": self.selected_logits_cid,
+            "work": dict(self.work),
+        }
+
+
+class HardWallExceeded(TimeoutError):
+    """The combined C1+C2 execution reached its frozen 900-second wall."""
+
+    def __init__(self, message: str, partial: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.partial = None if partial is None else dict(partial)
+
+
+def _with_cid(value: Mapping[str, Any], field: str) -> dict[str, Any]:
+    if field in value:
+        raise ValueError(f"self-CID field already exists: {field}")
+    result = dict(value)
+    result[field] = cid_bytes(canonical_json_bytes(value))
+    return result
+
+
+def _verify_self_cid(value: Mapping[str, Any], field: str) -> None:
+    unsigned = dict(value)
+    observed = unsigned.pop(field, None)
+    if observed != cid_bytes(canonical_json_bytes(unsigned)):
+        raise ValueError(f"{field} does not reproduce")
+
+
+def _read_json(path: Path, *, cid_field: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read {path.name}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} is not a JSON object")
+    _verify_self_cid(value, cid_field)
+    return value
+
+
+def _read_bound_json(
+    path: Path,
+    *,
+    cid_field: str,
+    relative_path: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    try:
+        payload = path.read_bytes()
+        value = json.loads(payload)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot bind {relative_path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{relative_path} is not a JSON object")
+    _verify_self_cid(value, cid_field)
+    return value, {
+        "path": relative_path,
+        "source_path": str(path),
+        "bytes": len(payload),
+        "file_cid": cid_bytes(payload),
+        cid_field: value[cid_field],
+    }
+
+
+def _write_exclusive(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(payload)
+            output.flush()
+            os.fsync(output.fileno())
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _write_exclusive_json(path: Path, value: Mapping[str, Any]) -> None:
+    _write_exclusive(path, canonical_json_bytes(value))
+
+
+def _peak_rss_bytes() -> int:
+    peak = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return peak if platform.system() == "Darwin" else peak * 1024
+
+
+def _row_query_count(rows: Sequence[ZoologyMQARRow]) -> int:
+    return sum(len(row.selected_positions) for row in rows)
+
+
+def _population_record(population: ZoologyMQARPopulation) -> dict[str, Any]:
+    role_rows = sum(
+        row.role_ids is not None
+        for row in (*population.train, *population.development)
+    )
+    return {
+        "name": population.name,
+        "population_cid": population.population_cid,
+        "vocab_size": population.vocab_size,
+        "input_seq_len": population.input_seq_len,
+        "num_kv_pairs": population.num_kv_pairs,
+        "train_seed": population.train_seed,
+        "development_seed": population.development_seed,
+        "source_split_cid": population.source_split_cid,
+        "train_rows": len(population.train),
+        "development_rows": len(population.development),
+        "train_queries": _row_query_count(population.train),
+        "development_queries": _row_query_count(population.development),
+        "role_sidecar_rows": role_rows,
+    }
+
+
+def _load_bound_populations(
+    source_root: Path,
+) -> tuple[ZoologyMQARPopulation, ZoologyMQARPopulation]:
+    source = build_source_calibration()
+    exact = load_exact_1045_population(source_root)
+    if (
+        len(source.train) != SOURCE_TRAIN_ROWS
+        or len(source.development) != SOURCE_DEVELOPMENT_ROWS
+        or source.vocab_size != 8_192
+        or source.input_seq_len != 64
+        or source.num_kv_pairs != 4
+        or source.train_seed != 0
+        or source.development_seed != 10
+    ):
+        raise ValueError("source-native C1 population differs from the freeze")
+    if (
+        len(exact.train) != EXACT_TRAIN_ROWS
+        or len(exact.development) != EXACT_DEVELOPMENT_ROWS
+        or exact.vocab_size != 4_096
+        or exact.input_seq_len != 120
+        or exact.num_kv_pairs != 8
+        or exact.source_split_cid != EXPECTED_1045_SPLIT_CID
+    ):
+        raise ValueError("exact #1045 C2 population differs from the freeze")
+    if any(row.role_ids is not None for row in (*source.train, *source.development)):
+        raise ValueError("source-native population unexpectedly carries roles")
+    if any(row.role_ids is None for row in (*exact.train, *exact.development)):
+        raise ValueError("exact #1045 population lacks provenance role bytes")
+    return source, exact
+
+
+def _bind_predecessor(predecessor_root: Path) -> dict[str, Any]:
+    """Bind only #1045's immutable open preflight/result JSON envelopes."""
+
+    preflight, preflight_file = _read_bound_json(
+        predecessor_root / PREDECESSOR_PREFLIGHT_RELATIVE_PATH,
+        cid_field="preflight_cid",
+        relative_path=PREDECESSOR_PREFLIGHT_RELATIVE_PATH,
+    )
+    result, result_file = _read_bound_json(
+        predecessor_root / PREDECESSOR_RESULT_RELATIVE_PATH,
+        cid_field="result_cid",
+        relative_path=PREDECESSOR_RESULT_RELATIVE_PATH,
+    )
+    decision = result.get("decision")
+    if (
+        result.get("result_cid") != EXPECTED_1045_RESULT_CID
+        or result.get("preflight_cid") != preflight.get("preflight_cid")
+        or preflight.get("source_split_cid") != EXPECTED_1045_SPLIT_CID
+        or not isinstance(decision, Mapping)
+        or decision.get("verdict") != "OPEN_MQAR_NOT_LEARNED"
+    ):
+        raise ValueError("#1045 predecessor result/preflight differs from the freeze")
+    return {
+        "root": str(predecessor_root),
+        "preflight": preflight_file,
+        "result": result_file,
+        "source_split_cid": preflight["source_split_cid"],
+        "result_cid": result["result_cid"],
+        "verdict": decision["verdict"],
+        "artifact_access": "FORBIDDEN_NOT_READ",
+        "sealed_access": "FORBIDDEN_NOT_READ",
+    }
+
+
+def prepare_zoology_control(
+    root: Path,
+    *,
+    source_root: Path,
+    predecessor_root: Path,
+) -> dict[str, Any]:
+    """Bind a new run root to source authority and the two open populations."""
+
+    root = root.resolve()
+    source_root = source_root.resolve()
+    predecessor_root = predecessor_root.resolve()
+    if not source_root.is_dir():
+        raise FileNotFoundError("#1045 open source root is absent")
+    if not predecessor_root.is_dir():
+        raise FileNotFoundError("#1045 predecessor run root is absent")
+    if len({root, source_root, predecessor_root}) != 3:
+        raise ValueError("run, source, and predecessor roots must differ")
+    path = root / PREPARATION_RELATIVE_PATH
+    source_population, exact_population = _load_bound_populations(source_root)
+    predecessor = _bind_predecessor(predecessor_root)
+    implementation = zoology_control_implementation_contract()
+    attribution = zoology_source_attribution()
+    if path.exists():
+        preparation = _read_json(path, cid_field="preparation_cid")
+        if (
+            preparation.get("source_root") != str(source_root)
+            or preparation.get("predecessor_root") != str(predecessor_root)
+            or preparation.get("predecessor") != predecessor
+            or preparation.get("implementation") != implementation
+            or preparation.get("source_attribution") != attribution
+            or preparation.get("populations")
+            != {
+                "c1_source_native": _population_record(source_population),
+                "c2_exact_1045": _population_record(exact_population),
+            }
+        ):
+            raise ValueError("cached #1047 preparation no longer reproduces")
+        return preparation
+    if root.exists() and any(root.iterdir()):
+        raise FileExistsError("#1047 preparation requires an empty run root")
+
+    body = {
+        "schema": PREPARATION_SCHEMA,
+        "issue": ISSUE,
+        "policy": POLICY,
+        "source_root": str(source_root),
+        "predecessor_root": str(predecessor_root),
+        "predecessor": predecessor,
+        "implementation": implementation,
+        "source_attribution": attribution,
+        "inputs": {
+            "source_attribution_cid": attribution["attribution_cid"],
+            "implementation_cid": implementation["implementation_cid"],
+            "implementation_tree_cid": implementation["tree_cid"],
+            "source_native_population_cid": source_population.population_cid,
+            "exact_1045_population_cid": exact_population.population_cid,
+            "source_1045_split_cid": exact_population.source_split_cid,
+            "source_1045_result_cid": EXPECTED_1045_RESULT_CID,
+            "source_1045_diagnostic_cid": EXPECTED_1045_DIAGNOSTIC_CID,
+            "source_1045_preflight_file_cid": predecessor["preflight"][
+                "file_cid"
+            ],
+            "source_1045_result_file_cid": predecessor["result"]["file_cid"],
+        },
+        "populations": {
+            "c1_source_native": _population_record(source_population),
+            "c2_exact_1045": _population_record(exact_population),
+        },
+        "forbidden_inputs": {
+            "source_1045_fitted_artifact_cid": FORBIDDEN_1045_ARTIFACT_CID,
+            "sealed_payloads": "FORBIDDEN",
+            "roles_as_model_input": "FORBIDDEN",
+            "h4_frames_as_model_input": "FORBIDDEN",
+            "teacher_provider_ollama_gemma": "FORBIDDEN",
+        },
+        "read_ledger": {
+            "allowed_predecessor_json_reads": 2,
+            "failed_source_artifact_reads": 0,
+            "sealed_input_reads": 0,
+            "provider_calls": 0,
+            "teacher_calls": 0,
+            "future_value_reads": 0,
+            "role_model_input_reads": 0,
+            "h4_model_input_reads": 0,
+            "cache_reads": 0,
+            "transport_reads": 0,
+        },
+        "mod256_boundary": {
+            "discrete_role_provenance": "VALIDATED_ONLY",
+            "softmax_probability_normalization": "REAL_VALUED_NOT_MOD256",
+        },
+    }
+    preparation = _with_cid(body, "preparation_cid")
+    _write_exclusive_json(path, preparation)
+    return preparation
+
+
+def select_execution_plan(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Select the fastest complete deterministic 1/4/8-thread measurement."""
+
+    expected = set(ELIGIBLE_THREADS)
+    observed: set[int] = set()
+    normalized: list[dict[str, Any]] = []
+    eligible: list[dict[str, Any]] = []
+    for source in records:
+        record = dict(source)
+        plan = record.get("plan")
+        if not isinstance(plan, Mapping):
+            raise ValueError("#1047 timing record lacks its plan")
+        threads = int(plan.get("threads", -1))
+        if threads in observed:
+            raise ValueError("#1047 timing matrix repeats a thread plan")
+        observed.add(threads)
+        projection = record.get("projected_c1_c2_seconds")
+        memory = record.get("peak_rss_bytes")
+        arms = record.get("arms")
+        measured_each_arm = bool(
+            isinstance(arms, Mapping)
+            and set(arms) == {"c1", "c2"}
+            and all(
+                isinstance(arms[name], Mapping)
+                and int(arms[name].get("timed_training_batches", 0))
+                >= TIMED_TRAINING_BATCHES
+                and arms[name].get("full_development_evaluation") is True
+                and arms[name].get("deterministic_replay") is True
+                for name in ("c1", "c2")
+            )
+        )
+        finite = all(
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+            and float(value) >= 0.0
+            for value in (projection, memory)
+        )
+        record["eligible"] = bool(
+            finite
+            and measured_each_arm
+            and record.get("deterministic_replay") is True
+            and int(record.get("timed_training_batches", 0))
+            >= TIMED_TRAINING_BATCHES
+            and record.get("full_development_evaluation") is True
+            and float(projection) <= HARD_WALL_SECONDS
+            and int(memory) <= MEMORY_CEILING_BYTES
+        )
+        normalized.append(record)
+        if record["eligible"]:
+            eligible.append(record)
+    if observed != expected:
+        raise ValueError("#1047 1/4/8-thread timing matrix is incomplete")
+    selected = min(
+        eligible,
+        key=lambda value: (
+            float(value["projected_c1_c2_seconds"]),
+            int(value["plan"]["threads"]),
+        ),
+        default=None,
+    )
+    return {
+        "available": selected is not None,
+        "plans": normalized,
+        "selected_plan": None if selected is None else selected["plan"],
+        "selected_projection_seconds": (
+            None if selected is None else selected["projected_c1_c2_seconds"]
+        ),
+        "hard_wall_seconds": HARD_WALL_SECONDS,
+        "memory_ceiling_bytes": MEMORY_CEILING_BYTES,
+        "projection_safety_factor": PROJECTION_SAFETY_FACTOR,
+    }
+
+
+def _project_rung_seconds(
+    *,
+    train_batches: int,
+    development_batches: int,
+    seconds_per_training_batch: float,
+    seconds_per_evaluation_batch: float,
+) -> float:
+    """Reserve the worst-case training and full-score work for one rung."""
+
+    return (
+        MAXIMUM_EPOCHS * train_batches * seconds_per_training_batch
+        + MAXIMUM_EPOCHS
+        * (development_batches + train_batches)
+        * seconds_per_evaluation_batch
+    )
+
+
+def decide_zoology_control(
+    *,
+    c0_passed: bool,
+    preflight_available: bool,
+    c1_train_rate: float | None = None,
+    c1_development_rate: float | None = None,
+    c1_consecutive_passes: int = 0,
+    c2_train_rate: float | None = None,
+    c2_development_rate: float | None = None,
+    c2_consecutive_passes: int = 0,
+    binding_permuted_rate: float | None = None,
+) -> dict[str, Any]:
+    """Return the first frozen #1047 decision without adding a stop code."""
+
+    c1_train = c1_train_rate is not None and c1_train_rate >= TRAIN_REQUIRED_RATE
+    c1_development = (
+        c1_development_rate is not None
+        and c1_development_rate >= DEVELOPMENT_REQUIRED_RATE
+    )
+    c1_two = c1_consecutive_passes >= REQUIRED_CONSECUTIVE_PASSES
+    c2_train = c2_train_rate is not None and c2_train_rate >= TRAIN_REQUIRED_RATE
+    c2_development = (
+        c2_development_rate is not None
+        and c2_development_rate >= DEVELOPMENT_REQUIRED_RATE
+    )
+    c2_two = c2_consecutive_passes >= REQUIRED_CONSECUTIVE_PASSES
+    gates: dict[str, Any] = {
+        "c0_source_mechanics": c0_passed,
+        "preflight_available": preflight_available,
+        "c1_train": c1_train,
+        "c1_development": c1_development,
+        "c1_two_consecutive": c1_two,
+        "c2_train": c2_train,
+        "c2_development": c2_development,
+        "c2_two_consecutive": c2_two,
+        "binding_permuted_drop": None,
+    }
+    if not c0_passed:
+        verdict: Verdict | None = "INVALID_CONTROL_PORT"
+        status = "DECIDED"
+        action = "repair only source parity; make no scientific inference"
+        passed = False
+    elif not preflight_available:
+        verdict = None
+        status = "NOT_RUN_PREFLIGHT"
+        action = "stop without a scientific verdict; do not tune #1047"
+        passed = False
+    elif not (c1_train and c1_development and c1_two):
+        verdict = "SCALED_SOURCE_CALIBRATION_MISS"
+        status = "DECIDED"
+        action = "stop before UOR bytes; do not modify R4"
+        passed = False
+    elif not c2_train:
+        verdict = "STOCK_CELL_EXACT_QUALIFICATION_MISS"
+        status = "DECIDED"
+        action = (
+            "make no assignment-disjoint transfer inference; isolate exact-byte "
+            "fit mechanics only in a new frozen contract"
+        )
+        passed = False
+    elif not c2_development:
+        verdict = "STOCK_CELL_TRANSFER_MISS"
+        status = "DECIDED"
+        action = (
+            "isolate source serialization versus assignment-disjointness in a "
+            "new frozen contract"
+        )
+        passed = False
+    elif not c2_two:
+        verdict = "STOCK_CELL_EXACT_QUALIFICATION_MISS"
+        status = "DECIDED"
+        action = (
+            "make no stable exact-byte transfer claim; isolate qualification "
+            "mechanics only in a new frozen contract"
+        )
+        passed = False
+    elif binding_permuted_rate is None:
+        verdict = None
+        status = "INCOMPLETE_BINDING_CONTROL"
+        action = "run only the frozen data-level binding-permuted control"
+        passed = False
+    else:
+        drop = float(c2_development_rate) - binding_permuted_rate
+        gates["binding_permuted_drop"] = drop >= CONTROL_REQUIRED_DROP
+        if drop < CONTROL_REQUIRED_DROP:
+            verdict = "NONASSOCIATIVE_SHORTCUT"
+            action = "do not accept the primary score as attention evidence"
+            passed = False
+        else:
+            verdict = "STOCK_CELL_PASSES_EXACT_BYTES"
+            action = (
+                "align the R4 cell to the demonstrated one-head width-64 "
+                "addressing boundary before English transfer"
+            )
+            passed = True
+        status = "DECIDED"
+    return {
+        "status": status,
+        "verdict": verdict,
+        "passed": passed,
+        "gates": gates,
+        "thresholds": {
+            "train": TRAIN_REQUIRED_RATE,
+            "development": DEVELOPMENT_REQUIRED_RATE,
+            "consecutive": REQUIRED_CONSECUTIVE_PASSES,
+            "binding_permuted_drop": CONTROL_REQUIRED_DROP,
+        },
+        "action": action,
+    }
+
+
+def _result_body(
+    *,
+    preparation: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    plan: Mapping[str, Any] | None,
+    c1: Mapping[str, Any] | str,
+    c2: Mapping[str, Any] | str,
+    binding_control: Mapping[str, Any] | str,
+    artifacts: Sequence[Mapping[str, Any]],
+    decision: Mapping[str, Any],
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    """Build the bounded result envelope without making out-of-scope claims."""
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "issue": ISSUE,
+        "policy": POLICY,
+        "preparation_cid": preparation["preparation_cid"],
+        "preflight_cid": preflight["preflight_cid"],
+        "implementation": preflight["implementation"],
+        "source_attribution_cid": preparation["inputs"][
+            "source_attribution_cid"
+        ],
+        "population_cids": {
+            "c1_source_native": preparation["inputs"][
+                "source_native_population_cid"
+            ],
+            "c2_exact_1045": preparation["inputs"][
+                "exact_1045_population_cid"
+            ],
+            "source_1045_split": preparation["inputs"]["source_1045_split_cid"],
+        },
+        "plan": None if plan is None else dict(plan),
+        "rungs": {"c1": c1, "c2": c2},
+        "binding_permuted_control": binding_control,
+        "artifacts": [dict(value) for value in artifacts],
+        "decision": dict(decision),
+        "elapsed_seconds": elapsed_seconds,
+        "hard_wall_seconds": HARD_WALL_SECONDS,
+        "read_work_ledger": {
+            "failed_source_artifact_reads": 0,
+            "sealed_input_reads": 0,
+            "provider_calls": 0,
+            "teacher_calls": 0,
+            "future_value_reads": 0,
+            "role_model_input_reads": 0,
+            "h4_model_input_reads": 0,
+            "cache_reads": 0,
+            "transport_reads": 0,
+        },
+        "controls_not_invented": {
+            "current_only": "NOT_RUN_NO_STOCK_INTERVENTION",
+            "cache": "NOT_RUN_NO_STOCK_INTERVENTION",
+            "transport": "NOT_RUN_NO_STOCK_INTERVENTION",
+            "attention_off": "NOT_RUN_NO_STOCK_INTERVENTION",
+        },
+        "claim_boundary": {
+            "ordinary_causal_softmax": "ONLY",
+            "r4_or_geometric_attention": "NOT_CLAIMED",
+            "english": "NOT_RUN",
+            "generation": "NOT_RUN",
+            "reasoning": "NOT_RUN",
+            "recurrence": "NOT_RUN",
+            "quantization": "NOT_RUN",
+            "exact_lowering": "NOT_RUN",
+            "browser_wasm_product_release": "NOT_RUN",
+        },
+    }
+
+
+def _configure_cpu(threads: int) -> torch.device:
+    ExecutionPlan(threads)
+    os.environ["OMP_NUM_THREADS"] = str(threads)
+    os.environ["VECLIB_MAXIMUM_THREADS"] = str(threads)
+    torch.set_num_threads(threads)
+    if torch.get_num_interop_threads() != 1:
+        try:
+            torch.set_num_interop_threads(1)
+        except RuntimeError as error:
+            if torch.get_num_interop_threads() != 1:
+                raise RuntimeError(
+                    "#1047 CPU inter-op threads were initialized before the frozen plan"
+                ) from error
+    return torch.device("cpu")
+
+
+def _tensor_mapping_cid(tensors: Mapping[str, Tensor]) -> str:
+    digest = blake3()
+    for name in sorted(tensors):
+        tensor = tensors[name].detach().cpu().contiguous()
+        digest.update(
+            canonical_json_bytes(
+                {
+                    "name": name,
+                    "shape": list(tensor.shape),
+                    "dtype": str(tensor.dtype),
+                }
+            )
+        )
+        digest.update(tensor.numpy().tobytes(order="C"))
+    return f"blake3:{digest.hexdigest()}"
+
+
+def _model_config(population: ZoologyMQARPopulation) -> ZoologyFigure2Config:
+    return ZoologyFigure2Config(
+        vocab_size=population.vocab_size,
+        max_position_embeddings=population.input_seq_len,
+    )
+
+
+def _new_model(
+    population: ZoologyMQARPopulation,
+    *,
+    device: torch.device,
+) -> ZoologyFigure2Model:
+    set_zoology_seed(SOURCE_MODEL_SEED)
+    return ZoologyFigure2Model(_model_config(population)).to(device)
+
+
+def _artifact_payload(
+    model: ZoologyFigure2Model,
+    *,
+    rung: str,
+    population_cid: str,
+) -> bytes:
+    tensors = {
+        name: tensor.detach().cpu().contiguous()
+        for name, tensor in sorted(model.state_dict().items())
+        if name != "lm_head.weight"
+    }
+    if "backbone.embeddings.word_embeddings.weight" not in tensors:
+        raise RuntimeError("Zoology artifact lacks its canonical tied embedding")
+    metadata = {
+        "schema": "uor-r4.zoology-control-model/1",
+        "issue": str(ISSUE),
+        "policy": POLICY,
+        "rung": rung,
+        "population_cid": population_cid,
+        "config": canonical_json_bytes(asdict(model.config)).decode("utf-8"),
+        "tied_omission": "lm_head.weight",
+    }
+    return save_safetensors(tensors, metadata=metadata)
+
+
+def _write_model_artifact(
+    root: Path,
+    model: ZoologyFigure2Model,
+    *,
+    rung: str,
+    population_cid: str,
+) -> dict[str, Any]:
+    relative = (
+        C1_ARTIFACT_RELATIVE_PATH if rung == "c1" else C2_ARTIFACT_RELATIVE_PATH
+    )
+    payload = _artifact_payload(model, rung=rung, population_cid=population_cid)
+    _write_exclusive(root / relative, payload)
+    return {
+        "rung": rung,
+        "path": relative,
+        "bytes": len(payload),
+        "cid": cid_bytes(payload),
+        "state_cid": _tensor_mapping_cid(
+            {
+                name: tensor
+                for name, tensor in model.state_dict().items()
+                if name != "lm_head.weight"
+            }
+        ),
+        "population_cid": population_cid,
+    }
+
+
+def _batch_work(batch: ZoologyMQARBatch, *, vocab_size: int) -> dict[str, int]:
+    batch_size, time_width = batch.input_ids.shape
+    visible = 0
+    masked_future = 0
+    for positions in batch.selected_positions.detach().cpu().tolist():
+        for position in positions:
+            visible += int(position) + 1
+            masked_future += time_width - int(position) - 1
+    decisions = int(batch.targets.numel())
+    return {
+        "batches": 1,
+        "rows": batch_size,
+        "input_tensor_tokens": int(batch.input_ids.numel()),
+        "query_decisions": decisions,
+        "target_reads": decisions,
+        "visible_query_token_pairs": visible,
+        "causally_masked_future_token_pairs": masked_future,
+        "materialized_attention_scores": 2 * batch_size * time_width * time_width,
+        "materialized_vocabulary_scores": int(batch.targets.numel()) * vocab_size,
+        "cache_reads": 0,
+        "transport_reads": 0,
+        "future_value_reads": 0,
+        "role_model_input_reads": 0,
+        "h4_model_input_reads": 0,
+        "provider_calls": 0,
+        "teacher_calls": 0,
+        "forbidden_reads": 0,
+        "sealed_input_reads": 0,
+    }
+
+
+def _merge_work(total: dict[str, int], later: Mapping[str, int]) -> None:
+    for name, value in later.items():
+        total[name] = total.get(name, 0) + int(value)
+
+
+def _score_rows(
+    model: ZoologyFigure2Model,
+    rows: Sequence[ZoologyMQARRow],
+    *,
+    device: torch.device,
+    batch_size: int = BATCH_SIZE,
+    deadline: float | None = None,
+) -> ScoreResult:
+    if not rows:
+        raise ValueError("#1047 score population cannot be empty")
+    was_training = model.training
+    model.eval()
+    decisions = 0
+    correct = 0
+    loss_sum = 0.0
+    digest = blake3()
+    work: dict[str, int] = {}
+    try:
+        with torch.inference_mode():
+            for start in range(0, len(rows), batch_size):
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise HardWallExceeded("#1047 scoring reached the 900-second wall")
+                batch = batch_rows(rows[start : start + batch_size], device=device)
+                output = model.forward_selected(
+                    batch.input_ids,
+                    batch.selected_positions,
+                    batch.targets,
+                )
+                if output.selected_targets is None:
+                    raise RuntimeError("#1047 query score lacks selected targets")
+                flat_logits = output.logits.float().reshape(
+                    -1, output.logits.shape[-1]
+                )
+                flat_targets = output.selected_targets.reshape(-1)
+                loss_sum += float(
+                    F.cross_entropy(flat_logits, flat_targets, reduction="sum")
+                )
+                predictions = flat_logits.argmax(dim=-1)
+                decisions += int(flat_targets.numel())
+                correct += int(torch.count_nonzero(predictions == flat_targets))
+                cpu_logits = output.logits.detach().cpu().contiguous()
+                digest.update(canonical_json_bytes({"shape": list(cpu_logits.shape)}))
+                digest.update(cpu_logits.numpy().tobytes(order="C"))
+                _merge_work(
+                    work,
+                    _batch_work(batch, vocab_size=model.config.vocab_size),
+                )
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise HardWallExceeded("#1047 scoring reached the 900-second wall")
+    finally:
+        model.train(was_training)
+    expected = _row_query_count(rows)
+    if decisions != expected or work.get("target_reads") != expected:
+        raise RuntimeError("#1047 query-score work ledger differs")
+    return ScoreResult(
+        decisions=decisions,
+        correct=correct,
+        loss_sum=loss_sum,
+        selected_logits_cid=f"blake3:{digest.hexdigest()}",
+        work=work,
+    )
+
+
+def _train_epoch(
+    model: ZoologyFigure2Model,
+    optimizer: torch.optim.Optimizer,
+    rows: Sequence[ZoologyMQARRow],
+    *,
+    epoch: int,
+    namespace: str,
+    device: torch.device,
+    deadline: float,
+) -> dict[str, Any]:
+    model.train()
+    ordered = deterministic_epoch_order(rows, epoch, namespace)
+    decisions = 0
+    correct = 0
+    loss_sum = 0.0
+    work: dict[str, int] = {}
+
+    def record(*, complete: bool) -> dict[str, Any]:
+        return {
+            "epoch": epoch + 1,
+            "complete": complete,
+            "query_presentations": decisions,
+            "online_top1_correct": correct,
+            "online_top1_rate": None if decisions == 0 else correct / decisions,
+            "online_nll_nats": None if decisions == 0 else loss_sum / decisions,
+            "work": dict(work),
+        }
+
+    for start in range(0, len(ordered), BATCH_SIZE):
+        if time.monotonic() >= deadline:
+            partial = record(complete=False)
+            raise HardWallExceeded(
+                "#1047 training reached the 900-second wall",
+                partial,
+            )
+        batch = batch_rows(ordered[start : start + BATCH_SIZE], device=device)
+        optimizer.zero_grad(set_to_none=True)
+        output = model.forward_selected(
+            batch.input_ids,
+            batch.selected_positions,
+            batch.targets,
+        )
+        if output.loss is None or output.selected_targets is None:
+            raise RuntimeError("#1047 training output lacks query loss/targets")
+        output.loss.backward()
+        optimizer.step()
+        batch_decisions = int(output.selected_targets.numel())
+        decisions += batch_decisions
+        loss_sum += float(output.loss.detach()) * batch_decisions
+        predictions = output.logits.detach().argmax(dim=-1)
+        correct += int(torch.count_nonzero(predictions == output.selected_targets))
+        _merge_work(
+            work,
+            _batch_work(batch, vocab_size=model.config.vocab_size),
+        )
+        if time.monotonic() >= deadline:
+            partial = record(complete=False)
+            raise HardWallExceeded(
+                "#1047 training reached the 900-second wall",
+                partial,
+            )
+    expected = _row_query_count(rows)
+    if decisions != expected or work.get("target_reads") != expected:
+        raise RuntimeError("#1047 training work ledger differs")
+    return record(complete=True)
+
+
+def _train_rung(
+    population: ZoologyMQARPopulation,
+    *,
+    rung: str,
+    device: torch.device,
+    deadline: float,
+) -> tuple[ZoologyFigure2Model, dict[str, Any]]:
+    model = _new_model(population, device=device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer,
+        T_max=MAXIMUM_EPOCHS,
+        eta_min=0.0,
+    )
+    history: list[dict[str, Any]] = []
+    consecutive = 0
+    presentations = 0
+    final_train: ScoreResult | None = None
+    final_development: ScoreResult | None = None
+    incomplete_reason: str | None = None
+    began = time.monotonic()
+    for epoch in range(MAXIMUM_EPOCHS):
+        try:
+            training = _train_epoch(
+                model,
+                optimizer,
+                population.train,
+                epoch=epoch,
+                namespace=f"uor-r4/1047/{rung}",
+                device=device,
+                deadline=deadline,
+            )
+        except HardWallExceeded as error:
+            if error.partial is not None:
+                presentations += int(error.partial["query_presentations"])
+                history.append(
+                    {
+                        "epoch": epoch + 1,
+                        "learning_rate": float(optimizer.param_groups[0]["lr"]),
+                        "training": error.partial,
+                        "development": None,
+                        "train_evaluation": None,
+                        "consecutive_passes": consecutive,
+                    }
+                )
+            incomplete_reason = str(error)
+            break
+        presentations += int(training["query_presentations"])
+        scheduler.step()
+        final_train = None
+        final_development = None
+        try:
+            final_development = _score_rows(
+                model,
+                population.development,
+                device=device,
+                deadline=deadline,
+            )
+            if final_development.rate >= DEVELOPMENT_REQUIRED_RATE:
+                final_train = _score_rows(
+                    model,
+                    population.train,
+                    device=device,
+                    deadline=deadline,
+                )
+        except HardWallExceeded as error:
+            incomplete_reason = str(error)
+        passed_epoch = bool(
+            incomplete_reason is None
+            and final_train is not None
+            and final_development is not None
+            and final_train.rate >= TRAIN_REQUIRED_RATE
+            and final_development.rate >= DEVELOPMENT_REQUIRED_RATE
+        )
+        consecutive = consecutive + 1 if passed_epoch else 0
+        history.append(
+            {
+                "epoch": epoch + 1,
+                "learning_rate": float(scheduler.get_last_lr()[0]),
+                "training": training,
+                "development": (
+                    None if final_development is None else final_development.record()
+                ),
+                "train_evaluation": (
+                    None if final_train is None else final_train.record()
+                ),
+                "consecutive_passes": consecutive,
+            }
+        )
+        if incomplete_reason is not None or consecutive >= REQUIRED_CONSECUTIVE_PASSES:
+            break
+
+    if incomplete_reason is None and final_train is None:
+        try:
+            final_train = _score_rows(
+                model,
+                population.train,
+                device=device,
+                deadline=deadline,
+            )
+        except HardWallExceeded as error:
+            incomplete_reason = str(error)
+    passed = bool(
+        incomplete_reason is None
+        and final_train is not None
+        and final_development is not None
+        and final_train.rate >= TRAIN_REQUIRED_RATE
+        and final_development.rate >= DEVELOPMENT_REQUIRED_RATE
+        and consecutive >= REQUIRED_CONSECUTIVE_PASSES
+    )
+    if rung == "c2" and presentations > MAXIMUM_C2_QUERY_PRESENTATIONS:
+        raise RuntimeError("#1047 C2 query-presentation cap was exceeded")
+    return model, {
+        "status": "INCOMPLETE_HARD_WALL" if incomplete_reason else "COMPLETE",
+        "passed": passed,
+        "population_cid": population.population_cid,
+        "epochs": len(history),
+        "query_presentations": presentations,
+        "history": history,
+        "final_train": None if final_train is None else final_train.record(),
+        "final_development": (
+            None if final_development is None else final_development.record()
+        ),
+        "consecutive_passes": consecutive,
+        "incomplete_reason": incomplete_reason,
+        "elapsed_seconds": time.monotonic() - began,
+        "optimizer": {
+            "name": "AdamW",
+            "learning_rate": LEARNING_RATE,
+            "weight_decay": WEIGHT_DECAY,
+            "betas": [0.9, 0.999],
+            "epsilon": 1e-8,
+            "gradient_clip": "NONE",
+            "schedule": "CosineAnnealingLR(epoch,to_zero)",
+            "maximum_epochs": MAXIMUM_EPOCHS,
+            "checkpoint_selection": "first two consecutive open passes",
+        },
+    }
+
+
+def _mechanics_checks(
+    population: ZoologyMQARPopulation,
+    *,
+    device: torch.device,
+) -> dict[str, Any]:
+    first = _new_model(population, device=device).eval()
+    first_state_cid = _tensor_mapping_cid(first.state_dict())
+    second = _new_model(population, device=device).eval()
+    second_state_cid = _tensor_mapping_cid(second.state_dict())
+    batch = batch_rows(population.train[:2], device=device)
+    with torch.inference_mode():
+        full = first.forward_full(batch.input_ids)
+        selected = first.forward_selected(
+            batch.input_ids,
+            batch.selected_positions,
+        )
+        gather_index = batch.selected_positions.unsqueeze(-1).expand(
+            -1,
+            -1,
+            population.vocab_size,
+        )
+        gathered = torch.gather(full.logits, dim=1, index=gather_index)
+        query_projection_parity = bool(
+            torch.allclose(gathered, selected.logits, rtol=2e-5, atol=2e-6)
+        )
+
+        position = int(batch.selected_positions[0, 0])
+        one_position = batch.selected_positions[:1, :1]
+        full_query = first.forward_selected(
+            batch.input_ids[:1],
+            one_position,
+        ).logits[:, 0]
+        prefix_logits = first(batch.input_ids[:1, : position + 1])[:, -1]
+        causal_prefix_parity = bool(
+            torch.allclose(full_query, prefix_logits, rtol=2e-5, atol=2e-6)
+        )
+    return {
+        "initialization_state_cid": first_state_cid,
+        "initialization_replay_state_cid": second_state_cid,
+        "initialization_exact_replay": first_state_cid == second_state_cid,
+        "query_projection_scale_aware_parity": query_projection_parity,
+        "causal_prefix_scale_aware_parity": causal_prefix_parity,
+        "passed": bool(
+            first_state_cid == second_state_cid
+            and query_projection_parity
+            and causal_prefix_parity
+        ),
+    }
+
+
+def _source_oracle_golden() -> dict[str, Any]:
+    """Execute the literal-source tiny loader/model goldens in the preflight."""
+
+    inputs, labels = zoology_data._released_mqar(
+        vocab_size=32,
+        num_examples=3,
+        input_seq_len=16,
+        seed=0,
+        num_kv_pairs=2,
+    )
+    expected_inputs = torch.tensor(_SOURCE_GOLDEN_INPUTS, dtype=torch.long)
+    expected_labels = torch.tensor(_SOURCE_GOLDEN_LABELS, dtype=torch.long)
+    loader_inputs_exact = bool(torch.equal(inputs, expected_inputs))
+    loader_labels_exact = bool(torch.equal(labels, expected_labels))
+
+    tiny = ZoologyFigure2Config(
+        vocab_size=32,
+        d_model=8,
+        n_layers=2,
+        num_heads=1,
+        max_position_embeddings=8,
+        attention_dropout=0.1,
+        embed_dropout=0.1,
+        resid_dropout=0.0,
+    )
+    set_zoology_seed(SOURCE_MODEL_SEED)
+    model = ZoologyFigure2Model(tiny).eval()
+    word = model.backbone.embeddings.word_embeddings.weight[0, :4].detach().cpu()
+    position = (
+        model.backbone.embeddings.position_embeddings.weight[0, :4]
+        .detach()
+        .cpu()
+    )
+    wqkv = (
+        model.backbone.layers[0].sequence_mixer.Wqkv.weight[0, :4]
+        .detach()
+        .cpu()
+    )
+    expected_word = torch.tensor(_SOURCE_GOLDEN_WORD)
+    expected_position = torch.tensor(_SOURCE_GOLDEN_POSITION)
+    expected_wqkv = torch.tensor(_SOURCE_GOLDEN_WQKV)
+    parameter_byte_exact = bool(
+        torch.equal(word, expected_word)
+        and torch.equal(position, expected_position)
+        and torch.equal(wqkv, expected_wqkv)
+    )
+    with torch.inference_mode():
+        observed_logits = model(
+            torch.tensor([[1, 2, 3, 4], [4, 3, 2, 1]], dtype=torch.long)
+        )[0, -1, :6].cpu()
+    expected_logits = torch.tensor(_SOURCE_GOLDEN_LOGITS)
+    logits_byte_exact = bool(torch.equal(observed_logits, expected_logits))
+    logits_scale_aware = bool(
+        torch.allclose(observed_logits, expected_logits, rtol=2e-6, atol=2e-7)
+    )
+    loader_digest = blake3()
+    loader_digest.update(inputs.contiguous().numpy().tobytes(order="C"))
+    loader_digest.update(labels.contiguous().numpy().tobytes(order="C"))
+    return {
+        "authority": "HazyResearch/Zoology@de4e258 ICLR24 literal execution",
+        "loader": {
+            "inputs_byte_exact": loader_inputs_exact,
+            "labels_byte_exact": loader_labels_exact,
+            "golden_cid": f"blake3:{loader_digest.hexdigest()}",
+            "passed": bool(loader_inputs_exact and loader_labels_exact),
+        },
+        "model": {
+            "parameters_byte_exact": parameter_byte_exact,
+            "logits_byte_exact": logits_byte_exact,
+            "logits_scale_aware_parity": logits_scale_aware,
+            "rtol": 2e-6,
+            "atol": 2e-7,
+            "passed": bool(parameter_byte_exact and logits_scale_aware),
+        },
+        "passed": bool(
+            loader_inputs_exact
+            and loader_labels_exact
+            and parameter_byte_exact
+            and logits_scale_aware
+        ),
+    }
+
+
+def _run_c0(
+    population: ZoologyMQARPopulation,
+    *,
+    device: torch.device,
+) -> dict[str, Any]:
+    source_oracle = _source_oracle_golden()
+    replay = build_source_calibration()
+    loader_exact_replay = replay.population_cid == population.population_cid
+    mechanics = _mechanics_checks(population, device=device)
+    rows = population.train[:OVERFIT_ROWS]
+    model = _new_model(population, device=device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer,
+        T_max=OVERFIT_UPDATES,
+        eta_min=0.0,
+    )
+    batch = batch_rows(rows, device=device)
+    passed = False
+    score: ScoreResult | None = None
+    began = time.monotonic()
+    updates = 0
+    for update in range(OVERFIT_UPDATES):
+        model.train()
+        optimizer.zero_grad(set_to_none=True)
+        output = model.forward_selected(
+            batch.input_ids,
+            batch.selected_positions,
+            batch.targets,
+        )
+        if output.loss is None:
+            raise RuntimeError("#1047 C0 lacks its query-only loss")
+        output.loss.backward()
+        optimizer.step()
+        scheduler.step()
+        updates = update + 1
+        score = _score_rows(model, rows, device=device, batch_size=OVERFIT_ROWS)
+        if score.rate == 1.0:
+            passed = True
+            break
+    return {
+        "rows": OVERFIT_ROWS,
+        "maximum_updates": OVERFIT_UPDATES,
+        "updates": updates,
+        "loader_population_cid": population.population_cid,
+        "loader_replay_population_cid": replay.population_cid,
+        "loader_exact_replay": loader_exact_replay,
+        "source_oracle_golden": source_oracle,
+        "mechanics": mechanics,
+        "overfit": None if score is None else score.record(),
+        "query_presentations": updates * _row_query_count(rows),
+        "elapsed_seconds": time.monotonic() - began,
+        "passed": bool(
+            source_oracle["passed"]
+            and loader_exact_replay
+            and mechanics["passed"]
+            and passed
+        ),
+    }
+
+
+def _determinism_signature(
+    population: ZoologyMQARPopulation,
+    *,
+    device: torch.device,
+    namespace: str,
+) -> dict[str, Any]:
+    model = _new_model(population, device=device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=LEARNING_RATE, weight_decay=WEIGHT_DECAY
+    )
+    ordered = deterministic_epoch_order(
+        population.train,
+        0,
+        f"uor-r4/1047/preflight-replay/{namespace}",
+    )
+    losses: list[float] = []
+    for start in (0, BATCH_SIZE):
+        batch = batch_rows(ordered[start : start + BATCH_SIZE], device=device)
+        optimizer.zero_grad(set_to_none=True)
+        output = model.forward_selected(
+            batch.input_ids,
+            batch.selected_positions,
+            batch.targets,
+        )
+        if output.loss is None:
+            raise RuntimeError("#1047 timing replay lacks loss")
+        output.loss.backward()
+        optimizer.step()
+        losses.append(float(output.loss.detach()))
+    return {"losses": losses, "state_cid": _tensor_mapping_cid(model.state_dict())}
+
+
+def _measure_probe_arm(
+    population: ZoologyMQARPopulation,
+    *,
+    rung: str,
+    threads: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    replay_a = _determinism_signature(
+        population,
+        device=device,
+        namespace=rung,
+    )
+    replay_b = _determinism_signature(
+        population,
+        device=device,
+        namespace=rung,
+    )
+    model = _new_model(population, device=device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=LEARNING_RATE, weight_decay=WEIGHT_DECAY
+    )
+    ordered = deterministic_epoch_order(
+        population.train,
+        0,
+        f"uor-r4/1047/preflight/{rung}/{threads}",
+    )
+    timed_rows = ordered[: TIMED_TRAINING_BATCHES * BATCH_SIZE]
+    began = time.monotonic()
+    for start in range(0, len(timed_rows), BATCH_SIZE):
+        batch = batch_rows(timed_rows[start : start + BATCH_SIZE], device=device)
+        optimizer.zero_grad(set_to_none=True)
+        output = model.forward_selected(
+            batch.input_ids,
+            batch.selected_positions,
+            batch.targets,
+        )
+        if output.loss is None:
+            raise RuntimeError("#1047 timing probe lacks loss")
+        output.loss.backward()
+        optimizer.step()
+    training_seconds = time.monotonic() - began
+    evaluation_began = time.monotonic()
+    development = _score_rows(model, population.development, device=device)
+    evaluation_seconds = time.monotonic() - evaluation_began
+
+    train_batches = math.ceil(len(population.train) / BATCH_SIZE)
+    development_batches = math.ceil(len(population.development) / BATCH_SIZE)
+    seconds_per_training_batch = training_seconds / TIMED_TRAINING_BATCHES
+    seconds_per_evaluation_batch = evaluation_seconds / development_batches
+    projected = _project_rung_seconds(
+        train_batches=train_batches,
+        development_batches=development_batches,
+        seconds_per_training_batch=seconds_per_training_batch,
+        seconds_per_evaluation_batch=seconds_per_evaluation_batch,
+    )
+    return {
+        "rung": rung,
+        "population_cid": population.population_cid,
+        "timed_training_batches": TIMED_TRAINING_BATCHES,
+        "training_seconds": training_seconds,
+        "seconds_per_training_batch": seconds_per_training_batch,
+        "full_development_evaluation": True,
+        "development_evaluation": development.record(),
+        "development_evaluation_seconds": evaluation_seconds,
+        "deterministic_replay": replay_a == replay_b,
+        "deterministic_replay_records": [replay_a, replay_b],
+        "projected_rung_seconds_before_safety": projected,
+    }
+
+
+def _probe_once(threads: int, source_root: Path) -> dict[str, Any]:
+    device = _configure_cpu(threads)
+    source_population, exact_population = _load_bound_populations(source_root)
+    c1 = _measure_probe_arm(
+        source_population,
+        rung="c1",
+        threads=threads,
+        device=device,
+    )
+    c2 = _measure_probe_arm(
+        exact_population,
+        rung="c2",
+        threads=threads,
+        device=device,
+    )
+    # A passing C2 performs one additional full binding-permuted development
+    # evaluation. Its cost is measured directly from the C2 development pass.
+    projected_before_safety = (
+        float(c1["projected_rung_seconds_before_safety"])
+        + float(c2["projected_rung_seconds_before_safety"])
+        + float(c2["development_evaluation_seconds"])
+    )
+    return {
+        "plan": ExecutionPlan(threads).record(),
+        "arms": {"c1": c1, "c2": c2},
+        "timed_training_batches": 2 * TIMED_TRAINING_BATCHES,
+        "timed_training_batches_per_arm": TIMED_TRAINING_BATCHES,
+        "full_development_evaluation": True,
+        "full_development_evaluation_per_arm": True,
+        "deterministic_replay": bool(
+            c1["deterministic_replay"] and c2["deterministic_replay"]
+        ),
+        "projected_c1_c2_seconds_before_safety": projected_before_safety,
+        "projected_c1_c2_seconds": (
+            PROJECTION_SAFETY_FACTOR * projected_before_safety
+        ),
+        "projection_safety_factor": PROJECTION_SAFETY_FACTOR,
+        "peak_rss_bytes": _peak_rss_bytes(),
+    }
+
+
+def _probe_worker(queue: Any, threads: int, source_root: str) -> None:
+    try:
+        queue.put(
+            {
+                "ok": True,
+                "record": _probe_once(threads, Path(source_root)),
+            }
+        )
+    except BaseException as error:
+        queue.put(
+            {
+                "ok": False,
+                "error": {
+                    "type": type(error).__name__,
+                    "reason": str(error),
+                    "traceback": traceback.format_exc(),
+                },
+            }
+        )
+
+
+def _spawn_probe(threads: int, source_root: Path) -> dict[str, Any]:
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    process = context.Process(
+        target=_probe_worker,
+        args=(queue, threads, str(source_root)),
+    )
+    process.start()
+    process.join(PROBE_TIMEOUT_SECONDS)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=10.0)
+        return {
+            "ok": False,
+            "error": {
+                "type": "TimeoutError",
+                "reason": f"{threads}-thread probe exceeded {PROBE_TIMEOUT_SECONDS:.0f}s",
+            },
+        }
+    try:
+        return dict(queue.get(timeout=2.0))
+    except queue_module.Empty:
+        return {
+            "ok": False,
+            "error": {
+                "type": "RuntimeError",
+                "reason": f"{threads}-thread probe exited without evidence",
+                "exitcode": process.exitcode,
+            },
+        }
+    finally:
+        queue.close()
+        queue.join_thread()
+
+
+def _started_record(
+    *,
+    phase: str,
+    preparation: Mapping[str, Any],
+    implementation: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _with_cid(
+        {
+            "schema": STARTED_SCHEMA,
+            "issue": ISSUE,
+            "policy": POLICY,
+            "phase": phase,
+            "preparation_cid": preparation["preparation_cid"],
+            "implementation_cid": implementation["implementation_cid"],
+            "implementation_tree_cid": implementation["tree_cid"],
+        },
+        "started_cid",
+    )
+
+
+def _failed_probe_record(threads: int, error: Mapping[str, Any]) -> dict[str, Any]:
+    empty_arm = {
+        "timed_training_batches": 0,
+        "full_development_evaluation": False,
+        "deterministic_replay": False,
+    }
+    return {
+        "plan": ExecutionPlan(threads).record(),
+        "arms": {"c1": dict(empty_arm), "c2": dict(empty_arm)},
+        "timed_training_batches": 0,
+        "timed_training_batches_per_arm": 0,
+        "full_development_evaluation": False,
+        "full_development_evaluation_per_arm": False,
+        "deterministic_replay": False,
+        "projected_c1_c2_seconds": HARD_WALL_SECONDS + 1.0,
+        "peak_rss_bytes": 0,
+        "error": dict(error),
+    }
+
+
+def preflight_zoology_control(root: Path) -> dict[str, Any]:
+    """Run C0 and the create-once measured 1/4/8-thread CPU admission."""
+
+    root = root.resolve()
+    path = root / PREFLIGHT_RELATIVE_PATH
+    started_path = root / PREFLIGHT_STARTED_RELATIVE_PATH
+    preparation = _read_json(
+        root / PREPARATION_RELATIVE_PATH,
+        cid_field="preparation_cid",
+    )
+    implementation = zoology_control_implementation_contract()
+    if preparation.get("implementation") != implementation:
+        raise ValueError("#1047 implementation changed after preparation")
+    source_root = Path(str(preparation["source_root"]))
+    predecessor_root = Path(str(preparation["predecessor_root"]))
+    source_population, exact_population = _load_bound_populations(source_root)
+    if preparation.get("predecessor") != _bind_predecessor(predecessor_root):
+        raise ValueError("#1045 predecessor changed after preparation")
+    if preparation.get("populations") != {
+        "c1_source_native": _population_record(source_population),
+        "c2_exact_1045": _population_record(exact_population),
+    }:
+        raise ValueError("#1047 populations changed after preparation")
+
+    if path.exists():
+        preflight = _read_json(path, cid_field="preflight_cid")
+        started = _read_json(started_path, cid_field="started_cid")
+        if (
+            preflight.get("preparation_cid") != preparation["preparation_cid"]
+            or preflight.get("implementation") != implementation
+            or started.get("phase") != "preflight"
+            or started.get("preparation_cid") != preparation["preparation_cid"]
+        ):
+            raise ValueError("cached #1047 preflight no longer reproduces")
+        return preflight
+    if started_path.exists():
+        raise FileExistsError("#1047 preflight already started and cannot be rerun")
+    _write_exclusive_json(
+        started_path,
+        _started_record(
+            phase="preflight",
+            preparation=preparation,
+            implementation=implementation,
+        ),
+    )
+
+    began = time.monotonic()
+    device = _configure_cpu(4)
+    c0 = _run_c0(source_population, device=device)
+    records: list[dict[str, Any]] = []
+    if c0["passed"]:
+        for threads in ELIGIBLE_THREADS:
+            envelope = _spawn_probe(threads, source_root)
+            record = envelope.get("record")
+            if envelope.get("ok") is True and isinstance(record, Mapping):
+                records.append(dict(record))
+            else:
+                error = envelope.get("error")
+                records.append(
+                    _failed_probe_record(
+                        threads,
+                        error if isinstance(error, Mapping) else {"type": "Unknown"},
+                    )
+                )
+    else:
+        error = {
+            "type": "NotRun",
+            "reason": "C0 source/mechanics did not pass",
+        }
+        records.extend(_failed_probe_record(threads, error) for threads in ELIGIBLE_THREADS)
+    selection = select_execution_plan(records)
+    if implementation != zoology_control_implementation_contract():
+        raise ValueError("#1047 implementation changed during preflight")
+    body = {
+        "schema": PREFLIGHT_SCHEMA,
+        "issue": ISSUE,
+        "policy": POLICY,
+        "preparation_cid": preparation["preparation_cid"],
+        "implementation": implementation,
+        "source_attribution_cid": preparation["inputs"][
+            "source_attribution_cid"
+        ],
+        "population_cids": {
+            "c1_source_native": source_population.population_cid,
+            "c2_exact_1045": exact_population.population_cid,
+            "source_1045_split": exact_population.source_split_cid,
+        },
+        "c0": c0,
+        "selection": selection,
+        "elapsed_seconds": time.monotonic() - began,
+        "passed": bool(c0["passed"] and selection["available"]),
+        "read_work_ledger": {
+            "failed_source_artifact_reads": 0,
+            "sealed_input_reads": 0,
+            "provider_calls": 0,
+            "teacher_calls": 0,
+            "future_value_reads": 0,
+            "role_model_input_reads": 0,
+            "h4_model_input_reads": 0,
+            "cache_reads": 0,
+            "transport_reads": 0,
+        },
+        "cuda": "FORBIDDEN",
+        "mps": "FORBIDDEN",
+    }
+    preflight = _with_cid(body, "preflight_cid")
+    _write_exclusive_json(path, preflight)
+    return preflight
+
+
+def _fit_rates(fit: Mapping[str, Any]) -> tuple[float | None, float | None, int]:
+    train = fit.get("final_train")
+    development = fit.get("final_development")
+    train_rate = (
+        float(train["top1_rate"])
+        if isinstance(train, Mapping) and isinstance(train.get("top1_rate"), (int, float))
+        else None
+    )
+    development_rate = (
+        float(development["top1_rate"])
+        if isinstance(development, Mapping)
+        and isinstance(development.get("top1_rate"), (int, float))
+        else None
+    )
+    return train_rate, development_rate, int(fit.get("consecutive_passes", 0))
+
+
+def _incomplete_decision(reason: str) -> dict[str, Any]:
+    return {
+        "status": "INCOMPLETE_HARD_WALL",
+        "verdict": None,
+        "passed": False,
+        "gates": {},
+        "thresholds": {
+            "hard_wall_seconds": HARD_WALL_SECONDS,
+        },
+        "action": "stop without scientific inference or same-issue tuning",
+        "reason": reason,
+    }
+
+
+def _has_hard_wall_evidence(
+    c1: Mapping[str, Any] | str | None,
+    c2: Mapping[str, Any] | str | None,
+    binding_control: Mapping[str, Any] | str | None,
+    elapsed_seconds: float,
+) -> bool:
+    """Recognize every explicit hard-wall marker emitted by the runner."""
+
+    def marked(value: Mapping[str, Any] | str | None) -> bool:
+        if isinstance(value, Mapping):
+            return value.get("status") == "INCOMPLETE_HARD_WALL"
+        return value in {"INCOMPLETE_HARD_WALL", "NOT_RUN_HARD_WALL"}
+
+    return bool(
+        marked(c1)
+        or marked(c2)
+        or marked(binding_control)
+        or elapsed_seconds >= HARD_WALL_SECONDS
+    )
+
+
+def _validate_hard_wall_decision(
+    decision: Mapping[str, Any],
+    *,
+    c1: Mapping[str, Any] | str | None,
+    c2: Mapping[str, Any] | str | None,
+    binding_control: Mapping[str, Any] | str | None,
+    elapsed_seconds: float,
+) -> bool:
+    """Validate the hard-wall ledger and report whether execution was incomplete."""
+
+    evidence = _has_hard_wall_evidence(
+        c1,
+        c2,
+        binding_control,
+        elapsed_seconds,
+    )
+    if decision.get("status") == "INCOMPLETE_HARD_WALL":
+        reason = decision.get("reason")
+        if (
+            not isinstance(reason, str)
+            or not reason.strip()
+            or not evidence
+            or dict(decision) != _incomplete_decision(reason)
+        ):
+            raise ValueError("#1047 incomplete result lacks hard-wall evidence")
+        return True
+    if evidence:
+        raise ValueError("#1047 hard-wall result has a scientific verdict")
+    return False
+
+
+def _finish_result(
+    root: Path,
+    *,
+    preparation: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    plan: Mapping[str, Any] | None,
+    c1: Mapping[str, Any] | str,
+    c2: Mapping[str, Any] | str,
+    binding_control: Mapping[str, Any] | str,
+    artifacts: Sequence[Mapping[str, Any]],
+    decision: Mapping[str, Any],
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    body = _result_body(
+        preparation=preparation,
+        preflight=preflight,
+        plan=plan,
+        c1=c1,
+        c2=c2,
+        binding_control=binding_control,
+        artifacts=artifacts,
+        decision=decision,
+        elapsed_seconds=elapsed_seconds,
+    )
+    result = _with_cid(body, "result_cid")
+    _write_exclusive_json(root / RESULT_RELATIVE_PATH, result)
+    return result
+
+
+def run_zoology_control(root: Path) -> dict[str, Any]:
+    """Execute C1 then C2 once, stopping at the first frozen miss."""
+
+    root = root.resolve()
+    result_path = root / RESULT_RELATIVE_PATH
+    if result_path.exists():
+        return verify_zoology_control(root)
+    preparation = _read_json(
+        root / PREPARATION_RELATIVE_PATH,
+        cid_field="preparation_cid",
+    )
+    preflight = _read_json(
+        root / PREFLIGHT_RELATIVE_PATH,
+        cid_field="preflight_cid",
+    )
+    implementation = zoology_control_implementation_contract()
+    if (
+        preflight.get("preparation_cid") != preparation["preparation_cid"]
+        or preflight.get("implementation") != implementation
+        or preparation.get("implementation") != implementation
+    ):
+        raise ValueError("#1047 implementation/preflight binding differs")
+    source_root = Path(str(preparation["source_root"]))
+    predecessor_root = Path(str(preparation["predecessor_root"]))
+    source_population, exact_population = _load_bound_populations(source_root)
+    if preparation.get("predecessor") != _bind_predecessor(predecessor_root):
+        raise ValueError("#1045 predecessor changed before execution")
+    if preflight.get("population_cids") != {
+        "c1_source_native": source_population.population_cid,
+        "c2_exact_1045": exact_population.population_cid,
+        "source_1045_split": exact_population.source_split_cid,
+    }:
+        raise ValueError("#1047 preflight populations changed before execution")
+
+    started_path = root / RUN_STARTED_RELATIVE_PATH
+    if started_path.exists():
+        raise FileExistsError("#1047 run already started and cannot be rerun")
+    _write_exclusive_json(
+        started_path,
+        _started_record(
+            phase="run",
+            preparation=preparation,
+            implementation=implementation,
+        ),
+    )
+
+    selection = preflight.get("selection")
+    selected_plan = (
+        selection.get("selected_plan") if isinstance(selection, Mapping) else None
+    )
+    c0_passed = bool(
+        isinstance(preflight.get("c0"), Mapping)
+        and preflight["c0"].get("passed") is True
+    )
+    if not c0_passed:
+        decision = decide_zoology_control(
+            c0_passed=False,
+            preflight_available=False,
+        )
+        return _finish_result(
+            root,
+            preparation=preparation,
+            preflight=preflight,
+            plan=None,
+            c1="NOT_RUN_C0_MISS",
+            c2="NOT_RUN_C0_MISS",
+            binding_control="NOT_RUN_C0_MISS",
+            artifacts=(),
+            decision=decision,
+            elapsed_seconds=0.0,
+        )
+    if preflight.get("passed") is not True or not isinstance(selected_plan, Mapping):
+        decision = decide_zoology_control(
+            c0_passed=True,
+            preflight_available=False,
+        )
+        return _finish_result(
+            root,
+            preparation=preparation,
+            preflight=preflight,
+            plan=None,
+            c1="NOT_RUN_PREFLIGHT",
+            c2="NOT_RUN_PREFLIGHT",
+            binding_control="NOT_RUN_PREFLIGHT",
+            artifacts=(),
+            decision=decision,
+            elapsed_seconds=0.0,
+        )
+
+    plan = ExecutionPlan(int(selected_plan["threads"])).record()
+    if plan != dict(selected_plan):
+        raise ValueError("#1047 selected CPU plan does not reproduce")
+    device = _configure_cpu(int(plan["threads"]))
+    began = time.monotonic()
+    deadline = began + HARD_WALL_SECONDS
+    artifacts: list[dict[str, Any]] = []
+
+    c1_model, c1 = _train_rung(
+        source_population,
+        rung="c1",
+        device=device,
+        deadline=deadline,
+    )
+    artifacts.append(
+        _write_model_artifact(
+            root,
+            c1_model,
+            rung="c1",
+            population_cid=source_population.population_cid,
+        )
+    )
+    if c1["status"] == "INCOMPLETE_HARD_WALL" or time.monotonic() >= deadline:
+        decision = _incomplete_decision(
+            str(c1.get("incomplete_reason") or "C1/export reached the hard wall")
+        )
+        return _finish_result(
+            root,
+            preparation=preparation,
+            preflight=preflight,
+            plan=plan,
+            c1=c1,
+            c2="NOT_RUN_HARD_WALL",
+            binding_control="NOT_RUN_HARD_WALL",
+            artifacts=artifacts,
+            decision=decision,
+            elapsed_seconds=time.monotonic() - began,
+        )
+    c1_train_rate, c1_development_rate, c1_consecutive = _fit_rates(c1)
+    if c1.get("passed") is not True:
+        decision = decide_zoology_control(
+            c0_passed=True,
+            preflight_available=True,
+            c1_train_rate=c1_train_rate,
+            c1_development_rate=c1_development_rate,
+            c1_consecutive_passes=c1_consecutive,
+        )
+        return _finish_result(
+            root,
+            preparation=preparation,
+            preflight=preflight,
+            plan=plan,
+            c1=c1,
+            c2="NOT_RUN_C1_MISS",
+            binding_control="NOT_RUN_C1_MISS",
+            artifacts=artifacts,
+            decision=decision,
+            elapsed_seconds=time.monotonic() - began,
+        )
+
+    c2_model, c2 = _train_rung(
+        exact_population,
+        rung="c2",
+        device=device,
+        deadline=deadline,
+    )
+    artifacts.append(
+        _write_model_artifact(
+            root,
+            c2_model,
+            rung="c2",
+            population_cid=exact_population.population_cid,
+        )
+    )
+    if c2["status"] == "INCOMPLETE_HARD_WALL" or time.monotonic() >= deadline:
+        decision = _incomplete_decision(
+            str(c2.get("incomplete_reason") or "C2/export reached the hard wall")
+        )
+        return _finish_result(
+            root,
+            preparation=preparation,
+            preflight=preflight,
+            plan=plan,
+            c1=c1,
+            c2=c2,
+            binding_control="NOT_RUN_HARD_WALL",
+            artifacts=artifacts,
+            decision=decision,
+            elapsed_seconds=time.monotonic() - began,
+        )
+    c2_train_rate, c2_development_rate, c2_consecutive = _fit_rates(c2)
+    binding: dict[str, Any] | str = "NOT_RUN_C2_PRIMARY_MISS"
+    binding_rate: float | None = None
+    if c2.get("passed") is True:
+        try:
+            permuted_rows = permute_exact_bindings(exact_population.development)
+            permuted = _score_rows(
+                c2_model,
+                permuted_rows,
+                device=device,
+                deadline=deadline,
+            )
+            binding_rate = permuted.rate
+            binding = {
+                "status": "COMPLETE",
+                "source_population_cid": exact_population.population_cid,
+                "rows": len(permuted_rows),
+                "native_development_rate": c2_development_rate,
+                "permuted": permuted.record(),
+                "drop": float(c2_development_rate) - binding_rate,
+                "required_drop": CONTROL_REQUIRED_DROP,
+            }
+        except HardWallExceeded as error:
+            decision = _incomplete_decision(str(error))
+            return _finish_result(
+                root,
+                preparation=preparation,
+                preflight=preflight,
+                plan=plan,
+                c1=c1,
+                c2=c2,
+                binding_control="INCOMPLETE_HARD_WALL",
+                artifacts=artifacts,
+                decision=decision,
+                elapsed_seconds=time.monotonic() - began,
+            )
+    decision = decide_zoology_control(
+        c0_passed=True,
+        preflight_available=True,
+        c1_train_rate=c1_train_rate,
+        c1_development_rate=c1_development_rate,
+        c1_consecutive_passes=c1_consecutive,
+        c2_train_rate=c2_train_rate,
+        c2_development_rate=c2_development_rate,
+        c2_consecutive_passes=c2_consecutive,
+        binding_permuted_rate=binding_rate,
+    )
+    elapsed = time.monotonic() - began
+    if elapsed >= HARD_WALL_SECONDS:
+        decision = _incomplete_decision("final scoring reached the hard wall")
+    if implementation != zoology_control_implementation_contract():
+        raise ValueError("#1047 implementation changed during execution")
+    return _finish_result(
+        root,
+        preparation=preparation,
+        preflight=preflight,
+        plan=plan,
+        c1=c1,
+        c2=c2,
+        binding_control=binding,
+        artifacts=artifacts,
+        decision=decision,
+        elapsed_seconds=elapsed,
+    )
+
+
+def _verify_artifact(
+    root: Path,
+    record: Mapping[str, Any],
+    *,
+    population: ZoologyMQARPopulation,
+) -> None:
+    path = root / str(record.get("path"))
+    payload = path.read_bytes()
+    if (
+        len(payload) != record.get("bytes")
+        or cid_bytes(payload) != record.get("cid")
+        or record.get("population_cid") != population.population_cid
+    ):
+        raise ValueError("#1047 artifact bytes/CID differ")
+    tensors = load_safetensors(payload)
+    if (
+        "lm_head.weight" in tensors
+        or "backbone.embeddings.word_embeddings.weight" not in tensors
+        or _tensor_mapping_cid(tensors) != record.get("state_cid")
+    ):
+        raise ValueError("#1047 deterministic tied-artifact structure differs")
+    expected_model = _new_model(population, device=torch.device("cpu"))
+    expected = {
+        name: tensor
+        for name, tensor in expected_model.state_dict().items()
+        if name != "lm_head.weight"
+    }
+    if set(tensors) != set(expected) or any(
+        tensors[name].shape != expected[name].shape
+        or tensors[name].dtype != expected[name].dtype
+        for name in expected
+    ):
+        raise ValueError("#1047 artifact tensor schema differs")
+
+
+def verify_zoology_control(root: Path) -> dict[str, Any]:
+    """Verify envelopes, CIDs, ledgers, decisions, and artifacts without rescore."""
+
+    root = root.resolve()
+    preparation = _read_json(
+        root / PREPARATION_RELATIVE_PATH,
+        cid_field="preparation_cid",
+    )
+    preflight = _read_json(
+        root / PREFLIGHT_RELATIVE_PATH,
+        cid_field="preflight_cid",
+    )
+    result = _read_json(root / RESULT_RELATIVE_PATH, cid_field="result_cid")
+    preflight_started = _read_json(
+        root / PREFLIGHT_STARTED_RELATIVE_PATH,
+        cid_field="started_cid",
+    )
+    run_started = _read_json(
+        root / RUN_STARTED_RELATIVE_PATH,
+        cid_field="started_cid",
+    )
+    implementation = zoology_control_implementation_contract()
+    if (
+        result.get("schema") != RESULT_SCHEMA
+        or result.get("issue") != ISSUE
+        or result.get("policy") != POLICY
+        or result.get("preparation_cid") != preparation["preparation_cid"]
+        or result.get("preflight_cid") != preflight["preflight_cid"]
+        or result.get("implementation") != implementation
+        or preflight.get("implementation") != implementation
+        or preparation.get("implementation") != implementation
+        or preflight_started.get("phase") != "preflight"
+        or run_started.get("phase") != "run"
+    ):
+        raise ValueError("#1047 lifecycle envelope differs")
+    source_root = Path(str(preparation["source_root"]))
+    predecessor_root = Path(str(preparation["predecessor_root"]))
+    source_population, exact_population = _load_bound_populations(source_root)
+    if preparation.get("predecessor") != _bind_predecessor(predecessor_root):
+        raise ValueError("#1045 predecessor changed after result")
+    selection = preflight.get("selection")
+    if not isinstance(selection, Mapping) or select_execution_plan(
+        selection.get("plans", [])
+    ) != selection:
+        raise ValueError("#1047 preflight selection does not reproduce")
+    ledger = result.get("read_work_ledger")
+    if not isinstance(ledger, Mapping) or any(int(value) != 0 for value in ledger.values()):
+        raise ValueError("#1047 result reports a forbidden read")
+
+    artifacts = result.get("artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) > 2:
+        raise ValueError("#1047 artifact list is malformed")
+    expected_by_rung = {"c1": source_population, "c2": exact_population}
+    observed_rungs: set[str] = set()
+    for record in artifacts:
+        if not isinstance(record, Mapping):
+            raise ValueError("#1047 artifact record is malformed")
+        rung = str(record.get("rung"))
+        if rung in observed_rungs or rung not in expected_by_rung:
+            raise ValueError("#1047 artifact rung is repeated or unknown")
+        observed_rungs.add(rung)
+        _verify_artifact(root, record, population=expected_by_rung[rung])
+
+    decision = result.get("decision")
+    rungs = result.get("rungs")
+    if not isinstance(decision, Mapping) or not isinstance(rungs, Mapping):
+        raise ValueError("#1047 decision/rung sections are malformed")
+    verdict = decision.get("verdict")
+    allowed: set[str | None] = {
+        None,
+        "INVALID_CONTROL_PORT",
+        "SCALED_SOURCE_CALIBRATION_MISS",
+        "STOCK_CELL_EXACT_QUALIFICATION_MISS",
+        "STOCK_CELL_TRANSFER_MISS",
+        "NONASSOCIATIVE_SHORTCUT",
+        "STOCK_CELL_PASSES_EXACT_BYTES",
+    }
+    if verdict not in allowed:
+        raise ValueError("#1047 result invented a decision code")
+    elapsed = result.get("elapsed_seconds")
+    if (
+        isinstance(elapsed, bool)
+        or not isinstance(elapsed, (int, float))
+        or not math.isfinite(float(elapsed))
+        or float(elapsed) < 0.0
+    ):
+        raise ValueError("#1047 hard-wall ledger differs")
+    elapsed_seconds = float(elapsed)
+    c1 = rungs.get("c1")
+    c2 = rungs.get("c2")
+    binding = result.get("binding_permuted_control")
+    incomplete = _validate_hard_wall_decision(
+        decision,
+        c1=c1,
+        c2=c2,
+        binding_control=binding,
+        elapsed_seconds=elapsed_seconds,
+    )
+    if not incomplete and isinstance(c1, Mapping):
+        c1_train, c1_development, c1_consecutive = _fit_rates(c1)
+        if isinstance(c2, Mapping):
+            c2_train, c2_development, c2_consecutive = _fit_rates(c2)
+        else:
+            c2_train = c2_development = None
+            c2_consecutive = 0
+        binding_rate = (
+            float(binding["permuted"]["top1_rate"])
+            if isinstance(binding, Mapping)
+            and isinstance(binding.get("permuted"), Mapping)
+            else None
+        )
+        expected_decision = decide_zoology_control(
+            c0_passed=True,
+            preflight_available=True,
+            c1_train_rate=c1_train,
+            c1_development_rate=c1_development,
+            c1_consecutive_passes=c1_consecutive,
+            c2_train_rate=c2_train,
+            c2_development_rate=c2_development,
+            c2_consecutive_passes=c2_consecutive,
+            binding_permuted_rate=binding_rate,
+        )
+        if dict(decision) != expected_decision:
+            raise ValueError("#1047 final decision does not reproduce")
+    return result
+
+
+def execute_zoology_control(
+    root: Path,
+    *,
+    source_root: Path,
+    predecessor_root: Path,
+) -> dict[str, Any]:
+    """Prepare, preflight, run, and structurally verify the open control."""
+
+    prepare_zoology_control(
+        root,
+        source_root=source_root,
+        predecessor_root=predecessor_root,
+    )
+    preflight_zoology_control(root)
+    run_zoology_control(root)
+    return verify_zoology_control(root)
+
+
+__all__ = [
+    "ExecutionPlan",
+    "decide_zoology_control",
+    "execute_zoology_control",
+    "prepare_zoology_control",
+    "preflight_zoology_control",
+    "run_zoology_control",
+    "select_execution_plan",
+    "verify_zoology_control",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/model.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/model.py
@@ -1,0 +1,542 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from HazyResearch/Zoology; Copyright 2021 The Meerkat Team.
+"""Stock Zoology causal-attention control adapted for issue #1047.
+
+This is a narrow, device-neutral port of the released Zoology ICLR 2024
+Figure-2 attention model.  The model equations, module registration order,
+two-stage residual path, and double initialization pass follow the Apache-2.0
+source at commit ``de4e258``:
+
+https://github.com/HazyResearch/zoology/tree/de4e258784224e09909c257ff3ea040f089ed660
+
+Only two integration changes are intentional: position IDs follow the input
+device (the released implementation hard-coded CUDA), and selected query
+positions can be gathered before the tied vocabulary projection so a
+query-only training run never materializes ``[batch, time, vocabulary]``.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+
+SOURCE_COMMIT = "de4e258784224e09909c257ff3ea040f089ed660"
+SOURCE_URL = f"https://github.com/HazyResearch/zoology/tree/{SOURCE_COMMIT}"
+SOURCE_SEED = 123
+SOURCE_INITIALIZER_RANGE = 0.02
+
+
+@dataclass(frozen=True, slots=True)
+class ZoologyFigure2Config:
+    """Frozen stock-attention shape with #1047 corpus dimensions.
+
+    The released Figure-2 control uses ``d_model=64``, two layers, one head,
+    learned absolute positions, attention/embedding dropout of 0.1, and no
+    state mixer.  ``vocab_size`` and ``max_position_embeddings`` are adapted
+    to the #1047 corpus rather than changing the learned mechanism.
+    """
+
+    vocab_size: int = 4096
+    d_model: int = 64
+    n_layers: int = 2
+    num_heads: int = 1
+    max_position_embeddings: int = 120
+    attention_dropout: float = 0.1
+    embed_dropout: float = 0.1
+    resid_dropout: float = 0.0
+    layer_norm_epsilon: float = 1.0e-5
+    pad_vocab_size_multiple: int = 1
+
+    def __post_init__(self) -> None:
+        if self.vocab_size < 1:
+            raise ValueError("vocab_size must be positive")
+        if self.d_model < 1:
+            raise ValueError("d_model must be positive")
+        if self.n_layers < 1:
+            raise ValueError("n_layers must be positive")
+        if self.num_heads < 1 or self.d_model % self.num_heads != 0:
+            raise ValueError("num_heads must divide d_model")
+        if self.max_position_embeddings < 1:
+            raise ValueError("max_position_embeddings must be positive")
+        if self.pad_vocab_size_multiple < 1:
+            raise ValueError("pad_vocab_size_multiple must be positive")
+        if self.vocab_size % self.pad_vocab_size_multiple != 0:
+            raise ValueError("vocab_size must already include padding multiple")
+        for name, value in (
+            ("attention_dropout", self.attention_dropout),
+            ("embed_dropout", self.embed_dropout),
+            ("resid_dropout", self.resid_dropout),
+        ):
+            if not 0.0 <= value < 1.0:
+                raise ValueError(f"{name} must be in [0, 1)")
+        if self.layer_norm_epsilon <= 0.0:
+            raise ValueError("layer_norm_epsilon must be positive")
+
+
+@dataclass(slots=True)
+class ZoologyModelOutput:
+    """Language-model output for either full or selected projection."""
+
+    logits: Tensor
+    loss: Tensor | None
+    hidden_states: Tensor
+    selected_positions: Tensor | None = None
+    selected_targets: Tensor | None = None
+    # One pre-dropout softmax tensor per layer, each [batch, heads, time, time].
+    attention_weights: tuple[Tensor, ...] | None = None
+
+
+def set_zoology_seed(seed: int = SOURCE_SEED) -> None:
+    """Apply the released CPU-relevant Zoology seed contract.
+
+    The upstream helper seeds Python, NumPy, Torch, and CUDA.  This CPU-native
+    control intentionally has no CUDA dependency; the first three calls retain
+    the released model's construction and dropout determinism.
+    """
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def _init_weights(
+    module: nn.Module,
+    *,
+    n_layers: int,
+    initializer_range: float = SOURCE_INITIALIZER_RANGE,
+    rescale_prenorm_residual: bool = True,
+) -> None:
+    """Port of ``zoology.model._init_weights`` at ``de4e258``.
+
+    The recursive ``named_parameters`` walk is deliberately retained.  In
+    combination with ``Module.apply`` in both the backbone and outer model,
+    this reproduces the released double-application initialization behavior.
+    """
+
+    if isinstance(module, nn.Linear):
+        nn.init.normal_(module.weight, std=initializer_range)
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+    elif isinstance(module, nn.Embedding):
+        nn.init.normal_(module.weight, std=initializer_range)
+
+    if rescale_prenorm_residual:
+        for name, parameter in module.named_parameters():
+            if "out_proj.weight" in name or "fc2.weight" in name:
+                nn.init.normal_(
+                    parameter,
+                    std=initializer_range / math.sqrt(2 * n_layers),
+                )
+            elif "output_linear.0.weight" in name:
+                nn.init.normal_(
+                    parameter,
+                    std=initializer_range / math.sqrt(2 * n_layers),
+                )
+
+
+class _SelfAttention(nn.Module):
+    """Released scaled dot-product causal-softmax equation."""
+
+    def __init__(self, *, dropout_p: float) -> None:
+        super().__init__()
+        self.dropout_p = dropout_p
+
+    def forward(self, qkv: Tensor) -> tuple[Tensor, Tensor]:
+        if qkv.ndim != 5 or qkv.shape[2] != 3:
+            raise ValueError("qkv must have shape [batch,time,3,heads,head_dim]")
+        sequence_length = qkv.shape[1]
+        query, key, value = qkv.unbind(dim=2)
+        softmax_scale = 1.0 / math.sqrt(query.shape[-1])
+        scores = torch.einsum(
+            "bthd,bshd->bhts",
+            query,
+            key * softmax_scale,
+        )
+        causal_mask = torch.triu(
+            torch.full(
+                (sequence_length, sequence_length),
+                -10000.0,
+                device=scores.device,
+            ),
+            diagonal=1,
+        )
+        scores = scores + causal_mask.to(dtype=scores.dtype)
+        attention = torch.softmax(scores, dim=-1, dtype=value.dtype)
+        attention_drop = F.dropout(
+            attention,
+            self.dropout_p if self.training else 0.0,
+        )
+        output = torch.einsum("bhts,bshd->bthd", attention_drop, value)
+        return output, attention
+
+
+class _MultiHeadAttention(nn.Module):
+    """Released biased combined-QKV and biased output projection."""
+
+    def __init__(self, config: ZoologyFigure2Config) -> None:
+        super().__init__()
+        self.d_model = config.d_model
+        self.num_heads = config.num_heads
+        self.head_dim = config.d_model // config.num_heads
+        self.Wqkv = nn.Linear(config.d_model, 3 * config.d_model, bias=True)
+        self.inner_attn = _SelfAttention(dropout_p=config.attention_dropout)
+        self.out_proj = nn.Linear(config.d_model, config.d_model, bias=True)
+
+    def forward(self, hidden_states: Tensor) -> tuple[Tensor, Tensor]:
+        batch, time, _ = hidden_states.shape
+        qkv = self.Wqkv(hidden_states).reshape(
+            batch,
+            time,
+            3,
+            self.num_heads,
+            self.head_dim,
+        )
+        context, attention = self.inner_attn(qkv)
+        output = self.out_proj(context.reshape(batch, time, self.d_model))
+        return output, attention
+
+
+class _TransformerBlock(nn.Module):
+    """Exact released pre-norm two-residual-path block with Identity state."""
+
+    def __init__(
+        self,
+        config: ZoologyFigure2Config,
+        *,
+        layer_index: int,
+    ) -> None:
+        super().__init__()
+        self.sequence_mixer = _MultiHeadAttention(config)
+        self.state_mixer = nn.Identity()
+        self.dropout1 = nn.Dropout(
+            config.embed_dropout if layer_index == 0 else config.resid_dropout
+        )
+        # Source StochasticDepth is exactly the identity at drop_path=0.
+        self.drop_path1 = nn.Identity()
+        self.norm1 = nn.LayerNorm(config.d_model)
+        self.dropout2 = nn.Dropout(config.resid_dropout)
+        self.drop_path2 = nn.Identity()
+        self.norm2 = nn.LayerNorm(config.d_model)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        residual: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        dropped = self.drop_path1(self.dropout1(hidden_states))
+        residual = dropped + residual if residual is not None else dropped
+        hidden_states = self.norm1(residual.to(dtype=self.norm1.weight.dtype))
+        hidden_states, attention = self.sequence_mixer(hidden_states)
+
+        dropped = self.drop_path2(self.dropout2(hidden_states))
+        residual = dropped + residual if residual is not None else dropped
+        hidden_states = self.norm2(residual.to(dtype=self.norm2.weight.dtype))
+        hidden_states = self.state_mixer(hidden_states)
+        return hidden_states, residual, attention
+
+
+class _TokenEmbeddings(nn.Module):
+    def __init__(self, config: ZoologyFigure2Config) -> None:
+        super().__init__()
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.d_model)
+        self.project_in = None
+        self.position_embeddings = nn.Embedding(
+            config.max_position_embeddings,
+            config.d_model,
+        )
+
+    def forward(self, input_ids: Tensor, position_ids: Tensor) -> Tensor:
+        embeddings = self.word_embeddings(input_ids)
+        if self.project_in is not None:
+            embeddings = self.project_in(embeddings)
+        return embeddings + self.position_embeddings(position_ids)
+
+
+class _LanguageModelBackbone(nn.Module):
+    def __init__(self, config: ZoologyFigure2Config) -> None:
+        super().__init__()
+        self.config = config
+        self.embeddings = _TokenEmbeddings(config)
+        self.layers = nn.ModuleList(
+            [
+                _TransformerBlock(config, layer_index=layer_index)
+                for layer_index in range(config.n_layers)
+            ]
+        )
+        self.drop_f = nn.Dropout(config.resid_dropout)
+        self.ln_f = nn.LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+        )
+
+        # This is the first of the released source's two apply passes.
+        self.apply(lambda module: _init_weights(module, n_layers=config.n_layers))
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        *,
+        position_ids: Tensor | None = None,
+        return_attention: bool = False,
+    ) -> tuple[Tensor, tuple[Tensor, ...] | None]:
+        batch, time = input_ids.shape
+        if position_ids is None:
+            position_ids = torch.arange(
+                time,
+                dtype=torch.long,
+                device=input_ids.device,
+            ).unsqueeze(0)
+        hidden_states = self.embeddings(input_ids, position_ids)
+        residual = None
+        attention_weights: list[Tensor] | None = [] if return_attention else None
+        for layer in self.layers:
+            hidden_states, residual, attention = layer(hidden_states, residual)
+            if attention_weights is not None:
+                attention_weights.append(attention)
+
+        dropped = self.drop_f(hidden_states)
+        residual = dropped + residual if residual is not None else dropped
+        hidden_states = self.ln_f(residual.to(dtype=self.ln_f.weight.dtype))
+        return hidden_states, (
+            tuple(attention_weights) if attention_weights is not None else None
+        )
+
+
+class ZoologyFigure2Model(nn.Module):
+    """Released two-layer attention control with a query-only projection API."""
+
+    def __init__(self, config: ZoologyFigure2Config | None = None) -> None:
+        super().__init__()
+        self.config = config if config is not None else ZoologyFigure2Config()
+        self.backbone = _LanguageModelBackbone(self.config)
+        self.lm_head = nn.Linear(
+            self.config.d_model,
+            self.config.vocab_size,
+            bias=False,
+        )
+
+        # The outer source model applies the initializer to the whole model
+        # again, consuming the same RNG sequence before tying the head.
+        self.apply(
+            lambda module: _init_weights(
+                module,
+                n_layers=self.config.n_layers,
+            )
+        )
+        self.tie_weights()
+
+    def tie_weights(self) -> None:
+        self.lm_head.weight = self.backbone.embeddings.word_embeddings.weight
+
+    @staticmethod
+    def _validate_input_ids(
+        input_ids: Tensor,
+        config: ZoologyFigure2Config,
+    ) -> None:
+        if input_ids.ndim != 2 or input_ids.dtype != torch.long:
+            raise ValueError("input_ids must be int64 [batch,time]")
+        if input_ids.shape[0] < 1 or input_ids.shape[1] < 1:
+            raise ValueError("input_ids must contain at least one token")
+        if input_ids.shape[1] > config.max_position_embeddings:
+            raise ValueError("input sequence exceeds learned position table")
+        if bool((input_ids < 0).any()) or bool(
+            (input_ids >= config.vocab_size).any()
+        ):
+            raise ValueError("input_ids contain an out-of-vocabulary value")
+
+    @staticmethod
+    def _validate_position_ids(
+        input_ids: Tensor,
+        position_ids: Tensor | None,
+        config: ZoologyFigure2Config,
+    ) -> None:
+        if position_ids is None:
+            return
+        batch, time = input_ids.shape
+        if (
+            position_ids.dtype != torch.long
+            or position_ids.device != input_ids.device
+            or position_ids.ndim != 2
+            or position_ids.shape[1] != time
+            or position_ids.shape[0] not in (1, batch)
+        ):
+            raise ValueError(
+                "position_ids must be int64 [1,time] or [batch,time] on input device"
+            )
+        if bool((position_ids < 0).any()) or bool(
+            (position_ids >= config.max_position_embeddings).any()
+        ):
+            raise ValueError("position_ids exceed learned position table")
+
+    @staticmethod
+    def _validate_targets(
+        targets: Tensor,
+        *,
+        shape: torch.Size,
+        device: torch.device,
+        vocab_size: int,
+    ) -> None:
+        if targets.dtype != torch.long or targets.device != device:
+            raise ValueError("targets must be int64 on the input device")
+        if targets.shape != shape:
+            raise ValueError("targets have the wrong shape")
+        valid = targets != -100
+        if bool(valid.any()):
+            admitted = targets[valid]
+            if bool((admitted < 0).any()) or bool((admitted >= vocab_size).any()):
+                raise ValueError("targets contain an out-of-vocabulary value")
+
+    @staticmethod
+    def _validate_selected_positions(
+        input_ids: Tensor,
+        selected_positions: Tensor,
+    ) -> None:
+        batch, time = input_ids.shape
+        if (
+            selected_positions.ndim != 2
+            or selected_positions.dtype != torch.long
+            or selected_positions.device != input_ids.device
+            or selected_positions.shape[0] != batch
+            or selected_positions.shape[1] < 1
+        ):
+            raise ValueError(
+                "selected_positions must be int64 [batch,queries] on input device"
+            )
+        if bool((selected_positions < 0).any()) or bool(
+            (selected_positions >= time).any()
+        ):
+            raise ValueError("selected_positions contain an out-of-prefix value")
+
+    def hidden_states(
+        self,
+        input_ids: Tensor,
+        *,
+        position_ids: Tensor | None = None,
+        return_attention: bool = False,
+    ) -> tuple[Tensor, tuple[Tensor, ...] | None]:
+        self._validate_input_ids(input_ids, self.config)
+        self._validate_position_ids(input_ids, position_ids, self.config)
+        return self.backbone(
+            input_ids,
+            position_ids=position_ids,
+            return_attention=return_attention,
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        *,
+        position_ids: Tensor | None = None,
+    ) -> Tensor:
+        """Match the released stock API: return full vocabulary logits."""
+
+        hidden_states, _ = self.hidden_states(
+            input_ids,
+            position_ids=position_ids,
+        )
+        return self.lm_head(hidden_states)
+
+    def forward_full(
+        self,
+        input_ids: Tensor,
+        targets: Tensor | None = None,
+        *,
+        position_ids: Tensor | None = None,
+        return_attention: bool = False,
+    ) -> ZoologyModelOutput:
+        """Project all positions, optionally computing masked token CE."""
+
+        hidden_states, attention_weights = self.hidden_states(
+            input_ids,
+            position_ids=position_ids,
+            return_attention=return_attention,
+        )
+        logits = self.lm_head(hidden_states)
+        loss = None
+        if targets is not None:
+            self._validate_targets(
+                targets,
+                shape=input_ids.shape,
+                device=input_ids.device,
+                vocab_size=self.config.vocab_size,
+            )
+            loss = F.cross_entropy(
+                logits.reshape(-1, self.config.vocab_size),
+                targets.reshape(-1),
+            )
+        return ZoologyModelOutput(
+            logits=logits,
+            loss=loss,
+            hidden_states=hidden_states,
+            attention_weights=attention_weights,
+        )
+
+    def forward_selected(
+        self,
+        input_ids: Tensor,
+        selected_positions: Tensor,
+        targets: Tensor | None = None,
+        *,
+        position_ids: Tensor | None = None,
+        return_attention: bool = False,
+    ) -> ZoologyModelOutput:
+        """Gather query hidden states before projecting them to vocabulary."""
+
+        self._validate_selected_positions(input_ids, selected_positions)
+        hidden_states, attention_weights = self.hidden_states(
+            input_ids,
+            position_ids=position_ids,
+            return_attention=return_attention,
+        )
+        gather_index = selected_positions.unsqueeze(-1).expand(
+            -1,
+            -1,
+            self.config.d_model,
+        )
+        selected_hidden = torch.gather(hidden_states, dim=1, index=gather_index)
+        logits = self.lm_head(selected_hidden)
+
+        selected_targets = None
+        loss = None
+        if targets is not None:
+            if targets.shape == input_ids.shape:
+                self._validate_targets(
+                    targets,
+                    shape=input_ids.shape,
+                    device=input_ids.device,
+                    vocab_size=self.config.vocab_size,
+                )
+                selected_targets = torch.gather(targets, 1, selected_positions)
+            else:
+                self._validate_targets(
+                    targets,
+                    shape=selected_positions.shape,
+                    device=input_ids.device,
+                    vocab_size=self.config.vocab_size,
+                )
+                selected_targets = targets
+            loss = F.cross_entropy(
+                logits.reshape(-1, self.config.vocab_size),
+                selected_targets.reshape(-1),
+            )
+
+        return ZoologyModelOutput(
+            logits=logits,
+            loss=loss,
+            hidden_states=selected_hidden,
+            selected_positions=selected_positions,
+            selected_targets=selected_targets,
+            attention_weights=attention_weights,
+        )
+
+    def parameter_count(self) -> int:
+        """Return unique trainable scalar parameters (the tied head counts once)."""
+
+        return sum(parameter.numel() for parameter in self.parameters())

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/provenance.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/zoology_control/provenance.py
@@ -1,0 +1,213 @@
+"""Source attribution and recursive implementation binding for issue #1047.
+
+The MQAR construction in :mod:`r4_softmax_trainer.zoology_control.data` is a
+bounded-memory adaptation of HazyResearch/Zoology's ICLR24 ``_mqar`` routine.
+The upstream work is Apache-2.0 licensed.  This module records the exact
+upstream revisions and source-file content hashes rather than treating the
+later repository head as the released executable oracle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..provenance import (
+    artifact_records,
+    canonical_json_bytes,
+    cid_bytes,
+    tree_cid,
+)
+
+
+ISSUE = 1047
+POLICY = "ZoologyMQARControlV1"
+ZOOLOGY_REPOSITORY = "https://github.com/HazyResearch/zoology"
+ZOOLOGY_LICENSE = "Apache-2.0"
+ZOOLOGY_RELEASE_REVISION = "de4e258784224e09909c257ff3ea040f089ed660"
+ZOOLOGY_LATER_REVISION = "1ad20d193b6113cae1e8f3c655c300d7b4b3f4bb"
+
+ZOOLOGY_RELEASE_MQAR_SOURCE_CID = (
+    "blake3:09fc47699144ba3b4f50093661be960d6881e1cbb4ed3d8f24bc53663fde9204"
+)
+ZOOLOGY_RELEASE_DATA_UTILS_SOURCE_CID = (
+    "blake3:1fb44d9d431b03e8eb7e40ee062c798dbfc8a06f06d9fb03714f4b59d00b1584"
+)
+ZOOLOGY_RELEASE_ATTENTION_SOURCE_CID = (
+    "blake3:c67f69d373302d019aafcd273e8b367143eaf7463e727ec1fc32e26eb9cd9502"
+)
+ZOOLOGY_RELEASE_MODEL_SOURCE_CID = (
+    "blake3:e1b894edf594730dcc305e92acd78e9c752ec63a33413cbe7dd0f642fceac3f9"
+)
+ZOOLOGY_RELEASE_TRAIN_SOURCE_CID = (
+    "blake3:adf492f3ac0dbfd53c4899fe33737ac92ec75ff6aa755341b95cadc23c078aac"
+)
+ZOOLOGY_RELEASE_FIGURE2_SOURCE_CID = (
+    "blake3:3d4bbf2c2a1f2bf2fa74fc3828b9e3b43569268b45680f5c9ad9a3c026df841b"
+)
+ZOOLOGY_RELEASE_LICENSE_CID = (
+    "blake3:6f1967ff88a71b26c1e9b2ae83c073256e76aa00dd0ca5145f99715d13695878"
+)
+ZOOLOGY_LATER_MQAR_SOURCE_CID = (
+    "blake3:af676426a692ad514f2296fed7011196f97142203918191186d7b676bb604863"
+)
+
+
+def _source_url(revision: str, path: str) -> str:
+    return f"{ZOOLOGY_REPOSITORY}/blob/{revision}/{path}"
+
+
+def zoology_source_attribution() -> dict[str, Any]:
+    """Return a canonical, self-addressed record of copied source authority."""
+
+    body: dict[str, Any] = {
+        "schema": "uor-r4/zoology-source-attribution/v1",
+        "issue": ISSUE,
+        "policy": POLICY,
+        "repository": ZOOLOGY_REPOSITORY,
+        "license": ZOOLOGY_LICENSE,
+        "release_oracle": {
+            "revision": ZOOLOGY_RELEASE_REVISION,
+            "files": [
+                {
+                    "path": "zoology/data/associative_recall.py",
+                    "bytes": 14_111,
+                    "cid": ZOOLOGY_RELEASE_MQAR_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/data/associative_recall.py",
+                    ),
+                },
+                {
+                    "path": "zoology/data/utils.py",
+                    "bytes": 6_580,
+                    "cid": ZOOLOGY_RELEASE_DATA_UTILS_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/data/utils.py",
+                    ),
+                },
+                {
+                    "path": "zoology/mixers/attention.py",
+                    "bytes": 2_207,
+                    "cid": ZOOLOGY_RELEASE_ATTENTION_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/mixers/attention.py",
+                    ),
+                },
+                {
+                    "path": "zoology/model.py",
+                    "bytes": 7_162,
+                    "cid": ZOOLOGY_RELEASE_MODEL_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/model.py",
+                    ),
+                },
+                {
+                    "path": "zoology/train.py",
+                    "bytes": 6_285,
+                    "cid": ZOOLOGY_RELEASE_TRAIN_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/train.py",
+                    ),
+                },
+                {
+                    "path": "zoology/experiments/paper/figure2.py",
+                    "bytes": 5_311,
+                    "cid": ZOOLOGY_RELEASE_FIGURE2_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_RELEASE_REVISION,
+                        "zoology/experiments/paper/figure2.py",
+                    ),
+                },
+                {
+                    "path": "LICENSE.md",
+                    "bytes": 11_346,
+                    "cid": ZOOLOGY_RELEASE_LICENSE_CID,
+                    "url": _source_url(ZOOLOGY_RELEASE_REVISION, "LICENSE.md"),
+                },
+            ],
+        },
+        "later_provenance_only": {
+            "revision": ZOOLOGY_LATER_REVISION,
+            "files": [
+                {
+                    "path": "zoology/data/multiquery_ar.py",
+                    "bytes": 5_983,
+                    "cid": ZOOLOGY_LATER_MQAR_SOURCE_CID,
+                    "url": _source_url(
+                        ZOOLOGY_LATER_REVISION,
+                        "zoology/data/multiquery_ar.py",
+                    ),
+                }
+            ],
+        },
+        "adaptations": [
+            "local legacy NumPy RandomState with the released integer stream",
+            "bounded row-wise sampling instead of materialized tiled vocabularies",
+            "query-position-only batching",
+            "deterministic explicit release-style epoch shuffle",
+            "device-neutral CPU tensors and create-once UOR provenance containers",
+        ],
+        "claim_boundary": (
+            "scaled source-derived CPU control; not byte-identical and not a full "
+            "published Figure 2 reproduction"
+        ),
+    }
+    return {
+        **body,
+        "attribution_cid": cid_bytes(canonical_json_bytes(body)),
+    }
+
+
+def zoology_control_implementation_contract(
+    root: Path | None = None,
+) -> dict[str, Any]:
+    """Recursively bind the nested control package, tests, and locked inputs."""
+
+    trainer_root = (
+        Path(__file__).resolve().parents[3] if root is None else root.resolve()
+    )
+    package_root = trainer_root / "src" / "r4_softmax_trainer" / "zoology_control"
+    tests_root = trainer_root / "tests"
+    if not package_root.is_dir() or not tests_root.is_dir():
+        raise FileNotFoundError("Zoology control package or test root is missing")
+
+    paths = [
+        str(path.relative_to(trainer_root))
+        for path in sorted(package_root.rglob("*.py"))
+        if path.is_file() and "__pycache__" not in path.parts
+    ]
+    paths.extend(
+        str(path.relative_to(trainer_root))
+        for path in sorted(tests_root.rglob("test_zoology_control*.py"))
+        if path.is_file()
+    )
+    for support in (
+        "src/r4_softmax_trainer/zoology_control/NOTICE.md",
+        "src/r4_softmax_trainer/zoology_control/LICENSE-APACHE-2.0.md",
+        "pyproject.toml",
+        "uv.lock",
+    ):
+        if (trainer_root / support).is_file():
+            paths.append(support)
+    if not paths:
+        raise ValueError("Zoology control implementation tree is empty")
+
+    records = artifact_records(trainer_root, paths)
+    source = zoology_source_attribution()
+    body = {
+        "schema": "uor-r4/zoology-control-implementation/v1",
+        "issue": ISSUE,
+        "policy": POLICY,
+        "source_attribution_cid": source["attribution_cid"],
+        "files": records,
+        "tree_cid": tree_cid(records),
+    }
+    return {
+        **body,
+        "implementation_cid": cid_bytes(canonical_json_bytes(body)),
+    }

--- a/tools/r4-softmax-trainer/tests/test_zoology_control_cli.py
+++ b/tools/r4-softmax-trainer/tests/test_zoology_control_cli.py
@@ -1,0 +1,59 @@
+"""Focused CLI tests for ``python -m r4_softmax_trainer.zoology_control``."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from r4_softmax_trainer.zoology_control import __main__ as subject
+
+
+class ZoologyControlCliTests(unittest.TestCase):
+    def test_parser_registers_the_create_once_lifecycle(self) -> None:
+        root = Path("/tmp/run")
+        source = Path("/tmp/source")
+        predecessor = Path("/tmp/predecessor")
+        prepared = subject._parser().parse_args(
+            [
+                "prepare",
+                str(root),
+                "--source-root",
+                str(source),
+                "--predecessor-root",
+                str(predecessor),
+            ]
+        )
+        self.assertEqual(prepared.command, "prepare")
+        for command in ("preflight", "run", "verify"):
+            self.assertEqual(
+                subject._parser().parse_args([command, str(root)]).command,
+                command,
+            )
+
+    def test_prepare_dispatches_both_open_roots(self) -> None:
+        expected = {"preparation_cid": "blake3:" + "1" * 64}
+        with (
+            patch.object(subject, "prepare_zoology_control", return_value=expected) as invoked,
+            patch.object(subject, "_print") as emitted,
+        ):
+            subject.main(
+                [
+                    "prepare",
+                    "/tmp/run",
+                    "--source-root",
+                    "/tmp/source",
+                    "--predecessor-root",
+                    "/tmp/predecessor",
+                ]
+            )
+        invoked.assert_called_once_with(
+            Path("/tmp/run"),
+            source_root=Path("/tmp/source"),
+            predecessor_root=Path("/tmp/predecessor"),
+        )
+        emitted.assert_called_once_with(expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_zoology_control_data.py
+++ b/tools/r4-softmax-trainer/tests/test_zoology_control_data.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from r4_softmax_trainer.provenance import cid_bytes, cid_file
+from r4_softmax_trainer.role_tagged_associative_data import derive_mqar_role_ids
+from r4_softmax_trainer.zoology_control import data
+from r4_softmax_trainer.zoology_control.data import (
+    ZoologyMQARRow,
+    batch_rows,
+    deterministic_epoch_order,
+    load_exact_1045_population,
+    permute_exact_bindings,
+)
+from r4_softmax_trainer.zoology_control.provenance import (
+    ZOOLOGY_RELEASE_LICENSE_CID,
+    ZOOLOGY_RELEASE_REVISION,
+    zoology_control_implementation_contract,
+    zoology_source_attribution,
+)
+
+
+def _cid(label: str) -> str:
+    return cid_bytes(label.encode("ascii"))
+
+
+def _exact_tagged_row(index: int) -> SimpleNamespace:
+    inputs = [2] * data.EXACT_1045_CONTEXT
+    keys = tuple(256 + index * 16 + offset for offset in range(8))
+    values = tuple(2_048 + index * 16 + offset for offset in range(8))
+    for record_index, (key, value) in enumerate(zip(keys, values, strict=True)):
+        inputs[record_index * 4] = key
+        inputs[record_index * 4 + 1] = value
+    positions = tuple(32 + offset * 8 for offset in range(8))
+    for position, key in zip(positions, reversed(keys), strict=True):
+        inputs[position] = key
+    mapping = dict(zip(keys, values, strict=True))
+    answers = tuple(mapping[inputs[position]] for position in positions)
+    labels = [-100] * len(inputs)
+    for position, answer in zip(positions, answers, strict=True):
+        labels[position] = answer
+    input_ids = tuple(inputs)
+    return SimpleNamespace(
+        input_ids=input_ids,
+        role_ids=derive_mqar_role_ids(input_ids),
+        label_ids=tuple(labels),
+        stable_id=_cid(f"exact-row-{index}"),
+        source=SimpleNamespace(
+            query_positions=positions,
+            query_keys=tuple(input_ids[position] for position in positions),
+            answers=answers,
+        ),
+    )
+
+
+class ZoologyControlDataTests(unittest.TestCase):
+    def test_released_mqar_zero_filler_integer_golden(self) -> None:
+        inputs, labels = data._released_mqar(
+            vocab_size=32,
+            num_examples=3,
+            input_seq_len=16,
+            seed=0,
+            num_kv_pairs=2,
+        )
+        self.assertEqual(inputs.dtype, torch.long)
+        self.assertEqual(labels.dtype, torch.long)
+        self.assertEqual(
+            inputs.tolist(),
+            [
+                [2, 29, 7, 22, 2, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [3, 21, 5, 16, 3, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [5, 17, 13, 18, 13, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0],
+            ],
+        )
+        self.assertEqual(
+            labels.tolist(),
+            [
+                [
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    29,
+                    -100,
+                    22,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                ],
+                [
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    21,
+                    -100,
+                    16,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                ],
+                [
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    18,
+                    -100,
+                    -100,
+                    -100,
+                    17,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                    -100,
+                ],
+            ],
+        )
+
+    def test_source_calibration_declares_scaled_release_parameters(self) -> None:
+        calls: list[tuple[str, int, int]] = []
+
+        def fake_source_rows(*, split: str, count: int, seed: int):
+            calls.append((split, count, seed))
+            inputs = tuple([1] * data.SOURCE_NATIVE_INPUT_SEQ_LEN)
+            positions = tuple(range(8, 16, 2))
+            return (
+                ZoologyMQARRow(
+                    input_ids=inputs,
+                    selected_positions=positions,
+                    targets=(4_096, 4_097, 4_098, 4_099),
+                    stable_id=_cid(split),
+                ),
+            )
+
+        with patch.object(data, "_source_rows", fake_source_rows):
+            population = data.build_source_calibration()
+        self.assertEqual(
+            calls,
+            [
+                ("train", 8_192, 0),
+                ("development", 1_024, 10),
+            ],
+        )
+        self.assertEqual(population.name, "scaled_source_native")
+        self.assertEqual(population.vocab_size, 8_192)
+        self.assertEqual(population.input_seq_len, 64)
+        self.assertEqual(population.num_kv_pairs, 4)
+        self.assertEqual(population.train_seed, 0)
+        self.assertEqual(population.development_seed, 10)
+
+    def test_exact_1045_adapter_keeps_bytes_and_roles_out_of_batch(self) -> None:
+        train = (_exact_tagged_row(0), _exact_tagged_row(1))
+        development = (_exact_tagged_row(2),)
+        construction = SimpleNamespace(
+            mqar_train=train,
+            mqar_development=development,
+            split_cid=_cid("1045-split"),
+        )
+        with (
+            patch.object(data, "EXACT_1045_TRAIN_ROWS", len(train)),
+            patch.object(data, "EXACT_1045_DEVELOPMENT_ROWS", len(development)),
+            patch.object(
+                data,
+                "load_role_tagged_construction",
+                return_value=construction,
+            ),
+        ):
+            population = load_exact_1045_population(Path("unused"))
+        self.assertEqual(population.source_split_cid, construction.split_cid)
+        self.assertEqual(
+            tuple(row.input_ids for row in population.train),
+            tuple(row.input_ids for row in train),
+        )
+        self.assertEqual(
+            tuple(row.selected_positions for row in population.development),
+            tuple(row.source.query_positions for row in development),
+        )
+        self.assertEqual(
+            tuple(row.targets for row in population.development),
+            tuple(row.source.answers for row in development),
+        )
+
+        batch = batch_rows(population.train)
+        self.assertEqual(
+            tuple(batch.__dataclass_fields__),
+            ("input_ids", "selected_positions", "targets"),
+        )
+        self.assertFalse(hasattr(batch, "role_ids"))
+        self.assertTrue(torch.equal(batch.input_ids[0], torch.tensor(train[0].input_ids)))
+
+    def test_exact_adapter_rejects_role_byte_drift(self) -> None:
+        native = _exact_tagged_row(0)
+        corrupted = SimpleNamespace(
+            **{
+                **native.__dict__,
+                "role_ids": (0,) + native.role_ids[1:],
+            }
+        )
+        construction = SimpleNamespace(
+            mqar_train=(corrupted,),
+            mqar_development=(_exact_tagged_row(1),),
+            split_cid=_cid("1045-split-corrupt"),
+        )
+        with (
+            patch.object(data, "EXACT_1045_TRAIN_ROWS", 1),
+            patch.object(data, "EXACT_1045_DEVELOPMENT_ROWS", 1),
+            patch.object(
+                data,
+                "load_role_tagged_construction",
+                return_value=construction,
+            ),
+            self.assertRaisesRegex(ValueError, "role bytes"),
+        ):
+            load_exact_1045_population(Path("unused"))
+
+    def test_binding_permutation_changes_only_physical_values_and_identity(self) -> None:
+        native = data._adapt_exact_row(_exact_tagged_row(0))
+        (control,) = permute_exact_bindings((native,))
+        value_positions = tuple(range(1, 32, 4))
+        native_values = tuple(native.input_ids[position] for position in value_positions)
+        self.assertEqual(
+            tuple(control.input_ids[position] for position in value_positions),
+            native_values[1:] + native_values[:1],
+        )
+        self.assertTrue(
+            all(
+                control.input_ids[position] == native.input_ids[position]
+                for position in range(len(native.input_ids))
+                if position not in value_positions
+            )
+        )
+        self.assertEqual(control.selected_positions, native.selected_positions)
+        self.assertEqual(control.targets, native.targets)
+        self.assertEqual(control.role_ids, native.role_ids)
+        self.assertNotEqual(control.stable_id, native.stable_id)
+        self.assertFalse(hasattr(batch_rows((control,)), "role_ids"))
+
+    def test_release_style_shuffle_is_replayable_and_data_bound(self) -> None:
+        rows = tuple(
+            ZoologyMQARRow(
+                input_ids=(index, 0, 0, 0),
+                selected_positions=(0,),
+                targets=(index,),
+                stable_id=_cid(f"shuffle-{index}"),
+            )
+            for index in range(12)
+        )
+        first = deterministic_epoch_order(rows, 3, "train")
+        replay = deterministic_epoch_order(rows, 3, "train")
+        next_epoch = deterministic_epoch_order(rows, 4, "train")
+        self.assertEqual(first, replay)
+        self.assertEqual(set(first), set(rows))
+        self.assertNotEqual(first, next_epoch)
+
+    def test_source_attribution_and_recursive_tree_binding(self) -> None:
+        attribution = zoology_source_attribution()
+        self.assertEqual(
+            attribution["release_oracle"]["revision"],
+            ZOOLOGY_RELEASE_REVISION,
+        )
+        files = {
+            record["path"]: record
+            for record in attribution["release_oracle"]["files"]
+        }
+        self.assertEqual(
+            set(files),
+            {
+                "zoology/data/associative_recall.py",
+                "zoology/data/utils.py",
+                "zoology/mixers/attention.py",
+                "zoology/model.py",
+                "zoology/train.py",
+                "zoology/experiments/paper/figure2.py",
+                "LICENSE.md",
+            },
+        )
+        local_license = Path(data.__file__).with_name("LICENSE-APACHE-2.0.md")
+        local_license_bytes = local_license.read_bytes()
+        self.assertTrue(local_license_bytes.endswith(b"\n"))
+        self.assertEqual(
+            cid_bytes(local_license_bytes[:-1]),
+            ZOOLOGY_RELEASE_LICENSE_CID,
+        )
+        live_contract = zoology_control_implementation_contract()
+        live_files = {
+            record["path"]: record for record in live_contract["files"]
+        }
+        local_license_path = (
+            "src/r4_softmax_trainer/zoology_control/LICENSE-APACHE-2.0.md"
+        )
+        self.assertEqual(live_files[local_license_path]["cid"], cid_file(local_license))
+
+        with tempfile.TemporaryDirectory() as directory:
+            trainer_root = Path(directory)
+            package = (
+                trainer_root / "src" / "r4_softmax_trainer" / "zoology_control"
+            )
+            nested = package / "nested"
+            nested.mkdir(parents=True)
+            (package / "data.py").write_text("VALUE = 1\n", encoding="utf-8")
+            (nested / "helper.py").write_text("VALUE = 2\n", encoding="utf-8")
+            (package / "NOTICE.md").write_text("notice\n", encoding="utf-8")
+            (package / "LICENSE-APACHE-2.0.md").write_text(
+                "license\n", encoding="utf-8"
+            )
+            test_dir = trainer_root / "tests" / "nested"
+            test_dir.mkdir(parents=True)
+            (test_dir / "test_zoology_control_nested.py").write_text(
+                "def test_placeholder(): pass\n", encoding="utf-8"
+            )
+            (trainer_root / "pyproject.toml").write_text(
+                "[project]\n", encoding="utf-8"
+            )
+            (trainer_root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+
+            first = zoology_control_implementation_contract(trainer_root)
+            paths = {record["path"] for record in first["files"]}
+            self.assertIn(
+                "src/r4_softmax_trainer/zoology_control/nested/helper.py",
+                paths,
+            )
+            self.assertIn("tests/nested/test_zoology_control_nested.py", paths)
+            self.assertIn(
+                "src/r4_softmax_trainer/zoology_control/NOTICE.md",
+                paths,
+            )
+            self.assertIn(
+                "src/r4_softmax_trainer/zoology_control/LICENSE-APACHE-2.0.md",
+                paths,
+            )
+            (nested / "helper.py").write_text("VALUE = 3\n", encoding="utf-8")
+            second = zoology_control_implementation_contract(trainer_root)
+            self.assertNotEqual(first["tree_cid"], second["tree_cid"])
+            self.assertNotEqual(
+                first["implementation_cid"], second["implementation_cid"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_zoology_control_development.py
+++ b/tools/r4-softmax-trainer/tests/test_zoology_control_development.py
@@ -1,0 +1,415 @@
+"""Focused lifecycle tests for the credited #1047 Zoology control."""
+
+from __future__ import annotations
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from r4_softmax_trainer.zoology_control import development as subject
+
+
+def _score(rate: float) -> subject.ScoreResult:
+    decisions = 100
+    return subject.ScoreResult(
+        decisions=decisions,
+        correct=round(rate * decisions),
+        loss_sum=10.0,
+        selected_logits_cid="blake3:" + "a" * 64,
+        work={"target_reads": decisions},
+    )
+
+
+def _passing_fit(population_cid: str) -> dict[str, object]:
+    return {
+        "status": "COMPLETE",
+        "passed": True,
+        "population_cid": population_cid,
+        "epochs": 2,
+        "query_presentations": 2,
+        "history": [],
+        "final_train": _score(1.0).record(),
+        "final_development": _score(1.0).record(),
+        "consecutive_passes": 2,
+        "incomplete_reason": None,
+        "elapsed_seconds": 1.0,
+        "optimizer": {},
+    }
+
+
+class ZoologyControlDevelopmentTests(unittest.TestCase):
+    def test_source_oracle_is_executed_inside_c0_contract(self) -> None:
+        golden = subject._source_oracle_golden()
+        self.assertTrue(golden["passed"])
+        self.assertTrue(golden["loader"]["inputs_byte_exact"])
+        self.assertTrue(golden["loader"]["labels_byte_exact"])
+        self.assertTrue(golden["model"]["parameters_byte_exact"])
+        self.assertTrue(golden["model"]["logits_scale_aware_parity"])
+
+    def test_plan_selection_uses_both_measured_arms_and_fastest_cpu(self) -> None:
+        records = []
+        for threads, projected in ((1, 300.0), (4, 100.0), (8, 150.0)):
+            arm = {
+                "timed_training_batches": subject.TIMED_TRAINING_BATCHES,
+                "full_development_evaluation": True,
+                "deterministic_replay": True,
+            }
+            records.append(
+                {
+                    "plan": subject.ExecutionPlan(threads).record(),
+                    "arms": {"c1": dict(arm), "c2": dict(arm)},
+                    "timed_training_batches": 2 * subject.TIMED_TRAINING_BATCHES,
+                    "full_development_evaluation": True,
+                    "deterministic_replay": True,
+                    "projected_c1_c2_seconds": projected,
+                    "peak_rss_bytes": 1_000_000,
+                }
+            )
+
+        selection = subject.select_execution_plan(records)
+        self.assertTrue(selection["available"])
+        self.assertEqual(selection["selected_plan"]["threads"], 4)
+        self.assertEqual(selection["selected_projection_seconds"], 100.0)
+
+        missing_c2 = [dict(record) for record in records]
+        missing_c2[1] = {**missing_c2[1], "arms": {"c1": records[1]["arms"]["c1"]}}
+        degraded = subject.select_execution_plan(missing_c2)
+        self.assertNotEqual(degraded["selected_plan"]["threads"], 4)
+
+    def test_projection_reserves_a_train_score_after_every_epoch(self) -> None:
+        with patch.object(subject, "MAXIMUM_EPOCHS", 64):
+            projected = subject._project_rung_seconds(
+                train_batches=128,
+                development_batches=16,
+                seconds_per_training_batch=0.02,
+                seconds_per_evaluation_batch=0.01,
+            )
+        expected = 64 * 128 * 0.02 + 64 * (16 + 128) * 0.01
+        self.assertEqual(projected, expected)
+
+    def test_hard_wall_evidence_covers_runner_exit_shapes(self) -> None:
+        complete = {"status": "COMPLETE"}
+        incomplete = {"status": "INCOMPLETE_HARD_WALL"}
+        self.assertTrue(
+            subject._has_hard_wall_evidence(incomplete, None, None, 1.0)
+        )
+        self.assertTrue(
+            subject._has_hard_wall_evidence(complete, incomplete, None, 1.0)
+        )
+        self.assertTrue(
+            subject._has_hard_wall_evidence(
+                complete,
+                complete,
+                "INCOMPLETE_HARD_WALL",
+                1.0,
+            )
+        )
+        self.assertTrue(
+            subject._has_hard_wall_evidence(
+                complete,
+                complete,
+                "NOT_RUN_HARD_WALL",
+                1.0,
+            )
+        )
+        self.assertTrue(
+            subject._has_hard_wall_evidence(
+                complete,
+                complete,
+                "COMPLETE",
+                subject.HARD_WALL_SECONDS,
+            )
+        )
+        self.assertFalse(
+            subject._has_hard_wall_evidence(complete, complete, "COMPLETE", 1.0)
+        )
+
+    def test_hard_wall_decision_requires_matching_evidence(self) -> None:
+        complete = {"status": "COMPLETE"}
+        decision = subject._incomplete_decision("binding score reached wall")
+        self.assertTrue(
+            subject._validate_hard_wall_decision(
+                decision,
+                c1=complete,
+                c2=complete,
+                binding_control="INCOMPLETE_HARD_WALL",
+                elapsed_seconds=1.0,
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "lacks hard-wall evidence"):
+            subject._validate_hard_wall_decision(
+                decision,
+                c1=complete,
+                c2=complete,
+                binding_control="COMPLETE",
+                elapsed_seconds=1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "scientific verdict"):
+            subject._validate_hard_wall_decision(
+                {"status": "DECIDED", "verdict": "STOCK_CELL_TRANSFER_MISS"},
+                c1=complete,
+                c2=complete,
+                binding_control="NOT_RUN_HARD_WALL",
+                elapsed_seconds=1.0,
+            )
+        forged = {**decision, "passed": True}
+        with self.assertRaisesRegex(ValueError, "lacks hard-wall evidence"):
+            subject._validate_hard_wall_decision(
+                forged,
+                c1=complete,
+                c2=complete,
+                binding_control="INCOMPLETE_HARD_WALL",
+                elapsed_seconds=1.0,
+            )
+
+    def test_decision_stops_at_each_frozen_boundary(self) -> None:
+        self.assertEqual(
+            subject.decide_zoology_control(
+                c0_passed=False,
+                preflight_available=False,
+            )["verdict"],
+            "INVALID_CONTROL_PORT",
+        )
+        self.assertEqual(
+            subject.decide_zoology_control(
+                c0_passed=True,
+                preflight_available=True,
+                c1_train_rate=1.0,
+                c1_development_rate=0.98,
+                c1_consecutive_passes=0,
+            )["verdict"],
+            "SCALED_SOURCE_CALIBRATION_MISS",
+        )
+        self.assertEqual(
+            subject.decide_zoology_control(
+                c0_passed=True,
+                preflight_available=True,
+                c1_train_rate=1.0,
+                c1_development_rate=1.0,
+                c1_consecutive_passes=2,
+                c2_train_rate=1.0,
+                c2_development_rate=0.98,
+                c2_consecutive_passes=0,
+            )["verdict"],
+            "STOCK_CELL_TRANSFER_MISS",
+        )
+        self.assertEqual(
+            subject.decide_zoology_control(
+                c0_passed=True,
+                preflight_available=True,
+                c1_train_rate=1.0,
+                c1_development_rate=1.0,
+                c1_consecutive_passes=2,
+                c2_train_rate=0.98,
+                c2_development_rate=0.97,
+                c2_consecutive_passes=0,
+            )["verdict"],
+            "STOCK_CELL_EXACT_QUALIFICATION_MISS",
+        )
+        self.assertEqual(
+            subject.decide_zoology_control(
+                c0_passed=True,
+                preflight_available=True,
+                c1_train_rate=1.0,
+                c1_development_rate=1.0,
+                c1_consecutive_passes=2,
+                c2_train_rate=1.0,
+                c2_development_rate=1.0,
+                c2_consecutive_passes=1,
+            )["verdict"],
+            "STOCK_CELL_EXACT_QUALIFICATION_MISS",
+        )
+        shortcut = subject.decide_zoology_control(
+            c0_passed=True,
+            preflight_available=True,
+            c1_train_rate=1.0,
+            c1_development_rate=1.0,
+            c1_consecutive_passes=2,
+            c2_train_rate=1.0,
+            c2_development_rate=1.0,
+            c2_consecutive_passes=2,
+            binding_permuted_rate=0.75,
+        )
+        self.assertEqual(shortcut["verdict"], "NONASSOCIATIVE_SHORTCUT")
+        passed = subject.decide_zoology_control(
+            c0_passed=True,
+            preflight_available=True,
+            c1_train_rate=1.0,
+            c1_development_rate=1.0,
+            c1_consecutive_passes=2,
+            c2_train_rate=1.0,
+            c2_development_rate=1.0,
+            c2_consecutive_passes=2,
+            binding_permuted_rate=0.10,
+        )
+        self.assertEqual(passed["verdict"], "STOCK_CELL_PASSES_EXACT_BYTES")
+        self.assertTrue(passed["passed"])
+
+    def test_hard_wall_cannot_reuse_a_prior_epoch_score(self) -> None:
+        model = torch.nn.Linear(1, 1)
+        population = SimpleNamespace(
+            train=(object(),),
+            development=(object(),),
+            population_cid="blake3:" + "b" * 64,
+        )
+        training = {"query_presentations": 1, "complete": True}
+        passed_score = _score(1.0)
+
+        def completed_epoch(
+            _model: torch.nn.Module,
+            optimizer: torch.optim.Optimizer,
+            *_args: object,
+            **_kwargs: object,
+        ) -> dict[str, object]:
+            for parameter in model.parameters():
+                parameter.grad = torch.zeros_like(parameter)
+            optimizer.step()
+            return training
+
+        with (
+            patch.object(subject, "MAXIMUM_EPOCHS", 2),
+            patch.object(subject, "_new_model", return_value=model),
+            patch.object(subject, "_train_epoch", side_effect=completed_epoch),
+            patch.object(
+                subject,
+                "_score_rows",
+                side_effect=[
+                    passed_score,
+                    passed_score,
+                    subject.HardWallExceeded("wall"),
+                ],
+            ),
+        ):
+            _, fit = subject._train_rung(
+                population,
+                rung="c1",
+                device=torch.device("cpu"),
+                deadline=time.monotonic() + 60.0,
+            )
+        self.assertEqual(fit["status"], "INCOMPLETE_HARD_WALL")
+        self.assertIsNone(fit["final_train"])
+        self.assertIsNone(fit["final_development"])
+        self.assertFalse(fit["passed"])
+
+    def test_result_boundary_keeps_w8_and_geometry_out_of_the_control(self) -> None:
+        body = subject._result_body(
+            preparation={
+                "preparation_cid": "blake3:" + "1" * 64,
+                "inputs": {
+                    "source_attribution_cid": "blake3:" + "2" * 64,
+                    "source_native_population_cid": "blake3:" + "3" * 64,
+                    "exact_1045_population_cid": "blake3:" + "4" * 64,
+                    "source_1045_split_cid": "blake3:" + "5" * 64,
+                },
+            },
+            preflight={
+                "preflight_cid": "blake3:" + "6" * 64,
+                "implementation": {"tree_cid": "blake3:" + "7" * 64},
+            },
+            plan=subject.ExecutionPlan(4).record(),
+            c1="NOT_RUN",
+            c2="NOT_RUN",
+            binding_control="NOT_RUN",
+            artifacts=(),
+            decision={"status": "NOT_RUN", "verdict": None, "passed": False},
+            elapsed_seconds=1.0,
+        )
+        self.assertEqual(body["claim_boundary"]["ordinary_causal_softmax"], "ONLY")
+        self.assertEqual(body["claim_boundary"]["r4_or_geometric_attention"], "NOT_CLAIMED")
+        self.assertEqual(body["claim_boundary"]["exact_lowering"], "NOT_RUN")
+        self.assertEqual(body["read_work_ledger"]["future_value_reads"], 0)
+
+    def test_c2_pass_reaches_binding_control_with_the_correct_call_shape(self) -> None:
+        implementation = {
+            "implementation_cid": "blake3:" + "8" * 64,
+            "tree_cid": "blake3:" + "9" * 64,
+        }
+        predecessor = {"result_cid": "blake3:" + "a" * 64}
+        source = SimpleNamespace(
+            train=(object(),),
+            development=(object(),),
+            population_cid="blake3:" + "b" * 64,
+            source_split_cid=None,
+        )
+        exact = SimpleNamespace(
+            train=(object(),),
+            development=(object(),),
+            population_cid="blake3:" + "c" * 64,
+            source_split_cid=subject.EXPECTED_1045_SPLIT_CID,
+        )
+        plan = subject.ExecutionPlan(4).record()
+        preparation = {
+            "preparation_cid": "blake3:" + "d" * 64,
+            "implementation": implementation,
+            "source_root": "/open/source",
+            "predecessor_root": "/open/predecessor",
+            "predecessor": predecessor,
+        }
+        preflight = {
+            "preflight_cid": "blake3:" + "e" * 64,
+            "preparation_cid": preparation["preparation_cid"],
+            "implementation": implementation,
+            "passed": True,
+            "c0": {"passed": True},
+            "selection": {"selected_plan": plan},
+            "population_cids": {
+                "c1_source_native": source.population_cid,
+                "c2_exact_1045": exact.population_cid,
+                "source_1045_split": exact.source_split_cid,
+            },
+        }
+        model = object()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            def read_record(path: Path, *, cid_field: str):
+                del cid_field
+                return preparation if path.name == subject.PREPARATION_RELATIVE_PATH else preflight
+
+            with (
+                patch.object(subject, "_read_json", side_effect=read_record),
+                patch.object(
+                    subject,
+                    "zoology_control_implementation_contract",
+                    return_value=implementation,
+                ),
+                patch.object(subject, "_load_bound_populations", return_value=(source, exact)),
+                patch.object(subject, "_bind_predecessor", return_value=predecessor),
+                patch.object(subject, "_configure_cpu", return_value=torch.device("cpu")),
+                patch.object(
+                    subject,
+                    "_train_rung",
+                    side_effect=[
+                        (model, _passing_fit(source.population_cid)),
+                        (model, _passing_fit(exact.population_cid)),
+                    ],
+                ),
+                patch.object(
+                    subject,
+                    "_write_model_artifact",
+                    side_effect=[
+                        {"rung": "c1", "path": "c1"},
+                        {"rung": "c2", "path": "c2"},
+                    ],
+                ),
+                patch.object(subject, "permute_exact_bindings", return_value=exact.development),
+                patch.object(subject, "_score_rows", return_value=_score(0.10)) as score_rows,
+                patch.object(subject, "_finish_result", return_value={"done": True}) as finish,
+            ):
+                result = subject.run_zoology_control(root)
+
+        self.assertEqual(result, {"done": True})
+        score_rows.assert_called_once()
+        self.assertEqual(score_rows.call_args.args, (model, exact.development))
+        self.assertEqual(score_rows.call_args.kwargs["device"], torch.device("cpu"))
+        decision = finish.call_args.kwargs["decision"]
+        self.assertEqual(decision["verdict"], "STOCK_CELL_PASSES_EXACT_BYTES")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/r4-softmax-trainer/tests/test_zoology_control_model.py
+++ b/tools/r4-softmax-trainer/tests/test_zoology_control_model.py
@@ -1,0 +1,287 @@
+"""Focused source-parity tests for the #1047 Zoology attention control."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+from torch.nn import functional as F
+
+from r4_softmax_trainer.zoology_control.model import (
+    SOURCE_COMMIT,
+    SOURCE_URL,
+    ZoologyFigure2Config,
+    ZoologyFigure2Model,
+    set_zoology_seed,
+)
+
+
+def _tiny_config() -> ZoologyFigure2Config:
+    return ZoologyFigure2Config(
+        vocab_size=32,
+        d_model=8,
+        n_layers=2,
+        num_heads=1,
+        max_position_embeddings=8,
+        attention_dropout=0.1,
+        embed_dropout=0.1,
+        resid_dropout=0.0,
+    )
+
+
+class ZoologyControlModelTests(unittest.TestCase):
+    def test_default_source_shape_and_parameter_contract(self) -> None:
+        set_zoology_seed()
+        model = ZoologyFigure2Model()
+        tokens = torch.tensor(
+            [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
+            dtype=torch.long,
+        )
+        result = model.forward_full(tokens, return_attention=True)
+
+        self.assertEqual(
+            model.config,
+            ZoologyFigure2Config(
+                vocab_size=4096,
+                d_model=64,
+                n_layers=2,
+                num_heads=1,
+                max_position_embeddings=120,
+                attention_dropout=0.1,
+                embed_dropout=0.1,
+                resid_dropout=0.0,
+                layer_norm_epsilon=1.0e-5,
+                pad_vocab_size_multiple=1,
+            ),
+        )
+        self.assertEqual(model.parameter_count(), 303_744)
+        self.assertEqual(result.logits.shape, (2, 5, 4096))
+        self.assertEqual(result.hidden_states.shape, (2, 5, 64))
+        self.assertIsNone(result.loss)
+        self.assertIsNotNone(result.attention_weights)
+        assert result.attention_weights is not None
+        self.assertEqual(len(result.attention_weights), 2)
+        for weights in result.attention_weights:
+            self.assertEqual(weights.shape, (2, 1, 5, 5))
+        self.assertEqual(result.logits.device.type, "cpu")
+
+        first = model.backbone.layers[0]
+        self.assertIsNotNone(first.sequence_mixer.Wqkv.bias)
+        self.assertIsNotNone(first.sequence_mixer.out_proj.bias)
+        self.assertIsInstance(first.state_mixer, torch.nn.Identity)
+        self.assertEqual(
+            model.backbone.embeddings.position_embeddings.num_embeddings,
+            120,
+        )
+
+    def test_attention_mask_is_causal_and_suffix_cannot_change_prefix(self) -> None:
+        set_zoology_seed()
+        model = ZoologyFigure2Model(_tiny_config()).eval()
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 6]], dtype=torch.long)
+        changed_suffix = tokens.clone()
+        changed_suffix[:, 4:] = torch.tensor([[29, 30]])
+
+        result = model.forward_full(tokens, return_attention=True)
+        changed = model.forward_full(changed_suffix)
+        assert result.attention_weights is not None
+        future = torch.triu(torch.ones(6, 6, dtype=torch.bool), diagonal=1)
+        for weights in result.attention_weights:
+            self.assertTrue(
+                torch.equal(
+                    weights[..., future],
+                    torch.zeros_like(weights[..., future]),
+                )
+            )
+            torch.testing.assert_close(
+                weights.sum(dim=-1),
+                torch.ones_like(weights.sum(dim=-1)),
+                rtol=0.0,
+                atol=2.0e-7,
+            )
+        torch.testing.assert_close(
+            result.logits[:, :4],
+            changed.logits[:, :4],
+            rtol=0.0,
+            atol=0.0,
+        )
+
+    def test_selected_projection_and_loss_equal_full_masked_cross_entropy(self) -> None:
+        set_zoology_seed()
+        model = ZoologyFigure2Model(_tiny_config()).eval()
+        tokens = torch.tensor(
+            [[1, 2, 3, 4, 5, 6], [6, 5, 4, 3, 2, 1]],
+            dtype=torch.long,
+        )
+        selected_positions = torch.tensor([[2, 5], [1, 4]], dtype=torch.long)
+        selected_targets = torch.tensor([[11, 12], [13, 14]], dtype=torch.long)
+        full_targets = torch.full_like(tokens, -100)
+        full_targets.scatter_(1, selected_positions, selected_targets)
+
+        projected_shapes: list[tuple[int, ...]] = []
+
+        def record_projection_input(
+            _module: torch.nn.Module,
+            inputs: tuple[torch.Tensor, ...],
+        ) -> None:
+            projected_shapes.append(tuple(inputs[0].shape))
+
+        handle = model.lm_head.register_forward_pre_hook(record_projection_input)
+        try:
+            selected = model.forward_selected(
+                tokens,
+                selected_positions,
+                full_targets,
+            )
+        finally:
+            handle.remove()
+        full = model.forward_full(tokens, full_targets)
+        direct = model.forward_selected(
+            tokens,
+            selected_positions,
+            selected_targets,
+        )
+
+        expected_logits = torch.gather(
+            full.logits,
+            1,
+            selected_positions.unsqueeze(-1).expand(-1, -1, 32),
+        )
+        self.assertEqual(projected_shapes, [(2, 2, 8)])
+        self.assertEqual(selected.logits.shape, (2, 2, 32))
+        self.assertEqual(selected.hidden_states.shape, (2, 2, 8))
+        self.assertTrue(torch.equal(selected.logits, expected_logits))
+        self.assertTrue(torch.equal(selected.selected_targets, selected_targets))
+        self.assertTrue(torch.equal(direct.selected_targets, selected_targets))
+        assert selected.loss is not None
+        assert full.loss is not None
+        assert direct.loss is not None
+        manual = F.cross_entropy(
+            expected_logits.reshape(-1, 32),
+            selected_targets.reshape(-1),
+        )
+        # The full and compact CE kernels reduce tensors with different
+        # physical extents; their four labelled terms agree within one f32
+        # reduction ulp even though the ignored full positions are absent.
+        torch.testing.assert_close(
+            selected.loss,
+            full.loss,
+            rtol=0.0,
+            atol=3.0e-7,
+        )
+        torch.testing.assert_close(selected.loss, direct.loss, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(selected.loss, manual, rtol=0.0, atol=0.0)
+
+    def test_tied_head_and_released_seed_are_deterministic(self) -> None:
+        set_zoology_seed(123)
+        first = ZoologyFigure2Model(_tiny_config())
+        set_zoology_seed(123)
+        second = ZoologyFigure2Model(_tiny_config())
+
+        self.assertIs(
+            first.lm_head.weight,
+            first.backbone.embeddings.word_embeddings.weight,
+        )
+        self.assertEqual(
+            first.lm_head.weight.data_ptr(),
+            first.backbone.embeddings.word_embeddings.weight.data_ptr(),
+        )
+        self.assertEqual(list(first.state_dict()), list(second.state_dict()))
+        for name, tensor in first.state_dict().items():
+            self.assertTrue(torch.equal(tensor, second.state_dict()[name]), name)
+
+        set_zoology_seed(124)
+        different = ZoologyFigure2Model(_tiny_config())
+        self.assertFalse(
+            torch.equal(
+                first.backbone.embeddings.word_embeddings.weight,
+                different.backbone.embeddings.word_embeddings.weight,
+            )
+        )
+
+    def test_iclr24_source_parity_golden(self) -> None:
+        """Bind init/forward to literal pinned source execution.
+
+        These float32 values were generated by executing the unmodified
+        ``zoology/model.py`` and ``zoology/mixers/attention.py`` blobs at the
+        exact Apache-2.0 ICLR24 tag, with only Identity dependency stubs for
+        zero-probability stochastic depth and the two released reshape calls.
+        The port and pinned source produced byte-equal state dictionaries and
+        byte-equal logits before these values were recorded.
+        """
+
+        self.assertEqual(
+            SOURCE_COMMIT,
+            "de4e258784224e09909c257ff3ea040f089ed660",
+        )
+        self.assertEqual(
+            SOURCE_URL,
+            "https://github.com/HazyResearch/zoology/tree/"
+            "de4e258784224e09909c257ff3ea040f089ed660",
+        )
+        set_zoology_seed(123)
+        model = ZoologyFigure2Model(_tiny_config()).eval()
+
+        torch.testing.assert_close(
+            model.backbone.embeddings.word_embeddings.weight[0, :4],
+            torch.tensor(
+                [
+                    0.01682600937783718,
+                    0.007630460895597935,
+                    0.03871878609061241,
+                    0.004360933322459459,
+                ]
+            ),
+            rtol=0.0,
+            atol=0.0,
+        )
+        torch.testing.assert_close(
+            model.backbone.embeddings.position_embeddings.weight[0, :4],
+            torch.tensor(
+                [
+                    0.002722495701164007,
+                    -0.0014288985403254628,
+                    -0.004648478236049414,
+                    -0.01643170788884163,
+                ]
+            ),
+            rtol=0.0,
+            atol=0.0,
+        )
+        torch.testing.assert_close(
+            model.backbone.layers[0].sequence_mixer.Wqkv.weight[0, :4],
+            torch.tensor(
+                [
+                    0.03611164167523384,
+                    -0.02012898586690426,
+                    0.003164451103657484,
+                    0.00013401817705016583,
+                ]
+            ),
+            rtol=0.0,
+            atol=0.0,
+        )
+        logits = model(
+            torch.tensor(
+                [[1, 2, 3, 4], [4, 3, 2, 1]],
+                dtype=torch.long,
+            )
+        )
+        torch.testing.assert_close(
+            logits[0, -1, :6],
+            torch.tensor(
+                [
+                    -0.03831605240702629,
+                    -0.05481904745101929,
+                    -0.031969670206308365,
+                    0.005645290017127991,
+                    0.10721376538276672,
+                    -0.07025852799415588,
+                ]
+            ),
+            rtol=0.0,
+            atol=0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1047

## Outcome

Ports and credits the released ICLR24 HazyResearch/Zoology one-head width-64 causal-softmax MQAR cell and loader as the frozen ordinary-attention integration control. Source goldens, deterministic mechanics, causal/query-only parity, and the disposable 32-row overfit pass.

The scientific C1/C2 run is honestly `NOT_RUN_PREFLIGHT`: the fastest frozen plan used all eight host CPU cores and projected `959.212581 s` after the required `1.25` safety factor, above the frozen 900-second wall. No model artifact or scientific attention verdict was produced.

## Bound evidence

- implementation tree: `blake3:c848c05ae53bc3adc0a8f7099ceed43657b6348e4e00fe3aaef5cf1368cc38de`
- preparation: `blake3:560dd6e9abbabbeccbb32b2dbec6b815b5f7842bbb30c387af79177bd32a98f8`
- preflight: `blake3:78158700e632d303bf674ed544f997a0e14eb89947470f5032e6acc75c830c9b`
- result: `blake3:b453abccc6ae0db9cc186c791aba268555dc0e75fe687c994e940254b0ac9ef6`
- C0 overfit: `128/128` after 87 updates
- all forbidden/read-ledger counters: zero

## Verification

- 23 focused Zoology-control tests pass
- Python module compilation passes
- `cargo fmt --check` passes
- repository claim-wording gate passes
- `git diff --check` passes

## Next action

Preserve the exact scientific cell, data identities, batch, optimizer, gates, and CPU-only scope. Continue on a fresh issue that widens only the execution wall enough to admit the already measured all-core plan. This is a resource-policy continuation, not same-issue tuning.