### PR TITLE
Expose artifact-only source-free table generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,21 @@ the deterministic packed artifact, and emits the exact decoded continuation.
 It is a statistical lexical baseline command, not an attention, semantic,
 correctness, chat, or release surface.
 
+Once the artifact exists, generate from it directly without the corpus:
+
+```bash
+cargo run --bin r4 -- source-free-generate \
+  --artifact /path/to/source-free-table.bin \
+  --prompt "The United States" \
+  --continuation-cap 16
+```
+
+Add `--json` to include the artifact CID, prompt, continuation, completed text,
+stop reason, and source-closure counters. This invocation loads only the packed
+table artifact. Its output is deterministic and prompt-conditioned within the
+table's lexical statistics; it does not establish semantic understanding or
+general language capability.
+
 To run the one frozen #953 comparison against that unchanged table baseline:
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,8 @@ enum Command {
     Route(RouteArgs),
     /// Run the bounded #953 provider-free decoded geometric generation witness.
     BoundedGeometricGenerate(BoundedGeometricGenerateArgs),
+    /// Load a source-free table artifact and generate without its source corpus.
+    SourceFreeGenerate(SourceFreeGenerateArgs),
     /// Build and measure the #989 source-free lexical table baseline.
     SourceFreeTable(SourceFreeTableArgs),
     /// Generate bounded text through all-layer R4/Spin causal softmax.
@@ -301,6 +303,25 @@ struct BoundedGeometricGenerateArgs {
     control: BoundedGeometricControl,
 
     /// Emit the generator's deterministic canonical JSON report.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args, Debug)]
+struct SourceFreeGenerateArgs {
+    /// Canonical SFTBL001 artifact produced by `source-free-table`.
+    #[arg(long, value_name = "FILE")]
+    artifact: PathBuf,
+
+    /// Exact UTF-8 prompt bytes to continue.
+    #[arg(long, value_name = "PROMPT")]
+    prompt: String,
+
+    /// Hard maximum number of emitted continuation lexical units.
+    #[arg(long, value_name = "UNITS")]
+    continuation_cap: usize,
+
+    /// Emit the generation result and artifact identity as JSON.
     #[arg(long)]
     json: bool,
 }
@@ -1755,6 +1776,7 @@ fn bounded_geometric_generate(args: &BoundedGeometricGenerateArgs) -> Result<(),
 }
 
 const SOURCE_FREE_TABLE_REPORT_SCHEMA: &str = "uor-r4-source-free-table-report/1";
+const SOURCE_FREE_GENERATION_SCHEMA: &str = "uor-r4-source-free-generation/1";
 const SOURCE_FREE_TABLE_POSITIVE: &str = "NUMERIC_BASELINE_GATE_MET_PENDING_REPLAY_BINDING";
 const SOURCE_FREE_TABLE_NEGATIVE: &str = "REPAIR_LEXICAL_REPRESENTATION_OR_COUNT_OBJECTIVE";
 const SOURCE_FREE_GEOMETRIC_REPORT_SCHEMA: &str =
@@ -1792,6 +1814,20 @@ struct SourceFreeClosureCounters {
     provider_calls: u64,
     source_weight_reads: u64,
     geometry_operations: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceFreeGenerationReport {
+    schema: &'static str,
+    artifact_cid: String,
+    artifact_bytes: usize,
+    prompt: String,
+    continuation_cap: usize,
+    emitted_units: usize,
+    continuation: String,
+    text: String,
+    stop: &'static str,
+    source_closure: SourceFreeClosureCounters,
 }
 
 #[derive(Debug, Serialize)]
@@ -1987,6 +2023,57 @@ struct SourceFreeGeometricReport {
 struct SourceFreeGeometricEnvelope {
     report_payload_cid: String,
     report: SourceFreeGeometricReport,
+}
+
+fn source_free_generate(args: &SourceFreeGenerateArgs) -> Result<(), RunError> {
+    let artifact_bytes = std::fs::read(&args.artifact).map_err(|error| {
+        RunError::Command(format!(
+            "read source-free table artifact {}: {error}",
+            args.artifact.display()
+        ))
+    })?;
+    let table = SourceFreeTable::from_bytes(&artifact_bytes).map_err(|error| {
+        RunError::Command(format!(
+            "load source-free table artifact {}: {error}",
+            args.artifact.display()
+        ))
+    })?;
+    let continuation = table
+        .continue_text(args.prompt.as_bytes(), args.continuation_cap)
+        .map_err(|error| RunError::Command(format!("generate from source-free table: {error}")))?;
+    let continuation_text = String::from_utf8(continuation.decoded).map_err(|error| {
+        RunError::Command(format!("source-free continuation is not UTF-8: {error}"))
+    })?;
+    let generated_text = format!("{}{}", args.prompt, continuation_text);
+
+    if args.json {
+        let report = SourceFreeGenerationReport {
+            schema: SOURCE_FREE_GENERATION_SCHEMA,
+            artifact_cid: table.artifact_cid(),
+            artifact_bytes: artifact_bytes.len(),
+            prompt: args.prompt.clone(),
+            continuation_cap: args.continuation_cap,
+            emitted_units: continuation.tokens.len(),
+            continuation: continuation_text,
+            text: generated_text,
+            stop: source_free_continuation_stop(continuation.stop),
+            source_closure: SourceFreeClosureCounters {
+                teacher_calls: 0,
+                provider_calls: 0,
+                source_weight_reads: 0,
+                geometry_operations: 0,
+            },
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).map_err(|error| {
+                RunError::Command(format!("serialize source-free generation: {error}"))
+            })?
+        );
+    } else {
+        println!("{generated_text}");
+    }
+    Ok(())
 }
 
 fn source_free_table(args: &SourceFreeTableArgs) -> Result<(), RunError> {
@@ -2534,6 +2621,7 @@ fn local_generation_stop_label(reason: LocalGenerationStopReason) -> String {
 
 fn print_research_tools() {
     println!("Active capability-first command:");
+    println!("  source-free-generate");
     println!("  source-free-table");
     println!();
     println!("Preserved research commands (not required for the table baseline):");
@@ -2632,6 +2720,7 @@ fn run(cli: &Cli) -> Result<(), RunError> {
         }
         Some(Command::Route(args)) => route_demo(args),
         Some(Command::BoundedGeometricGenerate(args)) => bounded_geometric_generate(args),
+        Some(Command::SourceFreeGenerate(args)) => source_free_generate(args),
         Some(Command::SourceFreeTable(args)) => source_free_table(args),
         Some(Command::R4SoftmaxGenerate(args)) => {
             let workers = std::num::NonZeroUsize::new(args.workers).ok_or_else(|| {


### PR DESCRIPTION
## What changed

Adds `r4 source-free-generate`, an artifact-only inference path for the established `SFTBL001` lexical table. The command validates and loads canonical packed bytes, continues the exact prompt through the existing deterministic table runtime, and emits either completed text or compact JSON with the artifact identity and stop reason. The source corpus, teacher, provider, and source weights are not opened by this invocation.

README now shows the direct artifact-loading command separately from table construction/evaluation.

## Direct behavior

Built the `r4` binary and loaded the retained 35,655,288-byte #973 artifact at `blake3:ccdc399731cb866a329be478467a434cda4e445813421e5d17c21ccc87288297`.

- `The United States` continued as `. It is the most important thing to do so.\n 1985 – The first people`.
- `Albert Einstein` continued as ` (14 January 1798 - 4.5 million people live in the United States.`.

Both emitted 16 lexical units and stopped at the requested cap. The outputs are distinct, demonstrating prompt-suffix-conditioned artifact execution. The Einstein continuation is factually wrong, so this is not coherent language, semantic correctness, or completion of #973.

## Checks

- `cargo check --bin r4`
- `cargo clippy --bin r4 -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check_claim_wording.py`
- direct CLI help plus two real-artifact generation invocations

References #973.
