### PR TITLE
Implement finite-indexed R4 nonlinear block

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ recurrent memory, sparse geometric attention, a nonlinear geometric block,
 scale/data/instruction, retrieval/tools, product alpha, Rust/table lowering,
 and release proof/evidence/QA.
 
-The fixed recurrent stage now executes with eight exact K/V records, four
-H4-local summary banks, and a constant 9,216-byte f32 K/V ledger. Its sole
-two-prompt no-fit comparison read summaries after eviction and produced
-distinct post-compression trajectories. This establishes the mechanism only;
-quality, long-context retention, architectural alpha, and final serving remain
-open. Sparse geometric attention is next under
-[#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
+The fixed recurrent, sparse attention, and first nonlinear R4 stages now
+execute mechanically under [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
+The path keeps a constant 9,216-byte f32 K/V ledger, reads at most eight
+persistent records plus current, and can replace dense SwiGLU execution with a
+finite H4-frame-indexed quaternion-cube residual. Its 120 signed frame indices
+contain antipodal pairs that select the same odd map. The no-fit cube runs stayed
+bounded but diverged immediately from the fitted dense comparator and produced
+visibly degraded text. The next stage is a bounded development-data fit;
+useful language, architectural alpha, and final serving remain open.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/built%20with-Rust-orange.svg)](rust-toolchain.toml)
@@ -33,8 +35,9 @@ target serving engine uses no Ollama, hosted model, or source-model weights.
 **Current programme:** [#973](https://github.com/UOR-Foundation/uor-r4/issues/973)
 owns the model track under the
 [build-first policy](docs/integration/agent-execution-policy.md). The next
-implementation is bounded sparse geometric attention over the accepted
-full-cache and fixed-recurrent comparators. [#1107](docs/r4_workbench_candidate_1107.md)
+implementation is a bounded development-data fit of the assembled sparse plus
+quaternion-cube path against its retained dense-SwiGLU comparator.
+[#1107](docs/r4_workbench_candidate_1107.md)
 remains an unbuilt historical workbench source and #1084 is parked until
 product-alpha integration. Start a later task with
 [CONTINUE.md](docs/integration/CONTINUE.md). Broad proof, evidence

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -29,9 +29,20 @@ forbidden reads. Against the fixed recurrent arm, its common generated prefixes
 were 12 tokens for the turtle prompt and 3 for Einstein; aggregate materialized
 scores fell 15.27%. This establishes bounded pre-read geometric admission, not
 useful retrieval, language improvement, long-context retention, geometric
-advantage, architectural alpha, or table-native execution. RoPE still limits
-the reference to 120 positions. The next implementation is the nonlinear
-geometric block.
+advantage, architectural alpha, or table-native execution.
+
+`R4H4FrameQuaternionCubeResidualV1` now applies twelve continuous R4
+quaternion-cube residuals through the current element of the validated
+120-index H4 bank after each sparse attention residual; antipodal frame pairs
+select the same odd map, leaving at most 60 distinct operators. Across the same two
+no-fit prompts it executed 1,272 R4 blocks, no dense-MLP call, no new parameter
+or recurrent state, and a largest f32 block-norm error of
+`7.152557373046875e-07`. Prompt-stage sparse selections remained exact, but
+both generated trajectories diverged from the fitted dense comparator at their
+first token and were visibly degraded. This establishes the finite-indexed
+nonlinear mechanism only. RoPE still limits the reference to 120 positions.
+The next implementation is a bounded development-data fit of the assembled
+sparse-plus-quaternion-cube architecture before any larger scale increase.
 
 Historical positive, negative, and unavailable results below retain their exact
 scope. A negative binds its artifact/population/operator/controls/budget and may

--- a/docs/integration/CONTINUE.md
+++ b/docs/integration/CONTINUE.md
@@ -13,7 +13,7 @@ alpha → Rust/table lowering → release proof/evidence/QA.
 
 ## Current checkpoint
 
-[#973](https://github.com/UOR-Foundation/uor-r4/issues/973) now has three
+[#973](https://github.com/UOR-Foundation/uor-r4/issues/973) now has four
 artifact-only causal paths over the same accepted ordinary weights:
 
 - `R4PositionPreservingCausalKVBindingV1` is the full 120-position comparator.
@@ -24,6 +24,10 @@ artifact-only causal paths over the same accepted ordinary weights:
 - `R4SparseGeometricCandidateSoftmaxKVBindingV1` ranks only those twelve
   persistent metadata slots by exact signed-S3 shell and full-H4-root maximin
   diversity, admits at most eight plus current, and gathers K/V only afterward.
+- `R4H4FrameQuaternionCubeResidualV1` keeps that sparse reader and replaces
+  each dense SwiGLU residual with twelve ordered R4 blocks evaluated through a
+  finite bank addressed by 120 current-H4-frame indices. Antipodal frame pairs
+  select the same odd cube map, so there are at most 60 distinct operators.
 
 The focused causal check is exact through the decision that performs the first
 post-read eviction. In the frozen full-prompt no-fit, seed-9738, top-k-40, 16-token
@@ -43,14 +47,24 @@ measured mechanism results. They do not establish useful retrieval, language
 quality, long-context retention, geometric advantage, architectural alpha, or
 table-native execution. The trained RoPE ceiling remains 120.
 
+The quaternion-cube arm completed the same two prompts with 1,272 R4 block
+evaluations, no dense-MLP call, no new parameter or state, a largest f32
+block-norm error of `7.152557373046875e-07`, and the same nine-source/causal
+ceilings. Its forced-prompt sparse selections exactly matched the dense arm.
+Both generated trajectories diverged from the fitted dense-SwiGLU comparator
+at token zero and produced visibly degraded text. This completes the
+nonlinear mechanical checkpoint while leaving trainability and useful language
+unestablished.
+
 ## Next implementation action
 
-Implement the first versioned **nonlinear geometric block** successor under
-#973. Keep `R4SparseGeometricCandidateSoftmaxKVBindingV1` as the attention path
-and the current dense SwiGLU block as the comparator. Define one finite R4
-operator block with an explicit state map, nonlinearity, residual/readout, and
-bounded cost. Keep E8/R8 separate unless a typed bridge is implemented. Run one
-direct prompt execution before any scale or instruction campaign.
+Specify and execute the first bounded **development-data fit** of the assembled
+sparse-plus-quaternion-cube architecture under #973. Keep the fitted
+`R4SparseGeometricCandidateSoftmaxKVBindingV1` dense-SwiGLU path as comparator,
+keep the nonlinear law and sparse reader fixed, and use open development data
+with an explicit resource ceiling. Decide whether this architecture can learn
+useful prompt-dependent text before increasing width, corpus dose, or
+instruction scope. Keep final held-out evaluation separate.
 
 SpiralCore's finite labelled E8 action graph may inform an operator-indexed
 candidate selector, but it is not already attention. Keep its H4/R4 and E8/R8
@@ -59,8 +73,8 @@ W33, NEMESIS, UOR, and H4/zeta sources remain on-demand donors. Inspect original
 source for the exact mechanism used and do not transfer external proof or
 capability claims.
 
-Do not start the nonlinear block, scale campaign, workbench, lowering, release
-proof, or broad QA in the same task.
+Do not start a larger scale campaign, retrieval/tools, workbench integration,
+lowering, release proof, or broad QA in the same task.
 
 ```text
 $uor-project-workflow
@@ -71,12 +85,13 @@ docs/integration/project-track.md. Complete exactly one active implementation
 task and stop.
 
 Apply build_first_architectural_alpha. Use one isolated full Git worktree.
-Implement the first versioned nonlinear geometric block successor under #973.
-Keep the accepted sparse geometric reader and dense SwiGLU block as
-comparators. Specify and execute one finite R4 state map, nonlinearity,
-residual/readout, and bounded-cost path. Keep H4/R4 and E8/R8 typed separately
-unless an explicit bridge is implemented. Run the smallest direct no-fit prompt
-comparison that resolves the mechanism.
+Specify and execute one bounded development-data fit of the exact
+`R4H4FrameQuaternionCubeResidualV1` architecture under #973. Keep its accepted
+sparse geometric reader, continuous quaternion-cube law, and dense-SwiGLU
+comparator fixed. Use open development data, a hard resource ceiling, and the
+smallest fit that can decide whether the assembled bounded path learns useful
+prompt-dependent text. Keep final held-out evaluation and any larger scale or
+instruction campaign separate.
 
 Query the knowledge index or inspect SpiralCore/HELM/W33/NEMESIS/UOR/H4-zeta
 sources only for the concrete selector/read decision. Treat them as donor

--- a/docs/integration/agent-execution-policy.json
+++ b/docs/integration/agent-execution-policy.json
@@ -51,7 +51,7 @@
   "mode": "build_first_architectural_alpha",
   "project_track": {
     "architectural_alpha": "useful_prompt_dependent_text_through_bounded_recurrent_geometric_memory_and_bounded_geometric_selection_without_complete_prefix_scan_or_runtime_teacher_provider_or_source_model",
-    "current_stage": "nonlinear_geometric_block",
+    "current_stage": "scale_data_and_instruction_behavior",
     "ordered_stages": [
       "fixed_recurrent_geometric_memory",
       "sparse_geometric_attention",

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -11,7 +11,7 @@ comparator preserves full chronological K/V through exact H4 transport, and
 `R4FixedRecurrentCausalKVBindingV1` provides the fixed 2,304-value / 9,216-byte
 f32 K/V ledger.
 
-`R4SparseGeometricCandidateSoftmaxKVBindingV1` is the next executed mechanical
+`R4SparseGeometricCandidateSoftmaxKVBindingV1` is an executed mechanical
 checkpoint. It ranks only the fixed twelve-slot metadata directory by exact
 signed-S3 shell and full-H4-root maximin diversity, admits at most eight
 persistent records, appends current, and gathers K/V only after admission. The
@@ -20,7 +20,18 @@ complete-prefix scans or omitted-payload reads. They shared 12 and 3 generated
 tokens respectively with the fixed recurrent comparator; this uneven result is
 mechanism evidence, not useful-retrieval or language-quality evidence.
 
-The nonlinear geometric block is next. Broad proofs, evidence ledgers,
+`R4H4FrameQuaternionCubeResidualV1` is the next executed mechanical
+checkpoint. It splits the post-attention normalized residual into twelve R4
+blocks, applies `q^3 / ||q||^2` in the current H4 frame with an exact zero
+branch, decodes, and adds the resulting displacement. It uses the same sparse
+reader and learned artifact, but bypasses every dense SwiGLU call. Both no-fit
+prompts completed with bounded f32 errors and unchanged recurrent/causal
+contracts; both diverged from the fitted dense comparator at their first
+generated token and produced visibly degraded text. This establishes the
+mechanism only. The current stage is a bounded development-data fit of the
+assembled sparse-plus-nonlinear architecture before any larger scale increase.
+
+Broad proofs, evidence ledgers,
 publication, programme-wide research mapping, and release QA do not sit between
 the build stages. SpiralCore, HELM, W33, NEMESIS, UOR, and H4/zeta sources are
 consulted only for a concrete design seam, with original-source inspection and
@@ -196,9 +207,9 @@ The active build sequence is fixed:
 | Order | Stage | Current decision |
 |---:|---|---|
 | 1 | Fixed recurrent geometric memory | Executed mechanical checkpoint under #973; bounded state and summary use observed, quality unestablished |
-| 2 | Sparse geometric attention | **Next:** bounded geometry-selected candidates and read operator without a complete-prefix scan |
-| 3 | Nonlinear geometric block | Replace dense SwiGLU/MLP with a versioned R4 operator or separately typed E8/R8 bank |
-| 4 | Scale, data, and instruction behavior | Grow and train the bounded architecture; measure useful language and composition |
+| 2 | Sparse geometric attention | Executed mechanical checkpoint under #973; nine-source ceiling observed, useful retrieval unestablished |
+| 3 | Nonlinear geometric block | Executed mechanical checkpoint under #973; finite-indexed R4 cube bypasses dense SwiGLU, useful language unestablished |
+| 4 | Scale, data, and instruction behavior | **Next:** bound and fit the assembled architecture on open development data before increasing scale |
 | 5 | Retrieval and tools | Typed retrieval/refusal plus real tool execution, feedback, and result ingestion |
 | 6 | Representative product alpha | Grounding, composition, identity memory, coding, and tools in one local workbench |
 | 7 | Rust/table lowering and optimization | Preserve accepted behavior in the bounded packed Rust runtime |

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -67,11 +67,12 @@ execution.
    and publication against the release candidate. This work does not gate the
    earlier build stages unless a concrete implementation decision needs it.
 
-Fixed recurrent memory and sparse geometric attention are completed mechanical
-checkpoints under [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
-The current stage is the nonlinear geometric block. #954 and the old capability chain remain
-historical issue structure; they do not insert a proof or bookkeeping campaign
-between these build stages.
+Fixed recurrent memory, sparse geometric attention, and the first nonlinear
+geometric block are completed mechanical checkpoints under
+[#973](https://github.com/UOR-Foundation/uor-r4/issues/973). The current stage
+is bounded scale/data/instruction fitting of the assembled architecture. #954
+and the old capability chain remain historical issue structure; they do not
+insert a proof or bookkeeping campaign between these build stages.
 
 ## Current measured boundary
 
@@ -104,6 +105,19 @@ geometric set differed from age-only on 33/35 sparse decisions and admitted 55
 summary records. Common generated prefixes against the fixed recurrent path
 were 12 and 3 tokens. This completes the sparse mechanical checkpoint while
 leaving useful retrieval and geometric advantage unestablished.
+
+`R4H4FrameQuaternionCubeResidualV1` now replaces each executed dense SwiGLU
+residual with twelve ordered R4 cells and a current-H4-frame-indexed
+quaternion-cube map. The 120 signed frame indices form antipodal pairs for this
+odd map, leaving at most 60 distinct operators. It keeps continuous f32 hidden state, adds no
+parameter or persistent state, and retains the dense tensors only so the
+accepted artifact remains a byte-identical comparator. Across the two no-fit
+prompts it executed 1,272 R4 blocks and zero dense-MLP calls while preserving
+the nine-source attention ceiling and all causal prohibitions. Its largest f32
+block-norm error was `7.152557373046875e-07`; both continuations diverged from
+the fitted dense comparator at the first generated token and were visibly
+degraded. This completes a mechanical nonlinear checkpoint, not useful
+language or a selected training architecture.
 
 ## Research reservoirs
 

--- a/docs/r4_quaternion_cube_nonlinear_973.md
+++ b/docs/r4_quaternion_cube_nonlinear_973.md
@@ -1,7 +1,7 @@
 # #973 finite-indexed R4 nonlinear block
 
-**Date:** 2026-09-04  
-**Status:** `PRE_EXECUTION_OPERATOR_FIXED`
+**Date:** 2026-09-04
+**Status:** `FINITE_INDEXED_R4_NONLINEAR_EXECUTED_LANGUAGE_UTILITY_UNESTABLISHED`
 
 ## Implemented decision
 
@@ -40,7 +40,8 @@ epsilon or fitted threshold. All twelve blocks are evaluated from the same
 normalized input and the same current frame. The operator adds no learned
 parameters or persistent state. Dense MLP tensors remain in the accepted
 artifact so the two runtime arms stay byte-compatible, but this candidate
-does not read or execute them.
+does not invoke or compute with them in its predictive forward path. Artifact
+validation and export still read and serialize every retained tensor.
 
 ## Why this operator
 
@@ -50,17 +51,22 @@ is odd and homogeneous over real scalars, and its residual obeys
 operator. They are not claims about f32 equality, trained behavior, language
 quality, or the surrounding learned decoder.
 
-The current H4 element selects one of 120 frame-conjugated nonlinear maps on
-continuous R4 blocks. “Finite” here means a finite indexed operator bank with
-fixed work and fixed state; it does not mean that hidden values are quantized.
+The current H4 element selects from 120 frame-index entries on continuous R4
+blocks. Because the cube is odd, antipodal frames `F` and `-F` produce the same
+conjugated map, so this bank has at most 60 distinct operators. “Finite” here
+means a finite indexed operator bank with fixed work and fixed state; it does
+not mean that hidden values are quantized.
 The implementation is transitional f32 compiler-side arithmetic. Integer/table
 lowering, zero-multiply serving, and allocation-free execution remain later
-work.
+work. The direct quotient is also not total over every possible finite
+subnormal input: a nonzero block's squared norm can underflow before the
+reciprocal, at which point the implementation rejects the nonfinite result.
+Neither observed prompt approached that case.
 
 At batch one, each layer and token evaluates twelve R4 blocks. Its declared
 logical work is 384 frame-coordinate products, 168 closed-form quaternion
 products, twelve reciprocals, and 48 residual subtractions. The dense
-comparator reads 18,432 learned matrix weights per layer and token across its
+comparator executes 18,432 learned-weight products per layer and token across its
 `48 -> 128`, `48 -> 128`, and `128 -> 48` projections. These are analytical
 operation counts, not latency or hardware-energy measurements.
 
@@ -109,8 +115,87 @@ dense-MLP calls, operator blocks, maximum f32 block-norm error, and maximum
 residual-bound ratio. Do not fit, tune, inspect held-out data, add a third arm,
 or launch a scale campaign in this task.
 
-Passing this comparison means only that the finite-indexed nonlinear R4 path
-executes end to end and bypasses dense SwiGLU while preserving the accepted
-bounded sparse reader. Language usefulness, trainability, H4 advantage,
-reasoning, coding, table-native execution, and architectural alpha remain
-unverified hypotheses.
+## Measured result
+
+The candidate completed both prompts. The accepted dense-SwiGLU sparse outputs
+were read from the preserved #1122 artifacts and were not rerun. Asset CIDs and
+prompt token IDs matched, and sparse candidate-selection traces matched exactly
+for every forced prompt token. After generation began, both candidate runs
+diverged on the first sampled token.
+
+| Prompt | Dense-SwiGLU sparse continuation | Quaternion-cube continuation | Common generated prefix |
+|---|---|---|---:|
+| `A purple turtle found a clock in the garden` | `, there was a time, there was a little girl named I saw a little` | ` Sue face heistol and�,\u0003 was� to<\|unk\|> She� up “` | 0 |
+| `Albert Einstein was born in` | ` his friend, and Lily were very sad. He said, "So and` | `` jack hisleton thenaug you` always'ter very�\n all bor.`` | 0 |
+
+The visibly degraded no-fit continuations are an honest observation, not a
+language-quality score. The accepted artifact was fitted jointly with its
+dense SwiGLU weights; this intervention disables 36,864 such weights without
+refitting the surrounding representation.
+
+Across 53 processed tokens, the candidate executed 1,272 R4 block evaluations,
+40,704 H4 frame-coordinate products, 17,808 quaternion-cube scalar products,
+1,272 reciprocals, and 5,088 residual subtractions. It executed zero dense-MLP
+calls and zero dense-MLP weight products; the corresponding dense comparator
+would analytically execute 1,953,792 MLP weight products across those
+layer-token calls.
+The largest observed f32 block-norm error was
+`7.152557373046875e-07`; the largest observed ratio
+`||delta|| / (2 ||normalized block||)` was `1.0`.
+
+Both runs kept the recurrent state at 2,304 f32 values / 9,216 bytes, stayed
+within nine attention sources, and reported zero complete-prefix scans,
+unselected K/V reads, provider calls, teacher calls, future reads, and
+forbidden reads. The focused causal/mechanism check reported:
+
+```text
+Ran 4 tests in 0.190s
+OK
+```
+
+Preserved raw artifacts:
+
+- turtle candidate SHA-256:
+  `2fd4e8a9945b0913c417badc97fb7cb9c7bec682c48bc533a1f0baea0ed418da`
+- Einstein candidate SHA-256:
+  `dd7de4ffd4da84b181e7559af327d7a6b1757a73938a3fabb6c8c6d49c690f1b`
+- comparison summary SHA-256:
+  `502bccf9482ba06f6582507243e884e4a97a5eddc6ee7eae43a64fb45ea5a5c3`
+
+They remain outside Git under
+`.uor-models/research/issue-973-quaternion-cube-r4-v1/comparison/`.
+Independent review corrected the descriptive bank cardinality from 120 maps to
+120 frame-index entries with at most 60 distinct maps. The canonical files were
+regenerated once after that metadata-only source correction; their numerical
+fields and continuations remained exact. The pre-correction bytes remain in
+the `pre-review-overstated-frame-count/` child directory.
+Review also narrowed the retained-weight claim to the predictive forward path:
+artifact validation and export read and serialize every retained tensor, while
+candidate prediction performs zero dense-MLP calls or weight products. The raw
+records were refreshed after that field-name correction; their only changes
+were the old and new model-field keys. The immediately preceding bytes remain
+in `pre-review-forward-path-claim/`.
+
+## Evidence boundary and next action
+
+- **Mathematical result:** over real quaternions the declared cube map is odd,
+  real-scale equivariant, block-norm preserving, and has the stated residual
+  bound. No formal proof artifact was produced.
+- **Measured behavior:** the focused test and two direct executions establish
+  the reported f32 bounds, deterministic audit counts, dense-MLP bypass,
+  unchanged prompt-stage sparse selection, bounded state, and causal access
+  counters for this implementation and these inputs.
+- **Unverified hypotheses:** that this finite-indexed operator can be fitted to
+  useful language, that H4 frame selection helps, or that it supports reasoning,
+  coding, table-native serving, or architectural-alpha behavior. Trainability
+  at the exact zero branch and numerical hardening for extreme subnormal inputs
+  also remain unmeasured.
+
+This completes the nonlinear geometric mechanical checkpoint. It does not
+erase any prior negative result and does not qualify the observed text as
+useful. #973 remains open because the bounded architecture still needs learned
+language behavior.
+
+The one next action is to specify a bounded development-data fit of this exact
+sparse-plus-quaternion-cube architecture against the retained dense-SwiGLU
+comparator before increasing model or data scale.

--- a/docs/r4_quaternion_cube_nonlinear_973.md
+++ b/docs/r4_quaternion_cube_nonlinear_973.md
@@ -1,0 +1,116 @@
+# #973 finite-indexed R4 nonlinear block
+
+**Date:** 2026-09-04  
+**Status:** `PRE_EXECUTION_OPERATOR_FIXED`
+
+## Implemented decision
+
+`R4H4FrameQuaternionCubeResidualV1` replaces the dense SwiGLU call in the
+accepted sparse recurrent path with one bounded, parameter-free R4
+nonlinearity. The sparse candidate selector, transported learned Q/K/V/O
+attention, recurrent state, tokenizer, vocabulary head, and sampler stay
+unchanged. `R4SparseGeometricCandidateSoftmaxKVBindingV1` remains the dense
+SwiGLU comparator over the same learned artifact.
+
+After each attention residual, the existing post-attention RMSNorm produces
+`n[B,48]`. The new state map splits it into twelve ordered R4 blocks
+`n_j in R4`. For the current token's cumulative H4 frame `F_h`, using the
+existing convention `F_h: local R4 -> model R4`, each block executes
+
+```text
+q_j       = transpose(F_h) n_j
+C(0)      = 0
+C(q_j)    = q_j^3 / ||q_j||^2                 when q_j != 0
+G_h(n_j)  = F_h C(q_j)
+delta_j   = G_h(n_j) - n_j
+values'   = values + flatten(delta_0, ..., delta_11)
+```
+
+Writing `q=(a,v)` with `v in R3`, the f32 implementation uses the closed form
+
+```text
+C(q) = (
+  a * (a^2 - 3 ||v||^2),
+  (3 a^2 - ||v||^2) * v
+) / (a^2 + ||v||^2).
+```
+
+The zero branch uses exact zero detection and returns zero. It introduces no
+epsilon or fitted threshold. All twelve blocks are evaluated from the same
+normalized input and the same current frame. The operator adds no learned
+parameters or persistent state. Dense MLP tensors remain in the accepted
+artifact so the two runtime arms stay byte-compatible, but this candidate
+does not read or execute them.
+
+## Why this operator
+
+Over real quaternions, norm multiplicativity gives `||C(q)||=||q||`. The map
+is odd and homogeneous over real scalars, and its residual obeys
+`||C(q)-q|| <= 2||q||`. These are algebraic consequences of the declared
+operator. They are not claims about f32 equality, trained behavior, language
+quality, or the surrounding learned decoder.
+
+The current H4 element selects one of 120 frame-conjugated nonlinear maps on
+continuous R4 blocks. “Finite” here means a finite indexed operator bank with
+fixed work and fixed state; it does not mean that hidden values are quantized.
+The implementation is transitional f32 compiler-side arithmetic. Integer/table
+lowering, zero-multiply serving, and allocation-free execution remain later
+work.
+
+At batch one, each layer and token evaluates twelve R4 blocks. Its declared
+logical work is 384 frame-coordinate products, 168 closed-form quaternion
+products, twelve reciprocals, and 48 residual subtractions. The dense
+comparator reads 18,432 learned matrix weights per layer and token across its
+`48 -> 128`, `48 -> 128`, and `128 -> 48` projections. These are analytical
+operation counts, not latency or hardware-energy measurements.
+
+## Donor boundary
+
+The project knowledge index was queried for the active nonlinear-block seam.
+Original sources were then inspected for that decision.
+
+- SpiralCore v66, SHA-256
+  `38449bddefd359d69a497ca4965e6d14a39f7ab2d33940e41fd9747598b3a4ea`,
+  supplies finite operator-index and refusal discipline, but its implemented
+  Cl(0,6) bivectors are linear signed 8x8 maps over a separate 240-root E8
+  system. It supplies no R4/R8 carrier or nonlinear language block, so no E8
+  operator is imported here.
+- The pinned W33 chamber operators act on `Q^160`. Their rank-48 projector is a
+  particular subspace, not a canonical identification with this decoder's
+  `R48`, so they are not imported.
+- The pinned NEMESIS material supplies an attributed Cayley-Dickson/quaternion
+  product description and a useful encode/operate/decode discipline. Its wider
+  ring, inverse, complexity, and physical claims are not transferred, and no
+  source code is copied.
+- The existing UOR/H4 sidecar supplies the validated 120-frame carrier used by
+  this implementation. Exact H4 table identities and f32 model behavior remain
+  different evidence layers.
+- The zeta channels and signed `Z[phi]` heatmap remain separate trace/control
+  hypotheses. The #970 0/6 strict-transfer result forbids treating those
+  classes as an established semantic activation.
+
+This mechanism does not revise the #967 shortest-Cayley 6/6 tie, the #970
+heatmap 0/6 transfer result, or the uneven 12-token/3-token sparse trajectory
+preservation recorded by the preceding checkpoint.
+
+## Direct comparison fixed before execution
+
+Run exactly the existing two development prompts through two no-fit arms:
+
+1. accepted sparse recurrent attention plus dense SwiGLU; and
+2. the identical sparse recurrent attention plus
+   `R4H4FrameQuaternionCubeResidualV1`.
+
+Both arms use the accepted artifact, tokenizer, exact-H4 geometry/frame
+sidecar, seed 9738, top-k 40, temperature 0.8, and at most sixteen generated
+tokens. Record the generated token IDs and continuations, common prefixes,
+finite output/state checks, sparse source ceiling, forbidden-read counters,
+dense-MLP calls, operator blocks, maximum f32 block-norm error, and maximum
+residual-bound ratio. Do not fit, tune, inspect held-out data, add a third arm,
+or launch a scale campaign in this task.
+
+Passing this comparison means only that the finite-indexed nonlinear R4 path
+executes end to end and bypasses dense SwiGLU while preserving the accepted
+bounded sparse reader. Language usefulness, trainability, H4 advantage,
+reasoning, coding, table-native execution, and architectural alpha remain
+unverified hypotheses.

--- a/docs/r4_quaternion_cube_nonlinear_973.md
+++ b/docs/r4_quaternion_cube_nonlinear_973.md
@@ -64,10 +64,10 @@ reciprocal, at which point the implementation rejects the nonfinite result.
 Neither observed prompt approached that case.
 
 At batch one, each layer and token evaluates twelve R4 blocks. Its declared
-logical work is 384 frame-coordinate products, 168 closed-form quaternion
-products, twelve reciprocals, and 48 residual subtractions. The dense
-comparator executes 18,432 learned-weight products per layer and token across its
-`48 -> 128`, `48 -> 128`, and `128 -> 48` projections. These are analytical
+logical work is 384 frame-coordinate products, 168 closed-form scalar products
+for the quaternion cube, twelve reciprocals, and 48 residual subtractions. The
+dense comparator executes 18,432 learned-weight products per layer and token
+across its `48 -> 128`, `48 -> 128`, and `128 -> 48` projections. These are analytical
 operation counts, not latency or hardware-energy measurements.
 
 ## Donor boundary

--- a/docs/uor_productization_integration_plan.md
+++ b/docs/uor_productization_integration_plan.md
@@ -250,9 +250,20 @@ frozen prompts shared 12 and 3 generated tokens with the fixed recurrent
 comparator, so bounded execution is measured while useful retrieval remains
 unestablished.
 
-The next implementation is one versioned nonlinear geometric block. Retain the
-sparse reader and dense SwiGLU block as comparators, define an explicit finite
-R4 state map, nonlinearity, residual/readout and cost, and execute one direct
-prompt comparison before scale work. Keep E8/R8 separately typed unless an
-explicit bridge is implemented. Do not start scale, workbench, final lowering,
-or release proof/QA in that same task.
+`R4H4FrameQuaternionCubeResidualV1` now completes the first nonlinear
+geometric mechanical checkpoint. It applies a finite H4-frame-indexed,
+continuous R4 quaternion-cube residual after the accepted sparse reader. Its
+120 signed frame indices reduce to at most 60 distinct operators because
+antipodal pairs select the same odd map. The block adds
+no parameter or recurrent state, and executes no dense SwiGLU matrix. Its two
+no-fit prompts preserved the bounded causal mechanics but diverged from the
+fitted dense comparator at the first generated token and produced visibly
+degraded text. This is a mechanism result, not useful language or an H4
+advantage claim.
+
+The next implementation is a separately specified, bounded development-data
+fit of this exact assembled sparse-plus-quaternion-cube architecture against
+the retained dense-SwiGLU comparator. Establish whether the replacement can
+learn useful prompt-dependent text before increasing width, corpus dose, or
+instruction scope. Do not start retrieval/tools, workbench integration, final
+lowering, or release proof/QA in that same task.

--- a/scripts/check_agent_execution_policy.py
+++ b/scripts/check_agent_execution_policy.py
@@ -120,7 +120,7 @@ def main() -> int:
         )
         require(
             policy["project_track"]["current_stage"]
-            == "nonlinear_geometric_block",
+            == "scale_data_and_instruction_behavior",
             "current project-track stage changed",
         )
         require(

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/cli.py
@@ -121,6 +121,9 @@ from .fixed_recurrent_r4_language_generation import (
 from .sparse_geometric_r4_language_generation import (
     generate_sparse_geometric_r4_language_path,
 )
+from .quaternion_cube_r4_language_generation import (
+    generate_quaternion_cube_r4_language_path,
+)
 from .role_tagged_associative_development import (
     preflight_role_tagged_associative_development,
     prepare_role_tagged_associative_development,
@@ -787,6 +790,38 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="emit artifact, candidate-trace, token, and execution details",
     )
+    generate_quaternion_cube = subcommands.add_parser(
+        "generate-quaternion-cube-r4-language-path",
+        help=(
+            "continue one prompt through #973's sparse recurrent reader and "
+            "finite-indexed H4-frame quaternion-cube residual"
+        ),
+    )
+    generate_quaternion_cube.add_argument("--prompt", required=True)
+    generate_quaternion_cube.add_argument(
+        "--geometry",
+        type=_root,
+        default=default_language_path_geometry(),
+        help="canonical exact-H4 group geometry",
+    )
+    generate_quaternion_cube.add_argument(
+        "--h4-sidecar",
+        type=_root,
+        default=default_predictive_block_delta_frame_sidecar(),
+        help="validated H4 frame sidecar used for sparse attention and the R4 cube",
+    )
+    generate_quaternion_cube.add_argument(
+        "--max-new-tokens", type=int, default=16
+    )
+    generate_quaternion_cube.add_argument("--seed", type=int, default=9_738)
+    generate_quaternion_cube.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "emit artifact, sparse trace, nonlinear audit, token, and "
+            "execution details"
+        ),
+    )
     prepare_paired_h4 = subcommands.add_parser(
         "prepare-paired-h4-prompt-capacity",
         help=(
@@ -1283,6 +1318,7 @@ def main() -> None:
         "generate-position-r4-language-path",
         "generate-fixed-recurrent-r4-language-path",
         "generate-sparse-geometric-r4-language-path",
+        "generate-quaternion-cube-r4-language-path",
     }
     paired_h4_prompt_capacity_commands = {
         "prepare-paired-h4-prompt-capacity",
@@ -1678,6 +1714,20 @@ def main() -> None:
         return
     if arguments.command == "generate-sparse-geometric-r4-language-path":
         result = generate_sparse_geometric_r4_language_path(
+            root,
+            geometry_path=arguments.geometry,
+            frame_path=arguments.h4_sidecar,
+            prompt=arguments.prompt,
+            max_new_tokens=arguments.max_new_tokens,
+            seed=arguments.seed,
+        )
+        if arguments.json:
+            _print_result(result)
+        else:
+            print(result["text"])
+        return
+    if arguments.command == "generate-quaternion-cube-r4-language-path":
+        result = generate_quaternion_cube_r4_language_path(
             root,
             geometry_path=arguments.geometry,
             frame_path=arguments.h4_sidecar,

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py
@@ -31,6 +31,7 @@ from .language_path_generalization import (
     HEAD_DIM,
     HEADS,
     HIDDEN_SIZE,
+    INTERMEDIATE_SIZE,
     LAYERS,
     PARAMETER_COUNT,
     VOCAB_SIZE,
@@ -52,6 +53,63 @@ RECURRENT_STATE_VALUES = (
 )
 RECURRENT_STATE_BYTES_F32 = RECURRENT_STATE_VALUES * 4
 RECURRENT_METADATA_I64_VALUES = LIVE_WINDOW * 2 + SUMMARY_BANKS * 3 + 1
+DENSE_SWIGLU_POLICY = "DenseSwiGLU"
+DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER = (
+    3 * HIDDEN_SIZE * INTERMEDIATE_SIZE
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RecurrentNonlinearAudit:
+    """Analytical work and bounded numerical errors for one nonlinear policy."""
+
+    policy: str
+    batch_size: int
+    layer_calls: int
+    dense_mlp_calls: int
+    dense_mlp_weight_products: int
+    r4_block_evaluations: int
+    h4_frame_maps: int
+    h4_frame_coefficient_products: int
+    quaternion_cube_scalar_products: int
+    quaternion_cube_reciprocals: int
+    residual_subtractions: int
+    maximum_block_norm_error: float
+    maximum_residual_bound_ratio: float
+
+    def accumulated_with(
+        self, later: RecurrentNonlinearAudit
+    ) -> RecurrentNonlinearAudit:
+        """Accumulate consecutive calls of the same nonlinear policy."""
+
+        if self.policy != later.policy or self.batch_size != later.batch_size:
+            raise ValueError("cannot accumulate unlike recurrent nonlinear policies")
+        summed = {
+            field: getattr(self, field) + getattr(later, field)
+            for field in (
+                "layer_calls",
+                "dense_mlp_calls",
+                "dense_mlp_weight_products",
+                "r4_block_evaluations",
+                "h4_frame_maps",
+                "h4_frame_coefficient_products",
+                "quaternion_cube_scalar_products",
+                "quaternion_cube_reciprocals",
+                "residual_subtractions",
+            )
+        }
+        return replace(
+            self,
+            **summed,
+            maximum_block_norm_error=max(
+                self.maximum_block_norm_error,
+                later.maximum_block_norm_error,
+            ),
+            maximum_residual_bound_ratio=max(
+                self.maximum_residual_bound_ratio,
+                later.maximum_residual_bound_ratio,
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,6 +237,7 @@ class FixedRecurrentKVStepOutput:
     audit: FixedRecurrentKVBindingAudit
     # [layers,batch,heads,MAXIMUM_READ_SOURCES]
     attention_weights: Tensor
+    nonlinear_audit: RecurrentNonlinearAudit
     candidate_selection: FixedRecurrentCandidateSelection | None = None
 
 
@@ -218,6 +277,7 @@ class FixedRecurrentKVBindingOutput:
     audit: FixedRecurrentKVBindingAudit
     # [layers,batch,heads,time,MAXIMUM_READ_SOURCES]
     attention_weights: Tensor
+    nonlinear_audit: RecurrentNonlinearAudit
 
 
 class R4FixedRecurrentCausalKVBindingV1(
@@ -226,6 +286,7 @@ class R4FixedRecurrentCausalKVBindingV1(
     """Accepted ordinary weights with bounded hierarchical H4 K/V memory."""
 
     POLICY_NAME = POLICY
+    NONLINEAR_POLICY = DENSE_SWIGLU_POLICY
     MAXIMUM_ATTENTION_SOURCES = MAXIMUM_READ_SOURCES
 
     def __init__(
@@ -260,6 +321,57 @@ class R4FixedRecurrentCausalKVBindingV1(
     @staticmethod
     def recurrent_metadata_i64_value_count() -> int:
         return RECURRENT_METADATA_I64_VALUES
+
+    def _empty_nonlinear_audit(
+        self, batch_size: int
+    ) -> RecurrentNonlinearAudit:
+        return RecurrentNonlinearAudit(
+            policy=self.NONLINEAR_POLICY,
+            batch_size=batch_size,
+            layer_calls=0,
+            dense_mlp_calls=0,
+            dense_mlp_weight_products=0,
+            r4_block_evaluations=0,
+            h4_frame_maps=0,
+            h4_frame_coefficient_products=0,
+            quaternion_cube_scalar_products=0,
+            quaternion_cube_reciprocals=0,
+            residual_subtractions=0,
+            maximum_block_norm_error=0.0,
+            maximum_residual_bound_ratio=0.0,
+        )
+
+    def _post_attention_nonlinear(
+        self,
+        values: Tensor,
+        *,
+        layer: object,
+        current_frames: Tensor,
+    ) -> tuple[Tensor, RecurrentNonlinearAudit]:
+        """Return the accepted dense residual and its analytical work audit."""
+
+        del current_frames
+        post_attention_layernorm = getattr(layer, "post_attention_layernorm")
+        mlp = getattr(layer, "mlp")
+        residual = mlp(post_attention_layernorm(values))
+        batch_size = int(values.shape[0])
+        return residual, RecurrentNonlinearAudit(
+            policy=self.NONLINEAR_POLICY,
+            batch_size=batch_size,
+            layer_calls=1,
+            dense_mlp_calls=1,
+            dense_mlp_weight_products=(
+                batch_size * DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER
+            ),
+            r4_block_evaluations=0,
+            h4_frame_maps=0,
+            h4_frame_coefficient_products=0,
+            quaternion_cube_scalar_products=0,
+            quaternion_cube_reciprocals=0,
+            residual_subtractions=0,
+            maximum_block_norm_error=0.0,
+            maximum_residual_bound_ratio=0.0,
+        )
 
     @classmethod
     def _empty_recurrent_audit(
@@ -1000,6 +1112,7 @@ class R4FixedRecurrentCausalKVBindingV1(
         admitted_sources_total = 0
         live_sources_total = 0
         summary_sources_total = 0
+        nonlinear_audit = self._empty_nonlinear_audit(batch_size)
 
         # The persistent state is not mutated in this loop.  Current K/V is a
         # transient causal source and is committed only after all logits exist.
@@ -1027,7 +1140,17 @@ class R4FixedRecurrentCausalKVBindingV1(
             summary_sources_total += summary_sources
             attended = attended * layer.log_output_gains.exp().view(1, -1, 1)
             values = values + layer.o_proj(attended.reshape(batch_size, HIDDEN_SIZE))
-            values = values + layer.mlp(layer.post_attention_layernorm(values))
+            nonlinear_residual, layer_nonlinear_audit = (
+                self._post_attention_nonlinear(
+                    values,
+                    layer=layer,
+                    current_frames=current_frames,
+                )
+            )
+            values = values + nonlinear_residual
+            nonlinear_audit = nonlinear_audit.accumulated_with(
+                layer_nonlinear_audit
+            )
             current_keys.append(key)
             current_values.append(value)
             padded_weights = torch.zeros(
@@ -1172,6 +1295,7 @@ class R4FixedRecurrentCausalKVBindingV1(
             final_state=final_state,
             audit=call_audit,
             attention_weights=torch.stack(layer_weights, dim=0),
+            nonlinear_audit=nonlinear_audit,
             candidate_selection=candidate_selection,
         )
 
@@ -1247,12 +1371,16 @@ class R4FixedRecurrentCausalKVBindingV1(
                 "token block exceeds the trained fixed-recurrent RoPE context"
             )
         call_audit = self._empty_recurrent_audit(batch_size)
+        nonlinear_audit = self._empty_nonlinear_audit(batch_size)
         logits: list[Tensor] = []
         weights: list[Tensor] = []
         for position in range(time):
             output = self.step_recurrent(token_ids[:, position], state)
             state = output.final_state
             call_audit = call_audit.accumulated_with(output.audit)
+            nonlinear_audit = nonlinear_audit.accumulated_with(
+                output.nonlinear_audit
+            )
             logits.append(output.logits)
             weights.append(output.attention_weights)
         stacked_logits = torch.stack(logits, dim=1)
@@ -1268,6 +1396,7 @@ class R4FixedRecurrentCausalKVBindingV1(
             final_state=state,
             audit=call_audit,
             attention_weights=torch.stack(weights, dim=3),
+            nonlinear_audit=nonlinear_audit,
         )
 
     def forward(
@@ -1298,9 +1427,12 @@ __all__ = [
     "RECURRENT_STATE_VALUES",
     "RECURRENT_METADATA_I64_VALUES",
     "SUMMARY_BANKS",
+    "DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER",
+    "DENSE_SWIGLU_POLICY",
     "FixedRecurrentKVBindingAudit",
     "FixedRecurrentKVBindingOutput",
     "FixedRecurrentKVState",
     "FixedRecurrentKVStepOutput",
+    "RecurrentNonlinearAudit",
     "R4FixedRecurrentCausalKVBindingV1",
 ]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/quaternion_cube_nonlinear.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/quaternion_cube_nonlinear.py
@@ -1,0 +1,155 @@
+"""Finite H4-indexed quaternion-cube nonlinearity for the #973 path.
+
+The accepted sparse recurrent reader and learned artifact are inherited
+unchanged.  This candidate replaces only the dense SwiGLU execution with a
+parameter-free residual in the current token's H4 frame.  It is an unfitted
+f32 mechanism, not a language-quality or table-native execution claim.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from .fixed_recurrent_kv_binding import RecurrentNonlinearAudit
+from .language_path_generalization import HIDDEN_SIZE
+from .position_kv_binding import R4_WIDTH
+from .sparse_geometric_kv_binding import (
+    R4SparseGeometricCandidateSoftmaxKVBindingV1,
+)
+
+
+POLICY = "R4H4FrameQuaternionCubeResidualV1"
+R4_BLOCKS_PER_HIDDEN = HIDDEN_SIZE // R4_WIDTH
+H4_FRAME_MAPS_PER_BLOCK = 2
+H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK = 2 * R4_WIDTH * R4_WIDTH
+QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK = 14
+QUATERNION_CUBE_RECIPROCALS_PER_BLOCK = 1
+RESIDUAL_SUBTRACTIONS_PER_BLOCK = R4_WIDTH
+
+if R4_WIDTH != 4 or HIDDEN_SIZE % R4_WIDTH != 0:
+    raise RuntimeError("quaternion-cube residual requires ordered R4 blocks")
+
+
+class R4H4FrameQuaternionCubeResidualV1(
+    R4SparseGeometricCandidateSoftmaxKVBindingV1
+):
+    """Sparse recurrent model with a finite H4-indexed R4 nonlinearity."""
+
+    POLICY_NAME = POLICY
+    NONLINEAR_POLICY = POLICY
+
+    def _post_attention_nonlinear(
+        self,
+        values: Tensor,
+        *,
+        layer: object,
+        current_frames: Tensor,
+    ) -> tuple[Tensor, RecurrentNonlinearAudit]:
+        """Apply ``F C(F^T n) - n`` after the existing RMS normalization."""
+
+        batch_size = int(values.shape[0])
+        if values.ndim != 2 or int(values.shape[1]) != HIDDEN_SIZE:
+            raise ValueError("quaternion-cube input must be [batch,hidden]")
+        if tuple(current_frames.shape) != (batch_size,):
+            raise ValueError("current H4 frames must be [batch]")
+
+        post_attention_layernorm = getattr(layer, "post_attention_layernorm")
+        normalized = post_attention_layernorm(values).float()
+        normalized_blocks = normalized.view(
+            batch_size, R4_BLOCKS_PER_HIDDEN, R4_WIDTH
+        )
+        frames = self._frames(current_frames, dtype=torch.float32)
+        local = torch.einsum("bji,bdj->bdi", frames, normalized_blocks)
+
+        scalar = local[..., :1]
+        vector = local[..., 1:]
+        scalar_squared = scalar * scalar
+        vector_squared_norm = (vector * vector).sum(dim=-1, keepdim=True)
+        norm_squared = scalar_squared + vector_squared_norm
+        cubed = torch.cat(
+            (
+                scalar * (scalar_squared - 3.0 * vector_squared_norm),
+                (3.0 * scalar_squared - vector_squared_norm) * vector,
+            ),
+            dim=-1,
+        )
+
+        nonzero = (local != 0.0).any(dim=-1, keepdim=True)
+        safe_norm_squared = torch.where(
+            nonzero,
+            norm_squared,
+            torch.ones_like(norm_squared),
+        )
+        inverse_norm_squared = torch.reciprocal(safe_norm_squared)
+        mapped_local = cubed * inverse_norm_squared
+        mapped_local = torch.where(
+            nonzero.expand_as(mapped_local),
+            mapped_local,
+            torch.zeros_like(mapped_local),
+        )
+        decoded = torch.einsum("bij,bdj->bdi", frames, mapped_local)
+        delta_blocks = decoded - normalized_blocks
+        if not bool(torch.isfinite(delta_blocks).all()):
+            raise ValueError("quaternion-cube residual produced a non-finite value")
+
+        input_norms = torch.linalg.vector_norm(normalized_blocks, dim=-1)
+        output_norms = torch.linalg.vector_norm(decoded, dim=-1)
+        norm_errors = (output_norms - input_norms).abs()
+        residual_norms = torch.linalg.vector_norm(delta_blocks, dim=-1)
+        nonzero_norms = input_norms != 0.0
+        safe_residual_bounds = torch.where(
+            nonzero_norms,
+            2.0 * input_norms,
+            torch.ones_like(input_norms),
+        )
+        residual_bound_ratios = torch.where(
+            nonzero_norms,
+            residual_norms / safe_residual_bounds,
+            torch.zeros_like(residual_norms),
+        )
+
+        block_evaluations = batch_size * R4_BLOCKS_PER_HIDDEN
+        audit = RecurrentNonlinearAudit(
+            policy=self.NONLINEAR_POLICY,
+            batch_size=batch_size,
+            layer_calls=1,
+            dense_mlp_calls=0,
+            dense_mlp_weight_products=0,
+            r4_block_evaluations=block_evaluations,
+            h4_frame_maps=block_evaluations * H4_FRAME_MAPS_PER_BLOCK,
+            h4_frame_coefficient_products=(
+                block_evaluations
+                * H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK
+            ),
+            quaternion_cube_scalar_products=(
+                block_evaluations
+                * QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK
+            ),
+            quaternion_cube_reciprocals=(
+                block_evaluations * QUATERNION_CUBE_RECIPROCALS_PER_BLOCK
+            ),
+            residual_subtractions=(
+                block_evaluations * RESIDUAL_SUBTRACTIONS_PER_BLOCK
+            ),
+            maximum_block_norm_error=float(norm_errors.amax().detach()),
+            maximum_residual_bound_ratio=float(
+                residual_bound_ratios.amax().detach()
+            ),
+        )
+        return (
+            delta_blocks.reshape(batch_size, HIDDEN_SIZE).to(values.dtype),
+            audit,
+        )
+
+
+__all__ = [
+    "H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK",
+    "H4_FRAME_MAPS_PER_BLOCK",
+    "POLICY",
+    "QUATERNION_CUBE_RECIPROCALS_PER_BLOCK",
+    "QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK",
+    "R4_BLOCKS_PER_HIDDEN",
+    "RESIDUAL_SUBTRACTIONS_PER_BLOCK",
+    "R4H4FrameQuaternionCubeResidualV1",
+]

--- a/tools/r4-softmax-trainer/src/r4_softmax_trainer/quaternion_cube_r4_language_generation.py
+++ b/tools/r4-softmax-trainer/src/r4_softmax_trainer/quaternion_cube_r4_language_generation.py
@@ -1,0 +1,517 @@
+"""Artifact-only generation through sparse attention and an H4-indexed R4 cube."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import torch
+from tokenizers import Tokenizer
+
+from .fixed_recurrent_kv_binding import (
+    DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER,
+    LIVE_WINDOW,
+    RECURRENT_METADATA_I64_VALUES,
+    RECURRENT_STATE_BYTES_F32,
+    RECURRENT_STATE_VALUES,
+    SUMMARY_BANKS,
+)
+from .group_retention_campaign import load_group_geometry_artifacts
+from .h4_spin_frame_sidecar import H4SpinFrameArtifactV1
+from .language_path_generalization import (
+    CONTEXT,
+    LAYERS,
+    PARAMETER_COUNT,
+    STATE_BYTES_F32,
+    STATE_VALUES,
+    VOCAB_SIZE,
+)
+from .language_path_generation import (
+    BOS_TOKEN_ID,
+    EOS_TOKEN_ID,
+    TEMPERATURE,
+    TOP_K,
+    ByteLevelRawDecoder,
+    SplitMix64,
+    sample_top_k_q32,
+    short_cycle_period,
+)
+from .ordinary_language_generation import (
+    ARTIFACT_RELATIVE_PATH,
+    DEFAULT_MAX_NEW_TOKENS,
+    DEFAULT_SEED,
+    EXPECTED_ARTIFACT_CID,
+    EXPECTED_TOKENIZER_CID,
+    RESULT_RELATIVE_PATH,
+    TOKENIZER_RELATIVE_PATH,
+    _decode_utf8,
+    _record,
+    _verify_arm_result,
+)
+from .position_r4_language_generation import (
+    EXPECTED_GEOMETRY_ARTIFACT_CID,
+    EXPECTED_GEOMETRY_FILE_CID,
+    EXPECTED_H4_FRAME_ARTIFACT_CID,
+    EXPECTED_H4_FRAME_FILE_CID,
+)
+from .sparse_geometric_kv_binding import (
+    MAXIMUM_READ_SOURCES,
+    PERSISTENT_CANDIDATE_BUDGET,
+    SIGNED_S3_SHELL_DEGREES,
+)
+from .quaternion_cube_nonlinear import (
+    H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK,
+    H4_FRAME_MAPS_PER_BLOCK,
+    POLICY as QUATERNION_CUBE_POLICY,
+    QUATERNION_CUBE_RECIPROCALS_PER_BLOCK,
+    QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK,
+    R4_BLOCKS_PER_HIDDEN,
+    RESIDUAL_SUBTRACTIONS_PER_BLOCK,
+    R4H4FrameQuaternionCubeResidualV1,
+)
+
+
+SCHEMA = "uor-r4.h4-frame-quaternion-cube-language-generation/1"
+STATUS = "GENERATED"
+
+
+def _validate_state(
+    model: R4H4FrameQuaternionCubeResidualV1,
+    state: Any,
+) -> None:
+    state_values = (
+        state.live_keys.numel()
+        + state.live_values.numel()
+        + state.summary_keys_local.numel()
+        + state.summary_values_local.numel()
+    )
+    represented = int(state.summary_counts[0].sum()) + state.live_length
+    if (
+        state_values != RECURRENT_STATE_VALUES
+        or model.recurrent_state_value_count() != RECURRENT_STATE_VALUES
+        or model.recurrent_state_byte_count_f32() != RECURRENT_STATE_BYTES_F32
+        or represented != state.tokens_seen
+        or state.audit.policy != QUATERNION_CUBE_POLICY
+        or state.audit.peak_attention_source_slots > MAXIMUM_READ_SOURCES
+        or state.audit.unselected_key_value_reads != 0
+        or state.audit.complete_prefix_scans != 0
+        or state.audit.provider_calls != 0
+        or state.audit.teacher_calls != 0
+        or state.audit.future_reads != 0
+        or state.audit.forbidden_reads != 0
+    ):
+        raise RuntimeError(
+            "generation left the quaternion-cube sparse R4 state contract"
+        )
+
+
+def generate_quaternion_cube_r4_language_path(
+    root: Path,
+    *,
+    geometry_path: Path,
+    frame_path: Path,
+    prompt: str,
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, Any]:
+    """Generate once through sparse attention and the no-fit R4 cube residual."""
+
+    if not isinstance(prompt, str) or not prompt:
+        raise ValueError("prompt must be a nonempty string")
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int):
+        raise TypeError("max_new_tokens must be an integer")
+    if max_new_tokens < 1:
+        raise ValueError("max_new_tokens must be positive")
+
+    resolved_root = root.expanduser().resolve()
+    resolved_geometry = geometry_path.expanduser().resolve()
+    resolved_frames = frame_path.expanduser().resolve()
+    tokenizer_path = resolved_root / TOKENIZER_RELATIVE_PATH
+    artifact_path = resolved_root / ARTIFACT_RELATIVE_PATH
+    result_path = resolved_root / RESULT_RELATIVE_PATH
+
+    tokenizer_payload = tokenizer_path.read_bytes()
+    artifact_payload = artifact_path.read_bytes()
+    result_payload = result_path.read_bytes()
+    geometry_payload = resolved_geometry.read_bytes()
+    frame_payload = resolved_frames.read_bytes()
+    if _record(tokenizer_path, tokenizer_payload)["cid"] != EXPECTED_TOKENIZER_CID:
+        raise ValueError("language-path tokenizer differs from the fitted control")
+    if _record(artifact_path, artifact_payload)["cid"] != EXPECTED_ARTIFACT_CID:
+        raise ValueError("ordinary artifact differs from the completed control")
+    if (
+        _record(resolved_geometry, geometry_payload)["cid"]
+        != EXPECTED_GEOMETRY_FILE_CID
+    ):
+        raise ValueError("sparse-R4 geometry differs from the validated sidecar")
+    if (
+        _record(resolved_frames, frame_payload)["cid"]
+        != EXPECTED_H4_FRAME_FILE_CID
+    ):
+        raise ValueError("sparse-R4 frame file differs from the validated sidecar")
+
+    arm_result = json.loads(result_payload)
+    if not isinstance(arm_result, dict):
+        raise ValueError("ordinary arm result must be a JSON object")
+    _verify_arm_result(arm_result, artifact_payload=artifact_payload)
+
+    tokenizer = Tokenizer.from_file(str(tokenizer_path))
+    if tokenizer.get_vocab_size(with_added_tokens=True) != VOCAB_SIZE:
+        raise ValueError("language-path tokenizer vocabulary differs")
+    raw_decoder = ByteLevelRawDecoder.from_tokenizer_json(tokenizer_path)
+    prompt_token_ids = list(tokenizer.encode(prompt, add_special_tokens=False).ids)
+    if not prompt_token_ids:
+        raise ValueError("prompt produced no tokenizer IDs")
+    if any(token < 0 or token >= VOCAB_SIZE for token in prompt_token_ids):
+        raise ValueError("prompt produced an out-of-vocabulary token ID")
+    if raw_decoder.decode_bytes(prompt_token_ids) != prompt.encode("utf-8"):
+        raise ValueError("prompt does not round-trip through the language tokenizer")
+
+    input_token_ids = [BOS_TOKEN_ID, *prompt_token_ids]
+    processed_ceiling = len(input_token_ids) + max_new_tokens - 1
+    if processed_ceiling > CONTEXT:
+        raise ValueError(
+            "prompt plus generated prefix exceeds the model's trained "
+            "120-position RoPE context"
+        )
+
+    geometry_bundle = load_group_geometry_artifacts(resolved_geometry)
+    if (
+        geometry_bundle.geometry_file_cid != EXPECTED_GEOMETRY_FILE_CID
+        or geometry_bundle.artifact_cid != EXPECTED_GEOMETRY_ARTIFACT_CID
+    ):
+        raise ValueError("sparse-R4 geometry artifact identity differs")
+    frames = H4SpinFrameArtifactV1.from_bytes(frame_payload)
+    if (
+        frames.file_cid != EXPECTED_H4_FRAME_FILE_CID
+        or frames.artifact_cid != EXPECTED_H4_FRAME_ARTIFACT_CID
+        or frames.transport_control_source_cid != geometry_bundle.artifact_cid
+    ):
+        raise ValueError("sparse-R4 frame artifact identity differs")
+
+    model = R4H4FrameQuaternionCubeResidualV1.from_learned_artifact(
+        artifact_payload,
+        geometry=geometry_bundle.exact_h4,
+        frames=frames,
+    )
+    model.to(device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+    torch.use_deterministic_algorithms(True)
+    if (
+        model.parameter_count() != PARAMETER_COUNT
+        or model.export_learned_artifact() != artifact_payload
+        or model.geometry_artifact_cid != EXPECTED_GEOMETRY_ARTIFACT_CID
+        or model.frame_artifact_cid != EXPECTED_H4_FRAME_ARTIFACT_CID
+    ):
+        raise RuntimeError("quaternion-cube wrapper changed the bound artifact")
+
+    sampler = SplitMix64(seed)
+    generated: list[int] = []
+    candidate_trace: list[dict[str, Any]] = []
+    stop: str | dict[str, Any] = "maximum_new_tokens"
+    initial_state_values = model.recurrent_state_value_count()
+    nonlinear_audit = model._empty_nonlinear_audit(1)
+
+    with torch.inference_mode():
+        state = model.initial_state(1)
+        logits: torch.Tensor | None = None
+        for token_id in input_token_ids:
+            step = model.step(torch.tensor([token_id], dtype=torch.long), state)
+            if step.candidate_selection is None:
+                raise RuntimeError("sparse step omitted its candidate selection")
+            candidate_trace.append(
+                model.describe_candidate_selection(step.candidate_selection)
+            )
+            nonlinear_audit = nonlinear_audit.accumulated_with(
+                step.nonlinear_audit
+            )
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(torch.float32).contiguous()
+        if logits is None:
+            raise RuntimeError("generation did not process a causal input token")
+
+        for decision in range(max_new_tokens):
+            token = int(sample_top_k_q32(logits, sampler))
+            if not 0 <= token < VOCAB_SIZE:
+                raise RuntimeError("sampler selected a token outside the vocabulary")
+            generated.append(token)
+            if token == EOS_TOKEN_ID:
+                stop = "eos"
+                break
+            period = short_cycle_period(generated)
+            if period is not None:
+                stop = {"short_cycle": {"period": period}}
+                break
+            if decision + 1 == max_new_tokens:
+                break
+            step = model.step(torch.tensor([token], dtype=torch.long), state)
+            if step.candidate_selection is None:
+                raise RuntimeError("sparse step omitted its candidate selection")
+            candidate_trace.append(
+                model.describe_candidate_selection(step.candidate_selection)
+            )
+            nonlinear_audit = nonlinear_audit.accumulated_with(
+                step.nonlinear_audit
+            )
+            state = step.final_state
+            logits = step.logits[0].detach().cpu().to(torch.float32).contiguous()
+
+    _validate_state(model, state)
+    if model.recurrent_state_value_count() != initial_state_values:
+        raise RuntimeError(
+            "sparse recurrent state storage changed with sequence length"
+        )
+    if len(candidate_trace) != state.tokens_seen:
+        raise RuntimeError("candidate trace does not cover every processed token")
+    expected_layer_calls = state.tokens_seen * LAYERS
+    expected_blocks = expected_layer_calls * R4_BLOCKS_PER_HIDDEN
+    if (
+        nonlinear_audit.policy != QUATERNION_CUBE_POLICY
+        or nonlinear_audit.layer_calls != expected_layer_calls
+        or nonlinear_audit.dense_mlp_calls != 0
+        or nonlinear_audit.dense_mlp_weight_products != 0
+        or nonlinear_audit.r4_block_evaluations != expected_blocks
+        or nonlinear_audit.h4_frame_maps
+        != expected_blocks * H4_FRAME_MAPS_PER_BLOCK
+        or nonlinear_audit.h4_frame_coefficient_products
+        != expected_blocks * H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK
+        or nonlinear_audit.quaternion_cube_scalar_products
+        != expected_blocks * QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK
+        or nonlinear_audit.quaternion_cube_reciprocals
+        != expected_blocks * QUATERNION_CUBE_RECIPROCALS_PER_BLOCK
+        or nonlinear_audit.residual_subtractions
+        != expected_blocks * RESIDUAL_SUBTRACTIONS_PER_BLOCK
+        or not math.isfinite(nonlinear_audit.maximum_block_norm_error)
+        or not math.isfinite(nonlinear_audit.maximum_residual_bound_ratio)
+        or nonlinear_audit.maximum_residual_bound_ratio > 1.00001
+    ):
+        raise RuntimeError("generation left the quaternion-cube nonlinear contract")
+
+    response_ids = (
+        generated[:-1]
+        if generated and generated[-1] == EOS_TOKEN_ID
+        else generated
+    )
+    continuation, utf8_decodable = _decode_utf8(
+        raw_decoder.decode_bytes(response_ids)
+    )
+    audit = state.audit
+    represented_summary_tokens = int(state.summary_counts[0].sum())
+    first_summary_read_position = next(
+        (
+            trace["position"]
+            for trace in candidate_trace
+            if any(
+                source["source_kind"] == "summary"
+                for source in trace["admitted"]
+            )
+        ),
+        None,
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "model": {
+            "policy": QUATERNION_CUBE_POLICY,
+            "execution": "r4",
+            "intervention": "native",
+            "parameter_count": PARAMETER_COUNT,
+            "learned_parameter_values_exercised_by_forward": (
+                PARAMETER_COUNT
+                - LAYERS * DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER
+            ),
+            "new_trainable_parameter_values": 0,
+            "trained_rope_context_tokens": CONTEXT,
+            "live_window_tokens": LIVE_WINDOW,
+            "summary_banks": SUMMARY_BANKS,
+            "persistent_candidate_budget": PERSISTENT_CANDIDATE_BUDGET,
+            "maximum_attention_sources": MAXIMUM_READ_SOURCES,
+            "recurrent_state_values": RECURRENT_STATE_VALUES,
+            "recurrent_state_bytes_f32": RECURRENT_STATE_BYTES_F32,
+            "recurrent_metadata_i64_values": RECURRENT_METADATA_I64_VALUES,
+            "exact_cache_state_values": STATE_VALUES,
+            "exact_cache_state_bytes_f32": STATE_BYTES_F32,
+            "f32_state_byte_reduction_fraction": (
+                1.0 - RECURRENT_STATE_BYTES_F32 / STATE_BYTES_F32
+            ),
+        },
+        "compression": {
+            "partition": "chronological-binary-age-levels",
+            "selection": "exact-signed-s3-shell-then-maximin-full-h4-root",
+            "selection_status": "unfitted-engineering-hypothesis",
+            "signed_s3_shell_degrees": list(SIGNED_S3_SHELL_DEGREES),
+            "summary_coordinates": "local-h4-frame",
+            "merge": "count-weighted-key-value-mean-in-newer-anchor",
+            "highest_bank": "absorbs-overflow",
+            "score_law": "unchanged-qk-softmax-over-admitted-sources",
+            "selection_inputs": "fixed-recurrent-source-metadata-only",
+            "exact_h4_heatmap_role": "trace-only-not-admission",
+            "group_address_collision": False,
+            "learned_gate": False,
+            "fit_performed": False,
+        },
+        "nonlinearity": {
+            "policy": QUATERNION_CUBE_POLICY,
+            "state_map": "R48-to-12-ordered-R4-blocks",
+            "operator_bank": "120-H4-frame-indices-with-antipodal-equivalence",
+            "operator_index_count": 120,
+            "distinct_operator_upper_bound": 60,
+            "signed_frame_antipodes_share_operator": True,
+            "hidden_state_domain": "continuous-f32",
+            "local_operator": "C(0)=0; C(q)=q^3/||q||^2 otherwise",
+            "residual": "F_current*C(transpose(F_current)*normalized)-normalized",
+            "exact_real_properties": [
+                "odd",
+                "real-scale-equivariant",
+                "block-norm-preserving",
+                "residual-norm-at-most-twice-input-norm",
+            ],
+            "implementation_status": "unfitted-f32-mechanical-candidate",
+            "dense_swiglu_parameters_retained_in_artifact": True,
+            "dense_swiglu_executed": False,
+            "new_persistent_state_values": 0,
+            "fit_performed": False,
+            "e8_r8_bridge": None,
+            "zeta_or_heatmap_activation": False,
+        },
+        "inputs": {
+            "model_artifact": _record(artifact_path, artifact_payload),
+            "artifact_result": _record(result_path, result_payload),
+            "tokenizer": _record(tokenizer_path, tokenizer_payload),
+            "geometry": _record(resolved_geometry, geometry_payload),
+            "h4_frames": _record(resolved_frames, frame_payload),
+            "corpus_files_read": 0,
+            "teacher_files_read": 0,
+            "checkpoint_files_read": 0,
+            "historical_fitted_artifact_files_read": 0,
+            "provider_files_read": 0,
+        },
+        "fit_provenance": {
+            "arm_result_cid": arm_result["arm_result_cid"],
+            "completed_steps": arm_result.get("completed_steps"),
+            "presentations": arm_result.get("presentations"),
+            "train_order_cid": arm_result.get("train_order_cid"),
+        },
+        "geometry": {
+            "group_artifact_cid": geometry_bundle.artifact_cid,
+            "frame_artifact_cid": frames.artifact_cid,
+            "frame_matrix_convention": frames.matrix_convention,
+            "identity_index": frames.identity_index,
+        },
+        "execution": {
+            "implementation": "sparse-geometric-r4-with-h4-frame-quaternion-cube",
+            "read_before_persistent_write": True,
+            "processed_tokens": state.tokens_seen,
+            "generation_decisions": len(generated),
+            "final_live_length": state.live_length,
+            "final_summary_counts": state.summary_counts[0].tolist(),
+            "final_summary_last_positions": (
+                state.summary_last_positions[0].tolist()
+            ),
+            "represented_summary_tokens": represented_summary_tokens,
+            "represented_total_tokens": represented_summary_tokens
+            + state.live_length,
+            "first_eviction_after_position": (
+                LIVE_WINDOW if audit.evictions else None
+            ),
+            "first_summary_read_position": first_summary_read_position,
+            "state_values_initial": initial_state_values,
+            "state_values_final": model.recurrent_state_value_count(),
+            "state_storage_constant": True,
+            "final_frame_index": int(state.current_frame_indices[0]),
+            "provider_calls": audit.provider_calls,
+            "teacher_calls": audit.teacher_calls,
+            "future_reads": audit.future_reads,
+            "forbidden_reads": audit.forbidden_reads,
+            "candidate_trace": candidate_trace,
+            "work": {
+                "cache_writes": audit.cache_writes,
+                "evictions": audit.evictions,
+                "summary_bank_updates": audit.summary_bank_updates,
+                "summary_merges": audit.summary_merges,
+                "summary_slots_read": audit.summary_slots_read,
+                "materialized_attention_scores": (
+                    audit.materialized_attention_scores
+                ),
+                "admitted_attention_scores": audit.admitted_attention_scores,
+                "live_attention_scores": audit.live_attention_scores,
+                "summary_attention_scores": audit.summary_attention_scores,
+                "current_attention_scores": audit.current_attention_scores,
+                "eligible_persistent_source_slots": (
+                    audit.eligible_persistent_source_slots
+                ),
+                "selected_persistent_source_slots": (
+                    audit.selected_persistent_source_slots
+                ),
+                "geometric_shell_evaluations": audit.geometric_shell_evaluations,
+                "pairwise_shell_evaluations": audit.pairwise_shell_evaluations,
+                "candidate_cost_comparisons": audit.candidate_cost_comparisons,
+                "unselected_key_value_reads": audit.unselected_key_value_reads,
+                "complete_prefix_scans": audit.complete_prefix_scans,
+                "attention_transported_r4_blocks": (
+                    audit.attention_transported_r4_blocks
+                ),
+                "compression_transported_r4_blocks": (
+                    audit.compression_transported_r4_blocks
+                ),
+                "value_reads": audit.value_reads,
+                "vocabulary_scores": audit.vocabulary_scores,
+                "peak_attention_source_slots": (
+                    audit.peak_attention_source_slots
+                ),
+                "nonlinear_layer_calls": nonlinear_audit.layer_calls,
+                "dense_mlp_calls": nonlinear_audit.dense_mlp_calls,
+                "dense_mlp_weight_products": (
+                    nonlinear_audit.dense_mlp_weight_products
+                ),
+                "r4_block_evaluations": (
+                    nonlinear_audit.r4_block_evaluations
+                ),
+                "h4_frame_maps": nonlinear_audit.h4_frame_maps,
+                "h4_frame_coefficient_products": (
+                    nonlinear_audit.h4_frame_coefficient_products
+                ),
+                "quaternion_cube_scalar_products": (
+                    nonlinear_audit.quaternion_cube_scalar_products
+                ),
+                "quaternion_cube_reciprocals": (
+                    nonlinear_audit.quaternion_cube_reciprocals
+                ),
+                "residual_subtractions": (
+                    nonlinear_audit.residual_subtractions
+                ),
+                "maximum_block_norm_error_f32": (
+                    nonlinear_audit.maximum_block_norm_error
+                ),
+                "maximum_residual_bound_ratio_f32": (
+                    nonlinear_audit.maximum_residual_bound_ratio
+                ),
+            },
+        },
+        "prompt": prompt,
+        "prompt_token_ids": prompt_token_ids,
+        "seed": seed,
+        "sampler": {
+            "type": "top-k-q32-splitmix64",
+            "top_k": TOP_K,
+            "temperature": TEMPERATURE,
+        },
+        "max_new_tokens": max_new_tokens,
+        "generated_token_ids": generated,
+        "continuation": continuation,
+        "text": prompt + continuation,
+        "utf8_decodable": utf8_decodable,
+        "stop": stop,
+    }
+
+
+__all__ = [
+    "DEFAULT_MAX_NEW_TOKENS",
+    "DEFAULT_SEED",
+    "SCHEMA",
+    "STATUS",
+    "generate_quaternion_cube_r4_language_path",
+]

--- a/tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py
+++ b/tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py
@@ -10,6 +10,8 @@ from types import SimpleNamespace
 import torch
 
 from r4_softmax_trainer.fixed_recurrent_kv_binding import (
+    DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER,
+    DENSE_SWIGLU_POLICY,
     LIVE_WINDOW,
     MAXIMUM_READ_SOURCES,
     POLICY,
@@ -36,6 +38,16 @@ from r4_softmax_trainer.sparse_geometric_kv_binding import (
     PERSISTENT_CANDIDATE_BUDGET,
     POLICY as SPARSE_POLICY,
     R4SparseGeometricCandidateSoftmaxKVBindingV1,
+)
+from r4_softmax_trainer.quaternion_cube_nonlinear import (
+    H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK,
+    H4_FRAME_MAPS_PER_BLOCK,
+    POLICY as QUATERNION_CUBE_POLICY,
+    QUATERNION_CUBE_RECIPROCALS_PER_BLOCK,
+    QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK,
+    R4_BLOCKS_PER_HIDDEN,
+    RESIDUAL_SUBTRACTIONS_PER_BLOCK,
+    R4H4FrameQuaternionCubeResidualV1,
 )
 
 
@@ -365,6 +377,137 @@ class FixedRecurrentKVBindingTests(unittest.TestCase):
                 item["relative_root_z_phi_over_2"],
                 [list(pair) for pair in frames.root_coordinates[expected_relative]],
             )
+
+    def test_quaternion_cube_replaces_only_the_dense_nonlinear_residual(self) -> None:
+        torch.manual_seed(1_123)
+        geometry, frames = _geometry_and_frames()
+        source = R4PositionPreservingCausalKVBindingV1(  # type: ignore[arg-type]
+            geometry, frames
+        )
+        artifact = source.export_learned_artifact()
+        dense = R4SparseGeometricCandidateSoftmaxKVBindingV1.from_learned_artifact(
+            artifact, geometry=geometry, frames=frames
+        )
+        cube = R4H4FrameQuaternionCubeResidualV1.from_learned_artifact(
+            artifact, geometry=geometry, frames=frames
+        )
+        dense.eval()
+        cube.eval()
+
+        # The new hook preserves the accepted comparator expression exactly.
+        values = torch.randn(1, 48)
+        expected_dense = dense.layers[0].mlp(
+            dense.layers[0].post_attention_layernorm(values)
+        )
+        observed_dense, dense_audit = dense._post_attention_nonlinear(
+            values,
+            layer=dense.layers[0],
+            current_frames=torch.tensor([0], dtype=torch.long),
+        )
+        self.assertTrue(torch.equal(observed_dense, expected_dense))
+        self.assertEqual(dense_audit.policy, DENSE_SWIGLU_POLICY)
+        self.assertEqual(dense_audit.dense_mlp_calls, 1)
+        self.assertEqual(
+            dense_audit.dense_mlp_weight_products,
+            DENSE_MLP_WEIGHT_PRODUCTS_PER_TOKEN_LAYER,
+        )
+
+        # The closed form is odd, norm preserving, and explicit at zero.
+        block_values = torch.zeros(1, 48)
+        block_values[0, 4] = 0.0
+        block_values[0, 5] = 1.0
+        identity_layer = SimpleNamespace(post_attention_layernorm=lambda item: item)
+        cube_delta, one_layer_audit = cube._post_attention_nonlinear(
+            block_values,
+            layer=identity_layer,
+            current_frames=torch.tensor([0], dtype=torch.long),
+        )
+        negative_delta, _ = cube._post_attention_nonlinear(
+            -block_values,
+            layer=identity_layer,
+            current_frames=torch.tensor([0], dtype=torch.long),
+        )
+        self.assertTrue(torch.equal(cube_delta, -negative_delta))
+        self.assertEqual(cube_delta[0, 5], -2.0)
+        self.assertEqual(int(torch.count_nonzero(cube_delta)), 1)
+        self.assertEqual(one_layer_audit.policy, QUATERNION_CUBE_POLICY)
+        self.assertEqual(one_layer_audit.r4_block_evaluations, R4_BLOCKS_PER_HIDDEN)
+        self.assertEqual(
+            one_layer_audit.h4_frame_maps,
+            R4_BLOCKS_PER_HIDDEN * H4_FRAME_MAPS_PER_BLOCK,
+        )
+        self.assertEqual(
+            one_layer_audit.h4_frame_coefficient_products,
+            R4_BLOCKS_PER_HIDDEN * H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK,
+        )
+        self.assertEqual(
+            one_layer_audit.quaternion_cube_scalar_products,
+            R4_BLOCKS_PER_HIDDEN * QUATERNION_CUBE_SCALAR_PRODUCTS_PER_BLOCK,
+        )
+        self.assertEqual(
+            one_layer_audit.quaternion_cube_reciprocals,
+            R4_BLOCKS_PER_HIDDEN * QUATERNION_CUBE_RECIPROCALS_PER_BLOCK,
+        )
+        self.assertEqual(
+            one_layer_audit.residual_subtractions,
+            R4_BLOCKS_PER_HIDDEN * RESIDUAL_SUBTRACTIONS_PER_BLOCK,
+        )
+        self.assertEqual(one_layer_audit.maximum_block_norm_error, 0.0)
+        self.assertEqual(one_layer_audit.maximum_residual_bound_ratio, 1.0)
+
+        # The candidate predictive forward must not call the retained dense MLP.
+        def forbidden_dense_call(_: torch.Tensor) -> torch.Tensor:
+            raise AssertionError("candidate executed dense SwiGLU")
+
+        for layer in cube.layers:
+            layer.mlp.forward = forbidden_dense_call  # type: ignore[method-assign]
+
+        dense_state = dense.initial_state(1)
+        cube_state = cube.initial_state(1)
+        token = torch.tensor([7], dtype=torch.long)
+        with torch.inference_mode():
+            dense_step = dense.step(token, dense_state)
+            cube_step = cube.step(token, cube_state)
+
+        self.assertEqual(cube.parameter_count(), PARAMETER_COUNT)
+        self.assertEqual(cube.export_learned_artifact(), artifact)
+        self.assertTrue(torch.isfinite(cube_step.logits).all())
+        self.assertEqual(cube_step.final_state.tokens_seen, 1)
+        self.assertEqual(
+            cube.recurrent_state_value_count(), RECURRENT_STATE_VALUES
+        )
+        self.assertIsNotNone(dense_step.candidate_selection)
+        self.assertIsNotNone(cube_step.candidate_selection)
+        assert dense_step.candidate_selection is not None
+        assert cube_step.candidate_selection is not None
+        self.assertTrue(
+            torch.equal(
+                dense_step.candidate_selection.source_slots,
+                cube_step.candidate_selection.source_slots,
+            )
+        )
+        nonlinear = cube_step.nonlinear_audit
+        self.assertEqual(nonlinear.policy, QUATERNION_CUBE_POLICY)
+        self.assertEqual(nonlinear.layer_calls, LAYERS)
+        self.assertEqual(nonlinear.dense_mlp_calls, 0)
+        self.assertEqual(nonlinear.dense_mlp_weight_products, 0)
+        self.assertEqual(
+            nonlinear.r4_block_evaluations,
+            LAYERS * R4_BLOCKS_PER_HIDDEN,
+        )
+        self.assertEqual(
+            nonlinear.h4_frame_coefficient_products,
+            LAYERS
+            * R4_BLOCKS_PER_HIDDEN
+            * H4_FRAME_COEFFICIENT_PRODUCTS_PER_BLOCK,
+        )
+        self.assertLessEqual(nonlinear.maximum_residual_bound_ratio, 1.000001)
+        self.assertEqual(cube_step.audit.complete_prefix_scans, 0)
+        self.assertEqual(cube_step.audit.unselected_key_value_reads, 0)
+        self.assertEqual(cube_step.audit.provider_calls, 0)
+        self.assertEqual(cube_step.audit.teacher_calls, 0)
+        self.assertEqual(cube_step.audit.future_reads, 0)
+        self.assertEqual(cube_step.audit.forbidden_reads, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The bounded sparse recurrent language path still executed its dense SwiGLU block, so the nonlinear geometric stage had no concrete implementation. This change adds `R4H4FrameQuaternionCubeResidualV1`: twelve ordered R4 cells execute a parameter-free quaternion cube in the current H4 frame after the accepted sparse attention residual, while the accepted learned artifact and dense-SwiGLU arm remain available as the matched comparator. The project track now advances to a separately bounded development-data fit of this exact architecture.

The fixed no-fit comparison completed on both existing development prompts. Across 53 processed tokens, the candidate executed 1,272 R4 blocks, zero dense-MLP calls, and zero dense-MLP learned-weight products; recurrent storage remained 2,304 f32 values, the read ceiling remained nine sources, and all recorded causal/provenance prohibitions remained zero. The maximum observed f32 block-norm error was `7.152557373046875e-07`, and the maximum residual-bound ratio was `1.0`. Both generated continuations diverged from the fitted dense comparator at the first token and were visibly degraded, so this is a mechanical execution result only: trainability, useful language, H4 benefit, reasoning, coding, table-native lowering, and release behavior remain unverified.

Independent review checked the quaternion law, frame orientation, recurrent seam, audit arithmetic, raw hashes, and evidence boundaries. It corrected the operator-bank description to 120 frame indices with at most 60 distinct maps and narrowed the dense-weight claim to the predictive forward path; all pre-correction raw artifacts remain preserved.

Validation:

- `PYTHONPATH=tools/r4-softmax-trainer/src .../python -m unittest tools/r4-softmax-trainer/tests/test_fixed_recurrent_kv_binding.py -v` (4 tests, pass)
- Python byte-compilation of the four changed/added implementation modules and focused test
- `python3 scripts/check_agent_execution_policy.py`
- `python3 scripts/check_claim_wording.py`
- `python3 -m json.tool docs/integration/agent-execution-policy.json`
- `git diff --check`
- raw artifact SHA-256 and recursive metadata-only correction checks

References #973
