### PR TITLE
Implement bounded sparse geometric recurrent attention

### DIFF
--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -7,12 +7,12 @@ implementation is fixed recurrent memory → sparse geometric attention →
 nonlinear geometric block → scale/data/instruction → retrieval/tools → product alpha
 → Rust/table lowering → release proof/evidence/QA.
 
-**Current measured mechanism:** `R4FixedRecurrentCausalKVBindingV1` uses eight
-exact live K/V records and four H4-local chronological summary banks. It keeps
-2,304 f32 K/V values (9,216 bytes) independent of processed sequence length,
-versus 23,040 values (92,160 bytes) in the 120-token full-cache comparator. A
-focused execution check is bit-exact with the comparator through the decision
-that causes the first post-read eviction.
+**Current measured mechanism:** `R4SparseGeometricCandidateSoftmaxKVBindingV1`
+uses the accepted eight-live/four-summary recurrent state. It ranks only source
+metadata by exact signed-S3 shell and full-H4-root diversity, admits at most
+eight persistent records plus current, and gathers K/V only after selection.
+The recurrent state remains 2,304 f32 values (9,216 bytes), and the learned Q/K
+softmax reader remains the bounded comparator inside the admitted set.
 
 The frozen full-prompt seed-9738, top-k-40, 16-token no-fit comparison observed:
 
@@ -23,13 +23,15 @@ The frozen full-prompt seed-9738, top-k-40, 16-token no-fit comparison observed:
   `he put it with` versus recurrent `and and a time`; 20 evictions, 80 summary
   reads, 18 merges.
 
-Both recurrent executions stayed within 13 attention sources and made zero
-teacher, provider, future, or forbidden reads. This establishes bounded
-read-before-write compression and executable post-eviction summary use. It does
-not establish language improvement, long-context retention, geometric
+The sparse successor stayed within nine attention sources and made zero
+complete-prefix scans, omitted-payload reads, teacher, provider, future, or
+forbidden reads. Against the fixed recurrent arm, its common generated prefixes
+were 12 tokens for the turtle prompt and 3 for Einstein; aggregate materialized
+scores fell 15.27%. This establishes bounded pre-read geometric admission, not
+useful retrieval, language improvement, long-context retention, geometric
 advantage, architectural alpha, or table-native execution. RoPE still limits
-the reference to 120 positions. The next implementation is sparse geometric
-attention.
+the reference to 120 positions. The next implementation is the nonlinear
+geometric block.
 
 Historical positive, negative, and unavailable results below retain their exact
 scope. A negative binds its artifact/population/operator/controls/budget and may

--- a/docs/integration/CONTINUE.md
+++ b/docs/integration/CONTINUE.md
@@ -13,7 +13,7 @@ alpha → Rust/table lowering → release proof/evidence/QA.
 
 ## Current checkpoint
 
-[#973](https://github.com/UOR-Foundation/uor-r4/issues/973) now has two
+[#973](https://github.com/UOR-Foundation/uor-r4/issues/973) now has three
 artifact-only causal paths over the same accepted ordinary weights:
 
 - `R4PositionPreservingCausalKVBindingV1` is the full 120-position comparator.
@@ -21,6 +21,9 @@ artifact-only causal paths over the same accepted ordinary weights:
   four chronological binary-age H4 summary banks. It reads before writing and
   keeps its f32 K/V ledger fixed at 2,304 values / 9,216 bytes, 90% below the
   comparator's 92,160 f32 bytes.
+- `R4SparseGeometricCandidateSoftmaxKVBindingV1` ranks only those twelve
+  persistent metadata slots by exact signed-S3 shell and full-H4-root maximin
+  diversity, admits at most eight plus current, and gathers K/V only afterward.
 
 The focused causal check is exact through the decision that performs the first
 post-read eviction. In the frozen full-prompt no-fit, seed-9738, top-k-40, 16-token
@@ -31,21 +34,23 @@ comparison:
 | `A purple turtle found a clock in the garden` | `, there was a time, there was a little girl named It found a big` | `, there was a time, there was a little girl named but so she saw` | 12 tokens |
 | `Albert Einstein was born in` | ` his friend, a time, there was a little girl named he put it with` | ` his friend, a time, there was a little girl named and and a time` | 12 tokens |
 
-The recurrent runs made 17/20 evictions, 66/80 summary-slot reads, and 15/18
-summary merges respectively. Both stayed within 13 attention sources, made zero
-teacher/provider/future/forbidden reads, and performed no fit. These are
-measured mechanism results. They do not establish language quality,
-long-context retention, geometric advantage, architectural alpha, or
+The sparse runs shared 12 and 3 generated tokens with the fixed recurrent arm.
+They selected a different set from age-only on 33/35 sparse decisions, admitted
+55 summary records, stayed within nine sources, and reduced aggregate score
+materialization from 3,824 to 3,240. Both reported zero complete-prefix scans,
+omitted-payload, teacher, provider, future, or forbidden reads. These are
+measured mechanism results. They do not establish useful retrieval, language
+quality, long-context retention, geometric advantage, architectural alpha, or
 table-native execution. The trained RoPE ceiling remains 120.
 
 ## Next implementation action
 
-Implement the first versioned **sparse geometric attention** successor under
-#973. Keep the full-cache path and fixed recurrent path as comparators. Map the
-current query/state to a bounded set of geometric candidates, read and aggregate
-only those candidates, and prevent any complete-prefix attention scan. Compare
-the same two prompt trajectories before fitting; add a small open-data retention
-probe only if those two executions leave a specific unresolved design choice.
+Implement the first versioned **nonlinear geometric block** successor under
+#973. Keep `R4SparseGeometricCandidateSoftmaxKVBindingV1` as the attention path
+and the current dense SwiGLU block as the comparator. Define one finite R4
+operator block with an explicit state map, nonlinearity, residual/readout, and
+bounded cost. Keep E8/R8 separate unless a typed bridge is implemented. Run one
+direct prompt execution before any scale or instruction campaign.
 
 SpiralCore's finite labelled E8 action graph may inform an operator-indexed
 candidate selector, but it is not already attention. Keep its H4/R4 and E8/R8
@@ -66,11 +71,12 @@ docs/integration/project-track.md. Complete exactly one active implementation
 task and stop.
 
 Apply build_first_architectural_alpha. Use one isolated full Git worktree.
-Implement the first versioned sparse geometric-attention successor under #973.
-Keep the accepted full-cache and fixed-recurrent paths as comparators. Select and
-read a bounded geometric candidate set without retaining or scanning the full
-prefix. Run the smallest direct no-fit comparison that resolves the mechanism;
-use bounded open development data only if a specific design choice remains.
+Implement the first versioned nonlinear geometric block successor under #973.
+Keep the accepted sparse geometric reader and dense SwiGLU block as
+comparators. Specify and execute one finite R4 state map, nonlinearity,
+residual/readout, and bounded-cost path. Keep H4/R4 and E8/R8 typed separately
+unless an explicit bridge is implemented. Run the smallest direct no-fit prompt
+comparison that resolves the mechanism.
 
 Query the knowledge index or inspect SpiralCore/HELM/W33/NEMESIS/UOR/H4-zeta
 sources only for the concrete selector/read decision. Treat them as donor

--- a/docs/integration/agent-execution-policy.json
+++ b/docs/integration/agent-execution-policy.json
@@ -51,7 +51,7 @@
   "mode": "build_first_architectural_alpha",
   "project_track": {
     "architectural_alpha": "useful_prompt_dependent_text_through_bounded_recurrent_geometric_memory_and_bounded_geometric_selection_without_complete_prefix_scan_or_runtime_teacher_provider_or_source_model",
-    "current_stage": "sparse_geometric_attention",
+    "current_stage": "nonlinear_geometric_block",
     "ordered_stages": [
       "fixed_recurrent_geometric_memory",
       "sparse_geometric_attention",

--- a/docs/integration/claim-ledger.json
+++ b/docs/integration/claim-ledger.json
@@ -1,7 +1,7 @@
 {
   "schema": "uor-r4.claim-ledger/1",
   "repository": "UOR-Foundation/uor-r4",
-  "source_revision": "db8682fb762aadc5e87c0afb0d4f1fd01cfc4495",
+  "source_revision": "9cbc14c43248bed9f04b099282f12f866253b115",
   "vocabulary": {
     "source": "formal_vocabulary",
     "role": "Statement class from the normative vocabulary.",
@@ -705,6 +705,55 @@
       "revision": "db8682fb762aadc5e87c0afb0d4f1fd01cfc4495",
       "sha256": "aa199fa8346a1cc0e58b58fb490092910e31a8a8f78a2204d0c915fde4f2a014",
       "evidence_status": "LOCAL_RAW_COMPARISON_OUTSIDE_GIT_SUMMARIZED_IN_NATIVE_ISSUE"
+    },
+    "sparse_recurrent_base_source_973": {
+      "path": "tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/e93822e944d1a8edfbc314153abc4585f2dcafc5/tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py",
+      "revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+      "git_blob_oid": "45f9f742b3302e69bca249fe0c49d721237beb62",
+      "evidence_status": "INDEPENDENTLY_REVIEWED_IMPLEMENTATION_SOURCE"
+    },
+    "sparse_selector_source_973": {
+      "path": "tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_kv_binding.py",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/e93822e944d1a8edfbc314153abc4585f2dcafc5/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_kv_binding.py",
+      "revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+      "git_blob_oid": "8e38b58b4c95aa95d1821c180229fc2164039be5",
+      "evidence_status": "INDEPENDENTLY_REVIEWED_IMPLEMENTATION_SOURCE"
+    },
+    "sparse_generation_source_973": {
+      "path": "tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_r4_language_generation.py",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/e93822e944d1a8edfbc314153abc4585f2dcafc5/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_r4_language_generation.py",
+      "revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+      "git_blob_oid": "63afe85c8c9fa1e7b69c5a7a5a43f1f5c5ed8358",
+      "evidence_status": "SOURCE_BACKED_GENERATION_PATH"
+    },
+    "sparse_focused_test_973": {
+      "path": "tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/e93822e944d1a8edfbc314153abc4585f2dcafc5/tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py",
+      "revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+      "git_blob_oid": "92f6e04c9277acb0eb46ec2ea6bfe0637d311c46",
+      "evidence_status": "FOCUSED_MECHANISM_REGRESSION_TEST"
+    },
+    "sparse_record_973": {
+      "path": "docs/r4_sparse_geometric_attention_973.md",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/9cbc14c43248bed9f04b099282f12f866253b115/docs/r4_sparse_geometric_attention_973.md",
+      "revision": "9cbc14c43248bed9f04b099282f12f866253b115",
+      "git_blob_oid": "6d9bc377855fb3938287aa4b3e368d7cc2c05857",
+      "evidence_status": "MEASURED_MECHANISM_RECORD"
+    },
+    "sparse_project_track_973": {
+      "path": "docs/integration/project-track.md",
+      "url": "https://github.com/UOR-Foundation/uor-r4/blob/9cbc14c43248bed9f04b099282f12f866253b115/docs/integration/project-track.md",
+      "revision": "9cbc14c43248bed9f04b099282f12f866253b115",
+      "git_blob_oid": "df57cb37bd6eabde1143be98324dc4542b61103f",
+      "evidence_status": "PROJECT_AUTHORITY"
+    },
+    "sparse_comparison_summary_973": {
+      "path": ".uor-models/research/issue-973-sparse-geometric-r4-v1/comparison/uor-sparse-geometric-comparison.json",
+      "url": "https://github.com/UOR-Foundation/uor-r4/issues/973",
+      "revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+      "sha256": "d592b5bb9c430a509c465ac8dbb38c706a240fb980df18dee2c4a98ed560d396",
+      "evidence_status": "LOCAL_RAW_COMPARISON_OUTSIDE_GIT_SUMMARIZED_IN_RECORD"
     }
   },
   "artifacts_1079": {
@@ -817,8 +866,8 @@
         "The #1082 construction-only diagnostic now measures role-selective exposure and pooling displacement; it does not establish a downstream causal explanation. The #1079 strong-sensitivity miss remains unchanged and does not falsify primary preservation or establish geometric superiority."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -848,8 +897,8 @@
         "#1079 evaluated already-observed controlled-language rows with supplied clause boundaries; it did not run general generation or coding. This is absence of qualification, not evidence that those future capabilities are impossible."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -983,8 +1032,8 @@
         "Numerical bound and replay checks are not a universal floating-point refinement proof."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1035,8 +1084,8 @@
         "#973 higher-context and #954 final source-free correctness terminals remain unmet."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1100,8 +1149,8 @@
         "Recorded worker RSS zero indicates no worker resource receipt; it is not a successful worker measurement."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1180,8 +1229,8 @@
         "#1079 weak-control and #1082 descriptive results are unchanged; #973 remains open and #954 blocked."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1235,8 +1284,8 @@
         "Supplied segmentation remains the qualified model entry; #1094 and #973 remain open and #954 blocked."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1312,8 +1361,8 @@
         "At this historical assembly checkpoint, supplied clauses remained the qualified model entry, #1079 weak-control and #1082 descriptive findings were unchanged, #1094/#973 were open and #954 was blocked."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1403,8 +1452,8 @@
         "The 120-second historical charge is a conservative policy debit; the resource snapshot excludes its own write/exit tail. Storage peak is a reconstructed bound, not an instantaneous measurement."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1549,8 +1598,8 @@
         "The successful ordinary qualify()/serving path remains NOT_RUN; the measured binary exposes research modes, not a service endpoint. Final integer/table lowering remains a separate contract."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1647,8 +1696,8 @@
         "#1084 remains open for implementation. #1083/#1087 retain separate boundaries; #973 remains open and #954 blocked."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1702,8 +1751,8 @@
         "#1084 remains open and unassigned. #1083/#1087 retain separate boundaries; #973 remains open and #954 blocked."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1783,8 +1832,94 @@
         "No mathematical proof or final held-out evaluation was performed."
       ],
       "next_action": {
-        "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-        "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
+        "issue_urls": [
+          "https://github.com/UOR-Foundation/uor-r4/issues/973"
+        ]
+      },
+      "proof_artifacts": []
+    },
+    {
+      "id": "R4-973-SPARSE-GEOMETRIC-ATTENTION",
+      "statement": "The accepted fixed recurrent language artifact executes causal generation through a deterministic exact-H4 metadata selector that admits at most eight persistent records plus current before gathering K/V, with no complete-prefix scan on the frozen two-prompt comparison.",
+      "role": "Empirical Criterion",
+      "evidence_status": "Empirical",
+      "outcome": "SPARSE_GEOMETRIC_MECHANISM_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED",
+      "scope": {
+        "parent_issue": 973,
+        "implementation_revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+        "policy": "R4SparseGeometricCandidateSoftmaxKVBindingV1",
+        "accepted_learned_artifact": "blake3:c1cd34b36c7df7c53915785a608ccd353a11de56eebb3ecc58e74092cb5d1933",
+        "prompts": 2,
+        "seed": 9738,
+        "maximum_new_tokens": 16,
+        "fits": 0,
+        "evaluations": 0,
+        "live_records": 8,
+        "summary_banks": 4,
+        "persistent_candidate_budget": 8,
+        "maximum_read_sources": 9,
+        "recurrent_state_values_f32": 2304,
+        "recurrent_state_bytes_f32": 9216
+      },
+      "assumptions": [
+        "The accepted tokenizer, learned artifact, exact-H4 geometry, H4 frame sidecar, sampler and frozen prompts retain the identities recorded by the raw comparison.",
+        "The signed-S3 shell plus full-root maximin rule is an unfitted engineering hypothesis about useful memory; exact finite selection does not establish semantic relevance.",
+        "The comparison covers two fixed prompts within the trained 120-position RoPE limit and is not a population-level language or retention evaluation."
+      ],
+      "observations": {
+        "mathematical_or_exact": "Canonical inverse/product/root lookup, nine signed-S3 shells, deterministic finite selection and the eight-plus-current ceiling; no formal proof artifact supplied.",
+        "independent_review": "CLEAN_AFTER_PER_LANE_TRACE_ACCOUNTING_CORRECTION_AND_14400_PAIR_CANONICAL_AUDIT",
+        "turtle": {
+          "common_generated_prefix_tokens_vs_fixed_recurrent": 12,
+          "sparse_selection_steps": 16,
+          "selected_summary_records": 26,
+          "materialized_attention_scores_fixed": 1776,
+          "materialized_attention_scores_sparse": 1512,
+          "sparse_raw_sha256": "b2ca5780bd5fc91faeab0ac9ee58737aff5fb0931f783ffdfd256d7fc82a7b4d"
+        },
+        "einstein": {
+          "common_generated_prefix_tokens_vs_fixed_recurrent": 3,
+          "sparse_selection_steps": 19,
+          "selected_summary_records": 29,
+          "materialized_attention_scores_fixed": 2048,
+          "materialized_attention_scores_sparse": 1728,
+          "sparse_raw_sha256": "3bcbddecda5e856d2cba095373f37769d6da6f16b7434c0ff4fb4ff793761018"
+        },
+        "sparse_decisions": 35,
+        "selection_different_from_age_only": 33,
+        "selected_live_records": 225,
+        "selected_summary_records": 55,
+        "aggregate_materialized_score_reduction_fraction": 0.15271966527196656,
+        "peak_attention_sources": 9,
+        "complete_prefix_scans": 0,
+        "unselected_key_value_reads": 0,
+        "provider_calls": 0,
+        "teacher_calls": 0,
+        "future_reads": 0,
+        "forbidden_reads": 0,
+        "comparison_summary_sha256": "d592b5bb9c430a509c465ac8dbb38c706a240fb980df18dee2c4a98ed560d396"
+      },
+      "evidence_refs": [
+        "sparse_recurrent_base_source_973",
+        "sparse_selector_source_973",
+        "sparse_generation_source_973",
+        "sparse_focused_test_973",
+        "sparse_record_973",
+        "sparse_project_track_973",
+        "sparse_comparison_summary_973"
+      ],
+      "limits": [
+        "The prompt trajectories preserve 12 and 3 generated tokens respectively against the fixed recurrent comparator; neither continuation is evidence of improved quality.",
+        "This does not establish useful retrieval, general language quality, long-context retention, geometric advantage, architectural alpha, reasoning, coding or table-native serving.",
+        "Learned f32 Q/K/V/O, bounded softmax, RMSNorm, SwiGLU, vocabulary projection and allocation remain; the trained RoPE limit remains 120 positions.",
+        "The #967 shortest-Cayley and #970 q0/q1 heatmap negatives retain their tested scope; the full-root set-valued selector is materially different but unverified.",
+        "No fit, population evaluation or formal proof artifact was produced."
+      ],
+      "next_action": {
+        "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+        "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
         "issue_urls": [
           "https://github.com/UOR-Foundation/uor-r4/issues/973"
         ]
@@ -1792,7 +1927,7 @@
       "proof_artifacts": []
     }
   ],
-  "previous_source_revision": "8399a71affd6eb3063a3a3765b1db44058b7f4fb",
+  "previous_source_revision": "db8682fb762aadc5e87c0afb0d4f1fd01cfc4495",
   "artifacts_1082": {
     "implementation_cid": "blake3:1451084b66531dbe5eb0cb1d3b3e60e5f0aa3f4bd59fffbf582a18d4dfc9380e",
     "preparation_cid": "blake3:c8a4a56de77767cbbe8fd31edc83251b42a6f729e182d065caa47d981f248741",
@@ -2088,10 +2223,10 @@
   },
   "current_project_track": {
     "document": "docs/integration/project-track.md",
-    "revision": "db8682fb762aadc5e87c0afb0d4f1fd01cfc4495",
+    "revision": "9cbc14c43248bed9f04b099282f12f866253b115",
     "status": "BUILD_FIRST_ARCHITECTURAL_ALPHA",
-    "completed_stage": "fixed_recurrent_geometric_memory",
-    "current_stage": "sparse_geometric_attention",
+    "completed_stage": "sparse_geometric_attention",
+    "current_stage": "nonlinear_geometric_block",
     "ordered_stages": [
       "fixed_recurrent_geometric_memory",
       "sparse_geometric_attention",
@@ -2113,8 +2248,26 @@
     "recurrent_state_bytes_f32": 9216,
     "maximum_read_sources": 13,
     "next_action": {
-      "status": "CURRENT_STAGE_SPARSE_GEOMETRIC_ATTENTION",
-      "scope": "After protected #1120 delivered fixed recurrent R4 memory, implement one versioned bounded geometric candidate selector over its eight live records and four summary banks. Compare admitted sources and frozen-prompt trajectories with the accepted recurrent softmax reader before fitting. #1084 and #1091 remain nonblocking reservoirs rather than scheduled qualification or proof gates.",
+      "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+      "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
+      "issue_urls": [
+        "https://github.com/UOR-Foundation/uor-r4/issues/973"
+      ]
+    }
+  },
+  "latest_sparse_geometric_attention": {
+    "issue": 973,
+    "status": "SPARSE_GEOMETRIC_MECHANISM_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED",
+    "source_revision": "e93822e944d1a8edfbc314153abc4585f2dcafc5",
+    "comparison_summary_sha256": "d592b5bb9c430a509c465ac8dbb38c706a240fb980df18dee2c4a98ed560d396",
+    "fit_performed": false,
+    "evaluation_performed": false,
+    "persistent_candidate_budget": 8,
+    "maximum_read_sources": 9,
+    "aggregate_materialized_score_reduction_fraction": 0.15271966527196656,
+    "next_action": {
+      "status": "CURRENT_STAGE_NONLINEAR_GEOMETRIC_BLOCK",
+      "scope": "Implement one versioned finite R4 nonlinear operator block under #973 while retaining R4SparseGeometricCandidateSoftmaxKVBindingV1 and the dense SwiGLU block as comparators. Define the state map, nonlinearity, residual/readout and bounded cost, then run one direct no-fit prompt comparison before scale work.",
       "issue_urls": [
         "https://github.com/UOR-Foundation/uor-r4/issues/973"
       ]

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,20 +7,20 @@ checkpoint definitions are in [project-track.md](project-track.md). Live
 model work.
 
 The old artifact-only pre-alpha condition is complete. The accepted #1119
-comparator preserves full chronological K/V through exact H4 transport.
-`R4FixedRecurrentCausalKVBindingV1` is the next executed mechanical
-checkpoint: eight exact live records, four H4-local summary banks, and a fixed
-2,304-value / 9,216-byte f32 K/V ledger. In the frozen full-prompt no-fit
-two-prompt
-comparison, both runs evicted and later read summaries;
-`A purple turtle found a clock in the garden` and
-`Albert Einstein was born in` each shared 12 generated tokens with the
-full-cache reference.
-This measures the bounded mechanism, not quality, long-context retention,
-geometric advantage, architectural alpha, or table-native serving. The RoPE
-limit remains 120.
+comparator preserves full chronological K/V through exact H4 transport, and
+`R4FixedRecurrentCausalKVBindingV1` provides the fixed 2,304-value / 9,216-byte
+f32 K/V ledger.
 
-Sparse geometric attention is next. Broad proofs, evidence ledgers,
+`R4SparseGeometricCandidateSoftmaxKVBindingV1` is the next executed mechanical
+checkpoint. It ranks only the fixed twelve-slot metadata directory by exact
+signed-S3 shell and full-H4-root maximin diversity, admits at most eight
+persistent records, appends current, and gathers K/V only after admission. The
+two frozen no-fit prompts reached at most nine attention sources with zero
+complete-prefix scans or omitted-payload reads. They shared 12 and 3 generated
+tokens respectively with the fixed recurrent comparator; this uneven result is
+mechanism evidence, not useful-retrieval or language-quality evidence.
+
+The nonlinear geometric block is next. Broad proofs, evidence ledgers,
 publication, programme-wide research mapping, and release QA do not sit between
 the build stages. SpiralCore, HELM, W33, NEMESIS, UOR, and H4/zeta sources are
 consulted only for a concrete design seam, with original-source inspection and

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -67,9 +67,9 @@ execution.
    and publication against the release candidate. This work does not gate the
    earlier build stages unless a concrete implementation decision needs it.
 
-Fixed recurrent geometric memory is the completed mechanical checkpoint under
-[#973](https://github.com/UOR-Foundation/uor-r4/issues/973). The current stage
-is sparse geometric attention. #954 and the old capability chain remain
+Fixed recurrent memory and sparse geometric attention are completed mechanical
+checkpoints under [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
+The current stage is the nonlinear geometric block. #954 and the old capability chain remain
 historical issue structure; they do not insert a proof or bookkeeping campaign
 between these build stages.
 
@@ -94,6 +94,16 @@ future, or forbidden reads.
 This is measured mechanism behavior. It does not establish better language,
 long-context retention, geometric advantage, architectural alpha, or
 table-native execution. The trained RoPE limit remains 120 positions.
+
+`R4SparseGeometricCandidateSoftmaxKVBindingV1` now ranks the fixed twelve-slot
+metadata directory with exact H4 inverse/product/root witnesses, admits at most
+eight persistent records plus current, and only then gathers K/V for unchanged
+learned Q/K softmax. On the same two no-fit prompts, peak attention sources fell
+from 13 to 9 and aggregate materialized scores fell from 3,824 to 3,240. The
+geometric set differed from age-only on 33/35 sparse decisions and admitted 55
+summary records. Common generated prefixes against the fixed recurrent path
+were 12 and 3 tokens. This completes the sparse mechanical checkpoint while
+leaving useful retrieval and geometric advantage unestablished.
 
 ## Research reservoirs
 

--- a/docs/r4_sparse_geometric_attention_973.md
+++ b/docs/r4_sparse_geometric_attention_973.md
@@ -1,0 +1,123 @@
+# #973 sparse geometric recurrent attention
+
+**Date:** 2026-09-04  
+**Status:** `SPARSE_GEOMETRIC_MECHANISM_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED`  
+**Implementation revision:** `e93822e944d1a8edfbc314153abc4585f2dcafc5`
+
+## Result
+
+`R4SparseGeometricCandidateSoftmaxKVBindingV1` now selects a bounded subset of
+the accepted fixed recurrent memory before reading K/V payloads. The eligible
+pool remains eight exact live records plus four H4-local summary banks. The new
+policy admits at most eight persistent records and always appends the transient
+current record, so learned Q/K softmax sees at most nine sources instead of
+thirteen.
+
+The persistent budget equals the accepted live-window size. States containing
+only the eight live records therefore preserve the comparator exactly. Sparse
+behavior starts on the first read after an eviction has created a competing
+summary. No fit or evaluation was performed.
+
+## Selector and evidence boundary
+
+For every occupied source frame `s` and current frame `q`, the selector obtains
+the exact relative H4 element `s^-1 * q` from the sidecar's inverse and product
+tables. It visits the nine signed S3 angular shells from coincident to
+antipodal. If a shell crosses the remaining budget, it greedily maximizes the
+minimum pairwise signed-S3 separation of the complete relative H4 roots, then
+breaks remaining ties by causal age and physical slot. Only the selected slots
+are gathered and transported. Their existing learned Q/K scores, softmax, and
+value aggregation remain unchanged.
+
+- **Exact construction:** the H4 inverse/product/root lookup, nine-shell order,
+  deterministic tie rule, eight-record persistent budget, and nine-source read
+  ceiling. Independent review reproduced the scalar-shell relation for all
+  14,400 ordered pairs in the canonical H4 sidecar.
+- **Measured behavior:** the focused mutation check and two source-backed
+  prompt executions below. They establish that selection executes before K/V
+  reads, summaries can be admitted, and work stays bounded.
+- **Unverified hypothesis:** H4 shell proximity and full-root maximin diversity
+  identify useful language memory.
+
+The exact `q0/q1` heatmap, activation, chirality, cosine polarity, typed-null
+projection, and all four `Z[phi]` root coordinates remain in the trace. The
+heatmap is not an admission score. A typed-null two-coordinate chart does not
+reject an otherwise valid full H4 root.
+
+This is materially different from the older tested selectors, but it does not
+erase their negative results. Shortest Cayley distance tied all six historical
+queries in #967. The #970 `q0/q1` heatmap construction transferred strict
+selection on 0/6 held-out queries and exposed eight incompatible classes. Those
+results still prohibit treating either representation as established semantic
+relevance.
+
+## Frozen no-fit comparison
+
+The new arm used the accepted artifact, tokenizer, exact-H4 geometry and frame
+sidecar, seed 9738, top-k 40, temperature 0.8, and sixteen generated tokens.
+The fixed recurrent comparator was read from its preserved JSON and was not
+rerun.
+
+| Prompt | Fixed recurrent continuation | Sparse continuation | Common generated prefix | Sparse decisions | Selected summaries | Score materialization |
+|---|---|---|---:|---:|---:|---:|
+| `A purple turtle found a clock in the garden` | `, there was a time, there was a little girl named but so she saw` | `, there was a time, there was a little girl named I saw a little` | 12 | 16 | 26 | 1,776 -> 1,512 (-14.86%) |
+| `Albert Einstein was born in` | ` his friend, a time, there was a little girl named and and a time` | ` his friend, and Lily were very sad. He said, "So and` | 3 | 19 | 29 | 2,048 -> 1,728 (-15.63%) |
+
+Across both executions, 35 decisions required sparse selection. The geometric
+set differed from age-only top-eight on 33 of them and admitted 225 live plus 55
+summary records. Aggregate materialized attention scores fell from 3,824 to
+3,240 (-15.27% over whole prompts, including their initially non-sparse
+prefixes). Peak attention sources fell from 13 to 9 (-30.77%). Both runs reached
+12 eligible persistent records while selecting no more than eight.
+
+Both runs reported zero complete-prefix scans, unselected K/V reads, teacher
+calls, provider calls, future reads, and forbidden reads. The recurrent K/V
+state remains 2,304 f32 values / 9,216 bytes. The two prompt trajectories are
+uneven: one retained the prior 12-token common prefix and the other retained
+three. That is a useful limit, not a language-quality verdict.
+
+Preserved artifacts:
+
+- sparse turtle raw JSON: SHA-256
+  `b2ca5780bd5fc91faeab0ac9ee58737aff5fb0931f783ffdfd256d7fc82a7b4d`
+- sparse Einstein raw JSON: SHA-256
+  `3bcbddecda5e856d2cba095373f37769d6da6f16b7434c0ff4fb4ff793761018`
+- comparison summary: SHA-256
+  `d592b5bb9c430a509c465ac8dbb38c706a240fb980df18dee2c4a98ed560d396`
+
+They remain outside Git under
+`.uor-models/research/issue-973-sparse-geometric-r4-v1/comparison/`.
+
+## Focused verification and review
+
+```text
+PYTHONPATH=tools/r4-softmax-trainer/src \
+  .uor-models/research/issue-1014/venv/bin/python -m unittest \
+  tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py
+
+Ran 3 tests in 0.161s
+OK
+```
+
+The focused test preserves fixed-reader parity through the eviction-producing
+decision, verifies the exact inverse/product/root trace and shell order, and
+mutates one omitted versus one admitted payload. The omitted mutation leaves
+the sparse logits bit-identical; the admitted mutation changes them.
+
+Independent source and artifact review found no blocking defect after one
+per-lane trace-accounting correction. It also checked divergent 16-lane
+selection and reconciled all final raw hashes.
+
+## Limits and next action
+
+The learned Q/K/V/O projections, bounded softmax, RMSNorm, SwiGLU, vocabulary
+head, f32 tensors, allocation, and 120-token RoPE ceiling remain. Two prompts do
+not establish useful retrieval, language quality, long-context retention,
+geometric advantage, architectural alpha, reasoning, coding, table-native
+serving, or release readiness.
+
+The sparse geometric attention mechanical checkpoint is complete. #973 remains
+open and owns the next build stage: implement one versioned nonlinear geometric
+block while retaining this sparse reader and the dense SwiGLU block as
+comparators. Selector-quality attribution belongs with scale/data work unless a
+direct regression blocks that implementation.

--- a/docs/r4_sparse_geometric_attention_973.md
+++ b/docs/r4_sparse_geometric_attention_973.md
@@ -1,7 +1,7 @@
 # #973 sparse geometric recurrent attention
 
-**Date:** 2026-09-04  
-**Status:** `SPARSE_GEOMETRIC_MECHANISM_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED`  
+**Date:** 2026-09-04
+**Status:** `SPARSE_GEOMETRIC_MECHANISM_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED`
 **Implementation revision:** `e93822e944d1a8edfbc314153abc4585f2dcafc5`
 
 ## Result

--- a/docs/uor_productization_integration_plan.md
+++ b/docs/uor_productization_integration_plan.md
@@ -242,14 +242,17 @@ These are workflow templates, not newly activated recurring schedules. No backgr
 
 ## 8. Current delivery and next action
 
-The fixed recurrent mechanical checkpoint is implemented under #973 and retains
-its raw no-fit comparison outside Git under the repository's `.uor-models`
-store. The next
-implementation is the first versioned sparse geometric-attention successor:
-select and read a bounded geometric candidate set without a complete-prefix
-scan, retaining the full-cache and fixed-recurrent paths as comparators. Compare
-the same two prompt trajectories before fitting. Use a small open-data retention
-probe only if the direct runs expose a concrete selector decision.
+The sparse geometric mechanical checkpoint is implemented under #973 and
+retains its raw no-fit comparison outside Git under the repository's
+`.uor-models` store. It admits at most eight persistent records plus current
+from the fixed recurrent state and gathers no omitted K/V payload. The two
+frozen prompts shared 12 and 3 generated tokens with the fixed recurrent
+comparator, so bounded execution is measured while useful retrieval remains
+unestablished.
 
-Do not start the nonlinear block, scale campaign, workbench, final lowering, or
-release proof/QA in that same task.
+The next implementation is one versioned nonlinear geometric block. Retain the
+sparse reader and dense SwiGLU block as comparators, define an explicit finite
+R4 state map, nonlinearity, residual/readout and cost, and execute one direct
+prompt comparison before scale work. Keep E8/R8 separately typed unless an
+explicit bridge is implemented. Do not start scale, workbench, final lowering,
+or release proof/QA in that same task.

--- a/scripts/check_agent_execution_policy.py
+++ b/scripts/check_agent_execution_policy.py
@@ -120,7 +120,7 @@ def main() -> int:
         )
         require(
             policy["project_track"]["current_stage"]
-            == "sparse_geometric_attention",
+            == "nonlinear_geometric_block",
             "current project-track stage changed",
         )
         require(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -118,6 +118,9 @@ from .position_r4_language_generation import generate_position_r4_language_path
 from .fixed_recurrent_r4_language_generation import (
     generate_fixed_recurrent_r4_language_path,
 )
+from .sparse_geometric_r4_language_generation import (
+    generate_sparse_geometric_r4_language_path,
+)
 from .role_tagged_associative_development import (
     preflight_role_tagged_associative_development,
     prepare_role_tagged_associative_development,
@@ -755,6 +758,35 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="emit artifact, recurrent-state, token, and execution details",
     )
+    generate_sparse_geometric = subcommands.add_parser(
+        "generate-sparse-geometric-r4-language-path",
+        help=(
+            "continue one prompt through #973's ordinary weights with bounded "
+            "H4 candidate admission over fixed recurrent memory"
+        ),
+    )
+    generate_sparse_geometric.add_argument("--prompt", required=True)
+    generate_sparse_geometric.add_argument(
+        "--geometry",
+        type=_root,
+        default=default_language_path_geometry(),
+        help="canonical exact-H4 group geometry",
+    )
+    generate_sparse_geometric.add_argument(
+        "--h4-sidecar",
+        type=_root,
+        default=default_predictive_block_delta_frame_sidecar(),
+        help="validated H4 frame sidecar used for candidate admission and transport",
+    )
+    generate_sparse_geometric.add_argument(
+        "--max-new-tokens", type=int, default=16
+    )
+    generate_sparse_geometric.add_argument("--seed", type=int, default=9_738)
+    generate_sparse_geometric.add_argument(
+        "--json",
+        action="store_true",
+        help="emit artifact, candidate-trace, token, and execution details",
+    )
     prepare_paired_h4 = subcommands.add_parser(
         "prepare-paired-h4-prompt-capacity",
         help=(
@@ -1250,6 +1282,7 @@ def main() -> None:
         "generate-ordinary-language-path",
         "generate-position-r4-language-path",
         "generate-fixed-recurrent-r4-language-path",
+        "generate-sparse-geometric-r4-language-path",
     }
     paired_h4_prompt_capacity_commands = {
         "prepare-paired-h4-prompt-capacity",
@@ -1631,6 +1664,20 @@ def main() -> None:
         return
     if arguments.command == "generate-fixed-recurrent-r4-language-path":
         result = generate_fixed_recurrent_r4_language_path(
+            root,
+            geometry_path=arguments.geometry,
+            frame_path=arguments.h4_sidecar,
+            prompt=arguments.prompt,
+            max_new_tokens=arguments.max_new_tokens,
+            seed=arguments.seed,
+        )
+        if arguments.json:
+            _print_result(result)
+        else:
+            print(result["text"])
+        return
+    if arguments.command == "generate-sparse-geometric-r4-language-path":
+        result = generate_sparse_geometric_r4_language_path(
             root,
             geometry_path=arguments.geometry,
             frame_path=arguments.h4_sidecar,

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py
@@ -81,6 +81,13 @@ class FixedRecurrentKVBindingAudit:
     vocabulary_scores: int
     source_reads: int
     peak_attention_source_slots: int
+    eligible_persistent_source_slots: int
+    selected_persistent_source_slots: int
+    geometric_shell_evaluations: int
+    pairwise_shell_evaluations: int
+    candidate_cost_comparisons: int
+    unselected_key_value_reads: int
+    complete_prefix_scans: int
     provider_calls: int = 0
     teacher_calls: int = 0
     future_reads: int = 0
@@ -117,6 +124,13 @@ class FixedRecurrentKVBindingAudit:
                 "value_reads",
                 "vocabulary_scores",
                 "source_reads",
+                "eligible_persistent_source_slots",
+                "selected_persistent_source_slots",
+                "geometric_shell_evaluations",
+                "pairwise_shell_evaluations",
+                "candidate_cost_comparisons",
+                "unselected_key_value_reads",
+                "complete_prefix_scans",
                 "provider_calls",
                 "teacher_calls",
                 "future_reads",
@@ -165,6 +179,35 @@ class FixedRecurrentKVStepOutput:
     audit: FixedRecurrentKVBindingAudit
     # [layers,batch,heads,MAXIMUM_READ_SOURCES]
     attention_weights: Tensor
+    candidate_selection: FixedRecurrentCandidateSelection | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FixedRecurrentCandidateSelection:
+    """Persistent metadata selected once for one causal token.
+
+    Physical slots 0..3 name summary banks and 4..11 name live-array slots.
+    K/V tensors are deliberately absent: selection must finish before a layer
+    gathers, transports, or scores any source state.
+    """
+
+    source_slots: Tensor
+    source_kind_codes: Tensor
+    source_positions: Tensor
+    source_represented_counts: Tensor
+    source_frame_indices: Tensor
+    relative_frame_indices: Tensor
+    query_shell_indices: Tensor
+    selection_ranks: Tensor
+    minimum_pairwise_shell_indices: Tensor
+    current_frame_indices: Tensor
+    current_position: int
+    eligible_persistent_sources: int
+    age_only_source_slots: Tensor | None = None
+    pairwise_shell_evaluations: int = 0
+    candidate_cost_comparisons: int = 0
+    pairwise_shell_evaluations_by_batch: Tensor | None = None
+    candidate_cost_comparisons_by_batch: Tensor | None = None
 
 
 @dataclass(slots=True)
@@ -181,6 +224,9 @@ class R4FixedRecurrentCausalKVBindingV1(
     R4PositionPreservingCausalKVBindingV1
 ):
     """Accepted ordinary weights with bounded hierarchical H4 K/V memory."""
+
+    POLICY_NAME = POLICY
+    MAXIMUM_ATTENTION_SOURCES = MAXIMUM_READ_SOURCES
 
     def __init__(
         self,
@@ -215,10 +261,12 @@ class R4FixedRecurrentCausalKVBindingV1(
     def recurrent_metadata_i64_value_count() -> int:
         return RECURRENT_METADATA_I64_VALUES
 
-    @staticmethod
-    def _empty_recurrent_audit(batch_size: int) -> FixedRecurrentKVBindingAudit:
+    @classmethod
+    def _empty_recurrent_audit(
+        cls, batch_size: int
+    ) -> FixedRecurrentKVBindingAudit:
         return FixedRecurrentKVBindingAudit(
-            policy=POLICY,
+            policy=cls.POLICY_NAME,
             batch_size=batch_size,
             token_steps=0,
             layers=LAYERS,
@@ -241,6 +289,13 @@ class R4FixedRecurrentCausalKVBindingV1(
             vocabulary_scores=0,
             source_reads=0,
             peak_attention_source_slots=0,
+            eligible_persistent_source_slots=0,
+            selected_persistent_source_slots=0,
+            geometric_shell_evaluations=0,
+            pairwise_shell_evaluations=0,
+            candidate_cost_comparisons=0,
+            unselected_key_value_reads=0,
+            complete_prefix_scans=0,
         )
 
     def initial_recurrent_state(
@@ -475,8 +530,21 @@ class R4FixedRecurrentCausalKVBindingV1(
         ):
             if not bool(torch.isfinite(tensor).all()):
                 raise ValueError("fixed-recurrent state contains a non-finite value")
-        if state.audit.policy != POLICY or state.audit.batch_size != batch_size:
+        if (
+            state.audit.policy != self.POLICY_NAME
+            or state.audit.batch_size != batch_size
+        ):
             raise ValueError("fixed-recurrent audit policy differs")
+
+    def _select_persistent_candidates(
+        self,
+        state: FixedRecurrentKVState,
+        current_frames: Tensor,
+    ) -> FixedRecurrentCandidateSelection | None:
+        """Return ``None`` for the accepted all-source comparator."""
+
+        del state, current_frames
+        return None
 
     def _model_to_local(self, values: Tensor, frame_indices: Tensor) -> Tensor:
         frames = self._frames(frame_indices, dtype=values.dtype)
@@ -602,6 +670,127 @@ class R4FixedRecurrentCausalKVBindingV1(
                 summary_last_positions[batch_offset, bank] = carry_last_position
         return bank_updates, merges, transported_blocks
 
+    def _selected_r4_attention(
+        self,
+        query: Tensor,
+        current_key: Tensor,
+        current_value: Tensor,
+        state: FixedRecurrentKVState,
+        layer_offset: int,
+        current_frames: Tensor,
+        score_gains: Tensor,
+        selection: FixedRecurrentCandidateSelection,
+    ) -> tuple[Tensor, Tensor, int, int, int]:
+        """Apply unchanged Q/K softmax after metadata-only sparse admission."""
+
+        batch_size = int(query.shape[0])
+        selected_count = int(selection.source_slots.shape[1])
+        selected_keys_local = torch.empty(
+            batch_size,
+            HEADS,
+            selected_count,
+            HEAD_DIM,
+            device=query.device,
+            dtype=torch.float32,
+        )
+        selected_values_local = torch.empty_like(selected_keys_local)
+
+        # Gather only admitted slots. Summary tensors are already local to their
+        # named H4 frames; live tensors enter that local frame after selection.
+        for batch_offset in range(batch_size):
+            for selected_offset, physical_slot in enumerate(
+                selection.source_slots[batch_offset].tolist()
+            ):
+                frame = selection.source_frame_indices[
+                    batch_offset, selected_offset
+                ]
+                if physical_slot < SUMMARY_BANKS:
+                    key_local = state.summary_keys_local[
+                        layer_offset, batch_offset, :, physical_slot, :
+                    ].float()
+                    value_local = state.summary_values_local[
+                        layer_offset, batch_offset, :, physical_slot, :
+                    ].float()
+                else:
+                    live_offset = physical_slot - SUMMARY_BANKS
+                    key_local = self._model_to_local(
+                        state.live_keys[
+                            layer_offset, batch_offset, :, live_offset, :
+                        ].float(),
+                        frame,
+                    )
+                    value_local = self._model_to_local(
+                        state.live_values[
+                            layer_offset, batch_offset, :, live_offset, :
+                        ].float(),
+                        frame,
+                    )
+                selected_keys_local[
+                    batch_offset, :, selected_offset, :
+                ] = key_local
+                selected_values_local[
+                    batch_offset, :, selected_offset, :
+                ] = value_local
+
+        current_key_local = self._model_to_local(current_key.float(), current_frames)
+        current_value_local = self._model_to_local(
+            current_value.float(), current_frames
+        )
+        source_keys_local = torch.cat(
+            (selected_keys_local, current_key_local.unsqueeze(2)), dim=2
+        )
+        source_values_local = torch.cat(
+            (selected_values_local, current_value_local.unsqueeze(2)), dim=2
+        )
+        source_frames = torch.cat(
+            (selection.source_frame_indices, current_frames.unsqueeze(1)), dim=1
+        )
+
+        current_frame_matrices = self._frames(current_frames, dtype=torch.float32)
+        source_frame_matrices = self._frames(source_frames, dtype=torch.float32)
+        transport = torch.einsum(
+            "bji,bsjk->bsik", current_frame_matrices, source_frame_matrices
+        )
+        query_local = torch.einsum(
+            "bji,bhdj->bhdi",
+            current_frame_matrices,
+            self._r4_blocks(query.float()),
+        )
+        transported_keys = torch.einsum(
+            "bsij,bhsdj->bhsdi",
+            transport,
+            self._r4_blocks(source_keys_local),
+        )
+        scores = torch.einsum("bhdi,bhsdi->bhs", query_local, transported_keys)
+        scores = scores / math.sqrt(HEAD_DIM)
+        scores = scores * score_gains.exp().view(1, -1, 1)
+        weights = torch.softmax(scores, dim=-1, dtype=torch.float32)
+
+        transported_values = torch.einsum(
+            "bsij,bhsdj->bhsdi",
+            transport,
+            self._r4_blocks(source_values_local),
+        )
+        attended_local = torch.einsum(
+            "bhs,bhsdi->bhdi", weights, transported_values
+        )
+        attended_model = torch.einsum(
+            "bij,bhdj->bhdi", current_frame_matrices, attended_local
+        )
+        summary_sources = int(
+            torch.count_nonzero(selection.source_kind_codes == 0)
+        )
+        live_sources = int(
+            torch.count_nonzero(selection.source_kind_codes == 1)
+        )
+        return (
+            self._from_r4_blocks(attended_model).to(query.dtype),
+            weights,
+            summary_sources + live_sources + batch_size,
+            live_sources,
+            summary_sources,
+        )
+
     def _fixed_r4_attention(
         self,
         query: Tensor,
@@ -611,8 +800,24 @@ class R4FixedRecurrentCausalKVBindingV1(
         layer_offset: int,
         current_frames: Tensor,
         score_gains: Tensor,
+        candidate_selection: FixedRecurrentCandidateSelection | None = None,
     ) -> tuple[Tensor, Tensor, int, int, int]:
         batch_size = int(query.shape[0])
+        if (
+            candidate_selection is not None
+            and candidate_selection.source_slots.numel()
+            < candidate_selection.eligible_persistent_sources
+        ):
+            return self._selected_r4_attention(
+                query,
+                current_key,
+                current_value,
+                state,
+                layer_offset,
+                current_frames,
+                score_gains,
+                candidate_selection,
+            )
         summary_order = torch.arange(
             SUMMARY_BANKS - 1,
             -1,
@@ -785,6 +990,9 @@ class R4FixedRecurrentCausalKVBindingV1(
         current_frames = self.frame_multiplication[
             state.current_frame_indices, leaves
         ]
+        candidate_selection = self._select_persistent_candidates(
+            state, current_frames
+        )
         values = self.token_embedding(token_ids)
         current_keys: list[Tensor] = []
         current_values: list[Tensor] = []
@@ -811,6 +1019,7 @@ class R4FixedRecurrentCausalKVBindingV1(
                     layer_offset,
                     current_frames,
                     layer.log_score_gains,
+                    candidate_selection,
                 )
             )
             admitted_sources_total += admitted
@@ -824,7 +1033,7 @@ class R4FixedRecurrentCausalKVBindingV1(
             padded_weights = torch.zeros(
                 batch_size,
                 HEADS,
-                MAXIMUM_READ_SOURCES,
+                self.MAXIMUM_ATTENTION_SOURCES,
                 device=weights.device,
                 dtype=weights.dtype,
             )
@@ -882,11 +1091,31 @@ class R4FixedRecurrentCausalKVBindingV1(
         summary_scores = summary_sources_total * HEADS
         current_scores = batch_size * LAYERS * HEADS
         materialized = admitted_scores
-        peak_sources = state.live_length + int(
+        eligible_per_batch = state.live_length + int(
             torch.count_nonzero(state.summary_counts[0])
-        ) + 1
+        )
+        if candidate_selection is None:
+            eligible_slots = batch_size * eligible_per_batch
+            selected_slots = eligible_slots
+            shell_evaluations = 0
+            pairwise_shell_evaluations = 0
+            candidate_cost_comparisons = 0
+            peak_sources = eligible_per_batch + 1
+        else:
+            eligible_slots = candidate_selection.eligible_persistent_sources
+            selected_slots = int(candidate_selection.source_slots.numel())
+            shell_evaluations = eligible_slots
+            pairwise_shell_evaluations = (
+                candidate_selection.pairwise_shell_evaluations
+            )
+            candidate_cost_comparisons = (
+                candidate_selection.candidate_cost_comparisons
+            )
+            peak_sources = (
+                int(candidate_selection.source_slots.shape[1]) + 1
+            )
         call_audit = FixedRecurrentKVBindingAudit(
-            policy=POLICY,
+            policy=self.POLICY_NAME,
             batch_size=batch_size,
             token_steps=batch_size,
             layers=LAYERS,
@@ -911,6 +1140,13 @@ class R4FixedRecurrentCausalKVBindingV1(
             vocabulary_scores=batch_size * VOCAB_SIZE,
             source_reads=batch_size,
             peak_attention_source_slots=peak_sources,
+            eligible_persistent_source_slots=eligible_slots,
+            selected_persistent_source_slots=selected_slots,
+            geometric_shell_evaluations=shell_evaluations,
+            pairwise_shell_evaluations=pairwise_shell_evaluations,
+            candidate_cost_comparisons=candidate_cost_comparisons,
+            unselected_key_value_reads=0,
+            complete_prefix_scans=0,
         )
         cumulative = state.audit.accumulated_with(call_audit)
         final_state = FixedRecurrentKVState(
@@ -936,6 +1172,7 @@ class R4FixedRecurrentCausalKVBindingV1(
             final_state=final_state,
             audit=call_audit,
             attention_weights=torch.stack(layer_weights, dim=0),
+            candidate_selection=candidate_selection,
         )
 
     @staticmethod

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_kv_binding.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_kv_binding.py
@@ -1,0 +1,509 @@
+"""Bounded H4 candidate admission over the fixed recurrent #973 state.
+
+The persistent memory, learned tensors, transported Q/K score, softmax, and
+value aggregation are inherited unchanged from the accepted fixed recurrent
+path.  This V1 changes only source admission.  It examines at most the eight
+live and four summary metadata records, selects at most eight persistent
+records, and only then gathers their K/V tensors.  The transient current record
+is always appended.
+
+Primary order is the exact signed S3 angular shell of ``source^-1 * current``.
+If one shell overfills the remaining budget, greedy maximin separation between
+the full exact H4 relative roots chooses a diverse subset.  Causal age and the
+physical recurrent slot are deterministic final tie breakers.  The budget and
+ranking are an unfitted engineering hypothesis, not a semantic or quality
+claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from .fixed_recurrent_kv_binding import (
+    LIVE_WINDOW,
+    SUMMARY_BANKS,
+    FixedRecurrentCandidateSelection,
+    FixedRecurrentKVState,
+    R4FixedRecurrentCausalKVBindingV1,
+)
+from .group_retention import GroupAddressArtifact
+
+
+POLICY = "R4SparseGeometricCandidateSoftmaxKVBindingV1"
+PERSISTENT_CANDIDATE_BUDGET = LIVE_WINDOW
+MAXIMUM_READ_SOURCES = PERSISTENT_CANDIDATE_BUDGET + 1
+SIGNED_S3_SHELL_DEGREES = (0, 36, 60, 72, 90, 108, 120, 144, 180)
+
+_SHELL_BY_SCALAR_Z_PHI = {
+    (2, 0): 0,
+    (0, 1): 1,
+    (1, 0): 2,
+    (-1, 1): 3,
+    (0, 0): 4,
+    (1, -1): 5,
+    (-1, 0): 6,
+    (0, -1): 7,
+    (-2, 0): 8,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    physical_slot: int
+    kind_code: int
+    position: int
+    represented_count: int
+    frame_index: int
+    relative_frame_index: int
+    query_shell_index: int
+    age: int
+    selection_rank: int = -1
+    minimum_pairwise_shell_index: int = -1
+
+
+def _z_phi_sign(a: int, b: int) -> int:
+    """Return the exact sign of ``a + b*phi`` using integer comparisons."""
+
+    p = 2 * a + b
+    q = b
+    if q == 0:
+        return (p > 0) - (p < 0)
+    if p == 0:
+        return (q > 0) - (q < 0)
+    if (p > 0) == (q > 0):
+        return 1 if p > 0 else -1
+    p_squared = p * p
+    five_q_squared = 5 * q * q
+    if p > 0:
+        return (p_squared > five_q_squared) - (p_squared < five_q_squared)
+    return (five_q_squared > p_squared) - (five_q_squared < p_squared)
+
+
+def _heatmap_trace(
+    root: tuple[tuple[int, int], ...],
+) -> dict[str, Any]:
+    """Retain the exact #970 (1,i) chart as trace, never as admission."""
+
+    q0 = root[0]
+    q1 = root[1]
+    activation = (
+        q0[0] * q0[0] + q0[1] * q0[1],
+        2 * q0[0] * q0[1] + q0[1] * q0[1],
+    )
+    return {
+        "sin_z_phi": {"numerator": list(q0), "denominator": 2},
+        "cos_z_phi": {"numerator": list(q1), "denominator": 2},
+        "activation_z_phi": {
+            "numerator": list(activation),
+            "denominator": 4,
+        },
+        "chirality": _z_phi_sign(*q0),
+        "cosine_polarity": _z_phi_sign(*q1),
+        "typed_null_projection": q0 == (0, 0) and q1 == (0, 0),
+        "used_for_admission": False,
+    }
+
+
+class R4SparseGeometricCandidateSoftmaxKVBindingV1(
+    R4FixedRecurrentCausalKVBindingV1
+):
+    """Fixed recurrent memory with exact-H4 sparse source admission."""
+
+    POLICY_NAME = POLICY
+    MAXIMUM_ATTENTION_SOURCES = MAXIMUM_READ_SOURCES
+
+    def __init__(
+        self,
+        geometry: GroupAddressArtifact,
+        frames: object,
+    ) -> None:
+        inverse_indices = getattr(frames, "inverse_indices", None)
+        root_coordinates = getattr(frames, "root_coordinates", None)
+        if inverse_indices is None or root_coordinates is None:
+            raise ValueError(
+                "sparse geometric admission requires exact H4 inverses and roots"
+            )
+        super().__init__(geometry, frames)
+
+        inverses = torch.as_tensor(inverse_indices, dtype=torch.long).contiguous()
+        if tuple(inverses.shape) != (120,):
+            raise ValueError("H4 inverse indices must have shape [120]")
+        elements = torch.arange(120, dtype=torch.long)
+        identity = torch.full((120,), self.identity_index, dtype=torch.long)
+        multiplication = self.frame_multiplication.detach().cpu()
+        left_inverses = torch.equal(multiplication[inverses, elements], identity)
+        right_inverses = torch.equal(multiplication[elements, inverses], identity)
+        if not left_inverses or not right_inverses:
+            raise ValueError(
+                "H4 inverse indices do not invert the multiplication table"
+            )
+
+        roots = tuple(
+            tuple((int(coordinate[0]), int(coordinate[1])) for coordinate in root)
+            for root in root_coordinates
+        )
+        if len(roots) != 120 or any(len(root) != 4 for root in roots):
+            raise ValueError("H4 exact roots must contain 120 four-coordinate rows")
+        try:
+            shell_indices = torch.tensor(
+                [_SHELL_BY_SCALAR_Z_PHI[root[0]] for root in roots],
+                dtype=torch.long,
+            )
+        except KeyError as error:
+            raise ValueError("H4 root has an unknown signed S3 scalar shell") from error
+        if int(shell_indices[self.identity_index]) != 0:
+            raise ValueError("H4 identity does not occupy the coincident shell")
+
+        self.register_buffer("frame_inverse_indices", inverses)
+        self.register_buffer("signed_s3_shell_indices", shell_indices)
+        self._exact_root_coordinates = roots
+
+    def _relative_index(self, source_frame: int, current_frame: int) -> int:
+        inverse = int(self.frame_inverse_indices[source_frame])
+        return int(self.frame_multiplication[inverse, current_frame])
+
+    def _pairwise_shell_index(self, left: int, right: int) -> int:
+        inverse = int(self.frame_inverse_indices[left])
+        relative = int(self.frame_multiplication[inverse, right])
+        return int(self.signed_s3_shell_indices[relative])
+
+    @staticmethod
+    def _attention_order(candidate: _Candidate) -> tuple[int, int]:
+        if candidate.kind_code == 0:
+            return (0, -candidate.physical_slot)
+        return (1, candidate.physical_slot)
+
+    def _rank_candidates(
+        self, candidates: list[_Candidate]
+    ) -> tuple[list[_Candidate], int, int]:
+        pairwise_shells: dict[tuple[int, int], int] = {}
+        for left_offset, left in enumerate(candidates):
+            for right in candidates[left_offset + 1 :]:
+                shell = self._pairwise_shell_index(
+                    left.relative_frame_index, right.relative_frame_index
+                )
+                pairwise_shells[
+                    (left.physical_slot, right.physical_slot)
+                ] = shell
+                pairwise_shells[
+                    (right.physical_slot, left.physical_slot)
+                ] = shell
+        selected: list[_Candidate] = []
+        cost_comparisons = 0
+        for query_shell in range(len(SIGNED_S3_SHELL_DEGREES)):
+            remaining = [
+                candidate
+                for candidate in candidates
+                if candidate.query_shell_index == query_shell
+            ]
+            while remaining and len(selected) < PERSISTENT_CANDIDATE_BUDGET:
+                choices: list[tuple[tuple[int, int, int], _Candidate, int]] = []
+                for candidate in remaining:
+                    cost_comparisons += 1
+                    minimum_pairwise = (
+                        min(
+                            pairwise_shells[
+                                (candidate.physical_slot, prior.physical_slot)
+                            ]
+                            for prior in selected
+                        )
+                        if selected
+                        else -1
+                    )
+                    choices.append(
+                        (
+                            (-minimum_pairwise, candidate.age, candidate.physical_slot),
+                            candidate,
+                            minimum_pairwise,
+                        )
+                    )
+                _, chosen, minimum_pairwise = min(choices, key=lambda item: item[0])
+                selected.append(
+                    _Candidate(
+                        physical_slot=chosen.physical_slot,
+                        kind_code=chosen.kind_code,
+                        position=chosen.position,
+                        represented_count=chosen.represented_count,
+                        frame_index=chosen.frame_index,
+                        relative_frame_index=chosen.relative_frame_index,
+                        query_shell_index=chosen.query_shell_index,
+                        age=chosen.age,
+                        selection_rank=len(selected),
+                        minimum_pairwise_shell_index=minimum_pairwise,
+                    )
+                )
+                remaining.remove(chosen)
+            if len(selected) == PERSISTENT_CANDIDATE_BUDGET:
+                break
+        return (
+            sorted(selected, key=self._attention_order),
+            len(pairwise_shells) // 2,
+            cost_comparisons,
+        )
+
+    def _select_persistent_candidates(
+        self,
+        state: FixedRecurrentKVState,
+        current_frames: Tensor,
+    ) -> FixedRecurrentCandidateSelection:
+        batch_size = int(current_frames.shape[0])
+        occupied_summary_banks = [
+            bank
+            for bank in range(SUMMARY_BANKS - 1, -1, -1)
+            if int(state.summary_counts[0, bank]) > 0
+        ]
+        selected_by_batch: list[list[_Candidate]] = []
+        age_only_by_batch: list[list[int]] = []
+        pairwise_shell_evaluations = 0
+        candidate_cost_comparisons = 0
+        pairwise_by_batch: list[int] = []
+        comparisons_by_batch: list[int] = []
+        eligible_per_batch = len(occupied_summary_banks) + state.live_length
+
+        for batch_offset in range(batch_size):
+            current_frame = int(current_frames[batch_offset])
+            candidates: list[_Candidate] = []
+            for bank in occupied_summary_banks:
+                frame = int(state.summary_frame_indices[batch_offset, bank])
+                position = int(state.summary_last_positions[batch_offset, bank])
+                relative = self._relative_index(frame, current_frame)
+                candidates.append(
+                    _Candidate(
+                        physical_slot=bank,
+                        kind_code=0,
+                        position=position,
+                        represented_count=int(
+                            state.summary_counts[batch_offset, bank]
+                        ),
+                        frame_index=frame,
+                        relative_frame_index=relative,
+                        query_shell_index=int(
+                            self.signed_s3_shell_indices[relative]
+                        ),
+                        age=state.tokens_seen - position,
+                    )
+                )
+            for live_offset in range(state.live_length):
+                frame = int(state.live_frame_indices[batch_offset, live_offset])
+                position = int(state.live_positions[batch_offset, live_offset])
+                relative = self._relative_index(frame, current_frame)
+                candidates.append(
+                    _Candidate(
+                        physical_slot=SUMMARY_BANKS + live_offset,
+                        kind_code=1,
+                        position=position,
+                        represented_count=1,
+                        frame_index=frame,
+                        relative_frame_index=relative,
+                        query_shell_index=int(
+                            self.signed_s3_shell_indices[relative]
+                        ),
+                        age=state.tokens_seen - position,
+                    )
+                )
+            selected, pairwise_count, comparison_count = self._rank_candidates(
+                candidates
+            )
+            selected_by_batch.append(selected)
+            pairwise_shell_evaluations += pairwise_count
+            candidate_cost_comparisons += comparison_count
+            pairwise_by_batch.append(pairwise_count)
+            comparisons_by_batch.append(comparison_count)
+            age_only_by_batch.append(
+                sorted(
+                    (
+                        candidate.physical_slot
+                        for candidate in sorted(
+                            candidates,
+                            key=lambda item: (item.age, item.physical_slot),
+                        )[:PERSISTENT_CANDIDATE_BUDGET]
+                    )
+                )
+            )
+
+        selected_count = min(eligible_per_batch, PERSISTENT_CANDIDATE_BUDGET)
+        if any(len(selected) != selected_count for selected in selected_by_batch):
+            raise RuntimeError("sparse candidate count differs across batch lanes")
+
+        def field_tensor(name: str) -> Tensor:
+            return torch.tensor(
+                [
+                    [int(getattr(candidate, name)) for candidate in selected]
+                    for selected in selected_by_batch
+                ],
+                device=current_frames.device,
+                dtype=torch.long,
+            )
+
+        return FixedRecurrentCandidateSelection(
+            source_slots=field_tensor("physical_slot"),
+            source_kind_codes=field_tensor("kind_code"),
+            source_positions=field_tensor("position"),
+            source_represented_counts=field_tensor("represented_count"),
+            source_frame_indices=field_tensor("frame_index"),
+            relative_frame_indices=field_tensor("relative_frame_index"),
+            query_shell_indices=field_tensor("query_shell_index"),
+            selection_ranks=field_tensor("selection_rank"),
+            minimum_pairwise_shell_indices=field_tensor(
+                "minimum_pairwise_shell_index"
+            ),
+            current_frame_indices=current_frames.detach().clone(),
+            current_position=state.tokens_seen,
+            eligible_persistent_sources=batch_size * eligible_per_batch,
+            age_only_source_slots=torch.tensor(
+                age_only_by_batch,
+                device=current_frames.device,
+                dtype=torch.long,
+            ),
+            pairwise_shell_evaluations=pairwise_shell_evaluations,
+            candidate_cost_comparisons=candidate_cost_comparisons,
+            pairwise_shell_evaluations_by_batch=torch.tensor(
+                pairwise_by_batch,
+                device=current_frames.device,
+                dtype=torch.long,
+            ),
+            candidate_cost_comparisons_by_batch=torch.tensor(
+                comparisons_by_batch,
+                device=current_frames.device,
+                dtype=torch.long,
+            ),
+        )
+
+    def describe_candidate_selection(
+        self,
+        selection: FixedRecurrentCandidateSelection,
+        *,
+        batch_offset: int = 0,
+    ) -> dict[str, Any]:
+        if not 0 <= batch_offset < int(selection.source_slots.shape[0]):
+            raise IndexError("candidate trace batch offset is out of range")
+        admitted: list[dict[str, Any]] = []
+        for selected_offset in range(int(selection.source_slots.shape[1])):
+            relative_index = int(
+                selection.relative_frame_indices[batch_offset, selected_offset]
+            )
+            root = self._exact_root_coordinates[relative_index]
+            pairwise_shell = int(
+                selection.minimum_pairwise_shell_indices[
+                    batch_offset, selected_offset
+                ]
+            )
+            admitted.append(
+                {
+                    "source_kind": (
+                        "summary"
+                        if int(
+                            selection.source_kind_codes[
+                                batch_offset, selected_offset
+                            ]
+                        )
+                        == 0
+                        else "live"
+                    ),
+                    "physical_slot": int(
+                        selection.source_slots[batch_offset, selected_offset]
+                    ),
+                    "causal_position": int(
+                        selection.source_positions[batch_offset, selected_offset]
+                    ),
+                    "represented_token_count": int(
+                        selection.source_represented_counts[
+                            batch_offset, selected_offset
+                        ]
+                    ),
+                    "causal_age": selection.current_position
+                    - int(
+                        selection.source_positions[batch_offset, selected_offset]
+                    ),
+                    "source_frame_index": int(
+                        selection.source_frame_indices[
+                            batch_offset, selected_offset
+                        ]
+                    ),
+                    "relative_frame_index": relative_index,
+                    "relative_root_z_phi_over_2": [list(pair) for pair in root],
+                    "query_shell_degrees": SIGNED_S3_SHELL_DEGREES[
+                        int(
+                            selection.query_shell_indices[
+                                batch_offset, selected_offset
+                            ]
+                        )
+                    ],
+                    "selection_rank": int(
+                        selection.selection_ranks[batch_offset, selected_offset]
+                    ),
+                    "minimum_pairwise_shell_degrees": (
+                        None
+                        if pairwise_shell < 0
+                        else SIGNED_S3_SHELL_DEGREES[pairwise_shell]
+                    ),
+                    "heatmap_trace": _heatmap_trace(root),
+                }
+            )
+
+        current_frame = int(selection.current_frame_indices[batch_offset])
+        identity_root = self._exact_root_coordinates[self.identity_index]
+        admitted.append(
+            {
+                "source_kind": "current",
+                "physical_slot": SUMMARY_BANKS + LIVE_WINDOW,
+                "causal_position": selection.current_position,
+                "represented_token_count": 1,
+                "causal_age": 0,
+                "source_frame_index": current_frame,
+                "relative_frame_index": self.identity_index,
+                "relative_root_z_phi_over_2": [
+                    list(pair) for pair in identity_root
+                ],
+                "query_shell_degrees": 0,
+                "selection_rank": None,
+                "minimum_pairwise_shell_degrees": None,
+                "heatmap_trace": _heatmap_trace(identity_root),
+            }
+        )
+        age_only = (
+            []
+            if selection.age_only_source_slots is None
+            else selection.age_only_source_slots[batch_offset].tolist()
+        )
+        selected_slots = selection.source_slots[batch_offset].tolist()
+        return {
+            "position": selection.current_position,
+            "eligible_persistent_sources": (
+                selection.eligible_persistent_sources
+                // int(selection.source_slots.shape[0])
+            ),
+            "selected_persistent_sources": len(selected_slots),
+            "admitted_sources_including_current": len(admitted),
+            "selected_physical_slots": selected_slots,
+            "age_only_physical_slots": age_only,
+            "differs_from_age_only": set(selected_slots) != set(age_only),
+            "pairwise_shell_evaluations": (
+                selection.pairwise_shell_evaluations
+                if selection.pairwise_shell_evaluations_by_batch is None
+                else int(
+                    selection.pairwise_shell_evaluations_by_batch[batch_offset]
+                )
+            ),
+            "candidate_cost_comparisons": (
+                selection.candidate_cost_comparisons
+                if selection.candidate_cost_comparisons_by_batch is None
+                else int(
+                    selection.candidate_cost_comparisons_by_batch[batch_offset]
+                )
+            ),
+            "admitted": admitted,
+        }
+
+
+__all__ = [
+    "MAXIMUM_READ_SOURCES",
+    "PERSISTENT_CANDIDATE_BUDGET",
+    "POLICY",
+    "SIGNED_S3_SHELL_DEGREES",
+    "R4SparseGeometricCandidateSoftmaxKVBindingV1",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_r4_language_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_r4_language_generation.py
@@ -1,0 +1,418 @@
+"""Artifact-only generation through sparse geometric recurrent R4/H4 memory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from tokenizers import Tokenizer
+
+from .fixed_recurrent_kv_binding import (
+    LIVE_WINDOW,
+    RECURRENT_METADATA_I64_VALUES,
+    RECURRENT_STATE_BYTES_F32,
+    RECURRENT_STATE_VALUES,
+    SUMMARY_BANKS,
+)
+from .group_retention_campaign import load_group_geometry_artifacts
+from .h4_spin_frame_sidecar import H4SpinFrameArtifactV1
+from .language_path_generalization import (
+    CONTEXT,
+    PARAMETER_COUNT,
+    STATE_BYTES_F32,
+    STATE_VALUES,
+    VOCAB_SIZE,
+)
+from .language_path_generation import (
+    BOS_TOKEN_ID,
+    EOS_TOKEN_ID,
+    TEMPERATURE,
+    TOP_K,
+    ByteLevelRawDecoder,
+    SplitMix64,
+    sample_top_k_q32,
+    short_cycle_period,
+)
+from .ordinary_language_generation import (
+    ARTIFACT_RELATIVE_PATH,
+    DEFAULT_MAX_NEW_TOKENS,
+    DEFAULT_SEED,
+    EXPECTED_ARTIFACT_CID,
+    EXPECTED_TOKENIZER_CID,
+    RESULT_RELATIVE_PATH,
+    TOKENIZER_RELATIVE_PATH,
+    _decode_utf8,
+    _record,
+    _verify_arm_result,
+)
+from .position_r4_language_generation import (
+    EXPECTED_GEOMETRY_ARTIFACT_CID,
+    EXPECTED_GEOMETRY_FILE_CID,
+    EXPECTED_H4_FRAME_ARTIFACT_CID,
+    EXPECTED_H4_FRAME_FILE_CID,
+)
+from .sparse_geometric_kv_binding import (
+    MAXIMUM_READ_SOURCES,
+    PERSISTENT_CANDIDATE_BUDGET,
+    POLICY,
+    SIGNED_S3_SHELL_DEGREES,
+    R4SparseGeometricCandidateSoftmaxKVBindingV1,
+)
+
+
+SCHEMA = "uor-r4.sparse-geometric-r4-language-generation/1"
+STATUS = "GENERATED"
+
+
+def _validate_state(
+    model: R4SparseGeometricCandidateSoftmaxKVBindingV1,
+    state: Any,
+) -> None:
+    state_values = (
+        state.live_keys.numel()
+        + state.live_values.numel()
+        + state.summary_keys_local.numel()
+        + state.summary_values_local.numel()
+    )
+    represented = int(state.summary_counts[0].sum()) + state.live_length
+    if (
+        state_values != RECURRENT_STATE_VALUES
+        or model.recurrent_state_value_count() != RECURRENT_STATE_VALUES
+        or model.recurrent_state_byte_count_f32() != RECURRENT_STATE_BYTES_F32
+        or represented != state.tokens_seen
+        or state.audit.policy != POLICY
+        or state.audit.peak_attention_source_slots > MAXIMUM_READ_SOURCES
+        or state.audit.unselected_key_value_reads != 0
+        or state.audit.complete_prefix_scans != 0
+        or state.audit.provider_calls != 0
+        or state.audit.teacher_calls != 0
+        or state.audit.future_reads != 0
+        or state.audit.forbidden_reads != 0
+    ):
+        raise RuntimeError("generation left the sparse geometric R4 state contract")
+
+
+def generate_sparse_geometric_r4_language_path(
+    root: Path,
+    *,
+    geometry_path: Path,
+    frame_path: Path,
+    prompt: str,
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, Any]:
+    """Generate once with unchanged weights and bounded H4 candidate admission."""
+
+    if not isinstance(prompt, str) or not prompt:
+        raise ValueError("prompt must be a nonempty string")
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int):
+        raise TypeError("max_new_tokens must be an integer")
+    if max_new_tokens < 1:
+        raise ValueError("max_new_tokens must be positive")
+
+    resolved_root = root.expanduser().resolve()
+    resolved_geometry = geometry_path.expanduser().resolve()
+    resolved_frames = frame_path.expanduser().resolve()
+    tokenizer_path = resolved_root / TOKENIZER_RELATIVE_PATH
+    artifact_path = resolved_root / ARTIFACT_RELATIVE_PATH
+    result_path = resolved_root / RESULT_RELATIVE_PATH
+
+    tokenizer_payload = tokenizer_path.read_bytes()
+    artifact_payload = artifact_path.read_bytes()
+    result_payload = result_path.read_bytes()
+    geometry_payload = resolved_geometry.read_bytes()
+    frame_payload = resolved_frames.read_bytes()
+    if _record(tokenizer_path, tokenizer_payload)["cid"] != EXPECTED_TOKENIZER_CID:
+        raise ValueError("language-path tokenizer differs from the fitted control")
+    if _record(artifact_path, artifact_payload)["cid"] != EXPECTED_ARTIFACT_CID:
+        raise ValueError("ordinary artifact differs from the completed control")
+    if (
+        _record(resolved_geometry, geometry_payload)["cid"]
+        != EXPECTED_GEOMETRY_FILE_CID
+    ):
+        raise ValueError("sparse-R4 geometry differs from the validated sidecar")
+    if (
+        _record(resolved_frames, frame_payload)["cid"]
+        != EXPECTED_H4_FRAME_FILE_CID
+    ):
+        raise ValueError("sparse-R4 frame file differs from the validated sidecar")
+
+    arm_result = json.loads(result_payload)
+    if not isinstance(arm_result, dict):
+        raise ValueError("ordinary arm result must be a JSON object")
+    _verify_arm_result(arm_result, artifact_payload=artifact_payload)
+
+    tokenizer = Tokenizer.from_file(str(tokenizer_path))
+    if tokenizer.get_vocab_size(with_added_tokens=True) != VOCAB_SIZE:
+        raise ValueError("language-path tokenizer vocabulary differs")
+    raw_decoder = ByteLevelRawDecoder.from_tokenizer_json(tokenizer_path)
+    prompt_token_ids = list(tokenizer.encode(prompt, add_special_tokens=False).ids)
+    if not prompt_token_ids:
+        raise ValueError("prompt produced no tokenizer IDs")
+    if any(token < 0 or token >= VOCAB_SIZE for token in prompt_token_ids):
+        raise ValueError("prompt produced an out-of-vocabulary token ID")
+    if raw_decoder.decode_bytes(prompt_token_ids) != prompt.encode("utf-8"):
+        raise ValueError("prompt does not round-trip through the language tokenizer")
+
+    input_token_ids = [BOS_TOKEN_ID, *prompt_token_ids]
+    processed_ceiling = len(input_token_ids) + max_new_tokens - 1
+    if processed_ceiling > CONTEXT:
+        raise ValueError(
+            "prompt plus generated prefix exceeds the model's trained "
+            "120-position RoPE context"
+        )
+
+    geometry_bundle = load_group_geometry_artifacts(resolved_geometry)
+    if (
+        geometry_bundle.geometry_file_cid != EXPECTED_GEOMETRY_FILE_CID
+        or geometry_bundle.artifact_cid != EXPECTED_GEOMETRY_ARTIFACT_CID
+    ):
+        raise ValueError("sparse-R4 geometry artifact identity differs")
+    frames = H4SpinFrameArtifactV1.from_bytes(frame_payload)
+    if (
+        frames.file_cid != EXPECTED_H4_FRAME_FILE_CID
+        or frames.artifact_cid != EXPECTED_H4_FRAME_ARTIFACT_CID
+        or frames.transport_control_source_cid != geometry_bundle.artifact_cid
+    ):
+        raise ValueError("sparse-R4 frame artifact identity differs")
+
+    model = R4SparseGeometricCandidateSoftmaxKVBindingV1.from_learned_artifact(
+        artifact_payload,
+        geometry=geometry_bundle.exact_h4,
+        frames=frames,
+    )
+    model.to(device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+    torch.use_deterministic_algorithms(True)
+    if (
+        model.parameter_count() != PARAMETER_COUNT
+        or model.export_learned_artifact() != artifact_payload
+        or model.geometry_artifact_cid != EXPECTED_GEOMETRY_ARTIFACT_CID
+        or model.frame_artifact_cid != EXPECTED_H4_FRAME_ARTIFACT_CID
+    ):
+        raise RuntimeError("sparse geometric wrapper changed the bound artifact")
+
+    sampler = SplitMix64(seed)
+    generated: list[int] = []
+    candidate_trace: list[dict[str, Any]] = []
+    stop: str | dict[str, Any] = "maximum_new_tokens"
+    initial_state_values = model.recurrent_state_value_count()
+
+    with torch.inference_mode():
+        state = model.initial_state(1)
+        logits: torch.Tensor | None = None
+        for token_id in input_token_ids:
+            step = model.step(torch.tensor([token_id], dtype=torch.long), state)
+            if step.candidate_selection is None:
+                raise RuntimeError("sparse step omitted its candidate selection")
+            candidate_trace.append(
+                model.describe_candidate_selection(step.candidate_selection)
+            )
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(torch.float32).contiguous()
+        if logits is None:
+            raise RuntimeError("generation did not process a causal input token")
+
+        for decision in range(max_new_tokens):
+            token = int(sample_top_k_q32(logits, sampler))
+            if not 0 <= token < VOCAB_SIZE:
+                raise RuntimeError("sampler selected a token outside the vocabulary")
+            generated.append(token)
+            if token == EOS_TOKEN_ID:
+                stop = "eos"
+                break
+            period = short_cycle_period(generated)
+            if period is not None:
+                stop = {"short_cycle": {"period": period}}
+                break
+            if decision + 1 == max_new_tokens:
+                break
+            step = model.step(torch.tensor([token], dtype=torch.long), state)
+            if step.candidate_selection is None:
+                raise RuntimeError("sparse step omitted its candidate selection")
+            candidate_trace.append(
+                model.describe_candidate_selection(step.candidate_selection)
+            )
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(torch.float32).contiguous()
+
+    _validate_state(model, state)
+    if model.recurrent_state_value_count() != initial_state_values:
+        raise RuntimeError(
+            "sparse recurrent state storage changed with sequence length"
+        )
+    if len(candidate_trace) != state.tokens_seen:
+        raise RuntimeError("candidate trace does not cover every processed token")
+
+    response_ids = (
+        generated[:-1]
+        if generated and generated[-1] == EOS_TOKEN_ID
+        else generated
+    )
+    continuation, utf8_decodable = _decode_utf8(
+        raw_decoder.decode_bytes(response_ids)
+    )
+    audit = state.audit
+    represented_summary_tokens = int(state.summary_counts[0].sum())
+    first_summary_read_position = next(
+        (
+            trace["position"]
+            for trace in candidate_trace
+            if any(
+                source["source_kind"] == "summary"
+                for source in trace["admitted"]
+            )
+        ),
+        None,
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "model": {
+            "policy": POLICY,
+            "execution": "r4",
+            "intervention": "native",
+            "parameter_count": PARAMETER_COUNT,
+            "trained_rope_context_tokens": CONTEXT,
+            "live_window_tokens": LIVE_WINDOW,
+            "summary_banks": SUMMARY_BANKS,
+            "persistent_candidate_budget": PERSISTENT_CANDIDATE_BUDGET,
+            "maximum_attention_sources": MAXIMUM_READ_SOURCES,
+            "recurrent_state_values": RECURRENT_STATE_VALUES,
+            "recurrent_state_bytes_f32": RECURRENT_STATE_BYTES_F32,
+            "recurrent_metadata_i64_values": RECURRENT_METADATA_I64_VALUES,
+            "exact_cache_state_values": STATE_VALUES,
+            "exact_cache_state_bytes_f32": STATE_BYTES_F32,
+            "f32_state_byte_reduction_fraction": (
+                1.0 - RECURRENT_STATE_BYTES_F32 / STATE_BYTES_F32
+            ),
+        },
+        "compression": {
+            "partition": "chronological-binary-age-levels",
+            "selection": "exact-signed-s3-shell-then-maximin-full-h4-root",
+            "selection_status": "unfitted-engineering-hypothesis",
+            "signed_s3_shell_degrees": list(SIGNED_S3_SHELL_DEGREES),
+            "summary_coordinates": "local-h4-frame",
+            "merge": "count-weighted-key-value-mean-in-newer-anchor",
+            "highest_bank": "absorbs-overflow",
+            "score_law": "unchanged-qk-softmax-over-admitted-sources",
+            "selection_inputs": "fixed-recurrent-source-metadata-only",
+            "exact_h4_heatmap_role": "trace-only-not-admission",
+            "group_address_collision": False,
+            "learned_gate": False,
+            "fit_performed": False,
+        },
+        "inputs": {
+            "model_artifact": _record(artifact_path, artifact_payload),
+            "artifact_result": _record(result_path, result_payload),
+            "tokenizer": _record(tokenizer_path, tokenizer_payload),
+            "geometry": _record(resolved_geometry, geometry_payload),
+            "h4_frames": _record(resolved_frames, frame_payload),
+            "corpus_files_read": 0,
+            "teacher_files_read": 0,
+            "checkpoint_files_read": 0,
+            "historical_fitted_artifact_files_read": 0,
+            "provider_files_read": 0,
+        },
+        "fit_provenance": {
+            "arm_result_cid": arm_result["arm_result_cid"],
+            "completed_steps": arm_result.get("completed_steps"),
+            "presentations": arm_result.get("presentations"),
+            "train_order_cid": arm_result.get("train_order_cid"),
+        },
+        "geometry": {
+            "group_artifact_cid": geometry_bundle.artifact_cid,
+            "frame_artifact_cid": frames.artifact_cid,
+            "frame_matrix_convention": frames.matrix_convention,
+            "identity_index": frames.identity_index,
+        },
+        "execution": {
+            "implementation": "sparse-geometric-fixed-recurrent-r4-kv-cache",
+            "read_before_persistent_write": True,
+            "processed_tokens": state.tokens_seen,
+            "generation_decisions": len(generated),
+            "final_live_length": state.live_length,
+            "final_summary_counts": state.summary_counts[0].tolist(),
+            "final_summary_last_positions": (
+                state.summary_last_positions[0].tolist()
+            ),
+            "represented_summary_tokens": represented_summary_tokens,
+            "represented_total_tokens": represented_summary_tokens
+            + state.live_length,
+            "first_eviction_after_position": (
+                LIVE_WINDOW if audit.evictions else None
+            ),
+            "first_summary_read_position": first_summary_read_position,
+            "state_values_initial": initial_state_values,
+            "state_values_final": model.recurrent_state_value_count(),
+            "state_storage_constant": True,
+            "final_frame_index": int(state.current_frame_indices[0]),
+            "provider_calls": audit.provider_calls,
+            "teacher_calls": audit.teacher_calls,
+            "future_reads": audit.future_reads,
+            "forbidden_reads": audit.forbidden_reads,
+            "candidate_trace": candidate_trace,
+            "work": {
+                "cache_writes": audit.cache_writes,
+                "evictions": audit.evictions,
+                "summary_bank_updates": audit.summary_bank_updates,
+                "summary_merges": audit.summary_merges,
+                "summary_slots_read": audit.summary_slots_read,
+                "materialized_attention_scores": (
+                    audit.materialized_attention_scores
+                ),
+                "admitted_attention_scores": audit.admitted_attention_scores,
+                "live_attention_scores": audit.live_attention_scores,
+                "summary_attention_scores": audit.summary_attention_scores,
+                "current_attention_scores": audit.current_attention_scores,
+                "eligible_persistent_source_slots": (
+                    audit.eligible_persistent_source_slots
+                ),
+                "selected_persistent_source_slots": (
+                    audit.selected_persistent_source_slots
+                ),
+                "geometric_shell_evaluations": audit.geometric_shell_evaluations,
+                "pairwise_shell_evaluations": audit.pairwise_shell_evaluations,
+                "candidate_cost_comparisons": audit.candidate_cost_comparisons,
+                "unselected_key_value_reads": audit.unselected_key_value_reads,
+                "complete_prefix_scans": audit.complete_prefix_scans,
+                "attention_transported_r4_blocks": (
+                    audit.attention_transported_r4_blocks
+                ),
+                "compression_transported_r4_blocks": (
+                    audit.compression_transported_r4_blocks
+                ),
+                "value_reads": audit.value_reads,
+                "vocabulary_scores": audit.vocabulary_scores,
+                "peak_attention_source_slots": (
+                    audit.peak_attention_source_slots
+                ),
+            },
+        },
+        "prompt": prompt,
+        "prompt_token_ids": prompt_token_ids,
+        "seed": seed,
+        "sampler": {
+            "type": "top-k-q32-splitmix64",
+            "top_k": TOP_K,
+            "temperature": TEMPERATURE,
+        },
+        "max_new_tokens": max_new_tokens,
+        "generated_token_ids": generated,
+        "continuation": continuation,
+        "text": prompt + continuation,
+        "utf8_decodable": utf8_decodable,
+        "stop": stop,
+    }
+
+
+__all__ = [
+    "DEFAULT_MAX_NEW_TOKENS",
+    "DEFAULT_SEED",
+    "SCHEMA",
+    "STATUS",
+    "generate_sparse_geometric_r4_language_path",
+]

--- a/tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py
+++ b/tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import copy
 import unittest
 from types import SimpleNamespace
 
@@ -30,6 +31,12 @@ from r4_softmax_trainer.language_path_generalization import (
 from r4_softmax_trainer.position_kv_binding import (
     R4PositionPreservingCausalKVBindingV1,
 )
+from r4_softmax_trainer.sparse_geometric_kv_binding import (
+    MAXIMUM_READ_SOURCES as SPARSE_MAXIMUM_READ_SOURCES,
+    PERSISTENT_CANDIDATE_BUDGET,
+    POLICY as SPARSE_POLICY,
+    R4SparseGeometricCandidateSoftmaxKVBindingV1,
+)
 
 
 def _geometry_and_frames() -> tuple[GroupAddressArtifact, SimpleNamespace]:
@@ -52,11 +59,35 @@ def _geometry_and_frames() -> tuple[GroupAddressArtifact, SimpleNamespace]:
     matrices[:, 1, 0] = torch.sin(angles)
     matrices[:, 1, 1] = torch.cos(angles)
     permutation = torch.arange(order, dtype=torch.long)
+    inverses = (-elements) % order
+    scalar_shells = (
+        (2, 0),
+        (0, 1),
+        (1, 0),
+        (-1, 1),
+        (0, 0),
+        (1, -1),
+        (-1, 0),
+        (0, -1),
+        (-2, 0),
+    )
+    roots = tuple(
+        (
+            scalar_shells[offset % len(scalar_shells)],
+            ((offset % 3) - 1, 0),
+            (0, (offset % 2)),
+            ((offset % 5) - 2, 1),
+        )
+        for offset in range(order)
+    )
+    roots = (((2, 0), (0, 0), (0, 0), (0, 0)), *roots[1:])
     frames = SimpleNamespace(
         frame_matrices=matrices,
         multiplication_indices=table,
+        inverse_indices=inverses,
         transport_permutation=permutation,
         identity_index=0,
+        root_coordinates=roots,
         artifact_cid="synthetic:fixed-recurrent-frames",
     )
     return geometry, frames
@@ -202,6 +233,138 @@ class FixedRecurrentKVBindingTests(unittest.TestCase):
         ).initial_state(1, execution="r4")
         with self.assertRaisesRegex(TypeError, "FixedRecurrentKVState"):
             model.step(tokens[:, 0], exact_state)
+
+    def test_sparse_geometry_selects_before_payload_reads(self) -> None:
+        torch.manual_seed(1_122)
+        geometry, frames = _geometry_and_frames()
+        source = R4PositionPreservingCausalKVBindingV1(  # type: ignore[arg-type]
+            geometry, frames
+        )
+        artifact = source.export_learned_artifact()
+        fixed = R4FixedRecurrentCausalKVBindingV1.from_learned_artifact(
+            artifact, geometry=geometry, frames=frames
+        )
+        sparse = (
+            R4SparseGeometricCandidateSoftmaxKVBindingV1.from_learned_artifact(
+                artifact, geometry=geometry, frames=frames
+            )
+        )
+        fixed.eval()
+        sparse.eval()
+
+        self.assertEqual(
+            SPARSE_POLICY, "R4SparseGeometricCandidateSoftmaxKVBindingV1"
+        )
+        self.assertEqual(PERSISTENT_CANDIDATE_BUDGET, LIVE_WINDOW)
+        self.assertEqual(SPARSE_MAXIMUM_READ_SOURCES, LIVE_WINDOW + 1)
+        self.assertEqual(sparse.parameter_count(), PARAMETER_COUNT)
+        self.assertEqual(sparse.export_learned_artifact(), artifact)
+
+        fixed_state = fixed.initial_state(1)
+        sparse_state = sparse.initial_state(1)
+        tokens = torch.tensor([0, 1, 7, 3, 9, 2, 12, 4, 8], dtype=torch.long)
+        with torch.inference_mode():
+            for token in tokens:
+                fixed_output = fixed.step(token.view(1), fixed_state)
+                sparse_output = sparse.step(token.view(1), sparse_state)
+                self.assertTrue(torch.equal(fixed_output.logits, sparse_output.logits))
+                admitted = fixed_state.live_length + int(
+                    torch.count_nonzero(fixed_state.summary_counts[0])
+                ) + 1
+                self.assertTrue(
+                    torch.equal(
+                        fixed_output.attention_weights[..., :admitted],
+                        sparse_output.attention_weights[..., :admitted],
+                    )
+                )
+                fixed_state = fixed_output.final_state
+                sparse_state = sparse_output.final_state
+
+        self.assertEqual(sparse_state.tokens_seen, LIVE_WINDOW + 1)
+        self.assertEqual(int(sparse_state.summary_counts.sum()), 1)
+        next_token = torch.tensor([5], dtype=torch.long)
+        pristine = copy.deepcopy(sparse_state)
+        with torch.inference_mode():
+            baseline = sparse.step(next_token, pristine)
+        selection = baseline.candidate_selection
+        self.assertIsNotNone(selection)
+        assert selection is not None
+        self.assertEqual(selection.eligible_persistent_sources, 9)
+        self.assertEqual(selection.source_slots.numel(), LIVE_WINDOW)
+        self.assertEqual(selection.pairwise_shell_evaluations, 36)
+        self.assertEqual(tuple(baseline.attention_weights.shape), (LAYERS, 1, HEADS, 9))
+        self.assertEqual(baseline.audit.eligible_persistent_source_slots, 9)
+        self.assertEqual(baseline.audit.selected_persistent_source_slots, 8)
+        self.assertEqual(baseline.audit.materialized_attention_scores, 72)
+        self.assertEqual(baseline.audit.unselected_key_value_reads, 0)
+        self.assertEqual(baseline.audit.complete_prefix_scans, 0)
+        self.assertEqual(baseline.audit.peak_attention_source_slots, 9)
+
+        all_slots = set(range(SUMMARY_BANKS)) | set(
+            range(SUMMARY_BANKS, SUMMARY_BANKS + sparse_state.live_length)
+        )
+        occupied_slots = {
+            bank
+            for bank in range(SUMMARY_BANKS)
+            if int(sparse_state.summary_counts[0, bank]) > 0
+        } | set(range(SUMMARY_BANKS, SUMMARY_BANKS + sparse_state.live_length))
+        self.assertEqual(all_slots & occupied_slots, occupied_slots)
+        selected_slots = set(selection.source_slots[0].tolist())
+        unselected_slots = occupied_slots - selected_slots
+        self.assertEqual(len(unselected_slots), 1)
+
+        omitted_state = copy.deepcopy(sparse_state)
+        omitted_slot = unselected_slots.pop()
+        if omitted_slot < SUMMARY_BANKS:
+            omitted_state.summary_keys_local[..., omitted_slot, :].add_(10_000.0)
+            omitted_state.summary_values_local[..., omitted_slot, :].add_(10_000.0)
+        else:
+            live_offset = omitted_slot - SUMMARY_BANKS
+            omitted_state.live_keys[..., live_offset, :].add_(10_000.0)
+            omitted_state.live_values[..., live_offset, :].add_(10_000.0)
+        with torch.inference_mode():
+            omitted_output = sparse.step(next_token, omitted_state)
+        self.assertTrue(torch.equal(baseline.logits, omitted_output.logits))
+
+        selected_state = copy.deepcopy(sparse_state)
+        selected_slot = next(iter(selected_slots))
+        if selected_slot < SUMMARY_BANKS:
+            selected_state.summary_values_local[..., selected_slot, :].add_(100.0)
+        else:
+            live_offset = selected_slot - SUMMARY_BANKS
+            selected_state.live_values[..., live_offset, :].add_(100.0)
+        with torch.inference_mode():
+            selected_output = sparse.step(next_token, selected_state)
+        self.assertFalse(torch.equal(baseline.logits, selected_output.logits))
+
+        trace = sparse.describe_candidate_selection(selection)
+        self.assertEqual(trace["eligible_persistent_sources"], 9)
+        self.assertEqual(trace["selected_persistent_sources"], 8)
+        self.assertEqual(trace["admitted_sources_including_current"], 9)
+        self.assertEqual(trace["admitted"][-1]["source_kind"], "current")
+        for source_trace in trace["admitted"]:
+            self.assertEqual(len(source_trace["relative_root_z_phi_over_2"]), 4)
+            self.assertFalse(source_trace["heatmap_trace"]["used_for_admission"])
+        ranked = sorted(
+            trace["admitted"][:-1], key=lambda item: item["selection_rank"]
+        )
+        self.assertEqual(
+            [item["query_shell_degrees"] for item in ranked],
+            sorted(item["query_shell_degrees"] for item in ranked),
+        )
+        current_frame = int(selection.current_frame_indices[0])
+        for item in ranked:
+            source_frame = item["source_frame_index"]
+            expected_relative = int(
+                frames.multiplication_indices[
+                    frames.inverse_indices[source_frame], current_frame
+                ]
+            )
+            self.assertEqual(item["relative_frame_index"], expected_relative)
+            self.assertEqual(
+                item["relative_root_z_phi_over_2"],
+                [list(pair) for pair in frames.root_coordinates[expected_relative]],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The fixed recurrent reader delivered by #1120 still considered every occupied live and summary record. This change adds the first versioned sparse geometric admission step so the accepted recurrent state can advance toward the architectural alpha without changing its learned reader.

The new `R4SparseGeometricCandidateSoftmaxKVBindingV1` inspects bounded metadata for at most eight live records and four summary banks, keeps current mandatory, and admits at most eight persistent sources before any selected K/V payload is gathered. It derives `source^-1 * current` from the exact H4 sidecar, prioritizes nine signed-S3 angular shells, resolves over-budget shells with full-root pairwise maximin separation, then breaks remaining ties by causal age and physical slot. The accepted learned Q/K softmax reader, recurrent fold/eviction behavior, state size, tokenizer, sampling, geometry identities, and artifact remain unchanged. The trace retains the full `Z[phi]` root and the established q0/q1 heatmap, chirality, cosine-polarity, and typed-null fields as evidence; those fields do not become semantic scores.

The frozen two-prompt, source-free comparison used seed 9738, 16 requested generated tokens, and no fit or population evaluation. Aggregate materialized attention scores fell from 3,824 to 3,240 (15.27%), and peak read sources fell from 13 to 9 while recurrent storage remained 2,304 f32 values / 9,216 bytes. Geometry selected a different set from age-only top-eight on 33 of 35 sparse decisions. The continuations shared 12 and 3 generated tokens with the fixed recurrent comparator, so this establishes execution and boundedness only; it does not establish language quality, retrieval benefit, long-context retention, or geometric advantage. The prior #967 shortest-Cayley and #970 q0/q1 heatmap negative results retain their tested scope.

The roadmap and evidence ledger now mark sparse geometric attention complete and make one finite R4 nonlinear operator block the next build stage under #973.

Validation:

- `PYTHONPATH=tools/r4-softmax-trainer/src /Users/casey.allard/uor-r4/.uor-models/research/issue-1014/venv/bin/python -m unittest tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py` — 3 passed
- Python byte-compilation for the four changed modules
- JSON parse for the policy and claim ledger
- `python3 scripts/check_claim_wording.py`
- `git diff origin/main...HEAD --check`
- Independent source and artifact review, including all 14,400 canonical ordered H4 root pairs, causal read-before-write, per-lane selection accounting, and omitted-payload independence

References #973
