### PR TITLE
#973: Make retained attention address-aware

### DIFF
--- a/docs/integration/CONTINUE.md
+++ b/docs/integration/CONTINUE.md
@@ -9,6 +9,17 @@ local service. #1107 remains historically source-frozen and unbuilt; #1084
 workbench qualification is not the current priority. #954 remains blocked by
 #973.
 
+The latest bounded #973 implementation makes the retained softmax consume its
+current relative H4 address through a versioned per-layer/head/address logit
+bias. Its first 128-update fit changed neither of the two direct continuations
+and moved the last-16 mean training loss by less than `0.00005` nat, so it does
+not advance to a longer fit. Artifact-resident persistent memory is not the
+next step. The next task is to expose the already-trained ordinary
+causal-softmax control through the same artifact-only generator and run the
+same two prompts without fitting. If that control is also incoherent, stop
+attention micro-edits and correct the compact language recipe or capacity; if
+it is materially more prompt-responsive, continue at the retained read seam.
+
 ```text
 $uor-project-workflow
 

--- a/tools/r4-softmax-trainer/README.md
+++ b/tools/r4-softmax-trainer/README.md
@@ -432,6 +432,33 @@ checks the artifact and geometry identities before loading the byte-compatible
 weights. The result measures one bounded intervention; it does not establish
 factual recall, general language quality, or geometric advantage.
 
+The address-aware read successor fixes one structural omission in that reader:
+the old content-only softmax was invariant when exact-H4 transport permuted its
+keys, values, and occupancy together. The versioned model adds one logit bias
+per layer, head, and current relative group address (`960` scalars; `253,120`
+parameters total). The bias starts at exact zero, so the warm start is the prior
+reader, and then learns whether a transported relative address should raise or
+lower the content score. K/V state, decay and writes remain unchanged.
+
+```bash
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" fit-contextual-key-value-address-read
+
+ADDRESS_READ="$ROOT/arms/contextual-key-value-address-read/model.safetensors"
+uv run --offline --project "$TRAINER" r4-softmax-trainer \
+  --root "$ROOT" generate-contextual-retained \
+  --artifact "$ADDRESS_READ" \
+  --prompt "A purple turtle found a clock in the garden" \
+  --max-new-tokens 16
+```
+
+This command has the same fixed 128 updates, 2,048 open windows, four CPU
+threads, and 840-second wall as the contextual K/V predecessor. It always
+starts from the original retained V1 artifact, creates a separate output, and
+has no resume path or automatic retry. The adjacent `fit.json` binds the exact
+address-scoring law and zero-bias initialization so same-shaped historical and
+address-aware artifacts cannot be silently interchanged.
+
 ## Terminal #973 paired-H4 prompt-capacity rung
 
 [`R4PairedH4PromptCapacityV1`](../../docs/r4_paired_h4_prompt_capacity_973.md)

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -35,6 +35,7 @@ from .continuation_data import (
     prepare_continuation_dataset,
 )
 from .contextual_retained_fit import (
+    fit_contextual_key_value_address_read,
     fit_contextual_key_value,
     fit_contextual_retained,
     fit_contextual_retained_full,
@@ -645,6 +646,13 @@ def parser() -> argparse.ArgumentParser:
             "supplying both retained key and value writes"
         ),
     )
+    subcommands.add_parser(
+        "fit-contextual-key-value-address-read",
+        help=(
+            "run #973's fixed bounded fit with relative exact-H4 address "
+            "participating in the retained attention score"
+        ),
+    )
     generate_contextual = subcommands.add_parser(
         "generate-contextual-retained",
         help=(
@@ -1161,6 +1169,7 @@ def main() -> None:
         "fit-contextual-retained",
         "fit-contextual-retained-full",
         "fit-contextual-key-value",
+        "fit-contextual-key-value-address-read",
         "generate-contextual-retained",
     }
     paired_h4_prompt_capacity_commands = {
@@ -1497,6 +1506,9 @@ def main() -> None:
         return
     if arguments.command == "fit-contextual-key-value":
         _print_result(fit_contextual_key_value(root))
+        return
+    if arguments.command == "fit-contextual-key-value-address-read":
+        _print_result(fit_contextual_key_value_address_read(root))
         return
     if arguments.command == "generate-contextual-retained":
         result = generate_contextual_retained(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_fit.py
@@ -12,8 +12,10 @@ import torch
 
 from .group_retention_campaign import load_group_geometry_artifacts
 from .language_path_generalization import (
+    ADDRESS_READ_PARAMETER_COUNT,
     CONTEXT,
     PARAMETER_COUNT,
+    R4ContextualKeyValueAddressReadLanguagePathV1,
     R4ContextualKeyValueWriteLanguagePathV1,
     R4ContextualValueWriteLanguagePathV1,
 )
@@ -39,6 +41,12 @@ SCHEMA = "uor-r4.contextual-retained-fit/1"
 STATUS = "CONTEXTUAL_RETAINED_ADAPTED"
 CONTEXTUAL_KEY_VALUE_SCHEMA = "uor-r4.contextual-key-value-fit/1"
 CONTEXTUAL_KEY_VALUE_STATUS = "CONTEXTUAL_KEY_VALUE_ADAPTED"
+CONTEXTUAL_KEY_VALUE_ADDRESS_READ_SCHEMA = (
+    "uor-r4.contextual-key-value-address-read-fit/1"
+)
+CONTEXTUAL_KEY_VALUE_ADDRESS_READ_STATUS = (
+    "CONTEXTUAL_KEY_VALUE_ADDRESS_READ_ADAPTED"
+)
 BATCH_SIZE = 16
 THREADS = 4
 MAX_UPDATES = 128
@@ -63,8 +71,15 @@ FULL_EPOCH_OUTPUT_DIRECTORY_RELATIVE_PATH = Path("arms/contextual-retained-full"
 CONTEXTUAL_KEY_VALUE_OUTPUT_DIRECTORY_RELATIVE_PATH = Path(
     "arms/contextual-key-value"
 )
+CONTEXTUAL_KEY_VALUE_ADDRESS_READ_OUTPUT_DIRECTORY_RELATIVE_PATH = Path(
+    "arms/contextual-key-value-address-read"
+)
 KEY_WRITE = "Wk(RMSNorm(x_t + strict_prior_retained_residual))"
 VALUE_WRITE = "Wv(RMSNorm(x_t + strict_prior_retained_residual))"
+ADDRESS_READ = (
+    "softmax((Wq(RMSNorm(x_t)) dot decayed_transported_keys) / sqrt(12) "
+    "+ address_score_bias[layer,head,address]) over occupied addresses"
+)
 
 
 def _input_record(path: Path, expected_cid: str) -> dict[str, Any]:
@@ -129,6 +144,7 @@ def _fit_contextual_retained(
     profile: str | None,
     model_type: type[R4ContextualValueWriteLanguagePathV1],
     model_writes: dict[str, str],
+    expected_parameter_count: int,
     progress_label: str,
 ) -> dict[str, Any]:
     if isinstance(updates, bool) or not isinstance(updates, int):
@@ -167,8 +183,12 @@ def _fit_contextual_retained(
     model = model_type(geometry).to(
         device=torch.device("cpu"), dtype=torch.float32
     )
-    model.load_learned_artifact(initial_artifact_path.read_bytes())
-    if model.parameter_count() != PARAMETER_COUNT:
+    initial_payload = initial_artifact_path.read_bytes()
+    if isinstance(model, R4ContextualKeyValueAddressReadLanguagePathV1):
+        model.load_retained_v1_warm_start(initial_payload)
+    else:
+        model.load_learned_artifact(initial_payload)
+    if model.parameter_count() != expected_parameter_count:
         raise RuntimeError("contextual retained parameter count changed")
 
     parameters = tuple(model.parameters())
@@ -184,7 +204,7 @@ def _fit_contextual_retained(
         for group in optimizer.param_groups
         for parameter in group["params"]
     )
-    if optimizer_values != PARAMETER_COUNT:
+    if optimizer_values != expected_parameter_count:
         raise RuntimeError("optimizer does not include every contextual retained parameter")
 
     losses: list[float] = []
@@ -252,7 +272,7 @@ def _fit_contextual_retained(
         "status": status,
         "model": {
             "policy": model.policy,
-            "parameter_count": PARAMETER_COUNT,
+            "parameter_count": expected_parameter_count,
             "initialization": "qualified retained V1 artifact",
             **model_writes,
         },
@@ -300,6 +320,7 @@ def fit_contextual_retained(
         profile=None,
         model_type=R4ContextualValueWriteLanguagePathV1,
         model_writes={"value_write": VALUE_WRITE},
+        expected_parameter_count=PARAMETER_COUNT,
         progress_label="contextual_retained_fit",
     )
 
@@ -320,6 +341,7 @@ def fit_contextual_retained_full(root: Path) -> dict[str, Any]:
         profile="full_epoch",
         model_type=R4ContextualValueWriteLanguagePathV1,
         model_writes={"value_write": VALUE_WRITE},
+        expected_parameter_count=PARAMETER_COUNT,
         progress_label="contextual_retained_fit",
     )
 
@@ -342,11 +364,43 @@ def fit_contextual_key_value(root: Path) -> dict[str, Any]:
         profile="contextual_key_value_adaptation",
         model_type=R4ContextualKeyValueWriteLanguagePathV1,
         model_writes={"key_write": KEY_WRITE, "value_write": VALUE_WRITE},
+        expected_parameter_count=PARAMETER_COUNT,
         progress_label="contextual_key_value_fit",
     )
 
 
+def fit_contextual_key_value_address_read(root: Path) -> dict[str, Any]:
+    """Fit one bounded address-aware retained attention candidate."""
+
+    return _fit_contextual_retained(
+        root,
+        updates=MAX_UPDATES,
+        threads=THREADS,
+        max_seconds=MAX_SECONDS,
+        maximum_updates=MAX_UPDATES,
+        maximum_seconds=MAX_SECONDS,
+        output_directory_relative_path=(
+            CONTEXTUAL_KEY_VALUE_ADDRESS_READ_OUTPUT_DIRECTORY_RELATIVE_PATH
+        ),
+        schema=CONTEXTUAL_KEY_VALUE_ADDRESS_READ_SCHEMA,
+        status=CONTEXTUAL_KEY_VALUE_ADDRESS_READ_STATUS,
+        profile="contextual_key_value_address_read_adaptation",
+        model_type=R4ContextualKeyValueAddressReadLanguagePathV1,
+        model_writes={
+            "key_write": KEY_WRITE,
+            "value_write": VALUE_WRITE,
+            "key_read": ADDRESS_READ,
+            "address_score_bias_initialization": "zeros",
+        },
+        expected_parameter_count=ADDRESS_READ_PARAMETER_COUNT,
+        progress_label="contextual_key_value_address_read_fit",
+    )
+
+
 __all__ = [
+    "ADDRESS_READ",
+    "CONTEXTUAL_KEY_VALUE_ADDRESS_READ_SCHEMA",
+    "CONTEXTUAL_KEY_VALUE_ADDRESS_READ_STATUS",
     "CONTEXTUAL_KEY_VALUE_SCHEMA",
     "CONTEXTUAL_KEY_VALUE_STATUS",
     "DEFAULT_UPDATES",
@@ -357,6 +411,7 @@ __all__ = [
     "MAX_UPDATES",
     "SCHEMA",
     "STATUS",
+    "fit_contextual_key_value_address_read",
     "fit_contextual_key_value",
     "fit_contextual_retained",
     "fit_contextual_retained_full",

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/contextual_retained_generation.py
@@ -16,6 +16,9 @@ from blake3 import blake3
 from tokenizers import Tokenizer
 
 from .contextual_retained_fit import (
+    ADDRESS_READ,
+    CONTEXTUAL_KEY_VALUE_ADDRESS_READ_SCHEMA,
+    CONTEXTUAL_KEY_VALUE_ADDRESS_READ_STATUS,
     CONTEXTUAL_KEY_VALUE_SCHEMA,
     CONTEXTUAL_KEY_VALUE_STATUS,
     EXPECTED_GEOMETRY_CID,
@@ -26,10 +29,14 @@ from .contextual_retained_fit import (
 )
 from .group_retention_campaign import load_group_geometry_artifacts
 from .language_path_generalization import (
+    ADDRESS_READ_PARAMETER_COUNT,
+    ADDRESS_SCORE_BIAS_PARAMETER_COUNT,
+    CONTEXTUAL_KEY_VALUE_ADDRESS_READ_POLICY,
     CONTEXTUAL_KEY_VALUE_WRITE_POLICY,
     CONTEXTUAL_VALUE_WRITE_POLICY,
     CONTEXT,
     VOCAB_SIZE,
+    R4ContextualKeyValueAddressReadLanguagePathV1,
     R4ContextualKeyValueWriteLanguagePathV1,
     R4ContextualValueWriteLanguagePathV1,
 )
@@ -108,6 +115,8 @@ def generate_contextual_retained(
     model_type = R4ContextualValueWriteLanguagePathV1
     fitted_under_key_write: str | None = None
     fitted_under_value_write = TOKEN_LOCAL_VALUE_WRITE
+    fitted_under_key_read: str | None = None
+    parameters_added = 0
     if fit_result_path.is_file():
         fit_result = json.loads(fit_result_path.read_text(encoding="utf-8"))
         if fit_result.get("artifact", {}).get("cid") != artifact_cid:
@@ -142,6 +151,31 @@ def generate_contextual_retained(
             selected_policy = CONTEXTUAL_KEY_VALUE_WRITE_POLICY
             model_type = R4ContextualKeyValueWriteLanguagePathV1
             fitted_under_key_write = fit_model["key_write"]
+        elif fit_policy == CONTEXTUAL_KEY_VALUE_ADDRESS_READ_POLICY:
+            if (
+                fit_result.get("schema")
+                != CONTEXTUAL_KEY_VALUE_ADDRESS_READ_SCHEMA
+                or fit_result.get("status")
+                != CONTEXTUAL_KEY_VALUE_ADDRESS_READ_STATUS
+            ):
+                raise ValueError(
+                    "address-aware fit metadata has an unsupported schema or status"
+                )
+            if fit_model.get("key_write") != CONTEXTUAL_KEY_WRITE:
+                raise ValueError("address-aware fit metadata names a different key write")
+            if fit_model.get("value_write") != CONTEXTUAL_VALUE_WRITE:
+                raise ValueError("address-aware fit metadata names a different value write")
+            if fit_model.get("key_read") != ADDRESS_READ:
+                raise ValueError("address-aware fit metadata names a different key read")
+            if fit_model.get("address_score_bias_initialization") != "zeros":
+                raise ValueError("address-aware fit metadata names a different bias initialization")
+            if fit_model.get("parameter_count") != ADDRESS_READ_PARAMETER_COUNT:
+                raise ValueError("address-aware fit metadata names a different parameter count")
+            selected_policy = CONTEXTUAL_KEY_VALUE_ADDRESS_READ_POLICY
+            model_type = R4ContextualKeyValueAddressReadLanguagePathV1
+            fitted_under_key_write = fit_model["key_write"]
+            fitted_under_key_read = fit_model["key_read"]
+            parameters_added = ADDRESS_SCORE_BIAS_PARAMETER_COUNT
         else:
             raise ValueError("contextual fit metadata names an unsupported model policy")
         fitted_under_value_write = fit_model["value_write"]
@@ -244,13 +278,16 @@ def generate_contextual_retained(
     model_report: dict[str, Any] = {
         "policy": selected_policy,
         "value_write": CONTEXTUAL_VALUE_WRITE,
-        "parameters_added": 0,
+        "parameters_added": parameters_added,
         "fitted_under_value_write": fitted_under_value_write,
         "fit": fit_summary,
     }
     if fitted_under_key_write is not None:
         model_report["key_write"] = CONTEXTUAL_KEY_WRITE
         model_report["fitted_under_key_write"] = fitted_under_key_write
+    if fitted_under_key_read is not None:
+        model_report["key_read"] = fitted_under_key_read
+        model_report["fitted_under_key_read"] = fitted_under_key_read
 
     return {
         "schema": SCHEMA,

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/group_retention_decoder.py
@@ -289,6 +289,32 @@ class _RetainedDecoderBlock(nn.Module):
         return torch.einsum("...hg,...hgd->...hd", weights, values.float()).to(values.dtype)
 
     @staticmethod
+    def _attend_with_address_bias(
+        query: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        occupied: Tensor,
+        address_score_bias: Tensor,
+    ) -> Tensor:
+        """Score content plus the transported field's current relative address."""
+
+        heads = int(query.shape[-2])
+        head_dim = int(query.shape[-1])
+        group = int(keys.shape[-2])
+        if tuple(address_score_bias.shape) != (heads, group):
+            raise ValueError("address score bias must have shape [heads,group]")
+        scores = torch.einsum("...hd,...hgd->...hg", query.float(), keys.float())
+        scores = scores / math.sqrt(head_dim)
+        scores = scores + address_score_bias.float()
+        valid = occupied.unsqueeze(-2)
+        has_any = occupied.any(dim=-1, keepdim=True).unsqueeze(-2)
+        masked = scores.masked_fill(~valid, torch.finfo(scores.dtype).min)
+        safe = torch.where(has_any, masked, torch.zeros_like(masked))
+        weights = torch.softmax(safe, dim=-1, dtype=torch.float32)
+        weights = weights * valid.to(weights.dtype)
+        return torch.einsum("...hg,...hgd->...hd", weights, values.float()).to(values.dtype)
+
+    @staticmethod
     def _inclusive_permutation_scan(actions: Tensor) -> Tensor:
         """Compose supplied new-slot-to-old-slot permutations in parallel."""
 
@@ -830,6 +856,74 @@ class _RetainedDecoderBlock(nn.Module):
         decayed_values = transported_values * rho.view(1, heads, 1, 1)
 
         retained = self._attend(query, decayed_keys, decayed_values, transported_occupied)
+        retained = self.o_proj(retained.reshape(batch, self.config.hidden_size))
+        contextual = self.input_layernorm(values + retained)
+        key = self._heads(self.k_proj(contextual))
+        value = self._heads(self.v_proj(contextual))
+
+        visible_retained = retained * (0.0 if state_off else 1.0)
+        values = values + visible_retained
+        values = values + self.mlp(self.post_attention_layernorm(values))
+
+        identity_mask = F.one_hot(
+            torch.tensor(identity_offset, device=values.device), num_classes=group
+        ).to(decayed_keys.dtype)
+        prior_keys = decayed_keys[:, :, identity_offset, :]
+        prior_values = decayed_values[:, :, identity_offset, :]
+        key_delta = eta.view(1, heads, 1) * (key - prior_keys)
+        value_delta = eta.view(1, heads, 1) * (value - prior_values)
+        final_keys = decayed_keys + key_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_values = decayed_values + value_delta[:, :, None, :] * identity_mask.view(
+            1, 1, group, 1
+        )
+        final_occupied = transported_occupied | identity_mask.bool().view(1, group)
+        return values, final_keys, final_values, final_occupied
+
+    def forward_direct_step_with_contextual_key_value_address_read(
+        self,
+        values: Tensor,
+        token_actions: Tensor,
+        key_state: Tensor,
+        value_state: Tensor,
+        occupied: Tensor,
+        identity_offset: int,
+        address_score_bias: Tensor,
+        *,
+        state_off: bool,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Use relative group address in the contextual K/V retained read.
+
+        The learned bias is attached to the destination slot after exact-H4
+        transport.  It therefore changes a stored record's score when the
+        current token moves that record to a different relative address.  The
+        recurrent tensors, decay, delta write, and contextual K/V source stay
+        identical to the contextual key/value-write policy.
+        """
+
+        batch = int(values.shape[0])
+        heads = self.config.heads
+        group = self.config.group_size
+        head_dim = self.config.head_dim
+        normalized = self.input_layernorm(values)
+        query = self._heads(self.q_proj(normalized))
+        rho, eta = self.resolved_gates()
+
+        indices = token_actions[:, None, :, None].expand(batch, heads, group, head_dim)
+        transported_keys = torch.gather(key_state, dim=2, index=indices)
+        transported_values = torch.gather(value_state, dim=2, index=indices)
+        transported_occupied = torch.gather(occupied, dim=1, index=token_actions)
+        decayed_keys = transported_keys * rho.view(1, heads, 1, 1)
+        decayed_values = transported_values * rho.view(1, heads, 1, 1)
+
+        retained = self._attend_with_address_bias(
+            query,
+            decayed_keys,
+            decayed_values,
+            transported_occupied,
+            address_score_bias,
+        )
         retained = self.o_proj(retained.reshape(batch, self.config.hidden_size))
         contextual = self.input_layernorm(values + retained)
         key = self._heads(self.k_proj(contextual))

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/language_path_generalization.py
@@ -37,6 +37,9 @@ from .model import RMSNorm, RotaryEmbedding, SwiGLU
 POLICY = "R4RetainedLanguagePathV1"
 CONTEXTUAL_VALUE_WRITE_POLICY = "R4ContextualValueWriteLanguagePathV1"
 CONTEXTUAL_KEY_VALUE_WRITE_POLICY = "R4ContextualKeyValueWriteLanguagePathV1"
+CONTEXTUAL_KEY_VALUE_ADDRESS_READ_POLICY = (
+    "R4ContextualKeyValueAddressReadLanguagePathV1"
+)
 ORDINARY_POLICY = "OrdinaryCausalSoftmaxLanguagePathV1"
 
 VOCAB_SIZE = 4_096
@@ -54,6 +57,8 @@ INITIALIZATION_STD = 0.02
 DECAY_HALF_LIVES = (4.0, 16.0, 64.0, 256.0)
 
 PARAMETER_COUNT = 252_160
+ADDRESS_SCORE_BIAS_PARAMETER_COUNT = LAYERS * HEADS * GROUP_SIZE
+ADDRESS_READ_PARAMETER_COUNT = PARAMETER_COUNT + ADDRESS_SCORE_BIAS_PARAMETER_COUNT
 STATE_VALUES = 23_040
 STATE_BYTES_F32 = 92_160
 VALIDITY_BITS = 240
@@ -431,6 +436,102 @@ class R4ContextualKeyValueWriteLanguagePathV1(
                         current.values[layer_index],
                         current.occupied[layer_index],
                         self.identity_offset,
+                        state_off=state_off,
+                    )
+                )
+                keys.append(layer_keys)
+                retained_values.append(layer_values)
+                occupied.append(layer_occupied)
+            current = DecoderState(
+                keys=torch.stack(keys),
+                values=torch.stack(retained_values),
+                occupied=torch.stack(occupied),
+            )
+            outputs.append(values)
+        return torch.stack(outputs, dim=1), current
+
+
+class R4ContextualKeyValueAddressReadLanguagePathV1(
+    R4ContextualKeyValueWriteLanguagePathV1
+):
+    """Contextual K/V retention whose softmax consumes relative H4 address.
+
+    The historical retained readers score only query/key content.  Because
+    exact-H4 transport applies the same slot permutation to keys, values, and
+    occupancy, that read is invariant to the transport itself.  This version
+    adds one learned scalar for every layer, head, and destination address to
+    the attention logit.  A zero bias is exactly the prior read law.
+    """
+
+    policy = CONTEXTUAL_KEY_VALUE_ADDRESS_READ_POLICY
+
+    def __init__(self, geometry: GroupAddressArtifact) -> None:
+        super().__init__(geometry)
+        self.address_score_bias = nn.Parameter(
+            torch.zeros(LAYERS, HEADS, GROUP_SIZE, dtype=torch.float32)
+        )
+        if (
+            self.parameter_count() != ADDRESS_READ_PARAMETER_COUNT
+            or self.state_value_count() != STATE_VALUES
+            or self.validity_bit_count() != VALIDITY_BITS
+        ):
+            raise RuntimeError("address-aware retained path changed its frozen ledger")
+
+    def load_learned_artifact(self, payload: bytes) -> None:
+        """Load an exact address-aware artifact for inference."""
+
+        loaded = load_safetensors(payload)
+        expected = dict(self.named_parameters())
+        if set(loaded) != set(expected):
+            raise ValueError("learned artifact parameter names differ from address reader")
+        with torch.no_grad():
+            for name in sorted(expected):
+                source = loaded[name]
+                target = expected[name]
+                if source.dtype != target.dtype or tuple(source.shape) != tuple(target.shape):
+                    raise ValueError(f"learned artifact tensor contract differs for {name}")
+                target.copy_(source.to(device=target.device))
+
+    def load_retained_v1_warm_start(self, payload: bytes) -> None:
+        """Load only the historical parameter set and initialize the new bias."""
+
+        loaded = load_safetensors(payload)
+        expected = dict(self.named_parameters())
+        base_names = set(expected) - {"address_score_bias"}
+        if set(loaded) != base_names:
+            raise ValueError("warm-start artifact parameter names differ from retained V1")
+        with torch.no_grad():
+            for name in sorted(base_names):
+                source = loaded[name]
+                target = expected[name]
+                if source.dtype != target.dtype or tuple(source.shape) != tuple(target.shape):
+                    raise ValueError(f"warm-start tensor contract differs for {name}")
+                target.copy_(source.to(device=target.device))
+            self.address_score_bias.zero_()
+
+    def _contextual_direct_hidden(
+        self, token_ids: Tensor, state: DecoderState, *, state_off: bool
+    ) -> tuple[Tensor, DecoderState]:
+        outputs: list[Tensor] = []
+        current = state
+        for time_index in range(int(token_ids.shape[1])):
+            token = token_ids[:, time_index]
+            values = self.token_embedding(token)
+            leaves = self.token_leaves.index_select(0, token)
+            actions = self.left_actions.index_select(0, leaves)
+            keys: list[Tensor] = []
+            retained_values: list[Tensor] = []
+            occupied: list[Tensor] = []
+            for layer_index, layer in enumerate(self.layers):
+                values, layer_keys, layer_values, layer_occupied = (
+                    layer.forward_direct_step_with_contextual_key_value_address_read(
+                        values,
+                        actions,
+                        current.keys[layer_index],
+                        current.values[layer_index],
+                        current.occupied[layer_index],
+                        self.identity_offset,
+                        self.address_score_bias[layer_index],
                         state_off=state_off,
                     )
                 )


### PR DESCRIPTION
The retained reader transported keys, values, and occupancy through the same H4 permutation, then scored only query/key content. That makes the immediate softmax read invariant to the transport and leaves the current relative group address out of the attention decision.

This adds `R4ContextualKeyValueAddressReadLanguagePathV1`, with one zero-initialized logit bias per layer, head, and current relative address. The version preserves the contextual K/V writes, exact-H4 state transport, decay/write gates, 23,040-value recurrent state, occupancy, tied head, and historical policies. It adds 960 learned scalars for 253,120 parameters total. Inference requires a complete address-aware artifact; only the fitter may load the pinned retained V1 artifact as a zero-bias warm start.

The one bounded fit completed 128 updates over 2,048 open windows / 245,760 targets in 96.298573 seconds on CPU4. Artifact: `blake3:fb82bfe43289f3de82ff4889eb1963bc426a446d6d8b574e724ef59094356ef1`. Last-16 mean training loss was 3.9163646698 versus 3.9164103419 for the immediately preceding contextual-K/V arm, a 0.0000456721-nat difference. Both fixed generated continuations were token- and byte-identical to that arm. This is a bounded negative; it does not justify a full epoch or establish that attention or H4 generally fails.

Validation:
- Python source compilation and diff checks
- zero-bias logits/K/V state exactly match the preceding reader
- nonconstant address bias changes logits
- strict inference rejects the base artifact; the fit-only loader accepts the pinned V1 warm start; the complete fitted artifact loads all 960 bias values
- build-first policy check
- independent focused source and result review

References #973.
