### PR TITLE
Implement contextual retained value writes

### DIFF
--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -359,6 +359,23 @@ without training or opening train, validation, source, or sealed data. Its
 create-once result is a local autonomous-decoding smoke, not a coherence,
 reasoning, H4-superiority, lowering, browser, or release claim.
 
+The build-first contextual value-write successor can be exercised directly on
+an arbitrary prompt without a fit or corpus read:
+
+```bash
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" generate-contextual-retained \
+  --prompt "A purple turtle found a clock in the garden" \
+  --max-new-tokens 32
+```
+
+This version writes `Wv(RMSNorm(x_t + a_t))`, where `a_t` is the ungated
+strict-prior retained residual, into the existing identity-addressed value
+field. It adds no parameters or recurrent tensors and leaves the historical V1
+path unchanged. The loaded weights were fitted under V1's token-only write, so
+the command demonstrates executable source-free behavior; it does not claim
+that the changed write has been fitted or improves language quality.
+
 ## Terminal #973 paired-H4 prompt-capacity rung
 
 [`R4PairedH4PromptCapacityV1`](../../docs/r4_paired_h4_prompt_capacity_973.md)

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -34,6 +34,7 @@ from .continuation_data import (
     load_continuation_training_view_manifest,
     prepare_continuation_dataset,
 )
+from .contextual_retained_generation import generate_contextual_retained
 from .data import download_source, load_dataset_manifest, prepare_dataset
 from .direct_retained_readout_campaign import (
     prepare_direct_retained_readout,
@@ -615,6 +616,27 @@ def parser() -> argparse.ArgumentParser:
             "autonomous generation smoke"
         ),
     )
+    generate_contextual = subcommands.add_parser(
+        "generate-contextual-retained",
+        help=(
+            "continue one arbitrary prompt through #973's contextual retained "
+            "value-write successor"
+        ),
+    )
+    generate_contextual.add_argument("--prompt", required=True)
+    generate_contextual.add_argument(
+        "--geometry",
+        type=_root,
+        default=default_language_path_geometry(),
+        help="canonical exact-H4 group geometry",
+    )
+    generate_contextual.add_argument("--max-new-tokens", type=int, default=32)
+    generate_contextual.add_argument("--seed", type=int, default=9_738)
+    generate_contextual.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the artifact identities, token IDs, and execution details",
+    )
     prepare_paired_h4 = subcommands.add_parser(
         "prepare-paired-h4-prompt-capacity",
         help=(
@@ -1102,6 +1124,7 @@ def main() -> None:
         "probe-language-path",
         "run-language-path",
         "generate-language-path",
+        "generate-contextual-retained",
     }
     paired_h4_prompt_capacity_commands = {
         "prepare-paired-h4-prompt-capacity",
@@ -1421,6 +1444,19 @@ def main() -> None:
         return
     if arguments.command == "generate-language-path":
         _print_result(run_language_path_generation(root))
+        return
+    if arguments.command == "generate-contextual-retained":
+        result = generate_contextual_retained(
+            root,
+            geometry_path=arguments.geometry,
+            prompt=arguments.prompt,
+            max_new_tokens=arguments.max_new_tokens,
+            seed=arguments.seed,
+        )
+        if arguments.json:
+            _print_result(result)
+        else:
+            print(result["text"])
         return
     if arguments.command == "prepare-paired-h4-prompt-capacity":
         prepared = prepare_paired_h4_prompt_capacity(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
@@ -1,0 +1,200 @@
+"""Direct source-free generation with the contextual retained value write.
+
+The command loads the already fitted compact retained artifact and changes only
+the recurrent value source used by the versioned contextual-write model.  It
+does not train, select a checkpoint, or read corpus data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from blake3 import blake3
+from tokenizers import Tokenizer
+
+from .group_retention_campaign import load_group_geometry_artifacts
+from .language_path_generalization import (
+    CONTEXT,
+    VOCAB_SIZE,
+    R4ContextualValueWriteLanguagePathV1,
+)
+from .language_path_generation import (
+    BOS_TOKEN_ID,
+    EOS_TOKEN_ID,
+    TEMPERATURE,
+    TOP_K,
+    ByteLevelRawDecoder,
+    SplitMix64,
+    sample_top_k_q32,
+    short_cycle_period,
+)
+
+
+SCHEMA = "uor-r4.contextual-retained-generation/1"
+POLICY = "R4ContextualValueWriteLanguagePathV1"
+DEFAULT_MAX_NEW_TOKENS = 32
+DEFAULT_SEED = 9_738
+TOKENIZER_RELATIVE_PATH = Path("tokenizer/tokenizer.json")
+ARTIFACT_RELATIVE_PATH = Path("arms/retained/model.safetensors")
+
+
+def _record(path: Path, payload: bytes) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "bytes": len(payload),
+        "cid": f"blake3:{blake3(payload).hexdigest()}",
+    }
+
+
+def _decode_utf8(payload: bytes) -> tuple[str, bool]:
+    try:
+        return payload.decode("utf-8"), True
+    except UnicodeDecodeError:
+        return payload.decode("utf-8", errors="replace"), False
+
+
+def generate_contextual_retained(
+    root: Path,
+    *,
+    geometry_path: Path,
+    prompt: str,
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, Any]:
+    """Generate one continuation through the contextual-write direct cell."""
+
+    if not isinstance(prompt, str) or not prompt:
+        raise ValueError("prompt must be a nonempty string")
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int):
+        raise TypeError("max_new_tokens must be an integer")
+    if max_new_tokens < 1:
+        raise ValueError("max_new_tokens must be positive")
+
+    resolved_root = root.expanduser().resolve()
+    resolved_geometry = geometry_path.expanduser().resolve()
+    tokenizer_path = resolved_root / TOKENIZER_RELATIVE_PATH
+    artifact_path = resolved_root / ARTIFACT_RELATIVE_PATH
+    tokenizer_payload = tokenizer_path.read_bytes()
+    artifact_payload = artifact_path.read_bytes()
+    geometry_payload = resolved_geometry.read_bytes()
+
+    tokenizer = Tokenizer.from_file(str(tokenizer_path))
+    raw_decoder = ByteLevelRawDecoder.from_tokenizer_json(tokenizer_path)
+    prompt_token_ids = list(tokenizer.encode(prompt, add_special_tokens=False).ids)
+    if not prompt_token_ids:
+        raise ValueError("prompt produced no tokenizer IDs")
+    if any(token < 0 or token >= VOCAB_SIZE for token in prompt_token_ids):
+        raise ValueError("prompt produced an out-of-vocabulary token ID")
+    if raw_decoder.decode_bytes(prompt_token_ids) != prompt.encode("utf-8"):
+        raise ValueError("prompt does not round-trip through the retained tokenizer")
+
+    input_token_ids = [BOS_TOKEN_ID, *prompt_token_ids]
+    processed_ceiling = len(input_token_ids) + max_new_tokens - 1
+    if processed_ceiling > CONTEXT:
+        raise ValueError(
+            "prompt plus generated prefix exceeds the model's 120-token context"
+        )
+
+    geometry = load_group_geometry_artifacts(resolved_geometry).exact_h4
+    model = R4ContextualValueWriteLanguagePathV1(geometry)
+    model.load_learned_artifact(artifact_payload)
+    model.to(device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+    torch.use_deterministic_algorithms(True)
+
+    state = model.initial_state(1, device=torch.device("cpu"), dtype=torch.float32)
+    sampler = SplitMix64(seed)
+    generated: list[int] = []
+    logits: torch.Tensor | None = None
+    processed_tokens = 0
+    stop: str | dict[str, Any] = "maximum_new_tokens"
+
+    with torch.inference_mode():
+        for token in input_token_ids:
+            step = model.step(
+                torch.tensor([token], dtype=torch.long),
+                state,
+                attention_off=False,
+            )
+            if (
+                step.audit.implementation != "direct"
+                or step.audit.state_off
+                or step.audit.forbidden_reads != 0
+            ):
+                raise RuntimeError("generation left the direct retained execution path")
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(dtype=torch.float32).contiguous()
+            processed_tokens += 1
+
+        if logits is None:
+            raise RuntimeError("prompt produced no next-token logits")
+        for decision in range(max_new_tokens):
+            token = int(sample_top_k_q32(logits, sampler))
+            if not 0 <= token < VOCAB_SIZE:
+                raise RuntimeError("sampler selected a token outside the vocabulary")
+            generated.append(token)
+            if token == EOS_TOKEN_ID:
+                stop = "eos"
+                break
+            period = short_cycle_period(generated)
+            if period is not None:
+                stop = {"short_cycle": {"period": period}}
+                break
+            if decision + 1 == max_new_tokens:
+                break
+            step = model.step(
+                torch.tensor([token], dtype=torch.long),
+                state,
+                attention_off=False,
+            )
+            if (
+                step.audit.implementation != "direct"
+                or step.audit.state_off
+                or step.audit.forbidden_reads != 0
+            ):
+                raise RuntimeError("generation left the direct retained execution path")
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(dtype=torch.float32).contiguous()
+            processed_tokens += 1
+
+    response_ids = generated[:-1] if generated and generated[-1] == EOS_TOKEN_ID else generated
+    continuation, utf8_decodable = _decode_utf8(raw_decoder.decode_bytes(response_ids))
+    return {
+        "schema": SCHEMA,
+        "status": "GENERATED",
+        "model": {
+            "policy": POLICY,
+            "value_write": "Wv(RMSNorm(x_t + strict_prior_retained_residual))",
+            "parameters_added": 0,
+            "fitted_under_value_write": "Wv(RMSNorm(x_t))",
+        },
+        "inputs": {
+            "model_artifact": _record(artifact_path, artifact_payload),
+            "tokenizer": _record(tokenizer_path, tokenizer_payload),
+            "geometry": _record(resolved_geometry, geometry_payload),
+            "corpus_files_read": 0,
+            "teacher_files_read": 0,
+        },
+        "prompt": prompt,
+        "prompt_token_ids": prompt_token_ids,
+        "seed": seed,
+        "sampler": {"type": "top-k-q32-splitmix64", "top_k": TOP_K, "temperature": TEMPERATURE},
+        "max_new_tokens": max_new_tokens,
+        "generated_token_ids": generated,
+        "continuation": continuation,
+        "text": prompt + continuation,
+        "utf8_decodable": utf8_decodable,
+        "stop": stop,
+        "processed_tokens": processed_tokens,
+    }
+
+
+__all__ = [
+    "DEFAULT_MAX_NEW_TOKENS",
+    "DEFAULT_SEED",
+    "POLICY",
+    "SCHEMA",
+    "generate_contextual_retained",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
@@ -733,6 +733,67 @@ class _RetainedDecoderBlock(nn.Module):
             transported_occupied,
         )
 
+    def forward_direct_step_with_contextual_value_write(
+        self,
+        values: Tensor,
+        token_actions: Tensor,
+        key_state: Tensor,
+        value_state: Tensor,
+        occupied: Tensor,
+        identity_offset: int,
+        *,
+        state_off: bool,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Write the current causal context through the existing value field.
+
+        This is the direct cell for the versioned contextual-write successor.
+        The retained read still uses only the transported strict-prior field.
+        Its ungated output is combined with the current residual-stream input
+        before ``v_proj`` supplies the identity-slot value write.  Existing V1
+        entry points above retain their original token-only write source.
+        """
+
+        batch = int(values.shape[0])
+        heads = self.config.heads
+        group = self.config.group_size
+        head_dim = self.config.head_dim
+        normalized = self.input_layernorm(values)
+        query = self._heads(self.q_proj(normalized))
+        key = self._heads(self.k_proj(normalized))
+        rho, eta = self.resolved_gates()
+
+        indices = token_actions[:, None, :, None].expand(batch, heads, group, head_dim)
+        transported_keys = torch.gather(key_state, dim=2, index=indices)
+        transported_values = torch.gather(value_state, dim=2, index=indices)
+        transported_occupied = torch.gather(occupied, dim=1, index=token_actions)
+        decayed_keys = transported_keys * rho.view(1, heads, 1, 1)
+        decayed_values = transported_values * rho.view(1, heads, 1, 1)
+
+        retained = self._attend(query, decayed_keys, decayed_values, transported_occupied)
+        retained = self.o_proj(retained.reshape(batch, self.config.hidden_size))
+        contextual = self.input_layernorm(values + retained)
+        value = self._heads(self.v_proj(contextual))
+
+        visible_retained = retained * (0.0 if state_off else 1.0)
+        values = values + visible_retained
+        values = values + self.mlp(self.post_attention_layernorm(values))
+
+        identity_mask = F.one_hot(
+            torch.tensor(identity_offset, device=values.device), num_classes=group
+        ).to(decayed_keys.dtype)
+        prior_keys = decayed_keys[:, :, identity_offset, :]
+        prior_values = decayed_values[:, :, identity_offset, :]
+        key_delta = eta.view(1, heads, 1) * (key - prior_keys)
+        value_delta = eta.view(1, heads, 1) * (value - prior_values)
+        final_keys = decayed_keys + key_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_values = decayed_values + value_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_occupied = transported_occupied | identity_mask.bool().view(1, group)
+        return values, final_keys, final_values, final_occupied
+
 
 class R4GroupAddressedRetentionDecoderV1(nn.Module):
     """Two-block tied-head language model with fixed-state geometric attention."""

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
@@ -35,6 +35,7 @@ from .model import RMSNorm, RotaryEmbedding, SwiGLU
 
 
 POLICY = "R4RetainedLanguagePathV1"
+CONTEXTUAL_VALUE_WRITE_POLICY = "R4ContextualValueWriteLanguagePathV1"
 ORDINARY_POLICY = "OrdinaryCausalSoftmaxLanguagePathV1"
 
 VOCAB_SIZE = 4_096
@@ -241,6 +242,149 @@ class R4RetainedLanguagePathV1(R4GroupAddressedRetentionDecoderV1):
             token_ids[:, None],
             initial_state=state,
             state_off=attention_off,
+            implementation="direct",
+        )
+        return DecoderStepOutput(
+            logits=output.logits[:, 0, :],
+            final_state=output.final_state,
+            audit=output.audit,
+        )
+
+
+class R4ContextualValueWriteLanguagePathV1(R4RetainedLanguagePathV1):
+    """Versioned retained path that writes its ungated causal attention context.
+
+    The learned parameters, recurrent-state tensors, geometry, and output head
+    are byte-compatible with ``R4RetainedLanguagePathV1``.  Only the value
+    written at the transported identity address changes.  Full-sequence,
+    incremental, and one-token calls all traverse the same causal direct cell;
+    the stationary closed form is inapplicable once a write depends on its
+    strict-prior retained read.
+    """
+
+    policy = CONTEXTUAL_VALUE_WRITE_POLICY
+
+    def __init__(self, geometry: GroupAddressArtifact) -> None:
+        super().__init__(geometry)
+        if (
+            self.parameter_count() != PARAMETER_COUNT
+            or self.state_value_count() != STATE_VALUES
+            or self.validity_bit_count() != VALIDITY_BITS
+        ):
+            raise RuntimeError("contextual value-write path changed the qualified ledger")
+
+    def _contextual_direct_hidden(
+        self, token_ids: Tensor, state: DecoderState, *, state_off: bool
+    ) -> tuple[Tensor, DecoderState]:
+        outputs: list[Tensor] = []
+        current = state
+        for time_index in range(int(token_ids.shape[1])):
+            token = token_ids[:, time_index]
+            values = self.token_embedding(token)
+            leaves = self.token_leaves.index_select(0, token)
+            actions = self.left_actions.index_select(0, leaves)
+            keys: list[Tensor] = []
+            retained_values: list[Tensor] = []
+            occupied: list[Tensor] = []
+            for layer_index, layer in enumerate(self.layers):
+                values, layer_keys, layer_values, layer_occupied = (
+                    layer.forward_direct_step_with_contextual_value_write(
+                        values,
+                        actions,
+                        current.keys[layer_index],
+                        current.values[layer_index],
+                        current.occupied[layer_index],
+                        self.identity_offset,
+                        state_off=state_off,
+                    )
+                )
+                keys.append(layer_keys)
+                retained_values.append(layer_values)
+                occupied.append(layer_occupied)
+            current = DecoderState(
+                keys=torch.stack(keys),
+                values=torch.stack(retained_values),
+                occupied=torch.stack(occupied),
+            )
+            outputs.append(values)
+        return torch.stack(outputs, dim=1), current
+
+    def forward(
+        self,
+        token_ids: Tensor,
+        targets: Tensor | None = None,
+        *,
+        attention_off: bool = False,
+        initial_state: DecoderState | None = None,
+        implementation: Literal["direct"] = "direct",
+    ) -> DecoderOutput:
+        """Run a full token sequence through the contextual direct recurrence."""
+
+        if token_ids.ndim != 2:
+            raise ValueError("token_ids must have shape [batch,time]")
+        if implementation != "direct":
+            raise ValueError("contextual value-write path requires 'direct' implementation")
+        state = (
+            self.initial_state(int(token_ids.shape[0]))
+            if initial_state is None
+            else initial_state
+        )
+        self._validate_inputs(token_ids, targets, state)
+        hidden, final_state = self._contextual_direct_hidden(
+            token_ids, state, state_off=attention_off
+        )
+        hidden = self.final_norm(hidden)
+        logits = F.linear(hidden, self.output_weight)
+        loss = None
+        if targets is not None:
+            loss = F.cross_entropy(
+                logits.float().reshape(-1, self.config.vocab_size), targets.reshape(-1)
+            )
+        return DecoderOutput(
+            logits=logits,
+            loss=loss,
+            final_state=final_state,
+            audit=self._audit(
+                int(token_ids.shape[0]),
+                int(token_ids.shape[1]),
+                state_off=attention_off,
+                implementation="direct",
+            ),
+        )
+
+    def forward_incremental(
+        self,
+        token_ids: Tensor,
+        targets: Tensor | None = None,
+        *,
+        attention_off: bool = False,
+        initial_state: DecoderState | None = None,
+    ) -> DecoderOutput:
+        """Run one or more tokens through the same contextual direct recurrence."""
+
+        return self.forward(
+            token_ids,
+            targets,
+            attention_off=attention_off,
+            initial_state=initial_state,
+            implementation="direct",
+        )
+
+    def step(
+        self,
+        token_ids: Tensor,
+        state: DecoderState,
+        *,
+        attention_off: bool = False,
+    ) -> DecoderStepOutput:
+        """Advance one token through the contextual direct recurrence."""
+
+        if token_ids.ndim != 1:
+            raise ValueError("incremental token_ids must have shape [batch]")
+        output = self.forward(
+            token_ids[:, None],
+            initial_state=state,
+            attention_off=attention_off,
             implementation="direct",
         )
         return DecoderStepOutput(


### PR DESCRIPTION
The retained decoder still wrote only `Wv(RMSNorm(x_t))` into its identity-addressed value field, so prompt context recovered by the strict-prior retained read was never stored for later tokens. This adds a versioned, parameter-compatible `R4ContextualValueWriteLanguagePathV1` that writes `Wv(RMSNorm(x_t + a_t))`, where `a_t` is the ungated strict-prior retained residual, while preserving the historical V1 implementation and artifact shape. An arbitrary-prompt `generate-contextual-retained` command loads the existing fitted artifact and exercises the new direct recurrence without training or corpus access.

Direct checks:
- `A purple turtle found a clock in the garden` -> `. She was a little cat named Tom. The cat went with Sam. They`
- `Albert Einstein was born in` -> ` the dog. He said to the ground. They said, "Max, you`
- both invocations loaded artifact `blake3:d1417b325e7a545057cd38e9f1a723933a3682801877433d20e98774a5e9172d`, completed on CPU, and reported zero corpus/teacher file reads
- `git diff --check`

The second output is factually incoherent. These weights were fitted under the old token-only write, so this PR establishes executable source-free behavior for the changed write law, not improved language quality or a fitted contextual model.

References #973.
