### PR TITLE
#973: Run one full contextual-write epoch

### DIFF
--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -384,6 +384,27 @@ sealed, teacher, or source-model files. This bounded adaptation is not a
 convergence or language-quality claim; the direct generation output remains the
 behavioral check.
 
+One complete deterministic epoch uses a separate fixed command and output so
+the bounded result remains intact:
+
+```bash
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" fit-contextual-retained-full
+
+FULL_CONTEXTUAL="$ROOT/arms/contextual-retained-full/model.safetensors"
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" generate-contextual-retained \
+  --artifact "$FULL_CONTEXTUAL" \
+  --prompt "A purple turtle found a clock in the garden" \
+  --max-new-tokens 16
+```
+
+The full command always starts from the original retained V1 artifact, consumes
+all 43,680 training windows exactly once in 2,730 batches, uses four CPU threads,
+and stops at a hard 2,700-second wall. It writes only
+`arms/contextual-retained-full/`; it has no update-count override or automatic
+retry.
+
 ## Terminal #973 paired-H4 prompt-capacity rung
 
 [`R4PairedH4PromptCapacityV1`](../../docs/r4_paired_h4_prompt_capacity_973.md)

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -34,7 +34,10 @@ from .continuation_data import (
     load_continuation_training_view_manifest,
     prepare_continuation_dataset,
 )
-from .contextual_retained_fit import fit_contextual_retained
+from .contextual_retained_fit import (
+    fit_contextual_retained,
+    fit_contextual_retained_full,
+)
 from .contextual_retained_generation import generate_contextual_retained
 from .data import download_source, load_dataset_manifest, prepare_dataset
 from .direct_retained_readout_campaign import (
@@ -627,6 +630,13 @@ def parser() -> argparse.ArgumentParser:
     fit_contextual.add_argument("--updates", type=int, default=128)
     fit_contextual.add_argument("--threads", type=int, choices=[4], default=4)
     fit_contextual.add_argument("--max-seconds", type=float, default=840.0)
+    subcommands.add_parser(
+        "fit-contextual-retained-full",
+        help=(
+            "fit one complete deterministic epoch through #973's contextual "
+            "value write using open training bytes only"
+        ),
+    )
     generate_contextual = subcommands.add_parser(
         "generate-contextual-retained",
         help=(
@@ -1141,6 +1151,7 @@ def main() -> None:
         "run-language-path",
         "generate-language-path",
         "fit-contextual-retained",
+        "fit-contextual-retained-full",
         "generate-contextual-retained",
     }
     paired_h4_prompt_capacity_commands = {
@@ -1471,6 +1482,9 @@ def main() -> None:
                 max_seconds=arguments.max_seconds,
             )
         )
+        return
+    if arguments.command == "fit-contextual-retained-full":
+        _print_result(fit_contextual_retained_full(root))
         return
     if arguments.command == "generate-contextual-retained":
         result = generate_contextual_retained(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
@@ -36,11 +36,16 @@ from .provenance import atomic_write, atomic_write_json, cid_bytes, cid_file
 
 SCHEMA = "uor-r4.contextual-retained-fit/1"
 STATUS = "CONTEXTUAL_RETAINED_ADAPTED"
-MAX_UPDATES = 128
-DEFAULT_UPDATES = MAX_UPDATES
 BATCH_SIZE = 16
 THREADS = 4
+MAX_UPDATES = 128
+DEFAULT_UPDATES = MAX_UPDATES
 MAX_SECONDS = 840.0
+FULL_EPOCH_STATUS = "CONTEXTUAL_RETAINED_FULL_EPOCH_FITTED"
+FULL_EPOCH_MAX_SECONDS = 2_700.0
+if TRAIN_WINDOWS % BATCH_SIZE != 0:
+    raise RuntimeError("contextual retained training windows must form full batches")
+FULL_EPOCH_UPDATES = TRAIN_WINDOWS // BATCH_SIZE
 EXPECTED_INITIAL_ARTIFACT_CID = (
     "blake3:d1417b325e7a545057cd38e9f1a723933a3682801877433d20e98774a5e9172d"
 )
@@ -51,8 +56,7 @@ TRAIN_RELATIVE_PATH = Path("data/train.u16")
 GEOMETRY_RELATIVE_PATH = Path("geometry/r4-group-address-geometry.json")
 INITIAL_ARTIFACT_RELATIVE_PATH = Path("arms/retained/model.safetensors")
 OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained")
-OUTPUT_ARTIFACT_RELATIVE_PATH = OUTPUT_DIRECTORY_RELATIVE_PATH / "model.safetensors"
-OUTPUT_RESULT_RELATIVE_PATH = OUTPUT_DIRECTORY_RELATIVE_PATH / "fit.json"
+FULL_EPOCH_OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained-full")
 VALUE_WRITE = "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
 
 
@@ -75,6 +79,11 @@ def _configure_cpu(threads: int) -> dict[str, Any]:
     except RuntimeError:
         if torch.get_num_interop_threads() != threads:
             raise
+    if (
+        torch.get_num_threads() != threads
+        or torch.get_num_interop_threads() != threads
+    ):
+        raise RuntimeError("contextual retained fit did not acquire four CPU threads")
     torch.use_deterministic_algorithms(True)
     return {
         "device": "cpu",
@@ -99,34 +108,39 @@ def _require_first_step_gradients(model: torch.nn.Module) -> int:
     return len(tuple(model.parameters()))
 
 
-def fit_contextual_retained(
+def _fit_contextual_retained(
     root: Path,
     *,
-    updates: int = DEFAULT_UPDATES,
-    threads: int = THREADS,
-    max_seconds: float = MAX_SECONDS,
+    updates: int,
+    threads: int,
+    max_seconds: float,
+    maximum_updates: int,
+    maximum_seconds: float,
+    output_directory_relative_path: Path,
+    status: str,
+    profile: str | None,
 ) -> dict[str, Any]:
-    """Warm-start and adapt all retained parameters using open training bytes."""
-
     if isinstance(updates, bool) or not isinstance(updates, int):
         raise TypeError("updates must be an integer")
-    if not 1 <= updates <= MAX_UPDATES:
-        raise ValueError(f"updates must be between 1 and {MAX_UPDATES}")
+    if not 1 <= updates <= maximum_updates:
+        raise ValueError(f"updates must be between 1 and {maximum_updates}")
     if (
         isinstance(max_seconds, bool)
         or not isinstance(max_seconds, (int, float))
-        or not 0.0 < float(max_seconds) <= MAX_SECONDS
+        or not 0.0 < float(max_seconds) <= maximum_seconds
     ):
-        raise ValueError(f"max_seconds must be positive and at most {MAX_SECONDS}")
+        raise ValueError(
+            f"max_seconds must be positive and at most {maximum_seconds}"
+        )
 
     started = time.monotonic()
     resolved_root = root.expanduser().resolve()
     train_path = resolved_root / TRAIN_RELATIVE_PATH
     geometry_path = resolved_root / GEOMETRY_RELATIVE_PATH
     initial_artifact_path = resolved_root / INITIAL_ARTIFACT_RELATIVE_PATH
-    output_directory = resolved_root / OUTPUT_DIRECTORY_RELATIVE_PATH
-    output_artifact_path = resolved_root / OUTPUT_ARTIFACT_RELATIVE_PATH
-    output_result_path = resolved_root / OUTPUT_RESULT_RELATIVE_PATH
+    output_directory = resolved_root / output_directory_relative_path
+    output_artifact_path = output_directory / "model.safetensors"
+    output_result_path = output_directory / "fit.json"
     if output_directory.exists():
         raise FileExistsError(f"contextual fit output already exists: {output_directory}")
 
@@ -199,32 +213,39 @@ def fit_contextual_retained(
         raise RuntimeError("contextual retained fit produced a nonfinite parameter")
 
     artifact = model.export_learned_artifact()
+    fit_result: dict[str, Any] = {
+        "updates": updates,
+        "maximum_updates": maximum_updates,
+        "batch_size": BATCH_SIZE,
+        "training_windows": updates * BATCH_SIZE,
+        "causal_targets": updates * BATCH_SIZE * CONTEXT,
+        "learning_rate_first": learning_rate(1),
+        "learning_rate_last": learning_rate(updates),
+        "loss_first": losses[0],
+        "loss_last": losses[-1],
+        "loss_mean_first_16": sum(losses[:16]) / min(16, len(losses)),
+        "loss_mean_last_16": sum(losses[-16:]) / min(16, len(losses)),
+        "elapsed_seconds": elapsed_seconds,
+        "hard_wall_seconds": float(max_seconds),
+        "gradient_parameter_tensors": gradient_parameter_tensors,
+        "optimizer_parameter_values": optimizer_values,
+    }
+    if profile is not None:
+        fit_result["profile"] = profile
+        fit_result["complete_training_store"] = (
+            updates * BATCH_SIZE == TRAIN_WINDOWS
+        )
+
     result = {
         "schema": SCHEMA,
-        "status": STATUS,
+        "status": status,
         "model": {
             "policy": model.policy,
             "parameter_count": PARAMETER_COUNT,
             "value_write": VALUE_WRITE,
             "initialization": "qualified retained V1 artifact",
         },
-        "fit": {
-            "updates": updates,
-            "maximum_updates": MAX_UPDATES,
-            "batch_size": BATCH_SIZE,
-            "training_windows": updates * BATCH_SIZE,
-            "causal_targets": updates * BATCH_SIZE * CONTEXT,
-            "learning_rate_first": learning_rate(1),
-            "learning_rate_last": learning_rate(updates),
-            "loss_first": losses[0],
-            "loss_last": losses[-1],
-            "loss_mean_first_16": sum(losses[:16]) / min(16, len(losses)),
-            "loss_mean_last_16": sum(losses[-16:]) / min(16, len(losses)),
-            "elapsed_seconds": elapsed_seconds,
-            "hard_wall_seconds": float(max_seconds),
-            "gradient_parameter_tensors": gradient_parameter_tensors,
-            "optimizer_parameter_values": optimizer_values,
-        },
+        "fit": fit_result,
         "execution": execution,
         "inputs": {
             "train": training_input,
@@ -246,11 +267,53 @@ def fit_contextual_retained(
     return result
 
 
+def fit_contextual_retained(
+    root: Path,
+    *,
+    updates: int = DEFAULT_UPDATES,
+    threads: int = THREADS,
+    max_seconds: float = MAX_SECONDS,
+) -> dict[str, Any]:
+    """Warm-start one bounded adaptation using open training bytes."""
+
+    return _fit_contextual_retained(
+        root,
+        updates=updates,
+        threads=threads,
+        max_seconds=max_seconds,
+        maximum_updates=MAX_UPDATES,
+        maximum_seconds=MAX_SECONDS,
+        output_directory_relative_path=OUTPUT_DIRECTORY_RELATIVE_PATH,
+        status=STATUS,
+        profile=None,
+    )
+
+
+def fit_contextual_retained_full(root: Path) -> dict[str, Any]:
+    """Fit one complete deterministic epoch from the original V1 artifact."""
+
+    return _fit_contextual_retained(
+        root,
+        updates=FULL_EPOCH_UPDATES,
+        threads=THREADS,
+        max_seconds=FULL_EPOCH_MAX_SECONDS,
+        maximum_updates=FULL_EPOCH_UPDATES,
+        maximum_seconds=FULL_EPOCH_MAX_SECONDS,
+        output_directory_relative_path=FULL_EPOCH_OUTPUT_DIRECTORY_RELATIVE_PATH,
+        status=FULL_EPOCH_STATUS,
+        profile="full_epoch",
+    )
+
+
 __all__ = [
     "DEFAULT_UPDATES",
+    "FULL_EPOCH_MAX_SECONDS",
+    "FULL_EPOCH_STATUS",
+    "FULL_EPOCH_UPDATES",
     "MAX_SECONDS",
     "MAX_UPDATES",
     "SCHEMA",
     "STATUS",
     "fit_contextual_retained",
+    "fit_contextual_retained_full",
 ]


### PR DESCRIPTION
The 128-update contextual adaptation exercised only 2,048 of 43,680 training windows, so it could not distinguish an undertrained write path from a structurally inadequate one. This adds a dedicated `fit-contextual-retained-full` command that runs the existing contextual-write model over the complete deterministic training order once.

The command is fixed in source: 2,730 updates, batch size 16, four CPU threads, the original retained V1 initialization, and a 2,700-second hard wall. It has no update/thread/wall override and writes to `arms/contextual-retained-full`, preserving the earlier bounded artifact and historical V1 artifact.

Measured result from the sole authorized run:

- 2,730/2,730 updates; all 43,680 windows and 5,241,600 causal targets consumed once
- 1,919.399615 seconds on four-thread CPU, 780.600385 seconds below the hard wall
- all 24 parameter tensors had finite, nonzero gradients on the first update
- optimizer included all 252,160 parameter values
- first/last 16-batch mean training loss: 3.903525 / 3.551273; this is training behavior, not held-out evaluation
- artifact CID: `blake3:f1cecf1bc70d239470ad2e27112ee47e9f32899118cba9ab82686b7e85050617`
- validation, sealed, teacher, and source-model reads: zero

The two predeclared direct CLI generations from that artifact were:

- `A purple turtle found a clock in the garden` → `. She loved to play. He saw a big tree in her pocket. She`
- `Albert Einstein was born in` → ` the water.\nTim took the kitchen and saw a small girl playing in the`

The full fit improves local sentence form relative to the bounded artifact, but prompt-specific factual binding remains inadequate: Einstein is still completed with a false location and the continuation drifts to unrelated text. This establishes one completed contextual-write epoch and source-free prompt-dependent generation. It does not establish factuality, coherence, reasoning, general chat, or held-out quality. No retry, second epoch, validation run, tuning pass, or architecture change occurred.

Checks were limited to `python3 -m py_compile`, `git diff --check`, the one full fit, and the two named direct generations. The protected merge queue remains the repository gate.

References #973
