### PR TITLE
#973: Fit contextual retained value writes

### DIFF
--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -359,12 +359,18 @@ without training or opening train, validation, source, or sealed data. Its
 create-once result is a local autonomous-decoding smoke, not a coherence,
 reasoning, H4-superiority, lowering, browser, or release claim.
 
-The build-first contextual value-write successor can be exercised directly on
-an arbitrary prompt without a fit or corpus read:
+The build-first contextual value-write successor can first adapt the existing
+weights on the copied open training store, then generate from the separate
+artifact without changing the historical V1 artifact:
 
 ```bash
 uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" fit-contextual-retained
+
+CONTEXTUAL="$ROOT/arms/contextual-retained/model.safetensors"
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
   --root "$ROOT" generate-contextual-retained \
+  --artifact "$CONTEXTUAL" \
   --prompt "A purple turtle found a clock in the garden" \
   --max-new-tokens 32
 ```
@@ -372,9 +378,11 @@ uv run --offline --project "$TRAINER" r4-softmax-trainer \
 This version writes `Wv(RMSNorm(x_t + a_t))`, where `a_t` is the ungated
 strict-prior retained residual, into the existing identity-addressed value
 field. It adds no parameters or recurrent tensors and leaves the historical V1
-path unchanged. The loaded weights were fitted under V1's token-only write, so
-the command demonstrates executable source-free behavior; it does not claim
-that the changed write has been fitted or improves language quality.
+path unchanged. The fit is a fixed maximum of 128 warm-start updates over 2,048
+open training windows, with a hard 840-second wall. It reads no validation,
+sealed, teacher, or source-model files. This bounded adaptation is not a
+convergence or language-quality claim; the direct generation output remains the
+behavioral check.
 
 ## Terminal #973 paired-H4 prompt-capacity rung
 

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -34,6 +34,7 @@ from .continuation_data import (
     load_continuation_training_view_manifest,
     prepare_continuation_dataset,
 )
+from .contextual_retained_fit import fit_contextual_retained
 from .contextual_retained_generation import generate_contextual_retained
 from .data import download_source, load_dataset_manifest, prepare_dataset
 from .direct_retained_readout_campaign import (
@@ -616,6 +617,16 @@ def parser() -> argparse.ArgumentParser:
             "autonomous generation smoke"
         ),
     )
+    fit_contextual = subcommands.add_parser(
+        "fit-contextual-retained",
+        help=(
+            "adapt the existing retained artifact through #973's contextual "
+            "value write using open training bytes only"
+        ),
+    )
+    fit_contextual.add_argument("--updates", type=int, default=128)
+    fit_contextual.add_argument("--threads", type=int, choices=[4], default=4)
+    fit_contextual.add_argument("--max-seconds", type=float, default=840.0)
     generate_contextual = subcommands.add_parser(
         "generate-contextual-retained",
         help=(
@@ -624,6 +635,11 @@ def parser() -> argparse.ArgumentParser:
         ),
     )
     generate_contextual.add_argument("--prompt", required=True)
+    generate_contextual.add_argument(
+        "--artifact",
+        type=_root,
+        help="retained artifact to load; defaults to the historical V1 artifact",
+    )
     generate_contextual.add_argument(
         "--geometry",
         type=_root,
@@ -1124,6 +1140,7 @@ def main() -> None:
         "probe-language-path",
         "run-language-path",
         "generate-language-path",
+        "fit-contextual-retained",
         "generate-contextual-retained",
     }
     paired_h4_prompt_capacity_commands = {
@@ -1445,11 +1462,22 @@ def main() -> None:
     if arguments.command == "generate-language-path":
         _print_result(run_language_path_generation(root))
         return
+    if arguments.command == "fit-contextual-retained":
+        _print_result(
+            fit_contextual_retained(
+                root,
+                updates=arguments.updates,
+                threads=arguments.threads,
+                max_seconds=arguments.max_seconds,
+            )
+        )
+        return
     if arguments.command == "generate-contextual-retained":
         result = generate_contextual_retained(
             root,
             geometry_path=arguments.geometry,
             prompt=arguments.prompt,
+            artifact_path=arguments.artifact,
             max_new_tokens=arguments.max_new_tokens,
             seed=arguments.seed,
         )

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
@@ -1,0 +1,256 @@
+"""Bounded training-only adaptation for the contextual retained value write."""
+
+from __future__ import annotations
+
+import os
+import platform
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .group_retention_campaign import load_group_geometry_artifacts
+from .language_path_generalization import (
+    CONTEXT,
+    PARAMETER_COUNT,
+    R4ContextualValueWriteLanguagePathV1,
+)
+from .language_path_generalization_campaign import (
+    ADAM_BETA1,
+    ADAM_BETA2,
+    ADAM_EPSILON,
+    GRADIENT_CLIP,
+    WEIGHT_DECAY,
+    learning_rate,
+)
+from .language_path_generalization_data import (
+    EXPECTED_TRAIN_SLICE_CID,
+    TRAIN_WINDOWS,
+    WINDOW_TOKENS,
+    LanguagePathWindowStore,
+    deterministic_window_order,
+)
+from .provenance import atomic_write, atomic_write_json, cid_bytes, cid_file
+
+
+SCHEMA = "uor-r4.contextual-retained-fit/1"
+STATUS = "CONTEXTUAL_RETAINED_ADAPTED"
+MAX_UPDATES = 128
+DEFAULT_UPDATES = MAX_UPDATES
+BATCH_SIZE = 16
+THREADS = 4
+MAX_SECONDS = 840.0
+EXPECTED_INITIAL_ARTIFACT_CID = (
+    "blake3:d1417b325e7a545057cd38e9f1a723933a3682801877433d20e98774a5e9172d"
+)
+EXPECTED_GEOMETRY_CID = (
+    "blake3:a812cf6749e637f4c486a6ad206b96c90d695b5c4bb2ed029df3c6bef147d702"
+)
+TRAIN_RELATIVE_PATH = Path("data/train.u16")
+GEOMETRY_RELATIVE_PATH = Path("geometry/r4-group-address-geometry.json")
+INITIAL_ARTIFACT_RELATIVE_PATH = Path("arms/retained/model.safetensors")
+OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained")
+OUTPUT_ARTIFACT_RELATIVE_PATH = OUTPUT_DIRECTORY_RELATIVE_PATH / "model.safetensors"
+OUTPUT_RESULT_RELATIVE_PATH = OUTPUT_DIRECTORY_RELATIVE_PATH / "fit.json"
+VALUE_WRITE = "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
+
+
+def _input_record(path: Path, expected_cid: str) -> dict[str, Any]:
+    observed_cid = cid_file(path)
+    if observed_cid != expected_cid:
+        raise ValueError(f"input artifact differs: {path}")
+    return {"path": str(path), "bytes": path.stat().st_size, "cid": observed_cid}
+
+
+def _configure_cpu(threads: int) -> dict[str, Any]:
+    if threads != THREADS:
+        raise ValueError("contextual retained fit requires four CPU threads")
+    os.environ["OMP_NUM_THREADS"] = str(threads)
+    os.environ["VECLIB_MAXIMUM_THREADS"] = str(threads)
+    os.environ["OPENBLAS_NUM_THREADS"] = str(threads)
+    torch.set_num_threads(threads)
+    try:
+        torch.set_num_interop_threads(threads)
+    except RuntimeError:
+        if torch.get_num_interop_threads() != threads:
+            raise
+    torch.use_deterministic_algorithms(True)
+    return {
+        "device": "cpu",
+        "dtype": "float32",
+        "platform": platform.system(),
+        "threads": threads,
+    }
+
+
+def _require_first_step_gradients(model: torch.nn.Module) -> int:
+    missing: list[str] = []
+    for name, parameter in model.named_parameters():
+        gradient = parameter.grad
+        if (
+            gradient is None
+            or not bool(torch.isfinite(gradient).all())
+            or not bool(torch.count_nonzero(gradient))
+        ):
+            missing.append(name)
+    if missing:
+        raise RuntimeError(f"contextual fit has absent, zero, or nonfinite gradients: {missing}")
+    return len(tuple(model.parameters()))
+
+
+def fit_contextual_retained(
+    root: Path,
+    *,
+    updates: int = DEFAULT_UPDATES,
+    threads: int = THREADS,
+    max_seconds: float = MAX_SECONDS,
+) -> dict[str, Any]:
+    """Warm-start and adapt all retained parameters using open training bytes."""
+
+    if isinstance(updates, bool) or not isinstance(updates, int):
+        raise TypeError("updates must be an integer")
+    if not 1 <= updates <= MAX_UPDATES:
+        raise ValueError(f"updates must be between 1 and {MAX_UPDATES}")
+    if (
+        isinstance(max_seconds, bool)
+        or not isinstance(max_seconds, (int, float))
+        or not 0.0 < float(max_seconds) <= MAX_SECONDS
+    ):
+        raise ValueError(f"max_seconds must be positive and at most {MAX_SECONDS}")
+
+    started = time.monotonic()
+    resolved_root = root.expanduser().resolve()
+    train_path = resolved_root / TRAIN_RELATIVE_PATH
+    geometry_path = resolved_root / GEOMETRY_RELATIVE_PATH
+    initial_artifact_path = resolved_root / INITIAL_ARTIFACT_RELATIVE_PATH
+    output_directory = resolved_root / OUTPUT_DIRECTORY_RELATIVE_PATH
+    output_artifact_path = resolved_root / OUTPUT_ARTIFACT_RELATIVE_PATH
+    output_result_path = resolved_root / OUTPUT_RESULT_RELATIVE_PATH
+    if output_directory.exists():
+        raise FileExistsError(f"contextual fit output already exists: {output_directory}")
+
+    training_input = _input_record(train_path, EXPECTED_TRAIN_SLICE_CID)
+    geometry_input = _input_record(geometry_path, EXPECTED_GEOMETRY_CID)
+    initial_input = _input_record(
+        initial_artifact_path, EXPECTED_INITIAL_ARTIFACT_CID
+    )
+    execution = _configure_cpu(threads)
+    store = LanguagePathWindowStore(train_path, window_count=TRAIN_WINDOWS)
+    order = deterministic_window_order(TRAIN_WINDOWS)
+    geometry = load_group_geometry_artifacts(geometry_path).exact_h4
+    model = R4ContextualValueWriteLanguagePathV1(geometry).to(
+        device=torch.device("cpu"), dtype=torch.float32
+    )
+    model.load_learned_artifact(initial_artifact_path.read_bytes())
+    if model.parameter_count() != PARAMETER_COUNT:
+        raise RuntimeError("contextual retained parameter count changed")
+
+    parameters = tuple(model.parameters())
+    optimizer = torch.optim.AdamW(
+        parameters,
+        lr=learning_rate(0),
+        betas=(ADAM_BETA1, ADAM_BETA2),
+        eps=ADAM_EPSILON,
+        weight_decay=WEIGHT_DECAY,
+    )
+    optimizer_values = sum(
+        parameter.numel()
+        for group in optimizer.param_groups
+        for parameter in group["params"]
+    )
+    if optimizer_values != PARAMETER_COUNT:
+        raise RuntimeError("optimizer does not include every contextual retained parameter")
+
+    losses: list[float] = []
+    gradient_parameter_tensors = 0
+    model.train()
+    for update in range(1, updates + 1):
+        if time.monotonic() - started >= float(max_seconds):
+            raise TimeoutError("contextual retained fit reached its hard wall limit")
+        offset = (update - 1) * BATCH_SIZE
+        inputs, targets = store.batch(order[offset : offset + BATCH_SIZE])
+        optimizer.zero_grad(set_to_none=True)
+        output = model(inputs, targets)
+        if output.loss is None or not bool(torch.isfinite(output.loss)):
+            raise RuntimeError("contextual retained fit produced a nonfinite loss")
+        output.loss.backward()
+        if update == 1:
+            gradient_parameter_tensors = _require_first_step_gradients(model)
+        gradient_norm = torch.nn.utils.clip_grad_norm_(parameters, GRADIENT_CLIP)
+        if not bool(torch.isfinite(gradient_norm)):
+            raise RuntimeError("contextual retained fit produced a nonfinite gradient norm")
+        rate = learning_rate(update)
+        for group in optimizer.param_groups:
+            group["lr"] = rate
+        optimizer.step()
+        losses.append(float(output.loss.detach()))
+        if update % 16 == 0 or update == updates:
+            print(
+                f"contextual_retained_fit update={update}/{updates} "
+                f"loss={losses[-1]:.6f} elapsed={time.monotonic() - started:.3f}s",
+                flush=True,
+            )
+
+    elapsed_seconds = time.monotonic() - started
+    if elapsed_seconds >= float(max_seconds):
+        raise TimeoutError("contextual retained fit reached its hard wall limit")
+    if not all(bool(torch.isfinite(parameter).all()) for parameter in parameters):
+        raise RuntimeError("contextual retained fit produced a nonfinite parameter")
+
+    artifact = model.export_learned_artifact()
+    result = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "model": {
+            "policy": model.policy,
+            "parameter_count": PARAMETER_COUNT,
+            "value_write": VALUE_WRITE,
+            "initialization": "qualified retained V1 artifact",
+        },
+        "fit": {
+            "updates": updates,
+            "maximum_updates": MAX_UPDATES,
+            "batch_size": BATCH_SIZE,
+            "training_windows": updates * BATCH_SIZE,
+            "causal_targets": updates * BATCH_SIZE * CONTEXT,
+            "learning_rate_first": learning_rate(1),
+            "learning_rate_last": learning_rate(updates),
+            "loss_first": losses[0],
+            "loss_last": losses[-1],
+            "loss_mean_first_16": sum(losses[:16]) / min(16, len(losses)),
+            "loss_mean_last_16": sum(losses[-16:]) / min(16, len(losses)),
+            "elapsed_seconds": elapsed_seconds,
+            "hard_wall_seconds": float(max_seconds),
+            "gradient_parameter_tensors": gradient_parameter_tensors,
+            "optimizer_parameter_values": optimizer_values,
+        },
+        "execution": execution,
+        "inputs": {
+            "train": training_input,
+            "geometry": geometry_input,
+            "initial_artifact": initial_input,
+            "validation_files_read": 0,
+            "sealed_files_read": 0,
+            "teacher_files_read": 0,
+            "source_model_files_read": 0,
+        },
+        "artifact": {
+            "path": str(output_artifact_path),
+            "bytes": len(artifact),
+            "cid": cid_bytes(artifact),
+        },
+    }
+    atomic_write(output_artifact_path, artifact)
+    atomic_write_json(output_result_path, result)
+    return result
+
+
+__all__ = [
+    "DEFAULT_UPDATES",
+    "MAX_SECONDS",
+    "MAX_UPDATES",
+    "SCHEMA",
+    "STATUS",
+    "fit_contextual_retained",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
@@ -7,6 +7,7 @@ does not train, select a checkpoint, or read corpus data.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +61,7 @@ def generate_contextual_retained(
     *,
     geometry_path: Path,
     prompt: str,
+    artifact_path: Path | None = None,
     max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
     seed: int = DEFAULT_SEED,
 ) -> dict[str, Any]:
@@ -75,10 +77,33 @@ def generate_contextual_retained(
     resolved_root = root.expanduser().resolve()
     resolved_geometry = geometry_path.expanduser().resolve()
     tokenizer_path = resolved_root / TOKENIZER_RELATIVE_PATH
-    artifact_path = resolved_root / ARTIFACT_RELATIVE_PATH
+    resolved_artifact = (
+        resolved_root / ARTIFACT_RELATIVE_PATH
+        if artifact_path is None
+        else artifact_path.expanduser().resolve()
+    )
     tokenizer_payload = tokenizer_path.read_bytes()
-    artifact_payload = artifact_path.read_bytes()
+    artifact_payload = resolved_artifact.read_bytes()
     geometry_payload = resolved_geometry.read_bytes()
+    artifact_cid = f"blake3:{blake3(artifact_payload).hexdigest()}"
+    fit_result_path = resolved_artifact.with_name("fit.json")
+    fit_summary: dict[str, Any] | None = None
+    fitted_under_value_write = "Wv(RMSNorm(x_t))"
+    if fit_result_path.is_file():
+        fit_result = json.loads(fit_result_path.read_text(encoding="utf-8"))
+        if fit_result.get("artifact", {}).get("cid") != artifact_cid:
+            raise ValueError("contextual fit metadata does not match the selected artifact")
+        if fit_result.get("model", {}).get("value_write") != (
+            "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
+        ):
+            raise ValueError("contextual fit metadata names a different value write")
+        fitted_under_value_write = fit_result["model"]["value_write"]
+        fit_summary = {
+            "updates": fit_result.get("fit", {}).get("updates"),
+            "causal_targets": fit_result.get("fit", {}).get("causal_targets"),
+            "elapsed_seconds": fit_result.get("fit", {}).get("elapsed_seconds"),
+            "result_path": str(fit_result_path),
+        }
 
     tokenizer = Tokenizer.from_file(str(tokenizer_path))
     raw_decoder = ByteLevelRawDecoder.from_tokenizer_json(tokenizer_path)
@@ -168,10 +193,11 @@ def generate_contextual_retained(
             "policy": POLICY,
             "value_write": "Wv(RMSNorm(x_t + strict_prior_retained_residual))",
             "parameters_added": 0,
-            "fitted_under_value_write": "Wv(RMSNorm(x_t))",
+            "fitted_under_value_write": fitted_under_value_write,
+            "fit": fit_summary,
         },
         "inputs": {
-            "model_artifact": _record(artifact_path, artifact_payload),
+            "model_artifact": _record(resolved_artifact, artifact_payload),
             "tokenizer": _record(tokenizer_path, tokenizer_payload),
             "geometry": _record(resolved_geometry, geometry_payload),
             "corpus_files_read": 0,


### PR DESCRIPTION
The contextual retained-write path was executable, but its weights still came from the earlier token-only write law. This adds one bounded warm-start fit that trains the existing 252,160 parameters through `Wv(RMSNorm(x_t + strict_prior_retained_residual))`, writes a separate artifact, and lets direct generation select and verify that fitted artifact.

The fit is deliberately capped at 128 updates, 2,048 open training windows, four CPU threads, and an 840-second hard wall. It does not open validation, sealed, teacher, or source-model files. The historical V1 artifact remains unchanged.

Measured direct result:

- completed 128/128 updates over 245,760 causal targets in 97.098266 seconds
- all 24 parameter tensors had finite, nonzero gradients on the first update
- the optimizer included all 252,160 parameter values
- fitted artifact CID: `blake3:909ac6647a1f923da5523509cf7a6abf03d827da755d0d852ede12172476a76d`
- first/last batch loss: 3.973213 / 4.034052; these are different training batches and are not an evaluation

The same two direct generation checks produced:

- `A purple turtle found a clock in the garden` → `.\n"Thank you you, "Yes, I is be proud of you`
- `Albert Einstein was born in` → ` the dog. He said, "Hi, I are so she put it?"`

The bounded fit and source-free generation mechanics work. The outputs remain incoherent and factually wrong, so this does not establish convergence, quality improvement, coherence, factuality, reasoning, or general chat capability. No retry, tuning pass, validation run, or architecture expansion was performed.

Checks:

- `python3 -m py_compile` on the new fit path, generator, and CLI
- `git diff --check`
- one bounded contextual fit
- the two named direct generation commands using the fitted artifact

Broad suites were not run because the active build-first policy calls for the smallest direct behavior check for this decision; the protected merge queue remains the binding repository gate.

References #973
