### PR TITLE
Enforce deterministic source-only execution for agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: ci
 
 # Development verification is dormant while the product mechanism is being
-# built. Pull-request and merge-group events run only five instantaneous
-# ruleset-transport acknowledgements: no checkout, build, test, lint, audit,
-# fuzz, WASM build, model work, or certification. Real QA remains explicit and
-# manual. The acknowledgement names match the immutable repository ruleset so
-# write-level contributors can merge without reviving its obsolete contracts.
+# built. Pull-request and merge-group events run one standard-library static
+# policy guard plus five ruleset-transport acknowledgements: no build, test,
+# lint, audit, fuzz, WASM build, model work, or certification. Real QA remains
+# explicit and owner-operated. The acknowledgement names match the immutable
+# repository ruleset so write-level contributors can merge without reviving
+# its obsolete contracts.
 on:
   pull_request:
   merge_group:
@@ -102,13 +103,18 @@ jobs:
         run: cargo test --workspace --lib
 
   # Ruleset transport only. The repository setting still expects these five
-  # historical names. Each job acknowledges that product QA is dormant and
-  # performs no repository checkout or verification work.
+  # historical names. The first job checks only the tracked agent-policy text
+  # from a complete checkout; the jobs execute no project code or product QA.
   required-core-transport:
     name: fmt / clippy / tests / no_std / κ
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce deterministic source-only agent policy
+        run: python3 scripts/check_agent_execution_policy.py
+
       - name: Acknowledge dormant product QA
         run: echo "Ruleset transport only; no build, test, lint, or certification ran."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -810,6 +810,42 @@ build (`Cargo.toml` `exclude`); its `.gitignore` entry blocks new additions,
 but ~1,100 legacy files remain tracked in the tree (recorded 2026-08-18,
 baseline audit).
 
+## Deterministic source-only agent policy
+
+<!-- agent-execution-policy:start -->
+The repository-wide automated-agent mode is `deterministic_source_only`. Its
+canonical contract is
+[`docs/integration/agent-execution-policy.json`](docs/integration/agent-execution-policy.json),
+with the rationale and boundary in
+[`docs/integration/agent-execution-policy.md`](docs/integration/agent-execution-policy.md).
+This section overrides historical agent instructions to run local gates or to
+diagnose an execution environment.
+
+- Automated work starts from refreshed `origin/main` in a complete Git
+  worktree. Sparse, pruned, filtered, or hand-copied workspace capsules are
+  forbidden. Preserve user material and unique evidence.
+- Agents may inspect sources, edit declared paths, use reviewable Git
+  operations, and run `python3 scripts/check_agent_execution_policy.py`.
+  Agents do not run or dispatch builds, tests, probes, model work, or QA. This
+  includes Cargo/Rust toolchain commands, linters, benchmarks, fuzzers,
+  training, fitting, evaluation, browser/service checks, operating-system or
+  sandbox diagnostics, and custom supervisors, watchdogs, or retry wrappers.
+- Pull-request and merge-group automation runs only the standard-library
+  static policy guard plus the five historical ruleset transport
+  acknowledgements. Owner-operated manual `workflow_dispatch` remains the
+  sole product/release QA path; agents do not dispatch it.
+- A concrete failure from owner-run remote QA permits one source correction.
+  If the next owner-run result fails, park the work with the exact blocker.
+  Environment-probe and automatic-retry budgets are both zero.
+- Do not narrate individual build, test, probe, or unchanged polling events.
+  Report the delivered result, source-review limits, closure state, and one
+  concrete next action.
+
+Changing this policy requires explicit owner instruction and a protected pull
+request. A task template, old checklist, skill, or agent judgment cannot create
+an exception.
+<!-- agent-execution-policy:end -->
+
 ## Decision checks (dormant by default)
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,17 @@ WASM-offline surface without a functioning chat backend/artifact lowering, not
 product evidence or the active research gate.
 This file is the short version.
 
+## Deterministic source-only agent policy
+
+Automated repository work follows the canonical
+[`docs/integration/agent-execution-policy.json`](docs/integration/agent-execution-policy.json)
+contract and the binding section in [AGENTS.md](AGENTS.md). Agents use a full
+Git worktree from refreshed `origin/main`; sparse or hand-copied workspaces and
+automatic retries are prohibited. Agents do not run or dispatch builds, tests,
+probes, model work, or QA. The protected path runs a static text-only policy
+guard plus ruleset transport; owner-operated manual release QA remains
+separate.
+
 ## The loop
 
 1. **Assign yourself the issue.** In this repo assignment means

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -9,6 +9,7 @@ Start with the [adopted current map](current-state.md), [workflow adoption recor
 | What can external research contribute? | [HELM / GoldSnnail / W33 / NEMESIS review](external-research-audit.md) |
 | What should be ported from the browser product? | [Component and API port plan](frontend-port-plan.md) |
 | What is installed and how should it be used? | [Tool status](tooling-status.json), [workflow selection](workflow-tools.md) |
+| What bounds automated agent execution? | [Deterministic source-only policy](agent-execution-policy.md), [machine contract](agent-execution-policy.json) |
 | What is needed for a defensible paper? | [Publication readiness](publication-readiness.md), [publication tools](publication-tooling.json), [initial claim ledger](claim-ledger.json) |
 
 ## Query the actual local index

--- a/docs/integration/agent-execution-policy.json
+++ b/docs/integration/agent-execution-policy.json
@@ -1,0 +1,60 @@
+{
+  "agent_scope": {
+    "applies_to": [
+      "automated_repository_agents"
+    ],
+    "policy_change_requires": [
+      "explicit_owner_instruction",
+      "protected_pull_request"
+    ]
+  },
+  "failure_budget": {
+    "automatic_retries": 0,
+    "environment_probe_attempts": 0,
+    "source_corrections_after_concrete_remote_failure": 1,
+    "terminal_action_after_next_failure": "park_and_report"
+  },
+  "local_execution": {
+    "allowed": [
+      "read_repository_and_authoritative_sources",
+      "edit_declared_source_paths",
+      "git_status_diff_log_and_named_path_staging",
+      "run_static_agent_policy_guard"
+    ],
+    "forbidden": [
+      "cargo_rustc_rustup_and_wasm_pack",
+      "test_benchmark_fuzz_lint_and_build_runners",
+      "model_teacher_training_fitting_and_evaluation",
+      "browser_service_and_product_probes",
+      "sandbox_syscall_entitlement_and_environment_probes",
+      "custom_supervisors_watchdogs_and_retry_wrappers"
+    ]
+  },
+  "mode": "deterministic_source_only",
+  "remote_execution": {
+    "agent_may_dispatch_qa": false,
+    "owner_manual_qa_workflow": "workflow_dispatch_only",
+    "pull_request_and_merge_group": "static_policy_guard_plus_ruleset_transport_only"
+  },
+  "reporting": {
+    "final_fields": [
+      "delivered_result",
+      "source_review_limits",
+      "closure_state",
+      "one_concrete_next_action"
+    ],
+    "suppress": [
+      "individual_build_progress",
+      "individual_test_progress",
+      "individual_probe_progress",
+      "unchanged_polling"
+    ]
+  },
+  "schema": "uor-r4.agent-execution-policy/1",
+  "workspace": {
+    "base": "refreshed_origin_main",
+    "preserve_user_and_unique_evidence": true,
+    "sparse_pruned_or_hand_copied_workspaces_forbidden": true,
+    "type": "full_git_worktree"
+  }
+}

--- a/docs/integration/agent-execution-policy.md
+++ b/docs/integration/agent-execution-policy.md
@@ -1,0 +1,59 @@
+# Deterministic source-only agent execution
+
+This is the repository-wide default for automated agents. Its machine-readable
+contract is [agent-execution-policy.json](agent-execution-policy.json), and the
+binding instructions are embedded in [AGENTS.md](../../AGENTS.md).
+
+## The failure this prevents
+
+An agent must not respond to a build-environment failure by constructing a
+partial workspace, adding diagnostic probes, wrapping commands in supervisors,
+or retrying variants. A partial copy can omit an explicitly declared Cargo
+target while still looking like a plausible source checkout. Repeated attempts
+then spend time and tokens without increasing evidence about the product
+decision.
+
+Every automated change now starts from refreshed `origin/main` in a complete
+Git worktree. Agent work is limited to source inspection, declared edits,
+reviewable Git operations, and the static policy guard. Sparse, pruned, or
+hand-copied workspace capsules are prohibited.
+
+## Execution boundary
+
+Agents do not run or dispatch Cargo, Rust toolchain commands, builds, tests,
+linters, benchmarks, fuzzers, model execution, fitting, evaluation, browser or
+service probes, operating-system probes, or custom retry/supervisor wrappers.
+Pull-request and merge-group automation performs this static policy guard and
+the five ruleset transport acknowledgements only. Product and release QA stays
+available solely through the owner-operated `workflow_dispatch` path already
+defined in `.github/workflows/ci.yml`.
+
+An explicit owner instruction plus a protected pull request is required to
+change this policy. A task prompt, issue template, historical checklist, or
+agent judgment cannot silently activate an exception.
+
+## Failure and reporting budget
+
+When owner-run remote QA reports a concrete source failure, an agent may make
+one source correction based on that evidence. If the next owner-run result
+still fails, the work is parked with the exact source blocker. The agent does
+not probe the environment, invent another harness, or begin a retry campaign.
+Environment-probe and automatic-retry budgets are both zero.
+
+Agent reports contain the delivered result, the limits of source review, the
+closure state, and one concrete next action. Individual build, test, probe, and
+unchanged-poll narration is suppressed.
+
+## What this establishes
+
+The policy makes the automated development workflow bounded and predictable.
+It prevents the specific runaway validation pattern described above and makes
+policy drift visible in the protected path. It does not prove that research
+algorithms, third-party tools, operating systems, or model outputs are
+deterministic. Those remain separate product or release questions that only the
+owner may choose to evaluate.
+
+For this policy change, project builds, tests, probes, model runs, and product
+evaluations are `NOT_RUN_BY_POLICY`. The only executable validation is the
+standard-library static policy guard; it reads tracked text and does not import
+or execute project code.

--- a/scripts/check_agent_execution_policy.py
+++ b/scripts/check_agent_execution_policy.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Fail closed when the deterministic source-only agent policy drifts.
+
+This script uses the Python standard library, reads tracked text, and never
+imports or executes project code.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "docs/integration/agent-execution-policy.json"
+AGENTS_PATH = ROOT / "AGENTS.md"
+CONTRIBUTING_PATH = ROOT / "CONTRIBUTING.md"
+WORKFLOW_PATH = ROOT / ".github/workflows/ci.yml"
+POLICY_DOC_PATH = ROOT / "docs/integration/agent-execution-policy.md"
+INTEGRATION_INDEX_PATH = ROOT / "docs/integration/README.md"
+
+EXPECTED_POLICY: dict[str, Any] = {
+    "agent_scope": {
+        "applies_to": ["automated_repository_agents"],
+        "policy_change_requires": [
+            "explicit_owner_instruction",
+            "protected_pull_request",
+        ],
+    },
+    "failure_budget": {
+        "automatic_retries": 0,
+        "environment_probe_attempts": 0,
+        "source_corrections_after_concrete_remote_failure": 1,
+        "terminal_action_after_next_failure": "park_and_report",
+    },
+    "local_execution": {
+        "allowed": [
+            "read_repository_and_authoritative_sources",
+            "edit_declared_source_paths",
+            "git_status_diff_log_and_named_path_staging",
+            "run_static_agent_policy_guard",
+        ],
+        "forbidden": [
+            "cargo_rustc_rustup_and_wasm_pack",
+            "test_benchmark_fuzz_lint_and_build_runners",
+            "model_teacher_training_fitting_and_evaluation",
+            "browser_service_and_product_probes",
+            "sandbox_syscall_entitlement_and_environment_probes",
+            "custom_supervisors_watchdogs_and_retry_wrappers",
+        ],
+    },
+    "mode": "deterministic_source_only",
+    "remote_execution": {
+        "agent_may_dispatch_qa": False,
+        "owner_manual_qa_workflow": "workflow_dispatch_only",
+        "pull_request_and_merge_group": (
+            "static_policy_guard_plus_ruleset_transport_only"
+        ),
+    },
+    "reporting": {
+        "final_fields": [
+            "delivered_result",
+            "source_review_limits",
+            "closure_state",
+            "one_concrete_next_action",
+        ],
+        "suppress": [
+            "individual_build_progress",
+            "individual_test_progress",
+            "individual_probe_progress",
+            "unchanged_polling",
+        ],
+    },
+    "schema": "uor-r4.agent-execution-policy/1",
+    "workspace": {
+        "base": "refreshed_origin_main",
+        "preserve_user_and_unique_evidence": True,
+        "sparse_pruned_or_hand_copied_workspaces_forbidden": True,
+        "type": "full_git_worktree",
+    },
+}
+
+REQUIRED_TRANSPORT_JOBS = {
+    "required-core-transport",
+    "required-audit-transport",
+    "required-fuzz-transport",
+    "required-wasm-transport",
+    "required-gate-c-transport",
+}
+
+# These tokens are prohibited only in automatic PR/merge transport job `run:`
+# commands. Manual workflow_dispatch jobs intentionally retain release QA.
+PROHIBITED_AUTOMATIC_RUN_TOKENS = (
+    "cargo ",
+    "rustc ",
+    "rustup ",
+    "wasm-pack ",
+    "nextest ",
+    "pytest ",
+    "cargo-fuzz ",
+    "npm ",
+    "pnpm ",
+    "yarn ",
+    "scripts/gate_c",
+)
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def load_policy() -> dict[str, Any]:
+    try:
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot read canonical policy: {exc}")
+    if policy != EXPECTED_POLICY:
+        fail("agent execution policy differs from the guarded version")
+    canonical = json.dumps(policy, indent=2, sort_keys=True) + "\n"
+    if POLICY_PATH.read_text(encoding="utf-8") != canonical:
+        fail("agent execution policy JSON is not canonically serialized")
+    return policy
+
+
+def require_text(path: Path, fragments: tuple[str, ...]) -> str:
+    text = path.read_text(encoding="utf-8")
+    for fragment in fragments:
+        if fragment not in text:
+            fail(f"{path.relative_to(ROOT)} is missing required text: {fragment!r}")
+    return text
+
+
+def job_blocks(workflow: str) -> dict[str, str]:
+    try:
+        jobs = workflow.split("\njobs:\n", maxsplit=1)[1]
+    except IndexError:
+        fail("workflow has no jobs section")
+    matches = list(re.finditer(r"(?m)^  ([a-zA-Z0-9_-]+):\n", jobs))
+    blocks: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(jobs)
+        blocks[match.group(1)] = jobs[match.start() : end]
+    return blocks
+
+
+def run_commands(block: str) -> list[str]:
+    commands: list[str] = []
+    lines = block.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        single = re.match(r"^\s+-?\s*run:\s*(?![>|]\s*$)(.*)$", line)
+        if single:
+            commands.append(single.group(1).strip())
+            index += 1
+            continue
+        multiline = re.match(r"^(\s*)-?\s*run:\s*[>|]\s*$", line)
+        if multiline:
+            base_indent = len(multiline.group(1))
+            index += 1
+            body: list[str] = []
+            while index < len(lines):
+                candidate = lines[index]
+                if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= base_indent:
+                    break
+                body.append(candidate.strip())
+                index += 1
+            commands.append("\n".join(body))
+            continue
+        index += 1
+    return commands
+
+
+def check_workflow() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    event_section = workflow.split("concurrency:", maxsplit=1)[0]
+    for forbidden_event in ("  push:\n", "  schedule:\n", "  workflow_run:\n"):
+        if forbidden_event in event_section:
+            fail(f"automatic CI trigger is forbidden: {forbidden_event.strip()}")
+
+    blocks = job_blocks(workflow)
+    if not REQUIRED_TRANSPORT_JOBS.issubset(blocks):
+        missing = sorted(REQUIRED_TRANSPORT_JOBS - blocks.keys())
+        fail(f"required transport jobs are missing: {missing}")
+
+    required_if = (
+        "github.event_name == 'pull_request' || "
+        "github.event_name == 'merge_group'"
+    )
+    for name in sorted(REQUIRED_TRANSPORT_JOBS):
+        block = blocks[name]
+        if required_if not in block:
+            fail(f"{name} no longer has the bounded PR/merge trigger")
+        commands = run_commands(block)
+        allowed_commands = {
+            command
+            for command in commands
+            if command == "python3 scripts/check_agent_execution_policy.py"
+            or command.startswith('echo "Ruleset transport only;')
+        }
+        if len(allowed_commands) != len(commands):
+            fail(f"{name} contains a command outside the static/transport allowlist")
+        for command in commands:
+            lowered = command.lower()
+            for token in PROHIBITED_AUTOMATIC_RUN_TOKENS:
+                if token in lowered:
+                    fail(f"{name} contains prohibited automatic command token {token!r}")
+
+        uses = re.findall(r"(?m)^\s+(?:-\s+)?uses:\s*(\S+)\s*$", block)
+        expected_uses = ["actions/checkout@v4"] if name == "required-core-transport" else []
+        if uses != expected_uses:
+            fail(f"{name} contains actions outside the static/transport allowlist")
+
+    core = blocks["required-core-transport"]
+    if "uses: actions/checkout@v4" not in core:
+        fail("required-core-transport must use the complete repository checkout")
+    if "\n        with:" in core:
+        fail("required-core-transport checkout must not be sparse or filtered")
+    if "run: python3 scripts/check_agent_execution_policy.py" not in core:
+        fail("required-core-transport must execute the static policy guard")
+
+    for name, block in blocks.items():
+        if name in REQUIRED_TRANSPORT_JOBS:
+            continue
+        has_executable_qa = bool(run_commands(block)) or "uses:" in block
+        if has_executable_qa:
+            dispatch_if = re.search(
+                r"(?m)^    if: github\.event_name == 'workflow_dispatch'(?: && [^|\n]+)?$",
+                block,
+            )
+            if dispatch_if is None:
+                fail(f"executable job {name} is not restricted to workflow_dispatch")
+
+
+def main() -> int:
+    try:
+        load_policy()
+        agents = require_text(
+            AGENTS_PATH,
+            (
+                "<!-- agent-execution-policy:start -->",
+                "mode is `deterministic_source_only`",
+                "Sparse, pruned, filtered, or hand-copied workspace capsules",
+                "Agents do not run or dispatch builds, tests,",
+                "probes, model work, or QA.",
+                "<!-- agent-execution-policy:end -->",
+            ),
+        )
+        if agents.count("<!-- agent-execution-policy:start -->") != 1:
+            fail("AGENTS.md must contain exactly one policy start marker")
+        if agents.count("<!-- agent-execution-policy:end -->") != 1:
+            fail("AGENTS.md must contain exactly one policy end marker")
+        require_text(
+            CONTRIBUTING_PATH,
+            (
+                "Deterministic source-only agent policy",
+                "docs/integration/agent-execution-policy.json",
+                "Agents do not run or dispatch builds, tests,",
+                "probes, model work, or QA.",
+            ),
+        )
+        require_text(
+            POLICY_DOC_PATH,
+            (
+                "# Deterministic source-only agent execution",
+                "Environment-probe and automatic-retry budgets are both zero.",
+                "project builds, tests, probes, model runs, and product",
+                "`NOT_RUN_BY_POLICY`",
+            ),
+        )
+        require_text(
+            INTEGRATION_INDEX_PATH,
+            (
+                "[Deterministic source-only policy](agent-execution-policy.md)",
+                "[machine contract](agent-execution-policy.json)",
+            ),
+        )
+        check_workflow()
+    except (OSError, ValueError) as exc:
+        print(f"agent execution policy: FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print("agent execution policy: OK (static text only; no project code executed)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
An execution-environment failure could previously send an automated agent into partial workspace copies, diagnostic probes, supervisor wrappers, and retries, spending time and tokens without adding product evidence. This change establishes one repository-wide `deterministic_source_only` mode for automated work.

The policy requires a complete Git worktree from refreshed `origin/main`, forbids agent-run or agent-dispatched builds, tests, probes, model work, QA, sparse copies, supervisors, and automatic retries, and limits a concrete owner-run remote failure to one source correction before parking. Owner-operated release QA remains available only through the existing manual `workflow_dispatch` path.

The machine-readable policy is bound into `AGENTS.md` and `CONTRIBUTING.md`. A Python standard-library guard now runs inside the existing required core status on pull requests and merge groups. It validates the canonical policy, binding text, complete checkout, five historical status jobs, automatic-command allowlist, and manual-only boundary for every executable QA job. It imports and executes no project code.

Static validation:

- `python3 scripts/check_agent_execution_policy.py` -> `OK (static text only; no project code executed)`
- staged diff whitespace inspection -> clean
- project builds, tests, probes, model runs, and product evaluations -> `NOT_RUN_BY_POLICY`

Closes #1108.
