### PR TITLE
#973: Context-bind retained keys and values

### DIFF
--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -405,6 +405,33 @@ and stops at a hard 2,700-second wall. It writes only
 `arms/contextual-retained-full/`; it has no update-count override or automatic
 retry.
 
+The context-bound key/value successor keeps the same reader, exact-H4 route,
+strict read-before-write recurrence, gates, state tensors, 252,160 learned
+parameters, and tied vocabulary head. After the strict-prior read it forms
+`c_t = RMSNorm(x_t + a_t)` and writes both `Wk(c_t)` and `Wv(c_t)` through the
+existing identity slot. Its separate fixed command always warm-starts from the
+original retained V1 artifact, runs 128 updates over 2,048 open training
+windows with four CPU threads and an 840-second hard wall, and has no flags,
+resume path, or automatic retry:
+
+```bash
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" fit-contextual-key-value
+
+CONTEXTUAL_KEY_VALUE="$ROOT/arms/contextual-key-value/model.safetensors"
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" generate-contextual-retained \
+  --artifact "$CONTEXTUAL_KEY_VALUE" \
+  --prompt "A purple turtle found a clock in the garden" \
+  --max-new-tokens 16
+```
+
+The fit reads no validation, sealed, teacher, or source-model files. The
+generator selects the versioned recurrence from the adjacent `fit.json` and
+checks the artifact and geometry identities before loading the byte-compatible
+weights. The result measures one bounded intervention; it does not establish
+factual recall, general language quality, or geometric advantage.
+
 ## Terminal #973 paired-H4 prompt-capacity rung
 
 [`R4PairedH4PromptCapacityV1`](../../docs/r4_paired_h4_prompt_capacity_973.md)

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -35,6 +35,7 @@ from .continuation_data import (
     prepare_continuation_dataset,
 )
 from .contextual_retained_fit import (
+    fit_contextual_key_value,
     fit_contextual_retained,
     fit_contextual_retained_full,
 )
@@ -637,6 +638,13 @@ def parser() -> argparse.ArgumentParser:
             "value write using open training bytes only"
         ),
     )
+    subcommands.add_parser(
+        "fit-contextual-key-value",
+        help=(
+            "run #973's fixed bounded fit with one strict-prior context "
+            "supplying both retained key and value writes"
+        ),
+    )
     generate_contextual = subcommands.add_parser(
         "generate-contextual-retained",
         help=(
@@ -1152,6 +1160,7 @@ def main() -> None:
         "generate-language-path",
         "fit-contextual-retained",
         "fit-contextual-retained-full",
+        "fit-contextual-key-value",
         "generate-contextual-retained",
     }
     paired_h4_prompt_capacity_commands = {
@@ -1485,6 +1494,9 @@ def main() -> None:
         return
     if arguments.command == "fit-contextual-retained-full":
         _print_result(fit_contextual_retained_full(root))
+        return
+    if arguments.command == "fit-contextual-key-value":
+        _print_result(fit_contextual_key_value(root))
         return
     if arguments.command == "generate-contextual-retained":
         result = generate_contextual_retained(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
@@ -14,6 +14,7 @@ from .group_retention_campaign import load_group_geometry_artifacts
 from .language_path_generalization import (
     CONTEXT,
     PARAMETER_COUNT,
+    R4ContextualKeyValueWriteLanguagePathV1,
     R4ContextualValueWriteLanguagePathV1,
 )
 from .language_path_generalization_campaign import (
@@ -36,6 +37,8 @@ from .provenance import atomic_write, atomic_write_json, cid_bytes, cid_file
 
 SCHEMA = "uor-r4.contextual-retained-fit/1"
 STATUS = "CONTEXTUAL_RETAINED_ADAPTED"
+CONTEXTUAL_KEY_VALUE_SCHEMA = "uor-r4.contextual-key-value-fit/1"
+CONTEXTUAL_KEY_VALUE_STATUS = "CONTEXTUAL_KEY_VALUE_ADAPTED"
 BATCH_SIZE = 16
 THREADS = 4
 MAX_UPDATES = 128
@@ -57,6 +60,10 @@ GEOMETRY_RELATIVE_PATH = Path("geometry/r4-group-address-geometry.json")
 INITIAL_ARTIFACT_RELATIVE_PATH = Path("arms/retained/model.safetensors")
 OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained")
 FULL_EPOCH_OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained-full")
+CONTEXTUAL_KEY_VALUE_OUTPUT_DIRECTORY_RELATIVE_PATH = Path(
+    "arms/contextual-key-value"
+)
+KEY_WRITE = "Wk(RMSNorm(x_t + strict_prior_retained_residual))"
 VALUE_WRITE = "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
 
 
@@ -117,8 +124,12 @@ def _fit_contextual_retained(
     maximum_updates: int,
     maximum_seconds: float,
     output_directory_relative_path: Path,
+    schema: str,
     status: str,
     profile: str | None,
+    model_type: type[R4ContextualValueWriteLanguagePathV1],
+    model_writes: dict[str, str],
+    progress_label: str,
 ) -> dict[str, Any]:
     if isinstance(updates, bool) or not isinstance(updates, int):
         raise TypeError("updates must be an integer")
@@ -153,7 +164,7 @@ def _fit_contextual_retained(
     store = LanguagePathWindowStore(train_path, window_count=TRAIN_WINDOWS)
     order = deterministic_window_order(TRAIN_WINDOWS)
     geometry = load_group_geometry_artifacts(geometry_path).exact_h4
-    model = R4ContextualValueWriteLanguagePathV1(geometry).to(
+    model = model_type(geometry).to(
         device=torch.device("cpu"), dtype=torch.float32
     )
     model.load_learned_artifact(initial_artifact_path.read_bytes())
@@ -201,7 +212,7 @@ def _fit_contextual_retained(
         losses.append(float(output.loss.detach()))
         if update % 16 == 0 or update == updates:
             print(
-                f"contextual_retained_fit update={update}/{updates} "
+                f"{progress_label} update={update}/{updates} "
                 f"loss={losses[-1]:.6f} elapsed={time.monotonic() - started:.3f}s",
                 flush=True,
             )
@@ -237,13 +248,13 @@ def _fit_contextual_retained(
         )
 
     result = {
-        "schema": SCHEMA,
+        "schema": schema,
         "status": status,
         "model": {
             "policy": model.policy,
             "parameter_count": PARAMETER_COUNT,
-            "value_write": VALUE_WRITE,
             "initialization": "qualified retained V1 artifact",
+            **model_writes,
         },
         "fit": fit_result,
         "execution": execution,
@@ -284,8 +295,12 @@ def fit_contextual_retained(
         maximum_updates=MAX_UPDATES,
         maximum_seconds=MAX_SECONDS,
         output_directory_relative_path=OUTPUT_DIRECTORY_RELATIVE_PATH,
+        schema=SCHEMA,
         status=STATUS,
         profile=None,
+        model_type=R4ContextualValueWriteLanguagePathV1,
+        model_writes={"value_write": VALUE_WRITE},
+        progress_label="contextual_retained_fit",
     )
 
 
@@ -300,12 +315,40 @@ def fit_contextual_retained_full(root: Path) -> dict[str, Any]:
         maximum_updates=FULL_EPOCH_UPDATES,
         maximum_seconds=FULL_EPOCH_MAX_SECONDS,
         output_directory_relative_path=FULL_EPOCH_OUTPUT_DIRECTORY_RELATIVE_PATH,
+        schema=SCHEMA,
         status=FULL_EPOCH_STATUS,
         profile="full_epoch",
+        model_type=R4ContextualValueWriteLanguagePathV1,
+        model_writes={"value_write": VALUE_WRITE},
+        progress_label="contextual_retained_fit",
+    )
+
+
+def fit_contextual_key_value(root: Path) -> dict[str, Any]:
+    """Run one bounded adaptation with a shared contextual key/value source."""
+
+    return _fit_contextual_retained(
+        root,
+        updates=MAX_UPDATES,
+        threads=THREADS,
+        max_seconds=MAX_SECONDS,
+        maximum_updates=MAX_UPDATES,
+        maximum_seconds=MAX_SECONDS,
+        output_directory_relative_path=(
+            CONTEXTUAL_KEY_VALUE_OUTPUT_DIRECTORY_RELATIVE_PATH
+        ),
+        schema=CONTEXTUAL_KEY_VALUE_SCHEMA,
+        status=CONTEXTUAL_KEY_VALUE_STATUS,
+        profile="contextual_key_value_adaptation",
+        model_type=R4ContextualKeyValueWriteLanguagePathV1,
+        model_writes={"key_write": KEY_WRITE, "value_write": VALUE_WRITE},
+        progress_label="contextual_key_value_fit",
     )
 
 
 __all__ = [
+    "CONTEXTUAL_KEY_VALUE_SCHEMA",
+    "CONTEXTUAL_KEY_VALUE_STATUS",
     "DEFAULT_UPDATES",
     "FULL_EPOCH_MAX_SECONDS",
     "FULL_EPOCH_STATUS",
@@ -314,6 +357,7 @@ __all__ = [
     "MAX_UPDATES",
     "SCHEMA",
     "STATUS",
+    "fit_contextual_key_value",
     "fit_contextual_retained",
     "fit_contextual_retained_full",
 ]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
@@ -15,10 +15,22 @@ import torch
 from blake3 import blake3
 from tokenizers import Tokenizer
 
+from .contextual_retained_fit import (
+    CONTEXTUAL_KEY_VALUE_SCHEMA,
+    CONTEXTUAL_KEY_VALUE_STATUS,
+    EXPECTED_GEOMETRY_CID,
+    EXPECTED_INITIAL_ARTIFACT_CID,
+    FULL_EPOCH_STATUS,
+    SCHEMA as CONTEXTUAL_FIT_SCHEMA,
+    STATUS as CONTEXTUAL_FIT_STATUS,
+)
 from .group_retention_campaign import load_group_geometry_artifacts
 from .language_path_generalization import (
+    CONTEXTUAL_KEY_VALUE_WRITE_POLICY,
+    CONTEXTUAL_VALUE_WRITE_POLICY,
     CONTEXT,
     VOCAB_SIZE,
+    R4ContextualKeyValueWriteLanguagePathV1,
     R4ContextualValueWriteLanguagePathV1,
 )
 from .language_path_generation import (
@@ -34,11 +46,14 @@ from .language_path_generation import (
 
 
 SCHEMA = "uor-r4.contextual-retained-generation/1"
-POLICY = "R4ContextualValueWriteLanguagePathV1"
+POLICY = CONTEXTUAL_VALUE_WRITE_POLICY
 DEFAULT_MAX_NEW_TOKENS = 32
 DEFAULT_SEED = 9_738
 TOKENIZER_RELATIVE_PATH = Path("tokenizer/tokenizer.json")
 ARTIFACT_RELATIVE_PATH = Path("arms/retained/model.safetensors")
+CONTEXTUAL_KEY_WRITE = "Wk(RMSNorm(x_t + strict_prior_retained_residual))"
+CONTEXTUAL_VALUE_WRITE = "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
+TOKEN_LOCAL_VALUE_WRITE = "Wv(RMSNorm(x_t))"
 
 
 def _record(path: Path, payload: bytes) -> dict[str, Any]:
@@ -86,24 +101,64 @@ def generate_contextual_retained(
     artifact_payload = resolved_artifact.read_bytes()
     geometry_payload = resolved_geometry.read_bytes()
     artifact_cid = f"blake3:{blake3(artifact_payload).hexdigest()}"
+    geometry_cid = f"blake3:{blake3(geometry_payload).hexdigest()}"
     fit_result_path = resolved_artifact.with_name("fit.json")
     fit_summary: dict[str, Any] | None = None
-    fitted_under_value_write = "Wv(RMSNorm(x_t))"
+    selected_policy = POLICY
+    model_type = R4ContextualValueWriteLanguagePathV1
+    fitted_under_key_write: str | None = None
+    fitted_under_value_write = TOKEN_LOCAL_VALUE_WRITE
     if fit_result_path.is_file():
         fit_result = json.loads(fit_result_path.read_text(encoding="utf-8"))
         if fit_result.get("artifact", {}).get("cid") != artifact_cid:
             raise ValueError("contextual fit metadata does not match the selected artifact")
-        if fit_result.get("model", {}).get("value_write") != (
-            "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
-        ):
-            raise ValueError("contextual fit metadata names a different value write")
-        fitted_under_value_write = fit_result["model"]["value_write"]
+        if fit_result.get("inputs", {}).get("geometry", {}).get("cid") != geometry_cid:
+            raise ValueError("contextual fit metadata names a different geometry")
+        fit_model = fit_result.get("model", {})
+        fit_policy = fit_model.get("policy")
+        if fit_policy == POLICY:
+            if (
+                fit_result.get("schema") != CONTEXTUAL_FIT_SCHEMA
+                or fit_result.get("status")
+                not in {CONTEXTUAL_FIT_STATUS, FULL_EPOCH_STATUS}
+            ):
+                raise ValueError(
+                    "contextual fit metadata has an unsupported schema or status"
+                )
+            if fit_model.get("value_write") != CONTEXTUAL_VALUE_WRITE:
+                raise ValueError("contextual fit metadata names a different value write")
+        elif fit_policy == CONTEXTUAL_KEY_VALUE_WRITE_POLICY:
+            if (
+                fit_result.get("schema") != CONTEXTUAL_KEY_VALUE_SCHEMA
+                or fit_result.get("status") != CONTEXTUAL_KEY_VALUE_STATUS
+            ):
+                raise ValueError(
+                    "contextual key/value fit metadata has an unsupported schema or status"
+                )
+            if fit_model.get("key_write") != CONTEXTUAL_KEY_WRITE:
+                raise ValueError("contextual fit metadata names a different key write")
+            if fit_model.get("value_write") != CONTEXTUAL_VALUE_WRITE:
+                raise ValueError("contextual fit metadata names a different value write")
+            selected_policy = CONTEXTUAL_KEY_VALUE_WRITE_POLICY
+            model_type = R4ContextualKeyValueWriteLanguagePathV1
+            fitted_under_key_write = fit_model["key_write"]
+        else:
+            raise ValueError("contextual fit metadata names an unsupported model policy")
+        fitted_under_value_write = fit_model["value_write"]
         fit_summary = {
             "updates": fit_result.get("fit", {}).get("updates"),
             "causal_targets": fit_result.get("fit", {}).get("causal_targets"),
             "elapsed_seconds": fit_result.get("fit", {}).get("elapsed_seconds"),
             "result_path": str(fit_result_path),
         }
+    else:
+        canonical_artifact = (resolved_root / ARTIFACT_RELATIVE_PATH).resolve()
+        if resolved_artifact != canonical_artifact:
+            raise ValueError("a noncanonical retained artifact requires adjacent fit metadata")
+        if artifact_cid != EXPECTED_INITIAL_ARTIFACT_CID:
+            raise ValueError("canonical retained artifact differs from the pinned V1 artifact")
+        if geometry_cid != EXPECTED_GEOMETRY_CID:
+            raise ValueError("canonical retained generation requires the pinned geometry")
 
     tokenizer = Tokenizer.from_file(str(tokenizer_path))
     raw_decoder = ByteLevelRawDecoder.from_tokenizer_json(tokenizer_path)
@@ -123,7 +178,7 @@ def generate_contextual_retained(
         )
 
     geometry = load_group_geometry_artifacts(resolved_geometry).exact_h4
-    model = R4ContextualValueWriteLanguagePathV1(geometry)
+    model = model_type(geometry)
     model.load_learned_artifact(artifact_payload)
     model.to(device=torch.device("cpu"), dtype=torch.float32)
     model.eval()
@@ -186,16 +241,21 @@ def generate_contextual_retained(
 
     response_ids = generated[:-1] if generated and generated[-1] == EOS_TOKEN_ID else generated
     continuation, utf8_decodable = _decode_utf8(raw_decoder.decode_bytes(response_ids))
+    model_report: dict[str, Any] = {
+        "policy": selected_policy,
+        "value_write": CONTEXTUAL_VALUE_WRITE,
+        "parameters_added": 0,
+        "fitted_under_value_write": fitted_under_value_write,
+        "fit": fit_summary,
+    }
+    if fitted_under_key_write is not None:
+        model_report["key_write"] = CONTEXTUAL_KEY_WRITE
+        model_report["fitted_under_key_write"] = fitted_under_key_write
+
     return {
         "schema": SCHEMA,
         "status": "GENERATED",
-        "model": {
-            "policy": POLICY,
-            "value_write": "Wv(RMSNorm(x_t + strict_prior_retained_residual))",
-            "parameters_added": 0,
-            "fitted_under_value_write": fitted_under_value_write,
-            "fit": fit_summary,
-        },
+        "model": model_report,
         "inputs": {
             "model_artifact": _record(resolved_artifact, artifact_payload),
             "tokenizer": _record(tokenizer_path, tokenizer_payload),

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
@@ -794,6 +794,67 @@ class _RetainedDecoderBlock(nn.Module):
         final_occupied = transported_occupied | identity_mask.bool().view(1, group)
         return values, final_keys, final_values, final_occupied
 
+    def forward_direct_step_with_contextual_key_value_write(
+        self,
+        values: Tensor,
+        token_actions: Tensor,
+        key_state: Tensor,
+        value_state: Tensor,
+        occupied: Tensor,
+        identity_offset: int,
+        *,
+        state_off: bool,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Write one shared causal context through the existing key/value fields.
+
+        The query and strict-prior read remain token-local.  After that read,
+        the same contextual residual supplies both projections written at the
+        transported identity address.  No parameter or recurrent-state tensor
+        is added, and the earlier token-key/context-value entry point remains
+        unchanged.
+        """
+
+        batch = int(values.shape[0])
+        heads = self.config.heads
+        group = self.config.group_size
+        head_dim = self.config.head_dim
+        normalized = self.input_layernorm(values)
+        query = self._heads(self.q_proj(normalized))
+        rho, eta = self.resolved_gates()
+
+        indices = token_actions[:, None, :, None].expand(batch, heads, group, head_dim)
+        transported_keys = torch.gather(key_state, dim=2, index=indices)
+        transported_values = torch.gather(value_state, dim=2, index=indices)
+        transported_occupied = torch.gather(occupied, dim=1, index=token_actions)
+        decayed_keys = transported_keys * rho.view(1, heads, 1, 1)
+        decayed_values = transported_values * rho.view(1, heads, 1, 1)
+
+        retained = self._attend(query, decayed_keys, decayed_values, transported_occupied)
+        retained = self.o_proj(retained.reshape(batch, self.config.hidden_size))
+        contextual = self.input_layernorm(values + retained)
+        key = self._heads(self.k_proj(contextual))
+        value = self._heads(self.v_proj(contextual))
+
+        visible_retained = retained * (0.0 if state_off else 1.0)
+        values = values + visible_retained
+        values = values + self.mlp(self.post_attention_layernorm(values))
+
+        identity_mask = F.one_hot(
+            torch.tensor(identity_offset, device=values.device), num_classes=group
+        ).to(decayed_keys.dtype)
+        prior_keys = decayed_keys[:, :, identity_offset, :]
+        prior_values = decayed_values[:, :, identity_offset, :]
+        key_delta = eta.view(1, heads, 1) * (key - prior_keys)
+        value_delta = eta.view(1, heads, 1) * (value - prior_values)
+        final_keys = decayed_keys + key_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_values = decayed_values + value_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_occupied = transported_occupied | identity_mask.bool().view(1, group)
+        return values, final_keys, final_values, final_occupied
+
 
 class R4GroupAddressedRetentionDecoderV1(nn.Module):
     """Two-block tied-head language model with fixed-state geometric attention."""

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
@@ -36,6 +36,7 @@ from .model import RMSNorm, RotaryEmbedding, SwiGLU
 
 POLICY = "R4RetainedLanguagePathV1"
 CONTEXTUAL_VALUE_WRITE_POLICY = "R4ContextualValueWriteLanguagePathV1"
+CONTEXTUAL_KEY_VALUE_WRITE_POLICY = "R4ContextualKeyValueWriteLanguagePathV1"
 ORDINARY_POLICY = "OrdinaryCausalSoftmaxLanguagePathV1"
 
 VOCAB_SIZE = 4_096
@@ -392,6 +393,57 @@ class R4ContextualValueWriteLanguagePathV1(R4RetainedLanguagePathV1):
             final_state=output.final_state,
             audit=output.audit,
         )
+
+
+class R4ContextualKeyValueWriteLanguagePathV1(
+    R4ContextualValueWriteLanguagePathV1
+):
+    """Versioned retained path with one shared contextual key/value source.
+
+    Query construction and the strict-prior retained read remain token-local.
+    Only the later identity-slot write changes: both its key and value derive
+    from the same current residual plus ungated retained context.  All learned
+    tensors, recurrent state, geometry, and output-head semantics remain byte
+    compatible with the earlier retained artifacts.
+    """
+
+    policy = CONTEXTUAL_KEY_VALUE_WRITE_POLICY
+
+    def _contextual_direct_hidden(
+        self, token_ids: Tensor, state: DecoderState, *, state_off: bool
+    ) -> tuple[Tensor, DecoderState]:
+        outputs: list[Tensor] = []
+        current = state
+        for time_index in range(int(token_ids.shape[1])):
+            token = token_ids[:, time_index]
+            values = self.token_embedding(token)
+            leaves = self.token_leaves.index_select(0, token)
+            actions = self.left_actions.index_select(0, leaves)
+            keys: list[Tensor] = []
+            retained_values: list[Tensor] = []
+            occupied: list[Tensor] = []
+            for layer_index, layer in enumerate(self.layers):
+                values, layer_keys, layer_values, layer_occupied = (
+                    layer.forward_direct_step_with_contextual_key_value_write(
+                        values,
+                        actions,
+                        current.keys[layer_index],
+                        current.values[layer_index],
+                        current.occupied[layer_index],
+                        self.identity_offset,
+                        state_off=state_off,
+                    )
+                )
+                keys.append(layer_keys)
+                retained_values.append(layer_values)
+                occupied.append(layer_occupied)
+            current = DecoderState(
+                keys=torch.stack(keys),
+                values=torch.stack(retained_values),
+                occupied=torch.stack(occupied),
+            )
+            outputs.append(values)
+        return torch.stack(outputs, dim=1), current
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
# Problem and result

The delivered contextual-value path stored prompt-conditioned values under token-local keys. This adds a versioned `R4ContextualKeyValueWriteLanguagePathV1` recurrence in which the current token first reads the transported strict-prior state, then forms `c_t = RMSNorm(x_t + retained)` and writes both `Wk(c_t)` and `Wv(c_t)` through the existing identity slot.

The existing value-only path and its artifacts remain unchanged. The successor preserves the token-local read query, exact-H4 transport, read-before-write causality, rho/eta gates, occupancy, recurrent-state shapes, 252,160 learned parameters, and tied vocabulary head. Generator loading now selects fitted semantics only from an exact allowlist bound to the adjacent fit schema, completion status, policy, formulas, artifact CID, and geometry CID. Metadata-free loading is restricted to the canonical pinned V1 artifact.

## One bounded comparison

The fixed `fit-contextual-key-value` command warm-started from the qualified V1 artifact and completed exactly once:

- 128 updates, batch 16
- 2,048 open training windows / 245,760 causal targets
- four CPU threads
- 90.369271 seconds under the 840-second wall
- 24/24 parameter tensors with finite nonzero first-step gradients
- all 252,160 parameter values covered by the optimizer
- artifact: `blake3:1bc5bb5fc2daae7d67d3b7e748a583ca00310245c4289dfb20c1655bf24c6050`
- validation, sealed, teacher, and source-model file reads: zero

The two declared 16-token direct generations ran once each:

- `A purple turtle found a clock in the garden` → `.\n"Thank you you, "Yes, I is there happened. He`
- `Albert Einstein was born in` → ` the dog. He said, "Hi, I are I were pretty."\n`

This bounded result is negative: contextualizing both stored keys and values did not recover factual/entity binding or coherent continuation. It does not erase the prior value-only negative and does not justify another fit, retry, or broader geometry change.

## Focused verification

- `python3 -m py_compile` on the five modified Python modules
- `git diff --check`
- independent read-only review of causal ordering, artifact compatibility, fit/CLI bounds, and loader binding; its fail-closed metadata findings were fixed before the run

No broad QA, proof work, replay campaign, validation reveal, or additional model run was performed for this decision.

References #973
