### PR TITLE
Add native typed-value binding and causal numeral emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,18 @@ results, remaining learned-operator work and capability limitations.
 
 The [native mechanism map](docs/native_geometric_mechanism_map_973.md) traces
 the implemented prime/zeta/R4 mechanisms from source to generated responses.
-The latest [response-state record](docs/native_geometric_response_state_973.md)
+The [response-state record](docs/native_geometric_response_state_973.md)
 adds explicit query persistence and model-selected source state. Both matched
 fits regress against the preceding occurrence reader: exact prose is 5/32
 versus 6/32, and Rust remains 0/32. They remain development options, with
-their controls, actual outputs and costs preserved. Useful response composition,
-coding and computed-value generation remain unresolved.
+their controls, actual outputs and costs preserved. Useful response composition
+and coding remain unresolved. The subsequent
+[typed-value record](docs/native_geometric_typed_value_973.md) adds learned
+operand/action selection, checked value creation and causal decimal emission.
+Its whole-word correction reaches 24/24 numeric targets and all four binding
+pairs on reused open development, while complete responses remain 2/16 prose
+and 0/16 Rust and all 20 generated Rust sources fail compilation. It preserves
+the earlier binding negative and establishes no new H4/zeta selection benefit.
 
 ## Preserved project entry points
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -1,0 +1,942 @@
+//! Small joint open-development exercise for learned typed-value selection.
+//!
+//! Fit receives raw prompt/response bytes only. Task and counterfactual labels
+//! are probe diagnostics and never enter inference or provide source positions.
+//! Generated code is saved unchanged; this probe does not compile or execute it.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uor_r4_core::native_geometric::{Control, Model, ValueExample, ValueFitConfig};
+
+type ProbeResult<T> = Result<T, Box<dyn Error>>;
+const SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/1";
+const LEXEME_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/2";
+const MAX_SOURCE_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+struct Options {
+    mode: String,
+    model: PathBuf,
+    source: Option<PathBuf>,
+    output_dir: PathBuf,
+    fit_worlds: usize,
+    development_worlds: usize,
+    epochs: usize,
+    learning_rate: f64,
+    max_features: usize,
+    generated_tokens: usize,
+    max_seconds: u64,
+    lexeme_cues: bool,
+}
+
+impl Options {
+    fn parse() -> ProbeResult<Self> {
+        let mut arguments = std::env::args().skip(1).peekable();
+        let mode = if arguments.peek().is_some_and(|arg| !arg.starts_with('-')) {
+            arguments.next().ok_or("missing mode")?
+        } else {
+            "fit".into()
+        };
+        let mut result = Self {
+            mode,
+            model: PathBuf::new(),
+            source: None,
+            output_dir: PathBuf::new(),
+            fit_worlds: 16,
+            development_worlds: 4,
+            epochs: 24,
+            learning_rate: 0.1,
+            max_features: 65_536,
+            generated_tokens: 32,
+            max_seconds: 120,
+            lexeme_cues: false,
+        };
+        while let Some(flag) = arguments.next() {
+            if flag == "--help" || flag == "-h" {
+                println!(
+                    "native_geometric_value_probe [prepare|fit|evaluate] --output-dir NEW_DIRECTORY\n\
+                     fit: --model BASELINE [--source source.json]\n\
+                     evaluate: --model VALUE_MODEL --source source.json\n\
+                     --fit-worlds EVEN_NUMBER --development-worlds EVEN_NUMBER\n\
+                     --epochs N --learning-rate F --max-features N\n\
+                     --generated-tokens N --max-seconds N\n\
+                     --lexeme-cues true|false (default false; true appends 64 fit\n\
+                     name swaps at default world count and uses source schema /2)\n\
+                     Defaults: 128 fit and 32 development cases across prose/Rust;\n\
+                     paired worlds alter one numeric literal. Full byte exactness,\n\
+                     leading numeral correctness and no-write behavior stay separate.\n\
+                     The elapsed limit is checked between bounded operations; fitting\n\
+                     and artifact serialization may overrun. Use an external monitor."
+                );
+                std::process::exit(0);
+            }
+            let value = arguments
+                .next()
+                .ok_or_else(|| format!("missing value for {flag}"))?;
+            match flag.as_str() {
+                "--model" => result.model = value.into(),
+                "--source" => result.source = Some(value.into()),
+                "--output-dir" => result.output_dir = value.into(),
+                "--fit-worlds" => result.fit_worlds = value.parse()?,
+                "--development-worlds" => result.development_worlds = value.parse()?,
+                "--epochs" => result.epochs = value.parse()?,
+                "--learning-rate" => result.learning_rate = value.parse()?,
+                "--max-features" => result.max_features = value.parse()?,
+                "--generated-tokens" => result.generated_tokens = value.parse()?,
+                "--max-seconds" => result.max_seconds = value.parse()?,
+                "--lexeme-cues" => result.lexeme_cues = value.parse()?,
+                _ => return Err(format!("unknown option {flag}").into()),
+            }
+        }
+        if !["prepare", "fit", "evaluate"].contains(&result.mode.as_str())
+            || result.output_dir.as_os_str().is_empty()
+            || (result.mode != "prepare" && result.model.as_os_str().is_empty())
+            || (result.mode == "evaluate" && result.source.is_none())
+            || !(2..=128).contains(&result.fit_worlds)
+            || !(2..=32).contains(&result.development_worlds)
+            || !result.fit_worlds.is_multiple_of(2)
+            || !result.development_worlds.is_multiple_of(2)
+            || !(1..=128).contains(&result.epochs)
+            || !result.learning_rate.is_finite()
+            || !(0.0..=1.0).contains(&result.learning_rate)
+            || result.learning_rate == 0.0
+            || !(1..=262_144).contains(&result.max_features)
+            || !(1..=256).contains(&result.generated_tokens)
+            || result.max_seconds == 0
+        {
+            return Err("unsupported options; see --help".into());
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Case {
+    id: String,
+    family: String,
+    task: String,
+    world: usize,
+    pair_id: String,
+    variant: usize,
+    prompt: String,
+    response: String,
+}
+
+impl Case {
+    fn example(&self) -> ValueExample {
+        ValueExample {
+            id: self.id.clone(),
+            prompt: self.prompt.clone(),
+            response: self.response.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Source {
+    schema: String,
+    scope: String,
+    tokenization_law: String,
+    fit: Vec<Case>,
+    development: Vec<Case>,
+}
+
+#[derive(Debug, Serialize)]
+struct BindingPair {
+    pair_id: String,
+    /// Identical query bytes follow both versions of the supplied context.
+    query: String,
+    original: Case,
+    swapped: Case,
+}
+
+#[derive(Debug, Serialize)]
+struct BindingSource {
+    schema: String,
+    scope: String,
+    pairs: Vec<BindingPair>,
+}
+
+// A source intervention, not a model-side parsing rule. All four pairs use
+// authored constants and preserve the exact numeric-byte sequence and query.
+// Only the identity attached to source values changes. A fixed numeric rank
+// therefore cannot return both correct answers within a pair.
+fn binding_source() -> ProbeResult<BindingSource> {
+    let (value, delta, earlier, irrelevant) = (73_i64, 4_i64, 31_i64, 301_i64);
+    let mut pairs = Vec::new();
+    for family in ["prose", "rust"] {
+        for task in ["copy_current", "add"] {
+            let (context, swapped_context, query, response, swapped_response) =
+                match (family, task) {
+                    ("prose", "copy_current") => (
+                        format!("User: suri had {earlier} coins. tavi has {irrelevant} coins.\nUser: Update: suri now has {value} coins.\n"),
+                        format!("User: tavi had {earlier} coins. suri has {irrelevant} coins.\nUser: Update: tavi now has {value} coins.\n"),
+                        "User: How many coins does suri have now?\nAssistant:".to_owned(),
+                        format!("{value}.\n"),
+                        format!("{irrelevant}.\n"),
+                    ),
+                    ("prose", "add") => (
+                        format!("User: suri has {value} coins. orin has {delta} coins. tavi has {irrelevant} coins.\n"),
+                        format!("User: suri has {value} coins. tavi has {delta} coins. orin has {irrelevant} coins.\n"),
+                        "User: What is the sum of suri's and orin's coins?\nAssistant:".to_owned(),
+                        format!("{}.\n", value + delta),
+                        format!("{}.\n", value + irrelevant),
+                    ),
+                    ("rust", "copy_current") => (
+                        format!("fn main() {{\n    let mut suri = {earlier};\n    let tavi = {irrelevant};\n    suri = {value};\n    "),
+                        format!("fn main() {{\n    let mut tavi = {earlier};\n    let suri = {irrelevant};\n    tavi = {value};\n    "),
+                        "assert_eq!(suri,".to_owned(),
+                        format!("{value});\n}}\n"),
+                        format!("{irrelevant});\n}}\n"),
+                    ),
+                    _ => (
+                        format!("fn main() {{\n    let suri = {value};\n    let orin = {delta};\n    let tavi = {irrelevant};\n    "),
+                        format!("fn main() {{\n    let suri = {value};\n    let tavi = {delta};\n    let orin = {irrelevant};\n    "),
+                        "assert_eq!(suri + orin,".to_owned(),
+                        format!("{});\n}}\n", value + delta),
+                        format!("{});\n}}\n", value + irrelevant),
+                    ),
+                };
+            let pair_id = format!("typed-value/binding/{family}/{task}");
+            let original = Case {
+                id: format!("{pair_id}/original"),
+                family: family.into(),
+                task: task.into(),
+                world: 100_000,
+                pair_id: pair_id.clone(),
+                variant: 0,
+                prompt: format!("{context}{query}"),
+                response,
+            };
+            let swapped = Case {
+                id: format!("{pair_id}/source_names_swapped"),
+                variant: 1,
+                prompt: format!("{swapped_context}{query}"),
+                response: swapped_response,
+                ..original.clone()
+            };
+            if raw_digit_runs(original.prompt.as_bytes())
+                != raw_digit_runs(swapped.prompt.as_bytes())
+                || !original.prompt.ends_with(&query)
+                || !swapped.prompt.ends_with(&query)
+                || original.response == swapped.response
+            {
+                return Err(
+                    "binding intervention changed numeric bytes/query or failed to change answer"
+                        .into(),
+                );
+            }
+            pairs.push(BindingPair {
+                pair_id,
+                query,
+                original,
+                swapped,
+            });
+        }
+    }
+    Ok(BindingSource {
+        schema: "uor-r4.native-typed-value-binding-control-source/1".into(),
+        scope: "Four authored source-name swaps, eight Full-only runs, frozen before fitting. Original numeric literals, their order and query bytes remain identical within each pair; source entity names change and expected answers change. The originals duplicate four default primary development prompts deliberately. Neither originals nor swaps are added to fit. These controls distinguish fixed numeric-occurrence rank selection from sensitivity to source identity in this tiny scope; success alone does not establish general identity binding or reasoning.".into(),
+        pairs,
+    })
+}
+
+/// Exact runs of ASCII digit bytes, including any digits embedded in source
+/// types. This validates a text intervention; it is not the model's lexer.
+fn raw_digit_runs(bytes: &[u8]) -> Vec<&[u8]> {
+    let mut runs = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        if bytes[cursor].is_ascii_digit() {
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            runs.push(&bytes[start..cursor]);
+        } else {
+            cursor += 1;
+        }
+    }
+    runs
+}
+
+fn make_cases(split: &str, worlds: usize) -> Vec<Case> {
+    let mut cases = Vec::with_capacity(worlds * 8);
+    let development = split == "development";
+    for local_world in 0..worlds {
+        let world = if development { 100_000 } else { 0 } + local_world;
+        let pair = local_world / 2;
+        let variant = local_world % 2;
+        let names = if development {
+            ["suri", "orin", "tavi"]
+        } else if pair.is_multiple_of(2) {
+            ["ada", "ben", "cyra"]
+        } else {
+            ["dara", "eli", "finn"]
+        };
+        let [first, second, distractor] = names;
+        let magnitude = if development { 73 } else { 11 } + pair as i64 * 5;
+        let original = if pair % 3 == 1 { -magnitude } else { magnitude };
+        let value = original + variant as i64 * 3;
+        let delta = 4 + pair as i64 % 5;
+        let earlier = 31 + pair as i64;
+        let reassigned = 181 + pair as i64;
+        let irrelevant = 301 + pair as i64;
+        for family in ["prose", "rust"] {
+            for task in [
+                "copy_current",
+                "add",
+                "dependency_before_update",
+                "no_write",
+            ] {
+                let (prompt, response) = if family == "prose" {
+                    match task {
+                        "copy_current" => (
+                            format!("User: {first} had {earlier} coins. {distractor} has {irrelevant} coins.\nUser: Update: {first} now has {value} coins.\nUser: How many coins does {first} have now?\nAssistant:"),
+                            format!("{value}.\n"),
+                        ),
+                        "add" => (
+                            format!("User: {first} has {value} coins. {second} has {delta} coins. {distractor} has {irrelevant} coins.\nUser: What is the sum of {first}'s and {second}'s coins?\nAssistant:"),
+                            format!("{}.\n", value + delta),
+                        ),
+                        "dependency_before_update" => (
+                            format!("User: {first} has {value} coins. {second}'s recorded count is {first}'s count plus {delta}.\nUser: {first} now has {reassigned} coins. {distractor} has {irrelevant} coins.\nUser: What was {second}'s recorded count before the update?\nAssistant:"),
+                            format!("{}.\n", value + delta),
+                        ),
+                        _ => (
+                            format!("User: {first} has {value} coins. {distractor} has {irrelevant} coins.\nUser: What city does {second} live in?\nAssistant:"),
+                            " Unknown. The conversation does not give a city.\n".into(),
+                        ),
+                    }
+                } else {
+                    match task {
+                        "copy_current" => (
+                            format!("fn main() {{\n    let mut {first} = {earlier};\n    let {distractor} = {irrelevant};\n    {first} = {value};\n    assert_eq!({first},"),
+                            format!("{value});\n}}\n"),
+                        ),
+                        "add" => (
+                            format!("fn main() {{\n    let {first} = {value};\n    let {second} = {delta};\n    let {distractor} = {irrelevant};\n    assert_eq!({first} + {second},"),
+                            format!("{});\n}}\n", value + delta),
+                        ),
+                        "dependency_before_update" => (
+                            format!("fn main() {{\n    let mut {first} = {value};\n    let {second} = {first} + {delta};\n    {first} = {reassigned};\n    let {distractor} = {irrelevant};\n    assert_eq!({second},"),
+                            format!("{});\n}}\n", value + delta),
+                        ),
+                        _ => (
+                            format!("// {first} has {value} coins; {distractor} has {irrelevant}.\n// Return the input unchanged.\nfn identity(value: i32) -> i32 {{\n    "),
+                            "value\n}\n".into(),
+                        ),
+                    }
+                };
+                cases.push(Case {
+                    id: format!("typed-value/{split}/{family}/{task}/{world}"),
+                    family: family.into(),
+                    task: task.into(),
+                    world,
+                    pair_id: format!("typed-value/{split}/{family}/{task}/pair-{pair}"),
+                    variant,
+                    prompt,
+                    response,
+                });
+            }
+        }
+    }
+    cases
+}
+
+/// Additional raw fit examples only. Each appended row has a corresponding
+/// original row in make_cases("fit", worlds). Context names exchange roles;
+/// numeric source order and the entire query stay fixed. The expected answer
+/// comes from authored world constants, never from a model-side source index.
+fn make_fit_name_swaps(worlds: usize) -> ProbeResult<Vec<Case>> {
+    let mut swaps = Vec::with_capacity(worlds * 4);
+    for original in make_cases("fit", worlds)
+        .into_iter()
+        .filter(|case| ["copy_current", "add"].contains(&case.task.as_str()))
+    {
+        let pair = original.world / 2;
+        let [first, second, distractor] = if pair.is_multiple_of(2) {
+            ["ada", "ben", "cyra"]
+        } else {
+            ["dara", "eli", "finn"]
+        };
+        let magnitude = 11 + pair as i64 * 5;
+        let initial = if pair % 3 == 1 { -magnitude } else { magnitude };
+        let value = initial + original.variant as i64 * 3;
+        let irrelevant = 301 + pair as i64;
+        let (left, expected) = if original.task == "copy_current" {
+            (first, irrelevant)
+        } else {
+            (second, value + irrelevant)
+        };
+        let query_start = original
+            .prompt
+            .rfind(if original.family == "prose" {
+                "User: "
+            } else {
+                "assert_eq!"
+            })
+            .ok_or("authored fit case lacks query boundary")?;
+        let (context, query) = original.prompt.split_at(query_start);
+        // All six authored fit names are distinct literal strings absent from
+        // ordinary words in these contexts. The temporary marker is never saved.
+        let swapped_context = context
+            .replace(left, "\0")
+            .replace(distractor, left)
+            .replace('\0', distractor);
+        let swapped = Case {
+            id: format!("{}/source_names_swapped", original.id),
+            pair_id: format!("{}/source_names_swapped", original.pair_id),
+            prompt: format!("{swapped_context}{query}"),
+            response: if original.family == "prose" {
+                format!("{expected}.\n")
+            } else {
+                format!("{expected});\n}}\n")
+            },
+            ..original.clone()
+        };
+        if raw_digit_runs(original.prompt.as_bytes()) != raw_digit_runs(swapped.prompt.as_bytes())
+            || !swapped.prompt.ends_with(query)
+            || original.response == swapped.response
+            || original.prompt == swapped.prompt
+        {
+            return Err("fit name swap changed numeric bytes/query or not the answer".into());
+        }
+        swaps.push(swapped);
+    }
+    Ok(swaps)
+}
+
+fn source(options: &Options) -> ProbeResult<Source> {
+    let mut result = if let Some(path) = &options.source {
+        if fs::metadata(path)?.len() > MAX_SOURCE_BYTES {
+            return Err("value source exceeds 4 MiB".into());
+        }
+        serde_json::from_slice(&fs::read(path)?)?
+    } else {
+        Source {
+            schema: SOURCE_SCHEMA.into(),
+            scope: "Small finite synthetic open development with shared templates, different names/values and disjoint world/document IDs. Counterfactual pairs change one relevant input literal. Both families share one fitted artifact. Task and pair labels are evaluator-only. The dependency examples test response-time original-occurrence binding; they do not demonstrate eager statement execution, arbitrary Rust interpretation, retention beyond eviction or alpha.".into(),
+            tokenization_law: "Numeric responses begin with exact signed decimal bytes, without an implicit leading space. Their punctuation and closing code are ordinary generated output. Leading-numeral accuracy and complete byte equality are separate from canonical lexical-token accuracy. No suffix or answer template is appended to generated output.".into(),
+            fit: make_cases("fit", options.fit_worlds),
+            development: make_cases("development", options.development_worlds),
+        }
+    };
+    if options.source.is_none() && options.lexeme_cues {
+        result.schema = LEXEME_SOURCE_SCHEMA.into();
+        result.scope.push_str(" Source /2 appends context-only copy/add name swaps to the unchanged /1 fit cases, with fixed numeric source order and query bytes but changed correct operands. Whole-word cues are an explicit model variant. The unchanged primary development cases and four binding controls have already informed this design and are reused OPEN development feedback, not sealed or final held-out evaluation.");
+        result.fit.extend(make_fit_name_swaps(options.fit_worlds)?);
+    }
+    validate_source(&result)?;
+    if (result.schema == LEXEME_SOURCE_SCHEMA) != options.lexeme_cues {
+        return Err(
+            "source schema must match --lexeme-cues; prepare a new /2 source with true".into(),
+        );
+    }
+    Ok(result)
+}
+
+fn validate_source(source: &Source) -> ProbeResult<()> {
+    if ![SOURCE_SCHEMA, LEXEME_SOURCE_SCHEMA].contains(&source.schema.as_str())
+        || source.fit.is_empty()
+        || source.development.is_empty()
+    {
+        return Err("invalid value source schema or empty split".into());
+    }
+    let mut ids = BTreeSet::new();
+    let mut prompts = BTreeSet::new();
+    let mut documents = BTreeSet::new();
+    let fit_worlds: BTreeSet<_> = source.fit.iter().map(|case| case.world).collect();
+    if source
+        .development
+        .iter()
+        .any(|case| fit_worlds.contains(&case.world))
+    {
+        return Err("fit/development world overlap".into());
+    }
+    let mut pairs: BTreeMap<&str, Vec<&Case>> = BTreeMap::new();
+    for case in source.fit.iter().chain(&source.development) {
+        if case.prompt.is_empty()
+            || case.response.is_empty()
+            || !["prose", "rust"].contains(&case.family.as_str())
+            || !ids.insert(&case.id)
+            || !prompts.insert(&case.prompt)
+            || !documents.insert(format!("{}{}", case.prompt, case.response))
+        {
+            return Err("empty, duplicated or unsupported source case".into());
+        }
+        pairs.entry(&case.pair_id).or_default().push(case);
+    }
+    for pair in pairs.values() {
+        if pair.len() != 2 || pair[0].variant == pair[1].variant {
+            return Err("each counterfactual pair must have two distinct variants".into());
+        }
+    }
+    Ok(())
+}
+
+/// Compare decimal spellings, not token IDs or parsed arithmetic answers. No
+/// leading whitespace is discarded. Reject an incomplete sign or an identifier
+/// or fractional continuation that happens to begin with the expected digits.
+fn leading_numeral(bytes: &[u8]) -> Option<&[u8]> {
+    let start = usize::from(bytes.first() == Some(&b'-'));
+    let mut end = start;
+    while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+        end += 1;
+    }
+    if end == start
+        || bytes
+            .get(end)
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+        || (bytes.get(end) == Some(&b'.') && bytes.get(end + 1).is_some_and(u8::is_ascii_digit))
+    {
+        return None;
+    }
+    Some(&bytes[..end])
+}
+
+#[derive(Default, Serialize)]
+struct Metrics {
+    cases: usize,
+    exact_responses: usize,
+    numeric_cases: usize,
+    correct_leading_numerals: usize,
+    nonnumeric_cases: usize,
+    nonnumeric_cases_with_leading_numerals: usize,
+    generated_tokens: usize,
+}
+
+fn write_new(path: &Path, bytes: &[u8]) -> ProbeResult<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(bytes)?;
+    Ok(())
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> ProbeResult<()> {
+    write_new(path, &serde_json::to_vec_pretty(value)?)
+}
+
+fn within_limit(start: Instant, options: &Options) -> ProbeResult<()> {
+    if start.elapsed().as_secs_f64() >= options.max_seconds as f64 {
+        Err("monitored model-work elapsed limit reached; retained partial files remain".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_training_overlap(model: &Model, cases: &[Case]) -> ProbeResult<()> {
+    for case in cases {
+        let pair = serde_json::to_vec(&(&case.prompt, &case.response))?;
+        let pair_cid = format!("blake3:{}", blake3::hash(&pair).to_hex());
+        let whole_cid = format!(
+            "blake3:{}",
+            blake3::hash(format!("{}{}", case.prompt, case.response).as_bytes()).to_hex()
+        );
+        if model
+            .construction()
+            .iter()
+            .chain(model.readout_training())
+            .chain(model.memory_read_training())
+            .chain(model.value_training())
+            .any(|known| {
+                known.id == case.id || known.text_cid == pair_cid || known.text_cid == whole_cid
+            })
+        {
+            return Err(format!(
+                "development case overlaps actual artifact training: {}",
+                case.id
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn evaluate(
+    model: &Model,
+    source: &Source,
+    options: &Options,
+    start: Instant,
+) -> ProbeResult<Value> {
+    reject_training_overlap(model, &source.development)?;
+    let mut arms = Vec::new();
+    let mut controls = vec![
+        Control::Full,
+        Control::ValuesDisabled,
+        Control::H4Disabled,
+        Control::ZetaDisabled,
+    ];
+    if options.lexeme_cues {
+        // Suppress kind-16 features in this fitted artifact while retaining its
+        // state. This measures feature sensitivity, not a separately fitted
+        // matched baseline.
+        controls.push(Control::ValueLexemesDisabled);
+    }
+    for control in controls {
+        let mut metrics: BTreeMap<String, Metrics> = BTreeMap::new();
+        let mut rows = Vec::new();
+        let mut pairs: BTreeMap<&str, Vec<(bool, Option<Vec<u8>>)>> = BTreeMap::new();
+        for (index, case) in source.development.iter().enumerate() {
+            within_limit(start, options)?;
+            let generation = model.generate(&case.prompt, options.generated_tokens, control)?;
+            let expected = leading_numeral(case.response.as_bytes());
+            let actual = leading_numeral(&generation.bytes);
+            let numeral_correct = expected.map(|value| actual == Some(value));
+            let exact = generation.bytes == case.response.as_bytes();
+            for key in [
+                case.family.clone(),
+                format!("{}/{}", case.family, case.task),
+            ] {
+                let row = metrics.entry(key).or_default();
+                row.cases += 1;
+                row.exact_responses += usize::from(exact);
+                row.generated_tokens += generation.token_ids.len();
+                if let Some(correct) = numeral_correct {
+                    row.numeric_cases += 1;
+                    row.correct_leading_numerals += usize::from(correct);
+                } else {
+                    row.nonnumeric_cases += 1;
+                    row.nonnumeric_cases_with_leading_numerals += usize::from(actual.is_some());
+                }
+            }
+            if let Some(correct) = numeral_correct {
+                pairs
+                    .entry(&case.pair_id)
+                    .or_default()
+                    .push((correct, actual.map(<[u8]>::to_vec)));
+            }
+            let generated_source = if control == Control::Full && case.family == "rust" {
+                let path = options.output_dir.join(format!("rust-case-{index}.rs"));
+                let mut bytes = case.prompt.as_bytes().to_vec();
+                bytes.extend_from_slice(&generation.bytes);
+                write_new(&path, &bytes)?;
+                Some(
+                    json!({"path":path,"blake3":blake3::hash(&bytes).to_hex().to_string(),"bytes":bytes.len(),"compilation":"NOT_RUN","execution":"NOT_RUN"}),
+                )
+            } else {
+                None
+            };
+            rows.push(json!({
+                "case":case,
+                "expected_leading_numeral":expected.map(String::from_utf8_lossy),
+                "actual_leading_numeral":actual.map(String::from_utf8_lossy),
+                "leading_numeral_correct":numeral_correct,
+                "exact_response":exact,
+                "generated_source":generated_source,
+                "generation":generation,
+            }));
+        }
+        let pair_rows: Vec<_> = pairs.into_iter().map(|(id, values)| json!({
+            "pair_id":id,
+            "cases":values.len(),
+            "both_leading_numerals_correct":values.len()==2 && values.iter().all(|value| value.0),
+            "generated_leading_numeral_changed":values.len()==2 && values[0].1.is_some() && values[1].1.is_some() && values[0].1!=values[1].1,
+        })).collect();
+        let mut arm = json!({"control":control,"metrics":metrics,"numeric_counterfactual_pairs":pair_rows,"cases":rows});
+        if control == Control::ValueLexemesDisabled {
+            arm["scope"] = json!("Within-artifact lexical-feature sensitivity: kind-16 query-position/source-word match features disabled while retaining the same fitted artifact and state. This is not a separately fitted matched baseline.");
+        }
+        write_json(
+            &options.output_dir.join(format!("arm-{}.json", arms.len())),
+            &arm,
+        )?;
+        arms.push(arm);
+    }
+    Ok(json!(arms))
+}
+
+fn evaluate_binding(
+    model: &Model,
+    source: &BindingSource,
+    options: &Options,
+    start: Instant,
+) -> ProbeResult<Value> {
+    // Check every original and swapped raw pair against the loaded artifact's
+    // actual construction, readout, memory and value receipts before any
+    // control generation. The supplied source.fit is not artifact authority.
+    for pair in &source.pairs {
+        reject_training_overlap(model, std::slice::from_ref(&pair.original))?;
+        reject_training_overlap(model, std::slice::from_ref(&pair.swapped))?;
+    }
+    let mut pairs = Vec::new();
+    for (pair_index, pair) in source.pairs.iter().enumerate() {
+        let mut rows = Vec::new();
+        let mut correct = 0;
+        let mut exact = 0;
+        let mut emitted_numerals = Vec::new();
+        for (label, case) in [
+            ("original", &pair.original),
+            ("source_names_swapped", &pair.swapped),
+        ] {
+            within_limit(start, options)?;
+            let generation =
+                model.generate(&case.prompt, options.generated_tokens, Control::Full)?;
+            let expected =
+                leading_numeral(case.response.as_bytes()).ok_or("binding target lacks numeral")?;
+            let actual = leading_numeral(&generation.bytes);
+            let numeral_correct = actual == Some(expected);
+            let response_exact = generation.bytes == case.response.as_bytes();
+            correct += usize::from(numeral_correct);
+            exact += usize::from(response_exact);
+            emitted_numerals.push(actual.map(<[u8]>::to_vec));
+            let generated_source = if case.family == "rust" {
+                let path = options
+                    .output_dir
+                    .join(format!("binding-{pair_index}-{label}.rs"));
+                let mut bytes = case.prompt.as_bytes().to_vec();
+                bytes.extend_from_slice(&generation.bytes);
+                write_new(&path, &bytes)?;
+                Some(
+                    json!({"path":path,"blake3":blake3::hash(&bytes).to_hex().to_string(),"bytes":bytes.len(),"compilation":"NOT_RUN","execution":"NOT_RUN"}),
+                )
+            } else {
+                None
+            };
+            rows.push(json!({"intervention":label,"case":case,
+                "expected_leading_numeral":String::from_utf8_lossy(expected),
+                "actual_leading_numeral":actual.map(String::from_utf8_lossy),
+                "leading_numeral_correct":numeral_correct,"exact_response":response_exact,
+                "generated_source":generated_source,"generation":generation}));
+        }
+        pairs.push(json!({"pair_id":pair.pair_id,"control":"full",
+            "numeric_byte_runs_equal":raw_digit_runs(pair.original.prompt.as_bytes())==raw_digit_runs(pair.swapped.prompt.as_bytes()),
+            "query_bytes_equal":pair.original.prompt.ends_with(&pair.query)&&pair.swapped.prompt.ends_with(&pair.query),
+            "both_leading_numerals_correct":correct==2,"both_responses_exact":exact==2,
+            "generated_leading_numeral_changed":emitted_numerals.iter().all(Option::is_some)&&emitted_numerals[0]!=emitted_numerals[1],
+            "cases":rows}));
+    }
+    let report = json!({"scope":source.scope,"primary_metrics_include_these_runs":false,"fit_includes_these_runs":false,"runs":8,"pairs":pairs});
+    write_json(
+        &options.output_dir.join("binding-controls-report.json"),
+        &report,
+    )?;
+    Ok(report)
+}
+
+fn main() -> ProbeResult<()> {
+    let options = Options::parse()?;
+    let start = Instant::now();
+    let source = source(&options)?;
+    if let Some(parent) = options
+        .output_dir
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::create_dir(&options.output_dir)?;
+    let source_bytes = serde_json::to_vec_pretty(&source)?;
+    write_new(&options.output_dir.join("source.json"), &source_bytes)?;
+    write_json(&options.output_dir.join("options.json"), &options)?;
+    let mut binding_source = binding_source()?;
+    if options.lexeme_cues {
+        binding_source.scope.push_str(" These exact four pairs informed the /2 complete-lexeme-cue and fit-name-swap revision. They are reused OPEN development feedback; they remain absent from fit and do not constitute final held-out evaluation.");
+    }
+    if binding_source
+        .pairs
+        .iter()
+        .flat_map(|pair| [&pair.original, &pair.swapped])
+        .any(|case| source.fit.iter().any(|fit| fit.prompt == case.prompt))
+    {
+        return Err("binding control prompt overlaps the supplied fit source".into());
+    }
+    let binding_bytes = serde_json::to_vec_pretty(&binding_source)?;
+    write_new(
+        &options.output_dir.join("binding-controls-source.json"),
+        &binding_bytes,
+    )?;
+    if options.mode == "prepare" {
+        println!(
+            "{}",
+            json!({"status":"prepared","fit_cases":source.fit.len(),"development_cases":source.development.len(),"source_blake3":blake3::hash(&source_bytes).to_hex().to_string(),"elapsed_ms":start.elapsed().as_millis()})
+        );
+        return Ok(());
+    }
+    within_limit(start, &options)?;
+    let baseline = Model::from_bytes(&fs::read(&options.model)?)?;
+    let input_artifact = baseline.artifact_cid().to_owned();
+    let (model, fit_report) = if options.mode == "fit" {
+        let examples: Vec<_> = source.fit.iter().map(Case::example).collect();
+        let config = ValueFitConfig {
+            epochs: options.epochs,
+            learning_rate: options.learning_rate,
+            max_features: options.max_features,
+        };
+        let (fitted, report) = if options.lexeme_cues {
+            baseline.fit_values_with_lexeme_cues(&examples, config)?
+        } else {
+            baseline.fit_values(&examples, config)?
+        };
+        write_json(&options.output_dir.join("fit-report.json"), &report)?;
+        write_new(&options.output_dir.join("model.json"), &fitted.to_bytes()?)?;
+        // Evaluate the serialized/reloaded artifact, not only the trainer's
+        // in-memory object. Parent monitoring charges this loading/serialization.
+        let reloaded = Model::from_bytes(&fs::read(options.output_dir.join("model.json"))?)?;
+        (reloaded, Some(serde_json::to_value(report)?))
+    } else {
+        (baseline, None)
+    };
+    within_limit(start, &options)?;
+    let arms = evaluate(&model, &source, &options, start)?;
+    let binding_controls = evaluate_binding(&model, &binding_source, &options, start)?;
+    let report = json!({
+        "schema":if options.lexeme_cues { "uor-r4.native-typed-value-probe/2" } else { "uor-r4.native-typed-value-probe/1" },
+        "status":"completed",
+        "scope":source.scope,
+        "tokenization_law":source.tokenization_law,
+        "input_artifact_cid":input_artifact,
+        "artifact_cid":model.artifact_cid(),
+        "source_blake3":blake3::hash(&source_bytes).to_hex().to_string(),
+        "source_schema":source.schema,
+        "lexeme_cues":options.lexeme_cues,
+        "development_reused_after_design_feedback":options.lexeme_cues,
+        "fit_cases":source.fit.len(),
+        "development_cases":source.development.len(),
+        "fit_report":fit_report,
+        "arms":arms,
+        "binding_controls_source_blake3":blake3::hash(&binding_bytes).to_hex().to_string(),
+        "binding_controls":binding_controls,
+        "resources":{"elapsed_ms":start.elapsed().as_millis(),"max_seconds":options.max_seconds,"threads":1,"rss":"NOT_MEASURED: use parent process monitor","time_boundary":"Checked between bounded operations, not a hard interruption of fitting/generation/serialization. All model work belongs to the inherited cumulative ledger."},
+        "compilation":"NOT_RUN: exact generated Rust saved for separate inspected-source assessment",
+        "execution":"NOT_RUN",
+    });
+    write_json(&options.output_dir.join("report.json"), &report)?;
+    println!(
+        "{}",
+        json!({"status":"completed","artifact_cid":model.artifact_cid(),"output_dir":options.output_dir,"elapsed_ms":start.elapsed().as_millis(),"metrics":report["arms"].as_array().map(|arms|arms.iter().map(|arm|json!({"control":arm["control"],"metrics":arm["metrics"]})).collect::<Vec<_>>())})
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_splits_and_counterfactuals_are_distinct() {
+        let source = Source {
+            schema: SOURCE_SCHEMA.into(),
+            scope: String::new(),
+            tokenization_law: String::new(),
+            fit: make_cases("fit", 16),
+            development: make_cases("development", 4),
+        };
+        validate_source(&source).unwrap();
+        assert_eq!(source.fit.len(), 128);
+        assert_eq!(source.development.len(), 32);
+        for pair in source.development.chunks(16) {
+            for index in 0..8 {
+                assert_eq!(pair[index].pair_id, pair[index + 8].pair_id);
+                assert_ne!(pair[index].prompt, pair[index + 8].prompt);
+                if pair[index].task != "no_write" {
+                    assert_ne!(pair[index].response, pair[index + 8].response);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn leading_numeral_does_not_credit_longer_or_implicit_spellings() {
+        assert_eq!(leading_numeral(b"17);\n}"), Some(&b"17"[..]));
+        assert_eq!(leading_numeral(b"-17.\n"), Some(&b"-17"[..]));
+        assert_ne!(leading_numeral(b"170);"), Some(&b"17"[..]));
+        for invalid in [
+            b" 17".as_slice(),
+            b"-",
+            b"17name",
+            b"17_",
+            b"17.2",
+            b"Unknown",
+        ] {
+            assert_eq!(leading_numeral(invalid), None);
+        }
+    }
+
+    #[test]
+    fn lexeme_source_adds_fit_name_swaps_without_changing_primary_cases() {
+        let original_fit = make_cases("fit", 16);
+        let development = make_cases("development", 4);
+        let swaps = make_fit_name_swaps(16).unwrap();
+        assert_eq!(swaps.len(), 64);
+        for swapped in &swaps {
+            let original_id = swapped.id.strip_suffix("/source_names_swapped").unwrap();
+            let original = original_fit
+                .iter()
+                .find(|case| case.id == original_id)
+                .unwrap();
+            assert_eq!(
+                raw_digit_runs(original.prompt.as_bytes()),
+                raw_digit_runs(swapped.prompt.as_bytes())
+            );
+            let query_start = original
+                .prompt
+                .rfind(if original.family == "prose" {
+                    "User: "
+                } else {
+                    "assert_eq!"
+                })
+                .unwrap();
+            assert!(swapped.prompt.ends_with(&original.prompt[query_start..]));
+            assert_ne!(original.response, swapped.response);
+            assert!(["copy_current", "add"].contains(&swapped.task.as_str()));
+            assert!(!swapped.prompt.contains("suri"));
+            assert!(!swapped.prompt.contains("orin"));
+            assert!(!swapped.prompt.contains("tavi"));
+        }
+        let mut fit = original_fit.clone();
+        fit.extend(swaps);
+        let source = Source {
+            schema: LEXEME_SOURCE_SCHEMA.into(),
+            scope: String::new(),
+            tokenization_law: String::new(),
+            fit,
+            development,
+        };
+        validate_source(&source).unwrap();
+        assert_eq!(source.fit.len(), 192);
+        assert_eq!(source.development.len(), 32);
+        assert_eq!(
+            serde_json::to_vec(&source.fit[..128]).unwrap(),
+            serde_json::to_vec(&original_fit).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_vec(&source.development).unwrap(),
+            serde_json::to_vec(&make_cases("development", 4)).unwrap()
+        );
+    }
+
+    #[test]
+    fn binding_controls_preserve_numeric_order_and_query_but_change_source_roles() {
+        let source = binding_source().unwrap();
+        let primary = make_cases("development", 2);
+        assert_eq!(source.pairs.len(), 4);
+        for pair in &source.pairs {
+            assert_eq!(
+                raw_digit_runs(pair.original.prompt.as_bytes()),
+                raw_digit_runs(pair.swapped.prompt.as_bytes())
+            );
+            assert!(pair.original.prompt.ends_with(&pair.query));
+            assert!(pair.swapped.prompt.ends_with(&pair.query));
+            assert_ne!(pair.original.response, pair.swapped.response);
+            let original = primary
+                .iter()
+                .find(|case| {
+                    case.world == 100_000
+                        && case.family == pair.original.family
+                        && case.task == pair.original.task
+                })
+                .unwrap();
+            assert_eq!(pair.original.prompt, original.prompt);
+            assert_eq!(pair.original.response, original.response);
+        }
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/memory_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/memory_training.rs
@@ -443,6 +443,9 @@ impl Model {
                     + memory.config.candidate_limit * std::mem::size_of::<MemoryReference>();
             }
         }
+        if self.values.is_some() {
+            bytes += 2 * super::value_types::VALUES * std::mem::size_of::<super::ValueRecord>();
+        }
         bytes
     }
 

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -12,10 +12,15 @@ mod memory_runtime;
 mod memory_training;
 mod memory_types;
 mod mixture;
+mod numeral;
 mod response_runtime;
 mod runtime;
 mod snapshot;
 mod training;
+mod value_lexemes;
+mod value_runtime;
+mod value_training;
+mod value_types;
 
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +34,10 @@ pub use memory_types::{ResponseAction, ResponseDecision, ResponseStateView};
 pub use mixture::{ReadoutFitConfig, ReadoutFitReport};
 pub use runtime::{Session, StateView};
 pub use training::Trainer;
+pub use value_training::{ValueExample, ValueFitConfig, ValueFitReport};
+pub use value_types::{
+    ValueAction, ValueDecision, ValueDerivation, ValueRecord, ValueStateView, ValueWork,
+};
 
 pub const SCHEMA: &str = "uor-r4.native-geometric-language/1";
 pub const BOS: u32 = 0;
@@ -115,6 +124,8 @@ pub enum Control {
     HeatmapDisabled,
     MemoryDisabled,
     ResponseStateDisabled,
+    ValuesDisabled,
+    ValueLexemesDisabled,
 }
 
 /// Explicit feature addresses, never content digests. Kinds 0/1 are full
@@ -150,7 +161,11 @@ impl Feature {
     }
     fn admitted(self, control: Control) -> bool {
         match control {
-            Control::Full | Control::MemoryDisabled | Control::ResponseStateDisabled => true,
+            Control::Full
+            | Control::MemoryDisabled
+            | Control::ResponseStateDisabled
+            | Control::ValuesDisabled
+            | Control::ValueLexemesDisabled => true,
             Control::GeometryDisabled => self.kind < 2,
             Control::ZetaDisabled => !(8..=15).contains(&self.kind) && self.kind != 5,
             Control::H4Disabled => self.kind < 2 || (8..=15).contains(&self.kind),
@@ -234,6 +249,8 @@ pub struct Model {
     readout_training: Vec<DocumentReceipt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     memory_read: Option<memory_types::MemoryModel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    values: Option<value_types::ValueModel>,
 }
 
 #[derive(Deserialize)]
@@ -254,6 +271,8 @@ struct ModelWire {
     readout_training: Vec<DocumentReceipt>,
     #[serde(default)]
     memory_read: Option<memory_types::MemoryModel>,
+    #[serde(default)]
+    values: Option<value_types::ValueModel>,
 }
 impl TryFrom<ModelWire> for Model {
     type Error = Error;
@@ -273,6 +292,7 @@ impl TryFrom<ModelWire> for Model {
             readout: wire.readout,
             readout_training: wire.readout_training,
             memory_read: wire.memory_read,
+            values: wire.values,
         };
         model.validate()?;
         Ok(model)
@@ -281,6 +301,8 @@ impl TryFrom<ModelWire> for Model {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Work {
+    #[serde(default, skip_serializing_if = "ValueWork::is_empty")]
+    pub values: ValueWork,
     #[serde(default, skip_serializing_if = "zero_work")]
     pub response_query_captures: u64,
     #[serde(default, skip_serializing_if = "zero_work")]
@@ -358,6 +380,8 @@ pub struct Prediction {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Generation {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub value_trace: Vec<ValueDecision>,
     /// First at most 96 decisions, recorded outside the allocation-free kernel.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub response_trace: Vec<ResponseDecision>,
@@ -387,3 +411,6 @@ pub struct Evaluation {
 mod response_runtime_tests;
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod value_runtime_tests;

--- a/crates/uor-r4-core/src/native_geometric/numeral.rs
+++ b/crates/uor-r4-core/src/native_geometric/numeral.rs
@@ -1,0 +1,398 @@
+//! Bounded decimal representation for typed integer values.
+//!
+//! This is a lexical codec, not an expression, assignment or answer parser.
+//! ASCII signed decimal fragments are recognized across token boundaries;
+//! identifiers, decimal fractions, exponent forms and numeric suffixes are
+//! excluded. A trailing sentence period is resolved by one-byte lookahead.
+//! A minus immediately before digits is a sign under this lexical law; source
+//! language unary/binary-minus interpretation belongs to a different operator.
+//! Every complete fragment retains its inclusive token-sequence interval.
+
+use crate::prime_route_attention::ZPhi;
+use serde::{Deserialize, Serialize};
+
+pub(super) const NUMERAL_CODEC: &str = "ascii-signed-i64-fragment-and-byte-emission/1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Numeral {
+    pub tokens: [u32; 20],
+    pub len: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Literal {
+    pub value: i64,
+    /// Inclusive token sequence containing the sign or first digit.
+    pub start: u64,
+    /// Inclusive token sequence containing the final digit, excluding a period.
+    pub end: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum ScanState {
+    #[default]
+    Idle,
+    Sign,
+    Digits,
+    TrailingPoint,
+    Word,
+    Rejected,
+}
+
+/// Fixed scanner state. Invalid or oversized fragments remain rejected until
+/// a lexical delimiter, so an overflowing prefix cannot leak a valid suffix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Scanner {
+    state: ScanState,
+    negative: bool,
+    // Negative accumulation admits i64::MIN without an intermediate positive
+    // magnitude outside the signed range.
+    accumulated: i64,
+    digits: u8,
+    start: u64,
+    end: u64,
+}
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+impl Numeral {
+    /// Emit the integer subdomain of exact Z[phi] into the existing raw-byte
+    /// vocabulary. No whitespace, punctuation or answer template is appended.
+    /// Nineteen fixed decimal places each require at most nine subtractions.
+    pub(super) fn from_zphi(value: ZPhi) -> Option<Self> {
+        if value.b != 0 {
+            return None;
+        }
+        let mut result = Self {
+            tokens: [0; 20],
+            len: 0,
+        };
+        if value.a < 0 {
+            result.tokens[0] = u32::from(b'-') + 2;
+            result.len = 1;
+        }
+        let mut remaining = value.a.unsigned_abs();
+        let mut started = false;
+        for place in [
+            1_000_000_000_000_000_000_u64,
+            100_000_000_000_000_000,
+            10_000_000_000_000_000,
+            1_000_000_000_000_000,
+            100_000_000_000_000,
+            10_000_000_000_000,
+            1_000_000_000_000,
+            100_000_000_000,
+            10_000_000_000,
+            1_000_000_000,
+            100_000_000,
+            10_000_000,
+            1_000_000,
+            100_000,
+            10_000,
+            1_000,
+            100,
+            10,
+            1,
+        ] {
+            let mut digit = 0_u8;
+            while remaining >= place {
+                remaining -= place;
+                digit += 1;
+            }
+            if digit != 0 || started || place == 1 {
+                result.tokens[usize::from(result.len)] = u32::from(b'0' + digit) + 2;
+                result.len += 1;
+                started = true;
+            }
+        }
+        Some(result)
+    }
+
+    pub(super) fn as_tokens(&self) -> &[u32] {
+        &self.tokens[..usize::from(self.len)]
+    }
+}
+
+fn word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || !byte.is_ascii()
+}
+
+impl Scanner {
+    /// Host checkpoint validation; old source bytes outside retained metadata
+    /// are user-provided state, not authenticated observations.
+    pub(super) fn snapshot_valid(&self, seen: u64) -> bool {
+        if seen == 0 {
+            return *self == Self::default();
+        }
+        let interval = self.start <= self.end && self.end < seen;
+        match self.state {
+            ScanState::Idle => *self == Self::default(),
+            ScanState::Word => {
+                !self.negative
+                    && self.accumulated == 0
+                    && self.digits == 0
+                    && self.start == 0
+                    && self.end == 0
+            }
+            ScanState::Sign => {
+                interval && self.start == self.end && self.accumulated == 0 && self.digits == 0
+            }
+            ScanState::Digits | ScanState::TrailingPoint => {
+                interval && (1..=19).contains(&self.digits) && self.accumulated <= 0
+            }
+            ScanState::Rejected => {
+                interval
+                    && self.digits <= 20
+                    && self.accumulated <= 0
+                    && (self.digits != 0 || self.accumulated == 0)
+            }
+        }
+    }
+
+    pub(super) fn snapshot_needs_suffix(&self) -> bool {
+        matches!(
+            self.state,
+            ScanState::Sign | ScanState::Digits | ScanState::TrailingPoint
+        )
+    }
+
+    fn start_byte(&mut self, byte: u8, sequence: u64) {
+        *self = Self::default();
+        if byte == b'+' || byte == b'-' {
+            self.state = ScanState::Sign;
+            self.negative = byte == b'-';
+            self.start = sequence;
+            self.end = sequence;
+        } else if byte.is_ascii_digit() {
+            self.state = ScanState::Digits;
+            self.start = sequence;
+            self.digit(byte, sequence);
+        } else if word_byte(byte) {
+            self.state = ScanState::Word;
+        } else if byte == b'.' {
+            self.state = ScanState::Rejected;
+        }
+    }
+
+    fn digit(&mut self, byte: u8, sequence: u64) {
+        // Four checked additions form ten times the negative prefix, then
+        // one checked subtraction appends the digit. No variable multiply.
+        let twice = self.accumulated.checked_add(self.accumulated);
+        let four = twice.and_then(|value| value.checked_add(value));
+        let eight = four.and_then(|value| value.checked_add(value));
+        let ten = eight.zip(twice).and_then(|(a, b)| a.checked_add(b));
+        let next = ten.and_then(|value| value.checked_sub(i64::from(byte - b'0')));
+        self.digits = self.digits.saturating_add(1);
+        self.end = sequence;
+        if self.digits > 19 || next.is_none() {
+            self.state = ScanState::Rejected;
+            return;
+        }
+        if let Some(next) = next {
+            self.accumulated = next;
+        }
+        self.state = ScanState::Digits;
+    }
+
+    fn literal(&self) -> Option<Literal> {
+        if !matches!(self.state, ScanState::Digits | ScanState::TrailingPoint) {
+            return None;
+        }
+        let value = if self.negative {
+            self.accumulated
+        } else {
+            self.accumulated.checked_neg()?
+        };
+        Some(Literal {
+            value,
+            start: self.start,
+            end: self.end,
+        })
+    }
+
+    /// Consume exactly one decoded source byte. The returned interval names
+    /// its actual numeric occurrence, never a predicted answer occurrence.
+    pub(super) fn feed(&mut self, byte: u8, sequence: u64) -> Option<Literal> {
+        match self.state {
+            ScanState::Idle => self.start_byte(byte, sequence),
+            ScanState::Sign => {
+                if byte.is_ascii_digit() {
+                    self.digit(byte, sequence);
+                } else if word_byte(byte) || matches!(byte, b'.' | b'+' | b'-') {
+                    self.state = ScanState::Rejected;
+                } else {
+                    self.start_byte(byte, sequence);
+                }
+            }
+            ScanState::Digits => {
+                if byte.is_ascii_digit() {
+                    self.digit(byte, sequence);
+                } else if word_byte(byte) {
+                    self.state = ScanState::Rejected;
+                } else if byte == b'.' {
+                    self.state = ScanState::TrailingPoint;
+                } else {
+                    let literal = self.literal();
+                    self.start_byte(byte, sequence);
+                    return literal;
+                }
+            }
+            ScanState::TrailingPoint => {
+                if byte.is_ascii_digit() || word_byte(byte) || byte == b'.' {
+                    self.state = ScanState::Rejected;
+                } else {
+                    let literal = self.literal();
+                    self.start_byte(byte, sequence);
+                    return literal;
+                }
+            }
+            ScanState::Word => {
+                if byte.is_ascii_digit() || word_byte(byte) {
+                    return None;
+                }
+                self.start_byte(byte, sequence);
+            }
+            ScanState::Rejected => {
+                if byte.is_ascii_digit() || word_byte(byte) || matches!(byte, b'.' | b'+' | b'-') {
+                    return None;
+                }
+                self.start_byte(byte, sequence);
+            }
+        }
+        None
+    }
+
+    /// An explicit end-of-input boundary closes a final integer fragment.
+    /// The caller supplies the boundary; this never detects task grammar.
+    pub(super) fn finish(&mut self) -> Option<Literal> {
+        let literal = self.literal();
+        *self = Self::default();
+        literal
+    }
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(chunks: &[&[u8]]) -> Vec<Literal> {
+        let mut scanner = Scanner::default();
+        let mut literals = Vec::new();
+        for (sequence, chunk) in chunks.iter().enumerate() {
+            for &byte in *chunk {
+                if let Some(literal) = scanner.feed(byte, sequence as u64) {
+                    literals.push(literal);
+                }
+            }
+        }
+        if let Some(literal) = scanner.finish() {
+            literals.push(literal);
+        }
+        literals
+    }
+
+    #[test]
+    fn native_numeral_exact_signed_extremes_and_zphi_boundary() {
+        for value in [0, 1, -1, 10, -17, 1000, i64::MAX, i64::MIN] {
+            let numeral = Numeral::from_zphi(ZPhi::new(value, 0)).unwrap();
+            let bytes = numeral
+                .as_tokens()
+                .iter()
+                .map(|&token| (token - 2) as u8)
+                .collect::<Vec<_>>();
+            assert_eq!(bytes, value.to_string().as_bytes());
+            assert!(numeral.len <= 20);
+            assert_eq!(scan(&[&bytes])[0].value, value);
+        }
+        assert!(Numeral::from_zphi(ZPhi::new(3, 1)).is_none());
+        let sum = ZPhi::new(13, 0).checked_add(ZPhi::new(4, 0)).unwrap();
+        assert_eq!(Numeral::from_zphi(sum).unwrap().as_tokens(), &[51, 57]);
+        assert!(ZPhi::new(i64::MAX, 0).checked_add(ZPhi::new(1, 0)).is_err());
+        assert!(ZPhi::new(i64::MIN, 0)
+            .checked_add(ZPhi::new(-1, 0))
+            .is_err());
+    }
+
+    #[test]
+    fn native_numeral_scanner_preserves_cross_token_provenance_and_repeated_values() {
+        assert_eq!(
+            scan(&[b"x = -", b"1", b"7; y = 17", b".", b" z = +", b"0004"]),
+            vec![
+                Literal {
+                    value: -17,
+                    start: 0,
+                    end: 2
+                },
+                Literal {
+                    value: 17,
+                    start: 2,
+                    end: 2
+                },
+                Literal {
+                    value: 4,
+                    start: 4,
+                    end: 5
+                },
+            ]
+        );
+        let split = scan(&[b"13", b".", b" ", b"13", b" "]);
+        assert_eq!(
+            split[0],
+            Literal {
+                value: 13,
+                start: 0,
+                end: 0
+            }
+        );
+        assert_eq!(
+            split[1],
+            Literal {
+                value: 13,
+                start: 3,
+                end: 3
+            }
+        );
+        assert_eq!(scan(&[b"13."])[0].value, 13);
+    }
+
+    #[test]
+    fn native_numeral_scanner_rejects_overflow_and_noninteger_fragments() {
+        let source = b"i64 x13 13x 13_i64 1.25 2e3 4e-2 .5 --6 9223372036854775808 -9223372036854775809 00000000000000000000 7";
+        let bytes = source.iter().map(std::slice::from_ref).collect::<Vec<_>>();
+        let values = scan(&bytes)
+            .into_iter()
+            .map(|literal| literal.value)
+            .collect::<Vec<_>>();
+        assert_eq!(values, [7]);
+        assert!(scan(&[b"-", b" "]).is_empty());
+        assert!(scan(&[b"13", b".", b"25"]).is_empty());
+    }
+
+    #[test]
+    fn native_numeral_scanner_serialization_keeps_unfinished_and_rejected_runs() {
+        for prefix in [
+            b"-922337203685477580".as_slice(),
+            b"13.",
+            b"92233720368547758089",
+        ] {
+            let mut scanner = Scanner::default();
+            for &byte in prefix {
+                assert!(scanner.feed(byte, 8).is_none());
+            }
+            let mut restored: Scanner =
+                serde_json::from_slice(&serde_json::to_vec(&scanner).unwrap()).unwrap();
+            for (sequence, byte) in b"8; +17".iter().copied().enumerate() {
+                assert_eq!(
+                    scanner.feed(byte, sequence as u64 + 9),
+                    restored.feed(byte, sequence as u64 + 9)
+                );
+            }
+            assert_eq!(scanner.finish(), restored.finish());
+            assert_eq!(scanner.finish(), None);
+        }
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -11,6 +11,8 @@ pub(super) const FEATURE_COUNT: usize = 26;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values: Option<super::ValueStateView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response: Option<super::ResponseStateView>,
     pub memory_read: Option<super::MemoryStateView>,
     pub tokens_seen: u64,
@@ -31,6 +33,7 @@ pub struct StateView {
 
 #[derive(Debug, Clone)]
 pub struct Session {
+    pub(super) values: Option<super::value_types::ValueState>,
     pub(super) memory: Option<super::memory_types::MemoryState>,
     pub(super) artifact_cid: String,
     pub(super) ring: Vec<u32>,
@@ -58,6 +61,10 @@ impl Session {
             .capacity()
             .saturating_mul(std::mem::size_of::<Candidate>());
         Self {
+            values: model
+                .values
+                .as_ref()
+                .map(|_| super::value_types::ValueState::new(model)),
             memory: model
                 .memory_read
                 .as_ref()
@@ -81,6 +88,16 @@ impl Session {
 
     pub fn state(&self) -> StateView {
         StateView {
+            values: self.values.as_ref().map(|s| super::ValueStateView {
+                active: s.active,
+                retained_values: s.records.len(),
+                captured_values: s.sources.len(),
+                committed_write: s.emission.map(|e| e.decision.write_id),
+                emission_cursor: s.emission.map(|e| e.cursor),
+                storage_bytes: std::mem::size_of::<super::value_types::ValueState>()
+                    + (s.records.capacity() + s.sources.capacity())
+                        * std::mem::size_of::<super::ValueRecord>(),
+            }),
             response: self.memory.as_ref().and_then(|state| state.response_view()),
             memory_read: self.memory.as_ref().map(|state| state.state()),
             tokens_seen: self.work.observed_tokens,
@@ -110,6 +127,10 @@ impl Session {
         self.memory.as_ref().and_then(|state| state.pending)
     }
 
+    pub fn value_decision(&self) -> Option<super::ValueDecision> {
+        self.values.as_ref().and_then(|s| s.pending)
+    }
+
     fn check_model(&self, model: &Model) -> Result<()> {
         if self.artifact_cid != model.artifact_cid {
             return Err(Error(
@@ -121,6 +142,9 @@ impl Session {
 
     pub fn begin_response(&mut self, model: &Model) -> Result<()> {
         self.check_model(model)?;
+        if let Some(state) = &mut self.values {
+            state.begin(&mut self.work.values);
+        }
         if self.control != Control::MemoryDisabled && self.control != Control::ResponseStateDisabled
         {
             if let (Some(state), Some(memory)) = (&mut self.memory, &model.memory_read) {
@@ -132,6 +156,9 @@ impl Session {
 
     pub fn end_response(&mut self, model: &Model) -> Result<()> {
         self.check_model(model)?;
+        if let Some(state) = &mut self.values {
+            state.end();
+        }
         if let Some(state) = &mut self.memory {
             state.end_response();
         }
@@ -208,6 +235,9 @@ impl Session {
         self.work.observed_tokens = self.work.observed_tokens.saturating_add(1);
         if let (Some(state), Some(memory)) = (&mut self.memory, &model.memory_read) {
             state.observe(model, memory, token, &mut self.work);
+        }
+        if let Some(state) = &mut self.values {
+            state.observe(model, token, &mut self.work.values);
         }
         Ok(())
     }
@@ -410,12 +440,24 @@ impl Session {
                 }
             }
         }
+        if let Some(baseline) = self.candidates.first().copied() {
+            let offer = self
+                .values
+                .as_mut()
+                .and_then(|s| s.offer(model, baseline, self.control, &mut self.work.values));
+            if let Some(candidate) = offer {
+                self.offer_memory(model, candidate);
+            }
+        }
         let best = *self
             .candidates
             .first()
             .ok_or_else(|| Error("artifact offers no output candidates".into()))?;
         if let Some(state) = &mut self.memory {
             state.select_response(model, best, &mut self.work);
+        }
+        if let Some(state) = &mut self.values {
+            state.selected(best);
         }
         Ok(Prediction {
             token: best.token,

--- a/crates/uor-r4-core/src/native_geometric/snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/snapshot.rs
@@ -1,11 +1,13 @@
 //! Host-only, artifact-bound persistence of a bounded conversation context.
 
 use super::memory_types::{MemoryEntry, MemoryReference, ResponseAction, RESPONSE_MEMORY_SCHEMA};
+use super::value_types::ValueState;
 use super::*;
 use serde::{Deserialize, Serialize};
 
 const LEGACY_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/1";
 const RESPONSE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/2";
+const VALUE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/3";
 const LEGACY_CHECKPOINT_LIMIT: usize = 1024 * 1024;
 const RESPONSE_CHECKPOINT_LIMIT: usize = 8 * 1024 * 1024;
 // Bound allocation before collecting the sparse index. A tuple has two
@@ -61,6 +63,8 @@ struct Checkpoint {
     work: Work,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     response_memory: Option<ResponseMemorySnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    values: Option<ValueState>,
 }
 
 impl Session {
@@ -77,7 +81,9 @@ impl Session {
             self.ring[..self.length].to_vec()
         };
         let response_memory = self.response_memory_snapshot()?;
-        let schema = if response_memory.is_some() {
+        let schema = if self.values.is_some() {
+            VALUE_SESSION_SCHEMA
+        } else if response_memory.is_some() {
             RESPONSE_SESSION_SCHEMA
         } else {
             LEGACY_SESSION_SCHEMA
@@ -93,9 +99,10 @@ impl Session {
             control: self.control,
             work: self.work,
             response_memory,
+            values: self.values.clone(),
         })
         .map_err(|error| Error(error.to_string()))?;
-        let limit = if schema == RESPONSE_SESSION_SCHEMA {
+        let limit = if schema != LEGACY_SESSION_SCHEMA {
             RESPONSE_CHECKPOINT_LIMIT
         } else {
             LEGACY_CHECKPOINT_LIMIT
@@ -121,20 +128,41 @@ impl Session {
             .memory_read
             .as_ref()
             .is_some_and(|memory| memory.schema == RESPONSE_MEMORY_SCHEMA);
+        let expected_schema = if model.values.is_some() {
+            VALUE_SESSION_SCHEMA
+        } else if response_model {
+            RESPONSE_SESSION_SCHEMA
+        } else {
+            LEGACY_SESSION_SCHEMA
+        };
+        let object: serde_json::Value =
+            serde_json::from_slice(bytes).map_err(|error| Error(error.to_string()))?;
+        value_snapshot::validate_lexeme_field_presence(model, &object)?;
         // The additive /2 field must remain an unknown field for historical
         // /1 inputs, including an explicit JSON null. Keep their old loader
         // law as well as their byte serialization unchanged.
         if checkpoint.schema == LEGACY_SESSION_SCHEMA {
-            let object: serde_json::Value =
-                serde_json::from_slice(bytes).map_err(|error| Error(error.to_string()))?;
             if object.get("response_memory").is_some() {
                 return Err(Error("historical session contains response state".into()));
             }
         }
-        if (checkpoint.schema != LEGACY_SESSION_SCHEMA
-            && checkpoint.schema != RESPONSE_SESSION_SCHEMA)
-            || (checkpoint.schema == RESPONSE_SESSION_SCHEMA) != response_model
+        if checkpoint.schema != VALUE_SESSION_SCHEMA && object.get("values").is_some() {
+            return Err(Error(
+                "historical session contains typed value state".into(),
+            ));
+        }
+        if object
+            .get("values")
+            .and_then(|value| value.get("pending"))
+            .is_some()
+        {
+            return Err(Error(
+                "session checkpoint contains transient value selection".into(),
+            ));
+        }
+        if checkpoint.schema != expected_schema
             || checkpoint.response_memory.is_some() != response_model
+            || checkpoint.values.is_some() != model.values.is_some()
             || (checkpoint.schema == LEGACY_SESSION_SCHEMA && bytes.len() > LEGACY_CHECKPOINT_LIMIT)
             || checkpoint.artifact_cid != model.artifact_cid()
             || checkpoint.retained_tokens.len() > model.config().context_tokens
@@ -215,6 +243,15 @@ impl Session {
         restored.previous_evicted = checkpoint.previous_evicted;
         if let Some(memory_snapshot) = checkpoint.response_memory {
             restored.restore_response_memory(model, memory_snapshot)?;
+        }
+        if let Some(values) = checkpoint.values {
+            restored.restore_value_state(
+                model,
+                values,
+                &checkpoint.retained_tokens,
+                checkpoint.work.observed_tokens,
+                checkpoint.work.values.input_bytes,
+            )?;
         }
         restored.work = checkpoint.work;
         Ok(restored)
@@ -549,3 +586,10 @@ impl Model {
 #[cfg(test)]
 #[path = "response_snapshot_tests.rs"]
 mod response_snapshot_tests;
+
+#[path = "value_snapshot.rs"]
+mod value_snapshot;
+
+#[cfg(test)]
+#[path = "value_snapshot_tests.rs"]
+mod value_snapshot_tests;

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -187,6 +187,7 @@ impl Trainer {
             rows: Vec::new(),
             readout: super::mixture::Readout::default(),
             readout_training: Vec::new(),
+            values: None,
             memory_read: None,
         };
         template.refresh_identity()?;
@@ -503,6 +504,9 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(values) = &self.values {
+            values.validate()?;
+        }
         self.readout.validate(self)?;
         if let Some(memory) = &self.memory_read {
             memory.validate(self)?;
@@ -637,16 +641,22 @@ impl Model {
         session.begin_response(self)?;
         let mut token_ids = Vec::new();
         let mut response_trace = Vec::new();
+        let mut value_trace = Vec::new();
         let mut stop = "token_budget".to_owned();
         for _ in 0..max_new_tokens {
             let token = session.predict(self)?.token;
+            if let Some(decision) = session.value_decision() {
+                if value_trace.len() < 96 {
+                    value_trace.push(decision);
+                }
+            }
             if let Some(decision) = session.response_decision() {
                 if response_trace.len() < 96 {
                     response_trace.push(decision);
                 }
             }
             if token == EOS {
-                if session.response_decision().is_some() {
+                if session.response_decision().is_some() || self.values.is_some() {
                     session.observe(self, token)?;
                 }
                 stop = "end_of_document".into();
@@ -663,6 +673,7 @@ impl Model {
             bytes,
             token_ids,
             response_trace,
+            value_trace,
             stop,
             work: session.work,
             state: session.state(),
@@ -685,6 +696,7 @@ impl Model {
                     .iter()
                     .chain(&self.readout_training)
                     .chain(self.memory_read_training())
+                    .chain(self.value_training())
                     .any(|known| known.id == candidate.id || known.text_cid == candidate.text_cid)
             {
                 return Err(Error(format!(

--- a/crates/uor-r4-core/src/native_geometric/value_lexemes.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_lexemes.rs
@@ -1,0 +1,349 @@
+//! Fixed whole-word identity across lexical-token and byte-token boundaries.
+//! This codec recognizes no task grammar. ASCII letter/underscore words may
+//! contain later digits; numeric-leading, non-ASCII and oversized runs are
+//! rejected through the next delimiter. Equality is exact bytes, never a hash
+//! distance. Punctuation separates words and is not assigned semantic meaning.
+use super::value_types::{ValueEntry, ValueWork};
+use super::PHASE_CHANNELS;
+use serde::{Deserialize, Serialize};
+
+pub(super) const WORD_BYTES: usize = 32;
+pub(super) const WORD_QUERY: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WordAtom {
+    pub bytes: [u8; WORD_BYTES],
+    pub len: u8,
+    /// Inclusive token sequence of the final byte.
+    pub end: u64,
+    /// Zero-based source-byte ordinal, excluding generated response bytes.
+    pub byte_end: u64,
+    pub pose: u16,
+    pub phases: [u16; PHASE_CHANNELS],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WordScanner {
+    pub pending: WordAtom,
+    pub rejected: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LexemeState {
+    pub scanner: WordScanner,
+    pub source_bytes_seen: u64,
+    /// Completed words, newest first; unused entries are exactly default.
+    pub recent: [WordAtom; WORD_QUERY],
+    pub recent_len: usize,
+    /// Frozen at the caller's response boundary, newest first.
+    pub queries: [WordAtom; WORD_QUERY],
+    pub query_len: usize,
+    /// Captured upon entering an open numeric fragment, before its delimiter.
+    pub literal_cues: [WordAtom; 4],
+}
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+fn initial(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn component(byte: u8) -> bool {
+    initial(byte) || byte.is_ascii_digit() || !byte.is_ascii()
+}
+
+impl WordAtom {
+    pub(super) fn matches(&self, other: &Self, work: &mut ValueWork) -> bool {
+        work.lexical_comparisons = work.lexical_comparisons.saturating_add(1);
+        if self.len == 0 || self.len != other.len {
+            return false;
+        }
+        for index in 0..usize::from(self.len) {
+            work.lexical_byte_comparisons = work.lexical_byte_comparisons.saturating_add(1);
+            if self.bytes[index] != other.bytes[index] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl WordScanner {
+    fn feed(&mut self, byte: u8, ordinal: u64, entry: ValueEntry) -> Option<WordAtom> {
+        if !component(byte) {
+            return self.finish();
+        }
+        if self.rejected {
+            return None;
+        }
+        if !byte.is_ascii()
+            || (self.pending.len == 0 && !initial(byte))
+            || usize::from(self.pending.len) == WORD_BYTES
+        {
+            self.pending = WordAtom::default();
+            self.rejected = true;
+            return None;
+        }
+        self.pending.bytes[usize::from(self.pending.len)] = byte;
+        self.pending.len += 1;
+        self.pending.end = entry.sequence;
+        self.pending.byte_end = ordinal;
+        self.pending.pose = entry.pose;
+        self.pending.phases = entry.phases;
+        None
+    }
+
+    fn finish(&mut self) -> Option<WordAtom> {
+        let word = (self.pending.len != 0 && !self.rejected).then_some(self.pending);
+        *self = Self::default();
+        word
+    }
+}
+
+impl LexemeState {
+    fn append(&mut self, word: WordAtom, work: &mut ValueWork) {
+        for index in (1..WORD_QUERY).rev() {
+            self.recent[index] = self.recent[index - 1];
+        }
+        self.recent[0] = word;
+        self.recent_len = (self.recent_len + 1).min(WORD_QUERY);
+        work.lexical_writes = work.lexical_writes.saturating_add(1);
+    }
+
+    pub(super) fn feed(&mut self, byte: u8, entry: ValueEntry, work: &mut ValueWork) {
+        let Some(next) = self.source_bytes_seen.checked_add(1) else {
+            self.scanner.pending = WordAtom::default();
+            self.scanner.rejected = true;
+            return;
+        };
+        if let Some(word) = self.scanner.feed(byte, self.source_bytes_seen, entry) {
+            self.append(word, work);
+        }
+        self.source_bytes_seen = next;
+    }
+
+    pub(super) fn finish(&mut self, work: &mut ValueWork) {
+        if let Some(word) = self.scanner.finish() {
+            self.append(word, work);
+        }
+    }
+
+    pub(super) fn capture_literal(&mut self) {
+        self.literal_cues.copy_from_slice(&self.recent[..4]);
+    }
+
+    pub(super) fn clear_literal(&mut self) {
+        self.literal_cues = [WordAtom::default(); 4];
+    }
+
+    pub(super) fn begin(&mut self) {
+        self.queries = self.recent;
+        self.query_len = self.recent_len;
+        self.clear_literal();
+    }
+
+    pub(super) fn end(&mut self) {
+        self.scanner = WordScanner::default();
+        self.queries = [WordAtom::default(); WORD_QUERY];
+        self.query_len = 0;
+        self.clear_literal();
+    }
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END
+
+impl WordAtom {
+    pub(super) fn snapshot_valid(&self, seen: u64, source_bytes: u64, geometry_len: usize) -> bool {
+        if self.len == 0 {
+            return *self == Self::default();
+        }
+        let len = usize::from(self.len);
+        len <= WORD_BYTES
+            && initial(self.bytes[0])
+            && self.bytes[..len]
+                .iter()
+                .all(|&byte| initial(byte) || byte.is_ascii_digit())
+            && self.bytes[len..].iter().all(|&byte| byte == 0)
+            && self.end < seen
+            && self.byte_end < source_bytes
+            && self.byte_end >= u64::from(self.len) - 1
+            && usize::from(self.pose) < geometry_len
+    }
+}
+
+impl LexemeState {
+    pub(super) fn snapshot_valid(&self, seen: u64, geometry_len: usize) -> bool {
+        let valid =
+            |word: &WordAtom| word.snapshot_valid(seen, self.source_bytes_seen, geometry_len);
+        let valid_words = |words: &[WordAtom], len: usize| {
+            len <= words.len()
+                && words[..len].iter().all(|word| word.len != 0 && valid(word))
+                && words[len..].iter().all(|word| *word == WordAtom::default())
+                && words[..len].windows(2).all(|pair| {
+                    pair[0].byte_end >= u64::from(pair[0].len)
+                        && pair[1].byte_end <= pair[0].byte_end - u64::from(pair[0].len)
+                        && pair[1].end <= pair[0].end
+                })
+        };
+        self.recent_len <= WORD_QUERY
+            && self.query_len <= WORD_QUERY
+            && valid_words(&self.recent, self.recent_len)
+            && valid_words(&self.queries, self.query_len)
+            && valid_words(
+                &self.literal_cues,
+                self.literal_cues
+                    .iter()
+                    .take_while(|word| word.len != 0)
+                    .count(),
+            )
+            && valid(&self.scanner.pending)
+            && (!self.scanner.rejected || self.scanner.pending == WordAtom::default())
+            && (self.scanner.pending.len == 0
+                || self.scanner.pending.byte_end.checked_add(1) == Some(self.source_bytes_seen))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed(state: &mut LexemeState, text: &[u8], token: u64) {
+        for &byte in text {
+            state.feed(
+                byte,
+                ValueEntry {
+                    sequence: token,
+                    ..ValueEntry::default()
+                },
+                &mut ValueWork::default(),
+            );
+        }
+    }
+
+    #[test]
+    fn complete_word_identity_is_independent_of_token_boundaries() {
+        let mut whole = LexemeState::default();
+        let mut split = LexemeState::default();
+        feed(&mut whole, b"suri has 73 coins. ", 0);
+        for (index, byte) in b"suri has 73 coins. ".iter().enumerate() {
+            feed(&mut split, &[*byte], index as u64);
+        }
+        assert_eq!(whole.recent_len, 3);
+        assert_eq!(split.recent_len, 3);
+        for (left, right) in whole.recent[..3].iter().zip(&split.recent[..3]) {
+            assert!(left.matches(right, &mut ValueWork::default()));
+        }
+        assert_eq!(&whole.recent[2].bytes[..4], b"suri");
+        assert!(whole.snapshot_valid(1, 1));
+        assert!(split.snapshot_valid(19, 1));
+    }
+
+    #[test]
+    fn rejects_whole_oversized_numeric_and_non_ascii_runs() {
+        let mut state = LexemeState::default();
+        feed(
+            &mut state,
+            b"abcdefghijklmnopqrstuvwxyzabcdefG x_1 17 17abc a\xc3\xa9z ok ",
+            0,
+        );
+        assert_eq!(state.recent_len, 2);
+        assert_eq!(&state.recent[0].bytes[..2], b"ok");
+        assert_eq!(&state.recent[1].bytes[..3], b"x_1");
+        assert!(state.snapshot_valid(1, 1));
+    }
+
+    #[test]
+    fn numeric_start_cues_survive_same_token_later_words() {
+        let mut state = LexemeState::default();
+        feed(&mut state, b"suri has ", 0);
+        state.capture_literal();
+        feed(&mut state, b"73 coins tavi has 301 coins ", 0);
+        assert_eq!(&state.literal_cues[1].bytes[..4], b"suri");
+        assert_eq!(&state.recent[1].bytes[..3], b"has");
+        state.begin();
+        assert_eq!(state.queries, state.recent);
+        assert_eq!(state.literal_cues, [WordAtom::default(); 4]);
+        state.end();
+        assert_eq!(state.query_len, 0);
+        assert_ne!(state.recent_len, 0);
+    }
+
+    #[test]
+    fn unfinished_word_snapshot_resumes_and_bad_shapes_reject() {
+        let mut state = LexemeState::default();
+        feed(&mut state, b"sur", 0);
+        let mut restored: LexemeState =
+            serde_json::from_slice(&serde_json::to_vec(&state).unwrap()).unwrap();
+        feed(&mut state, b"i ", 1);
+        feed(&mut restored, b"i ", 1);
+        assert_eq!(restored, state);
+        assert!(state.snapshot_valid(2, 1));
+        state.recent[0].len = 33;
+        assert!(!state.snapshot_valid(2, 1));
+    }
+
+    #[test]
+    fn value_capture_and_joint_match_preserve_names_inside_one_lexical_token() {
+        use super::super::numeral::NUMERAL_CODEC;
+        use super::super::value_types::{
+            ValueAction, ValueModel, ValueState, LEXEME_VALUE_SCHEMA, VALUES,
+        };
+        use super::super::{Config, Control, Document, Trainer, BOS, LEXICAL_BASE};
+
+        let documents = [Document {
+            id: "word-capture-unit".into(),
+            text: "source query".into(),
+        }];
+        let mut trainer = Trainer::new(Config::default(), &documents).unwrap();
+        trainer.train_documents(&documents).unwrap();
+        let mut model = trainer.compile().unwrap();
+        model.values = Some(ValueModel {
+            schema: LEXEME_VALUE_SCHEMA.into(),
+            codec: NUMERAL_CODEC.into(),
+            capacity: VALUES,
+            rows: Vec::new(),
+            continuation_score: 0,
+            fit_config: [0; 4],
+            training: Vec::new(),
+        });
+        // Mechanical token fixture: the entire source has one geometric token
+        // endpoint while literal cue capture still follows decoded byte order.
+        model.lexical_pieces[0] = b"suri has 73; tavi has 301; suri".to_vec();
+        let mut original = ValueState::new(&model);
+        original.observe(&model, BOS, &mut ValueWork::default());
+        original.observe(&model, LEXICAL_BASE, &mut ValueWork::default());
+        original.begin(&mut ValueWork::default());
+        assert_eq!(original.sources.len(), 2);
+        assert_eq!(original.sources[0].start, original.sources[1].start);
+        let first = original.sources[0].lexical.unwrap();
+        let second = original.sources[1].lexical.unwrap();
+        assert_eq!(&first[1].bytes[..4], b"suri");
+        assert_eq!(&second[1].bytes[..4], b"tavi");
+        assert!(first[1].byte_end < second[1].byte_end);
+
+        model.lexical_pieces[0] = b"tavi has 73; suri has 301; suri".to_vec();
+        let mut swapped = ValueState::new(&model);
+        swapped.observe(&model, BOS, &mut ValueWork::default());
+        swapped.observe(&model, LEXICAL_BASE, &mut ValueWork::default());
+        swapped.begin(&mut ValueWork::default());
+        let joint_first = |state: &ValueState| {
+            let operand = state.sources[0];
+            let (features, len) = state.features(
+                &model,
+                ValueAction::Copy,
+                operand,
+                operand,
+                Control::GeometryDisabled,
+                &mut ValueWork::default(),
+            );
+            features[..len]
+                .iter()
+                .find(|feature| feature.kind == 16 && feature.a == 0)
+                .unwrap()
+                .b
+        };
+        assert_eq!(joint_first(&original), 0x22);
+        assert_eq!(joint_first(&swapped), 0);
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/value_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime.rs
@@ -1,0 +1,458 @@
+//! Bounded typed operand selection, exact addition and causal byte emission.
+//! Source bytes are lexed without expression/assignment/answer parsing. At an
+//! explicit response boundary, at most sixteen typed records are captured.
+use super::numeral::{Literal, Numeral};
+use super::value_types::*;
+use super::*;
+use crate::prime_route_attention::ZPhi;
+
+impl ValueState {
+    fn recent_at(&self, distance: usize) -> Option<ValueEntry> {
+        if distance == 0 || distance > self.recent_len {
+            return None;
+        }
+        let index = if self.recent_cursor >= distance {
+            self.recent_cursor - distance
+        } else {
+            32 - (distance - self.recent_cursor)
+        };
+        Some(self.recent[index])
+    }
+    fn append_record(&mut self, record: ValueRecord, work: &mut ValueWork) {
+        if self.records.len() == VALUES {
+            self.records.remove(0);
+            work.record_evictions = work.record_evictions.saturating_add(1);
+        }
+        self.records.push(record);
+    }
+    fn literal(&mut self, literal: Literal, work: &mut ValueWork) {
+        let mut record = ValueRecord {
+            id: self.next_id,
+            value: literal.value,
+            start: literal.start,
+            end: literal.end,
+            lexical: self.lexemes.as_ref().map(|words| words.literal_cues),
+            ..ValueRecord::default()
+        };
+        // At most 32 recent token metadata records; oversized split fragments
+        // cannot borrow unrelated geometry or cues after metadata eviction.
+        let Some(endpoint) = self
+            .recent
+            .iter()
+            .find(|entry| entry.sequence == literal.end && entry.sequence < self.seen)
+        else {
+            return;
+        };
+        record.pose = endpoint.pose;
+        record.phases = endpoint.phases;
+        for offset in 0..4 {
+            if let Some(sequence) = literal.start.checked_sub(offset as u64 + 1) {
+                if let Some(entry) = self
+                    .recent
+                    .iter()
+                    .find(|entry| entry.sequence == sequence && entry.sequence < self.seen)
+                {
+                    record.cue[offset] = entry.cue;
+                }
+            }
+        }
+        let Some(next) = self.next_id.checked_add(1) else {
+            return;
+        };
+        self.next_id = next;
+        self.append_record(record, work);
+        work.literal_writes = work.literal_writes.saturating_add(1);
+    }
+    pub(super) fn observe(&mut self, model: &Model, token: u32, work: &mut ValueWork) {
+        let sequence = self.seen;
+        if self.active {
+            self.commit(token, work);
+        }
+        let geometry = &model.geometry.tokens[token as usize];
+        self.pose = model.geometry.products
+            [model.geometry.row_bases[usize::from(self.pose)] + usize::from(geometry.leaf)];
+        work.h4_reads = work.h4_reads.saturating_add(1);
+        for (phase, delta) in self.phases.iter_mut().zip(geometry.phases) {
+            *phase = phase.wrapping_add(delta);
+        }
+        work.phase_updates = work.phase_updates.saturating_add(PHASE_CHANNELS as u64);
+        let cue_token = model
+            .memory_read
+            .as_ref()
+            .and_then(|m| m.cue_aliases.as_ref())
+            .map_or(token, |a| a.representatives[token as usize]);
+        self.recent[self.recent_cursor] = ValueEntry {
+            sequence,
+            token,
+            cue: model.geometry.tokens[cue_token as usize].prime,
+            pose: self.pose,
+            phases: self.phases,
+        };
+        self.recent_cursor = (self.recent_cursor + 1) & 31;
+        self.recent_len = (self.recent_len + 1).min(32);
+        self.seen = self.seen.saturating_add(1);
+        // Generated response bytes do not become a second literal copy of a
+        // derived write. They still update ordinary token/geometric memory.
+        if self.active {
+            return;
+        }
+        if token == BOS || token == EOS {
+            if let Some(words) = &mut self.lexemes {
+                words.finish(work);
+            }
+            if let Some(literal) = self.scanner.finish() {
+                self.literal(literal, work);
+            }
+            if let Some(words) = &mut self.lexemes {
+                words.clear_literal();
+            }
+            return;
+        }
+        let byte;
+        let bytes = if token < LEXICAL_BASE {
+            byte = [(token - 2) as u8];
+            &byte[..]
+        } else {
+            &model.lexical_pieces[(token - LEXICAL_BASE) as usize][..]
+        };
+        for &value in bytes {
+            work.input_bytes = work.input_bytes.saturating_add(1);
+            if let Some(words) = &mut self.lexemes {
+                words.feed(value, self.recent[(self.recent_cursor + 31) & 31], work);
+            }
+            let was_open = self.scanner.snapshot_needs_suffix();
+            let literal = self.scanner.feed(value, sequence);
+            if let Some(literal) = literal {
+                self.literal(literal, work);
+            }
+            if let Some(words) = &mut self.lexemes {
+                if self.scanner.snapshot_needs_suffix() {
+                    // A delimiter can finish one numeral and start a signed
+                    // fragment in the same byte. Preserve the former receipt
+                    // before capturing the new source context.
+                    if !was_open || literal.is_some() {
+                        words.capture_literal();
+                    }
+                } else {
+                    words.clear_literal();
+                }
+            }
+        }
+    }
+    pub(super) fn begin(&mut self, work: &mut ValueWork) {
+        if let Some(words) = &mut self.lexemes {
+            words.finish(work);
+        }
+        if let Some(literal) = self.scanner.finish() {
+            self.literal(literal, work);
+        }
+        if let Some(words) = &mut self.lexemes {
+            words.begin();
+        }
+        self.pending = None;
+        self.emission = None;
+        self.consumed = false;
+        self.active = true;
+        self.started_at = self.seen;
+        self.sources.clear();
+        self.sources.extend_from_slice(&self.records);
+        self.query_len = self.recent_len.min(QUERY);
+        for index in 0..self.query_len {
+            if let Some(entry) = self.recent_at(index + 1) {
+                self.queries[index] = entry;
+            }
+        }
+    }
+    pub(super) fn end(&mut self) {
+        self.active = false;
+        self.pending = None;
+        self.emission = None;
+        self.consumed = false;
+        self.sources.clear();
+        self.query_len = 0;
+        self.scanner = super::numeral::Scanner::default();
+        if let Some(words) = &mut self.lexemes {
+            words.end();
+        }
+    }
+    pub(super) fn proposal(&self, index: usize) -> Option<(ValueAction, ValueRecord, ValueRecord)> {
+        // Fixed address space: low four bits address the first operand;
+        // upper bits select Copy (0), or one of sixteen second operands.
+        let left = index & 15;
+        let right = index >> 4;
+        let a = *self.sources.get(left)?;
+        if right == 0 {
+            return Some((ValueAction::Copy, a, a));
+        }
+        let b = *self.sources.get(right - 1)?;
+        (a.id != b.id).then_some((ValueAction::Add, a, b))
+    }
+    pub(super) fn features(
+        &self,
+        model: &Model,
+        action: ValueAction,
+        a: ValueRecord,
+        b: ValueRecord,
+        control: Control,
+        work: &mut ValueWork,
+    ) -> ([ValueFeature; VALUE_FEATURES], usize) {
+        let mut features = [ValueFeature::default(); VALUE_FEATURES];
+        let mut len = 0;
+        let op = match action {
+            ValueAction::Copy => 0,
+            ValueAction::Add => 1,
+        };
+        let rank_a = self
+            .sources
+            .iter()
+            .rev()
+            .position(|r| r.id == a.id)
+            .unwrap_or(VALUES) as u64;
+        let rank_b = self
+            .sources
+            .iter()
+            .rev()
+            .position(|r| r.id == b.id)
+            .unwrap_or(VALUES) as u64;
+        let mut add = |kind, a, b| {
+            if len < VALUE_FEATURES {
+                features[len] = ValueFeature { kind, a, b };
+                len += 1;
+            }
+        };
+        add(0, op, 0);
+        add(1, op, (rank_a << 8) | rank_b);
+        add(2, op, u64::from(a.derived) | (u64::from(b.derived) << 1));
+        for query in &self.queries[..self.query_len] {
+            add(3, op, u64::from(query.cue));
+            add(4, (op << 8) | rank_a, u64::from(query.cue));
+            add(5, (op << 8) | rank_b, u64::from(query.cue));
+            let mut matches = 0;
+            for offset in 0..4 {
+                work.cue_comparisons = work.cue_comparisons.saturating_add(2);
+                if query.cue == a.cue[offset] {
+                    matches |= 1 << offset;
+                }
+                if query.cue == b.cue[offset] {
+                    matches |= 1 << (offset + 4);
+                }
+            }
+            add(6, op, matches);
+        }
+        let endpoint = self.queries[0];
+        if !matches!(control, Control::GeometryDisabled | Control::H4Disabled) {
+            let inverse = model.geometry.inverses[usize::from(a.pose)];
+            let relative = model.geometry.products
+                [model.geometry.row_bases[usize::from(inverse)] + usize::from(endpoint.pose)];
+            let inverse_b = model.geometry.inverses[usize::from(b.pose)];
+            let pair = model.geometry.products
+                [model.geometry.row_bases[usize::from(inverse_b)] + usize::from(a.pose)];
+            work.h4_reads = work.h4_reads.saturating_add(4);
+            add(7, op, (u64::from(relative) << 8) | u64::from(pair));
+        }
+        if !matches!(control, Control::GeometryDisabled | Control::ZetaDisabled) {
+            for channel in 0..PHASE_CHANNELS {
+                let phase = endpoint.phases[channel].wrapping_sub(a.phases[channel]);
+                let pair = a.phases[channel].wrapping_sub(b.phases[channel]);
+                work.phase_updates = work.phase_updates.saturating_add(2);
+                add(
+                    8 + channel as u8,
+                    op,
+                    (u64::from(phase >> 12) << 4) | u64::from(pair >> 12),
+                );
+            }
+        }
+        if control != Control::ValueLexemesDisabled
+            && model
+                .values
+                .as_ref()
+                .is_some_and(|head| head.schema == LEXEME_VALUE_SCHEMA)
+        {
+            if let (Some(words), Some(cues_a), Some(cues_b)) = (&self.lexemes, a.lexical, b.lexical)
+            {
+                for (index, query) in words.queries[..words.query_len].iter().enumerate() {
+                    let mut matches = 0;
+                    for offset in 0..4 {
+                        if query.matches(&cues_a[offset], work) {
+                            matches |= 1 << offset;
+                        }
+                        if query.matches(&cues_b[offset], work) {
+                            matches |= 1 << (offset + 4);
+                        }
+                    }
+                    add(16, (op << 8) | index as u64, matches);
+                }
+            }
+        }
+        (features, len)
+    }
+    pub(super) fn offer(
+        &mut self,
+        model: &Model,
+        baseline: Candidate,
+        control: Control,
+        work: &mut ValueWork,
+    ) -> Option<Candidate> {
+        self.pending = None;
+        if !self.active || control == Control::ValuesDisabled || control == Control::MemoryDisabled
+        {
+            return None;
+        }
+        let head = model.values.as_ref()?;
+        if let Some(emission) = self.emission {
+            if usize::from(emission.cursor) >= usize::from(emission.numeral.len)
+                || head.continuation_score <= 0
+            {
+                return None;
+            }
+            let token = emission.numeral.tokens[usize::from(emission.cursor)];
+            let score = baseline.score + i64::from(head.continuation_score);
+            self.pending = Some(ValueDecision {
+                token,
+                cursor: emission.cursor,
+                score,
+                at_seen: self.seen,
+                ..emission.decision
+            });
+            return Some(Candidate { token, score });
+        }
+        if self.consumed || self.query_len == 0 || self.next_id == u64::MAX {
+            return None;
+        }
+        let mut selected = None;
+        let mut best = 0_i64;
+        for index in 0..272 {
+            let Some((action, a, b)) = self.proposal(index) else {
+                continue;
+            };
+            work.proposals = work.proposals.saturating_add(1);
+            let Some(value) = execute(action, a.value, b.value, work) else {
+                continue;
+            };
+            let (features, len) = self.features(model, action, a, b, control, work);
+            let mut score = 0_i64;
+            for feature in &features[..len] {
+                work.feature_lookups = work.feature_lookups.saturating_add(1);
+                if let Ok(index) = head.rows.binary_search_by(|row| {
+                    work.feature_comparisons = work.feature_comparisons.saturating_add(1);
+                    row.feature.cmp(feature)
+                }) {
+                    score += i64::from(head.rows[index].weight);
+                }
+            }
+            if score > best {
+                best = score;
+                selected = Some((action, a, b, value));
+            }
+        }
+        let (action, a, b, value) = selected?;
+        let numeral = Numeral::from_zphi(ZPhi::new(value, 0))?;
+        // Exact spelling has nineteen place visits plus one subtraction per
+        // digit value; this counter is the fixed worst-case visit bound.
+        work.numeral_steps = work.numeral_steps.saturating_add(190);
+        let token = numeral.tokens[0];
+        let score = baseline.score + best;
+        self.pending = Some(ValueDecision {
+            action,
+            operands: [a, b],
+            value,
+            write_id: self.next_id,
+            token,
+            cursor: 0,
+            score,
+            at_seen: self.seen,
+        });
+        Some(Candidate { token, score })
+    }
+    pub(super) fn selected(&mut self, best: Candidate) {
+        if self
+            .pending
+            .is_some_and(|p| p.token != best.token || p.score != best.score)
+        {
+            self.pending = None;
+        }
+    }
+    fn commit(&mut self, token: u32, work: &mut ValueWork) {
+        let pending = self.pending.take();
+        if token == EOS {
+            self.active = false;
+            self.emission = None;
+            return;
+        }
+        let Some(decision) = pending.filter(|p| p.token == token && p.at_seen == self.seen) else {
+            let interrupted = self.emission.take().is_some();
+            if interrupted {
+                self.consumed = true;
+            }
+            if pending.is_some() || interrupted {
+                work.emission_mismatches = work.emission_mismatches.saturating_add(1);
+            }
+            return;
+        };
+        if decision.cursor == 0 {
+            let Some(next) = self.next_id.checked_add(1) else {
+                return;
+            };
+            let Some(numeral) = Numeral::from_zphi(ZPhi::new(decision.value, 0)) else {
+                return;
+            };
+            work.numeral_steps = work.numeral_steps.saturating_add(190);
+            self.next_id = next;
+            let mut cue = [0; 4];
+            for (dst, entry) in cue.iter_mut().zip(&self.queries[..self.query_len]) {
+                *dst = entry.cue;
+            }
+            self.append_record(
+                ValueRecord {
+                    id: decision.write_id,
+                    value: decision.value,
+                    start: self.seen,
+                    end: self.seen,
+                    derived: true,
+                    derivation: Some(ValueDerivation {
+                        action: decision.action,
+                        operand_ids: decision.operands.map(|record| record.id),
+                        operand_values: decision.operands.map(|record| record.value),
+                    }),
+                    cue,
+                    pose: self.pose,
+                    phases: self.phases,
+                    lexical: self.lexemes.as_ref().map(|words| {
+                        let mut cue = [super::value_lexemes::WordAtom::default(); 4];
+                        cue.copy_from_slice(&words.queries[..4]);
+                        cue
+                    }),
+                },
+                work,
+            );
+            self.emission = Some(ValueEmission {
+                decision,
+                numeral,
+                cursor: 1,
+            });
+            self.consumed = true;
+            work.derived_writes = work.derived_writes.saturating_add(1);
+        } else if let Some(emission) = &mut self.emission {
+            emission.cursor = emission.cursor.saturating_add(1);
+        }
+        work.emission_commits = work.emission_commits.saturating_add(1);
+        if self.emission.is_some_and(|e| e.cursor >= e.numeral.len) {
+            self.emission = None;
+        }
+    }
+}
+pub(super) fn execute(action: ValueAction, a: i64, b: i64, work: &mut ValueWork) -> Option<i64> {
+    match action {
+        ValueAction::Copy => Some(a),
+        ValueAction::Add => {
+            work.additions = work.additions.saturating_add(1);
+            match ZPhi::new(a, 0).checked_add(ZPhi::new(b, 0)) {
+                Ok(value) => Some(value.a),
+                Err(_) => {
+                    work.overflow_rejections = work.overflow_rejections.saturating_add(1);
+                    None
+                }
+            }
+        }
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
@@ -1,0 +1,351 @@
+//! Focused typed-state checks. Deliberately set rows exercise causal mechanics;
+//! the separately named fitting check uses only raw prompt/response examples.
+use super::numeral::NUMERAL_CODEC;
+use super::value_types::*;
+use super::*;
+
+fn baseline() -> Model {
+    let catalog = [Document {
+        id: "typed-value-test-catalog".into(),
+        text: "left right total copy none 13 4 17 18 answer unknown result".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 32,
+            candidate_limit: 16,
+            max_lexical_pieces: 128,
+            ..Config::default()
+        },
+        &catalog,
+    )
+    .unwrap();
+    trainer.train_documents(&catalog).unwrap();
+    trainer.compile().unwrap()
+}
+
+fn mechanical_model(action: ValueAction) -> Model {
+    let mut model = baseline();
+    model.values = Some(ValueModel {
+        schema: VALUE_SCHEMA.into(),
+        codec: NUMERAL_CODEC.into(),
+        capacity: VALUES,
+        rows: [ValueAction::Copy, ValueAction::Add]
+            .into_iter()
+            .enumerate()
+            .map(|(index, candidate)| ValueRow {
+                feature: ValueFeature {
+                    kind: 0,
+                    a: index as u64,
+                    b: 0,
+                },
+                weight: if candidate == action { 4096 } else { -4096 },
+            })
+            .collect(),
+        continuation_score: 4096,
+        fit_config: [0; 4],
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    model
+}
+
+fn prefix(model: &Model, prompt: &str, control: Control) -> Session {
+    let mut session = model.session(control).unwrap();
+    session.observe(model, BOS).unwrap();
+    for token in model.encode(prompt).unwrap() {
+        session.observe(model, token).unwrap();
+    }
+    session.begin_response(model).unwrap();
+    session
+}
+
+#[test]
+fn native_value_prediction_is_causal_and_mismatch_never_selects_a_target_source() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "left = 13; right = 4; total:", Control::Full);
+    let before = session.state();
+    let first = session.predict(&model).unwrap();
+    let decision = session.value_decision().unwrap();
+    assert_eq!(decision.action, ValueAction::Add);
+    assert_eq!(decision.value, 17);
+    assert_ne!(decision.operands[0].id, decision.operands[1].id);
+    assert_eq!(session.state(), before);
+    assert_eq!(session.predict(&model).unwrap(), first);
+    assert_eq!(session.value_decision(), Some(decision));
+    assert_eq!(session.work.values.derived_writes, 0);
+    assert_eq!(session.work.values.emission_commits, 0);
+
+    let wrong = u32::from(b'9') + 2;
+    session.observe(&model, wrong).unwrap();
+    assert_eq!(session.work.values.derived_writes, 0);
+    assert_eq!(session.work.values.emission_mismatches, 1);
+    assert_eq!(session.value_decision(), None);
+    assert!(session.values.as_ref().unwrap().emission.is_none());
+    // Wrong observed bytes did not create a numeral or identify another pair.
+    session.predict(&model).unwrap();
+    let retry = session.value_decision().unwrap();
+    assert_eq!(retry.value, decision.value);
+    assert_eq!(retry.operands, decision.operands);
+    assert_eq!(retry.write_id, decision.write_id);
+    session.observe(&model, retry.token).unwrap();
+    assert_eq!(session.work.values.derived_writes, 1);
+    assert_eq!(session.work.values.emission_commits, 1);
+    assert_eq!(session.state().values.unwrap().emission_cursor, Some(1));
+
+    session.predict(&model).unwrap();
+    assert_eq!(session.value_decision().unwrap().token, u32::from(b'7') + 2);
+    session.observe(&model, wrong).unwrap();
+    assert!(session.values.as_ref().unwrap().emission.is_none());
+    assert_eq!(session.work.values.emission_commits, 1);
+    assert_eq!(session.work.values.emission_mismatches, 2);
+    session.predict(&model).unwrap();
+    assert!(session.value_decision().is_none());
+    let records = &session.values.as_ref().unwrap().records;
+    assert_eq!(records.iter().filter(|record| record.derived).count(), 1);
+    assert_eq!(records.last().unwrap().value, 17);
+}
+
+#[test]
+fn native_value_equal_first_bytes_preserve_complete_derivation_identity() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut first = prefix(&model, "left = 13; right = 4; total:", Control::Full);
+    let mut second = prefix(&model, "left = 13; right = 5; total:", Control::Full);
+    assert_eq!(
+        first.predict(&model).unwrap().token,
+        second.predict(&model).unwrap().token
+    );
+    let a = first.value_decision().unwrap();
+    let b = second.value_decision().unwrap();
+    assert_eq!(a.token, u32::from(b'1') + 2);
+    assert_eq!((a.value, b.value), (17, 18));
+    assert_ne!(a.operands, b.operands);
+    first.observe(&model, a.token).unwrap();
+    second.observe(&model, b.token).unwrap();
+    first.predict(&model).unwrap();
+    second.predict(&model).unwrap();
+    assert_eq!(first.value_decision().unwrap().token, u32::from(b'7') + 2);
+    assert_eq!(second.value_decision().unwrap().token, u32::from(b'8') + 2);
+    assert_eq!(
+        first.values.as_ref().unwrap().records.last().unwrap().value,
+        17
+    );
+    assert_eq!(
+        second
+            .values
+            .as_ref()
+            .unwrap()
+            .records
+            .last()
+            .unwrap()
+            .value,
+        18
+    );
+}
+
+#[test]
+fn native_value_signed_extrema_use_ordinary_tokens_and_complete_once() {
+    let model = mechanical_model(ValueAction::Copy);
+    for value in [i64::MIN, i64::MAX, -17, 0, 17] {
+        let expected = value.to_string();
+        let mut session = prefix(&model, &format!("copy {value}"), Control::Full);
+        let mut tokens = Vec::new();
+        for _ in expected.bytes() {
+            let token = session.predict(&model).unwrap().token;
+            let decision = session.value_decision().unwrap();
+            assert_eq!(decision.value, value);
+            assert_eq!(decision.action, ValueAction::Copy);
+            assert_eq!(session.candidates().first().unwrap().token, token);
+            tokens.push(token);
+            session.observe(&model, token).unwrap();
+        }
+        assert_eq!(model.decode(&tokens).unwrap(), expected.as_bytes());
+        assert_eq!(session.work.values.derived_writes, 1);
+        assert_eq!(session.work.values.emission_commits, expected.len() as u64);
+        assert!(session.values.as_ref().unwrap().emission.is_none());
+        session.predict(&model).unwrap();
+        assert!(session.value_decision().is_none());
+    }
+    // The lexical codec and byte emission may have different token counts,
+    // while their decoded bytes remain the same actual output interface.
+    let lexical = model.encode(" 17").unwrap();
+    assert_eq!(lexical.len(), 1);
+    assert_eq!(
+        model.decode(&lexical).unwrap(),
+        model.decode(&[34, 51, 57]).unwrap()
+    );
+}
+
+#[test]
+fn native_value_overflow_and_disabled_control_offer_no_derived_candidate() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut overflow = prefix(
+        &model,
+        "left = 9223372036854775807; right = 1; total:",
+        Control::Full,
+    );
+    overflow.predict(&model).unwrap();
+    assert_eq!(overflow.value_decision(), None);
+    assert_eq!(overflow.work.values.overflow_rejections, 2);
+    assert_eq!(overflow.work.values.derived_writes, 0);
+    for control in [Control::ValuesDisabled, Control::MemoryDisabled] {
+        let mut disabled = prefix(&model, "left = 13; right = 4; total:", control);
+        disabled.predict(&model).unwrap();
+        assert_eq!(disabled.value_decision(), None);
+        assert_eq!(disabled.work.values.proposals, 0);
+        assert_eq!(disabled.work.values.derived_writes, 0);
+    }
+}
+
+#[test]
+fn native_value_absence_preserves_legacy_serialized_fields_and_roundtrip() {
+    let model = baseline();
+    let bytes = model.to_bytes().unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(wire.get("values").is_none());
+    assert_eq!(
+        Model::from_bytes(&bytes).unwrap().to_bytes().unwrap(),
+        bytes
+    );
+    let state = prefix(&model, "left = 13; right = 4; total:", Control::Full);
+    assert!(state.values.is_none());
+    assert!(serde_json::to_value(state.state())
+        .unwrap()
+        .get("values")
+        .is_none());
+    assert!(serde_json::to_value(state.work)
+        .unwrap()
+        .get("values")
+        .is_none());
+    let saved = state.checkpoint().unwrap();
+    let checkpoint: serde_json::Value = serde_json::from_slice(&saved).unwrap();
+    assert_eq!(checkpoint["schema"], "uor-r4.native-geometric-session/1");
+    assert_eq!(
+        model.restore_session(&saved).unwrap().checkpoint().unwrap(),
+        saved
+    );
+}
+
+#[test]
+fn native_value_fit_uses_raw_responses_and_emits_an_absent_sum() {
+    let baseline = baseline();
+    let source = (0..12)
+        .flat_map(|index| {
+            let a = 11 + index;
+            let b = 3 + index;
+            [
+                ValueExample {
+                    id: format!("typed-sum-{index}"),
+                    prompt: format!("left = {a}; right = {b}; total:"),
+                    response: (a + b).to_string(),
+                },
+                ValueExample {
+                    id: format!("typed-no-write-{index}"),
+                    prompt: format!("left = {a}; right = {b}; none:"),
+                    response: "unknown".into(),
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+    let (learned, report) = baseline
+        .fit_values(
+            &source,
+            ValueFitConfig {
+                epochs: 96,
+                learning_rate: 0.25,
+                max_features: 4096,
+            },
+        )
+        .unwrap();
+    assert_eq!(report.numeric_targets, 12);
+    assert_eq!(report.reachable_numeric_targets, 12);
+    assert_eq!(report.no_write_targets, 12);
+    assert!(report.learned_features > 0);
+    assert!(report.continuation_positions > 0);
+    assert!(baseline.values.is_none());
+    let learned = Model::from_bytes(&learned.to_bytes().unwrap()).unwrap();
+    let mut correct_sums = 0;
+    let mut correct_no_writes = 0;
+    for example in &source {
+        let mut session = prefix(&learned, &example.prompt, Control::Full);
+        session.predict(&learned).unwrap();
+        if example.response == "unknown" {
+            correct_no_writes += usize::from(session.value_decision().is_none());
+            continue;
+        }
+        let mut output = Vec::new();
+        let mut decisions = Vec::new();
+        for _ in example.response.bytes() {
+            let prediction = session.predict(&learned).unwrap();
+            let Some(decision) = session.value_decision() else {
+                break;
+            };
+            decisions.push(decision);
+            output.push(prediction.token);
+            session.observe(&learned, prediction.token).unwrap();
+        }
+        if learned.decode(&output).unwrap() == example.response.as_bytes() {
+            correct_sums += 1;
+            assert!(decisions
+                .iter()
+                .all(|decision| decision.action == ValueAction::Add));
+            assert_eq!(session.work.values.derived_writes, 1);
+        }
+    }
+    // This is a finite construction-fitting integration smoke, not held-out
+    // capability evidence or a claim of a geometric contribution.
+    assert_eq!(correct_sums, 12);
+    assert_eq!(correct_no_writes, 12);
+}
+
+#[test]
+fn native_value_fit_preserves_canonical_spelling_and_terminal_punctuation() {
+    let baseline = baseline();
+    let examples = [
+        ("canonical", "17"),
+        ("plus", "+17"),
+        ("zero", "017"),
+        ("period", "17."),
+    ]
+    .into_iter()
+    .map(|(id, response)| ValueExample {
+        id: format!("typed-spelling-{id}"),
+        prompt: format!("{id}: left = 13; right = 4; total:"),
+        response: response.into(),
+    })
+    .collect::<Vec<_>>();
+    let (_, report) = baseline
+        .fit_values(
+            &examples,
+            ValueFitConfig {
+                epochs: 4,
+                learning_rate: 0.25,
+                max_features: 4096,
+            },
+        )
+        .unwrap();
+    assert_eq!(report.numeric_targets, 4);
+    // 17 is the generated numeral prefix; the terminal period remains an
+    // ordinary-token responsibility. +17 and 017 are different output bytes.
+    assert_eq!(report.reachable_numeric_targets, 2);
+    assert_eq!(report.no_write_targets, 0);
+}
+
+#[test]
+fn native_value_document_boundaries_do_not_join_numerals() {
+    let model = mechanical_model(ValueAction::Copy);
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(&model, BOS).unwrap();
+    session.observe(&model, u32::from(b'1') + 2).unwrap();
+    session.observe(&model, EOS).unwrap();
+    session.observe(&model, u32::from(b'2') + 2).unwrap();
+    session.begin_response(&model).unwrap();
+    let values: Vec<_> = session
+        .values
+        .as_ref()
+        .unwrap()
+        .records
+        .iter()
+        .map(|r| r.value)
+        .collect();
+    assert_eq!(values, vec![1, 2]);
+}

--- a/crates/uor-r4-core/src/native_geometric/value_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_snapshot.rs
@@ -1,0 +1,593 @@
+//! Host validation of bounded typed state. A checkpoint carries user-provided
+//! old state, not authenticated source truth. Retained token evidence is
+//! checked where available; evicted literal payloads remain explicit state.
+use super::*;
+use crate::native_geometric::numeral::{Numeral, Scanner};
+use crate::native_geometric::value_lexemes::{LexemeState, WordAtom, WordScanner};
+use crate::native_geometric::value_types::{
+    ValueAction, ValueDerivation, ValueEntry, ValueRecord, ValueWork, LEXEME_VALUE_SCHEMA, QUERY,
+    VALUES,
+};
+use crate::prime_route_attention::ZPhi;
+
+fn invalid(message: &str) -> Error {
+    Error(format!("session typed value {message}"))
+}
+
+pub(super) fn validate_lexeme_field_presence(
+    model: &Model,
+    wire: &serde_json::Value,
+) -> Result<()> {
+    let Some(head) = &model.values else {
+        return Ok(());
+    };
+    let Some(values) = wire.get("values").and_then(serde_json::Value::as_object) else {
+        return Ok(());
+    };
+    let lexical = head.schema == LEXEME_VALUE_SCHEMA;
+    if if lexical {
+        !values
+            .get("lexemes")
+            .is_some_and(serde_json::Value::is_object)
+    } else {
+        values.contains_key("lexemes")
+    } {
+        return Err(invalid(
+            "word state fields do not match the artifact schema",
+        ));
+    }
+    let validate_record = |record: &serde_json::Value| -> Result<()> {
+        if if lexical {
+            !record
+                .get("lexical")
+                .is_some_and(serde_json::Value::is_array)
+        } else {
+            record.get("lexical").is_some()
+        } {
+            return Err(invalid(
+                "record word fields do not match the artifact schema",
+            ));
+        }
+        Ok(())
+    };
+    for field in ["records", "sources"] {
+        if let Some(records) = values.get(field).and_then(serde_json::Value::as_array) {
+            for record in records {
+                validate_record(record)?;
+            }
+        }
+    }
+    if let Some(operands) = values
+        .get("emission")
+        .and_then(|emission| emission.get("decision"))
+        .and_then(|decision| decision.get("operands"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for record in operands {
+            validate_record(record)?;
+        }
+    }
+    Ok(())
+}
+
+fn bytes(model: &Model, token: u32, mut consume: impl FnMut(u8)) {
+    if token == BOS || token == EOS {
+        return;
+    }
+    if token < LEXICAL_BASE {
+        consume((token - 2) as u8);
+    } else {
+        for &byte in &model.lexical_pieces[(token - LEXICAL_BASE) as usize] {
+            consume(byte);
+        }
+    }
+}
+
+impl Session {
+    pub(super) fn restore_value_state(
+        &mut self,
+        model: &Model,
+        mut saved: ValueState,
+        retained: &[u32],
+        observed: u64,
+        source_bytes: u64,
+    ) -> Result<()> {
+        let lexical = model
+            .values
+            .as_ref()
+            .is_some_and(|head| head.schema == LEXEME_VALUE_SCHEMA);
+        if saved.seen != observed
+            || saved.lexemes.is_some() != lexical
+            || saved.recent_len != observed.min(32) as usize
+            || saved.recent_cursor != (observed & 31) as usize
+            || saved.records.len() != saved.next_id.min(VALUES as u64) as usize
+            || saved.sources.len() > VALUES
+            || saved.query_len > QUERY
+            || saved.started_at > observed
+            || usize::from(saved.pose) >= model.geometry.inverses.len()
+            || !saved.scanner.snapshot_valid(observed)
+            || (saved.active && saved.scanner != Scanner::default())
+            || (saved.active && saved.query_len != saved.started_at.min(QUERY as u64) as usize)
+            || (saved.query_len != 0
+                && saved.query_len != saved.started_at.min(QUERY as u64) as usize)
+            || saved.pending.is_some()
+        {
+            return Err(invalid("shape, scanner or counters are invalid"));
+        }
+        let oldest = observed - saved.recent_len as u64;
+        let ring_oldest = observed - retained.len() as u64;
+        let recent = |sequence: u64| -> Option<ValueEntry> {
+            if sequence < oldest || sequence >= observed {
+                return None;
+            }
+            Some(saved.recent[(sequence & 31) as usize])
+        };
+        let cue = |token: u32| {
+            let alias = model
+                .memory_read
+                .as_ref()
+                .and_then(|memory| memory.cue_aliases.as_ref())
+                .map_or(token, |aliases| aliases.representatives[token as usize]);
+            model.geometry.tokens[alias as usize].prime
+        };
+        let valid_entry = |entry: ValueEntry| -> bool {
+            (entry.token as usize) < model.vocabulary_size()
+                && usize::from(entry.pose) < model.geometry.inverses.len()
+                && entry.cue == cue(entry.token)
+        };
+        let follows = |older: ValueEntry, newer: ValueEntry| {
+            let geometry = &model.geometry.tokens[newer.token as usize];
+            model.geometry.products
+                [model.geometry.row_bases[usize::from(older.pose)] + usize::from(geometry.leaf)]
+                == newer.pose
+                && older
+                    .phases
+                    .iter()
+                    .zip(geometry.phases)
+                    .zip(newer.phases)
+                    .all(|((&old, delta), new)| old.wrapping_add(delta) == new)
+        };
+        let mut previous = None;
+        for sequence in oldest..observed {
+            let entry = saved.recent[(sequence & 31) as usize];
+            if entry.sequence != sequence
+                || !valid_entry(entry)
+                || (sequence >= ring_oldest
+                    && entry.token != retained[(sequence - ring_oldest) as usize])
+                || previous.is_some_and(|older| !follows(older, entry))
+            {
+                return Err(invalid("recent token or geometric path is invalid"));
+            }
+            if sequence == 0 {
+                let geometry = &model.geometry.tokens[entry.token as usize];
+                if entry.pose != geometry.leaf || entry.phases != geometry.phases {
+                    return Err(invalid("initial token geometry is invalid"));
+                }
+            }
+            previous = Some(entry);
+        }
+        if let Some(last) = previous {
+            if last.pose != saved.pose || last.phases != saved.phases {
+                return Err(invalid("current geometry differs from recent history"));
+            }
+        } else if saved.pose != model.geometry.identity || saved.phases != [0; PHASE_CHANNELS] {
+            return Err(invalid("empty state geometry is invalid"));
+        }
+        let validate_atom = |atom: &WordAtom| -> Result<()> {
+            if !atom.snapshot_valid(observed, source_bytes, model.geometry.inverses.len()) {
+                return Err(invalid(
+                    "word bytes, sequence or geometric endpoint are invalid",
+                ));
+            }
+            if atom.len == 0 {
+                return Ok(());
+            }
+            if recent(atom.end)
+                .is_some_and(|entry| entry.pose != atom.pose || entry.phases != atom.phases)
+            {
+                return Err(invalid("word endpoint differs from retained geometry"));
+            }
+            // A word spans at most one token per source byte. With complete
+            // history, even a long word within the first lexical token has
+            // exact retained evidence; partial windows need the span bound.
+            let span = u64::from(atom.len) - 1;
+            if atom.end >= oldest && (oldest == 0 || atom.end - oldest >= span) {
+                let mut found = false;
+                let matches = |word: WordAtom| {
+                    word.len == atom.len
+                        && word.bytes == atom.bytes
+                        && word.end == atom.end
+                        && word.pose == atom.pose
+                        && word.phases == atom.phases
+                };
+                for start in atom.end.saturating_sub(span).max(oldest)..=atom.end {
+                    let mut replay = LexemeState::default();
+                    let mut work = ValueWork::default();
+                    for sequence in start..=atom.end {
+                        let entry = saved.recent[(sequence & 31) as usize];
+                        bytes(model, entry.token, |byte| {
+                            let before = work.lexical_writes;
+                            replay.feed(byte, entry, &mut work);
+                            if work.lexical_writes != before {
+                                found |= matches(replay.recent[0]);
+                            }
+                        });
+                    }
+                    replay.finish(&mut work);
+                    found |= replay.recent_len != 0 && matches(replay.recent[0]);
+                    if found {
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(invalid("word payload differs from retained source bytes"));
+                }
+            }
+            Ok(())
+        };
+        let validate_word_array = |atoms: &[WordAtom]| -> Result<()> {
+            let len = atoms.iter().take_while(|atom| atom.len != 0).count();
+            for atom in atoms {
+                validate_atom(atom)?;
+            }
+            if atoms[len..].iter().any(|atom| *atom != WordAtom::default())
+                || atoms[..len].windows(2).any(|pair| {
+                    pair[0].byte_end < u64::from(pair[0].len)
+                        || pair[1].byte_end > pair[0].byte_end - u64::from(pair[0].len)
+                        || pair[1].end > pair[0].end
+                })
+            {
+                return Err(invalid("word order or unused padding is invalid"));
+            }
+            Ok(())
+        };
+        if let Some(words) = &saved.lexemes {
+            if !words.snapshot_valid(observed, model.geometry.inverses.len())
+                || words.source_bytes_seen != source_bytes
+                || (saved.active
+                    && (words.scanner != WordScanner::default()
+                        || words.queries != words.recent
+                        || words.query_len != words.recent_len))
+                || (saved.query_len == 0 && words.query_len != 0)
+                || (words.scanner.pending.len != 0
+                    && words.recent_len != 0
+                    && words
+                        .scanner
+                        .pending
+                        .byte_end
+                        .checked_sub(u64::from(words.scanner.pending.len))
+                        .is_none_or(|prior_limit| words.recent[0].byte_end > prior_limit))
+                || words.queries[..words.query_len]
+                    .iter()
+                    .any(|word| word.end >= saved.started_at)
+                || (saved.scanner.snapshot_needs_suffix()
+                    && words.literal_cues.as_slice() != &words.recent[..4])
+                || (!saved.scanner.snapshot_needs_suffix()
+                    && words.literal_cues != [WordAtom::default(); 4])
+            {
+                return Err(invalid(
+                    "word scanner, source counters or captured query are invalid",
+                ));
+            }
+            validate_word_array(&words.recent)?;
+            validate_word_array(&words.queries)?;
+            validate_word_array(&words.literal_cues)?;
+            validate_atom(&words.scanner.pending)?;
+            if words.scanner.pending.len != 0 {
+                let pending = words.scanner.pending;
+                // Unlike completed atoms, a pending word must end at the
+                // current observation and agree with an unclosed byte suffix.
+                if pending.end.checked_add(1) != Some(observed) {
+                    return Err(invalid(
+                        "pending word is not at the current source boundary",
+                    ));
+                }
+                let mut found = false;
+                for start in oldest..observed {
+                    let mut replay = LexemeState::default();
+                    for sequence in start..observed {
+                        let entry = saved.recent[(sequence & 31) as usize];
+                        bytes(model, entry.token, |byte| {
+                            replay.feed(byte, entry, &mut ValueWork::default())
+                        });
+                    }
+                    let actual = replay.scanner.pending;
+                    found |= pending.len == actual.len
+                        && pending.bytes == actual.bytes
+                        && pending.end == actual.end
+                        && pending.pose == actual.pose
+                        && pending.phases == actual.phases;
+                    if found {
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(invalid("pending word differs from retained source suffix"));
+                }
+            }
+        }
+        // An explicit end_response may reset the scanner at any token
+        // boundary. Require an open numeric prefix to be reachable from one
+        // such boundary within the retained raw-token metadata. Long rejected
+        // or identifier runs can predate that metadata and cannot emit values.
+        if saved.scanner.snapshot_needs_suffix() {
+            let mut matched = false;
+            for start in oldest..observed {
+                let mut scanner = Scanner::default();
+                for sequence in start..observed {
+                    let entry = saved.recent[(sequence & 31) as usize];
+                    bytes(model, entry.token, |byte| {
+                        scanner.feed(byte, sequence);
+                    });
+                }
+                if scanner == saved.scanner {
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                return Err(invalid(
+                    "scanner is inconsistent with retained source bytes",
+                ));
+            }
+        }
+        for offset in 0..saved.query_len {
+            let entry = saved.queries[offset];
+            if !valid_entry(entry)
+                || entry.sequence.checked_add(offset as u64 + 1) != Some(saved.started_at)
+                || recent(entry.sequence).is_some_and(|actual| actual != entry)
+                || (offset != 0 && !follows(entry, saved.queries[offset - 1]))
+            {
+                return Err(invalid("captured query is invalid"));
+            }
+        }
+        let valid_prime = |prime: u32| {
+            prime == 0
+                || model
+                    .geometry
+                    .tokens
+                    .iter()
+                    .any(|token| token.prime == prime)
+        };
+        let validate_record = |record: &ValueRecord| -> Result<()> {
+            if record.id >= saved.next_id
+                || record.start > record.end
+                || record.end >= observed
+                || usize::from(record.pose) >= model.geometry.inverses.len()
+                || record.cue.iter().any(|&prime| !valid_prime(prime))
+                || record.derived != record.derivation.is_some()
+                || record.lexical.is_some() != lexical
+                || (record.derived && record.start != record.end)
+                || (!record.derived && record.end - record.start > 19)
+            {
+                return Err(invalid("record identity, interval or geometry is invalid"));
+            }
+            if let Some(words) = &record.lexical {
+                validate_word_array(words)?;
+                if words.iter().any(|word| {
+                    word.len != 0
+                        && (word.end > record.start || (record.derived && word.end == record.start))
+                }) {
+                    return Err(invalid("record word cue follows its value source boundary"));
+                }
+                if !record.derived {
+                    let state = saved
+                        .lexemes
+                        .as_ref()
+                        .ok_or_else(|| invalid("record has words without word state"))?;
+                    // A shared lexical token can contain words on both sides
+                    // of the number. Without a byte interval for that number,
+                    // its token endpoint cannot order those same-token words.
+                    if !state.recent[..state.recent_len]
+                        .iter()
+                        .any(|word| word.end == record.start)
+                    {
+                        let mut compared = 0;
+                        for (index, actual) in state.recent[..state.recent_len]
+                            .iter()
+                            .filter(|word| word.end < record.start)
+                            .take(4)
+                            .enumerate()
+                        {
+                            if words[index] != *actual {
+                                return Err(invalid(
+                                    "literal word cues differ from retained source order",
+                                ));
+                            }
+                            compared += 1;
+                        }
+                        if state.recent_len < state.recent.len()
+                            && words[compared..]
+                                .iter()
+                                .any(|word| *word != WordAtom::default())
+                        {
+                            return Err(invalid(
+                                "literal word cues invent unavailable earlier words",
+                            ));
+                        }
+                    }
+                }
+            }
+            if let Some(derivation) = record.derivation {
+                let [left_id, right_id] = derivation.operand_ids;
+                let [left, right] = derivation.operand_values;
+                let computed = match derivation.action {
+                    ValueAction::Copy if left_id == right_id && left == right => Some(left),
+                    ValueAction::Add if left_id != right_id => ZPhi::new(left, 0)
+                        .checked_add(ZPhi::new(right, 0))
+                        .ok()
+                        .map(|value| value.a),
+                    _ => None,
+                };
+                if left_id >= record.id || right_id >= record.id || computed != Some(record.value) {
+                    return Err(invalid(
+                        "retained derivation identity or arithmetic is invalid",
+                    ));
+                }
+                for (id, value) in derivation
+                    .operand_ids
+                    .into_iter()
+                    .zip(derivation.operand_values)
+                {
+                    if saved
+                        .records
+                        .iter()
+                        .chain(&saved.sources)
+                        .any(|operand| operand.id == id && operand.value != value)
+                    {
+                        return Err(invalid("derivation operand differs from retained value"));
+                    }
+                }
+            }
+            if !record.derived {
+                if recent(record.end)
+                    .is_some_and(|entry| entry.pose != record.pose || entry.phases != record.phases)
+                {
+                    return Err(invalid("literal endpoint differs from retained geometry"));
+                }
+                for (offset, &prime) in record.cue.iter().enumerate() {
+                    if let Some(sequence) = record.start.checked_sub(offset as u64 + 1) {
+                        if recent(sequence).is_some_and(|entry| entry.cue != prime) {
+                            return Err(invalid("literal cue differs from retained tokens"));
+                        }
+                    } else if prime != 0 {
+                        return Err(invalid("literal cue precedes observation history"));
+                    }
+                }
+                if record.start >= oldest {
+                    let mut scanner = Scanner::default();
+                    let mut found = false;
+                    for sequence in record.start..=record.end {
+                        let entry = saved.recent[(sequence & 31) as usize];
+                        bytes(model, entry.token, |byte| {
+                            if let Some(literal) = scanner.feed(byte, sequence) {
+                                found |= literal.start == record.start
+                                    && literal.end == record.end
+                                    && literal.value == record.value;
+                            }
+                        });
+                    }
+                    if let Some(literal) = scanner.finish() {
+                        found |= literal.start == record.start
+                            && literal.end == record.end
+                            && literal.value == record.value;
+                    }
+                    if !found {
+                        return Err(invalid(
+                            "literal payload differs from retained source bytes",
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        };
+        for (offset, record) in saved.records.iter().enumerate() {
+            validate_record(record)?;
+            if record.id != saved.next_id - saved.records.len() as u64 + offset as u64 {
+                return Err(invalid("record IDs are not the retained write suffix"));
+            }
+        }
+        let mut previous_id = None;
+        for record in &saved.sources {
+            validate_record(record)?;
+            if record.end >= saved.started_at
+                || previous_id.is_some_and(|id| record.id != id + 1)
+                || saved
+                    .records
+                    .iter()
+                    .any(|current| current.id == record.id && current != record)
+            {
+                return Err(invalid("captured source identity is invalid"));
+            }
+            previous_id = Some(record.id);
+        }
+        if let Some(emission) = saved.emission {
+            let decision = emission.decision;
+            let [a, b] = decision.operands;
+            let computed = match decision.action {
+                ValueAction::Copy if a == b => Some(a.value),
+                ValueAction::Add if a.id != b.id => ZPhi::new(a.value, 0)
+                    .checked_add(ZPhi::new(b.value, 0))
+                    .ok()
+                    .map(|value| value.a),
+                _ => None,
+            };
+            let numeral = Numeral::from_zphi(ZPhi::new(decision.value, 0));
+            if !saved.active
+                || !saved.consumed
+                || saved.query_len == 0
+                || decision.cursor != 0
+                || emission.cursor == 0
+                || emission.cursor >= emission.numeral.len
+                || decision.at_seen < saved.started_at
+                || decision.at_seen.checked_add(u64::from(emission.cursor)) != Some(observed)
+                || decision.write_id.checked_add(1) != Some(saved.next_id)
+                || computed != Some(decision.value)
+                || numeral != Some(emission.numeral)
+                || decision.token != emission.numeral.tokens[0]
+                || !saved.sources.contains(&a)
+                || !saved.sources.contains(&b)
+            {
+                return Err(invalid("committed derivation or numeral cursor is invalid"));
+            }
+            let record = saved
+                .records
+                .last()
+                .ok_or_else(|| invalid("emission has no committed write"))?;
+            let mut expected_cue = [0; 4];
+            for (prime, query) in expected_cue
+                .iter_mut()
+                .zip(&saved.queries[..saved.query_len])
+            {
+                *prime = query.cue;
+            }
+            if !record.derived
+                || record.id != decision.write_id
+                || record.value != decision.value
+                || record.derivation
+                    != Some(ValueDerivation {
+                        action: decision.action,
+                        operand_ids: [a.id, b.id],
+                        operand_values: [a.value, b.value],
+                    })
+                || record.start != decision.at_seen
+                || record.end != decision.at_seen
+                || record.cue != expected_cue
+                || record.lexical
+                    != saved.lexemes.as_ref().map(|words| {
+                        let mut expected = [WordAtom::default(); 4];
+                        expected.copy_from_slice(&words.queries[..4]);
+                        expected
+                    })
+                || decision
+                    .at_seen
+                    .checked_sub(1)
+                    .and_then(recent)
+                    .is_some_and(|entry| entry.pose != record.pose || entry.phases != record.phases)
+            {
+                return Err(invalid("derived record differs from committed emission"));
+            }
+            for offset in 0..emission.cursor {
+                let sequence = decision.at_seen + u64::from(offset);
+                if recent(sequence)
+                    .is_none_or(|entry| entry.token != emission.numeral.tokens[usize::from(offset)])
+                {
+                    return Err(invalid(
+                        "emission cursor differs from observed numeral bytes",
+                    ));
+                }
+            }
+        }
+        // Deserialization allocates Vec capacity from serialized length;
+        // restore the fixed serving capacity before any model observation.
+        let mut records = Vec::with_capacity(VALUES);
+        records.extend_from_slice(&saved.records);
+        saved.records = records;
+        let mut sources = Vec::with_capacity(VALUES);
+        sources.extend_from_slice(&saved.sources);
+        saved.sources = sources;
+        saved.pending = None;
+        self.values = Some(saved);
+        Ok(())
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/value_snapshot_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_snapshot_tests.rs
@@ -1,0 +1,489 @@
+//! Mechanical state preservation and malformed-input checks. Synthetic
+//! decisions establish causal persistence, not learned operator quality.
+use super::*;
+use crate::native_geometric::memory_types::{
+    MemoryModel, MemoryReadFitConfig, OCCURRENCE_MEMORY_SCHEMA,
+};
+use crate::native_geometric::numeral::NUMERAL_CODEC;
+use crate::native_geometric::value_types::{
+    ValueAction, ValueDecision, ValueModel, LEXEME_VALUE_SCHEMA, VALUES, VALUE_SCHEMA,
+};
+
+fn fixture(response: bool) -> Model {
+    let documents = [Document {
+        id: "value-snapshot-fixture".into(),
+        text: "x = 13; y = 4; value query answer".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 8,
+            ..Config::default()
+        },
+        &documents,
+    )
+    .unwrap();
+    trainer.train_documents(&documents).unwrap();
+    let mut model = trainer.compile().unwrap();
+    model.memory_read = Some(MemoryModel {
+        schema: if response {
+            RESPONSE_MEMORY_SCHEMA
+        } else {
+            OCCURRENCE_MEMORY_SCHEMA
+        }
+        .into(),
+        baseline_artifact: model.artifact_cid().into(),
+        cue_aliases: None,
+        config: MemoryReadFitConfig {
+            query_tokens: 3,
+            source_offsets: 2,
+            postings_per_address: 2,
+            candidate_limit: 12,
+            ..MemoryReadFitConfig::default()
+        },
+        source_shift: 1,
+        posting_shift: 1,
+        training: model.construction.clone(),
+        rows: Vec::new(),
+        fit_positions: 1,
+        fit_schedule: None,
+    });
+    model.values = Some(ValueModel {
+        schema: VALUE_SCHEMA.into(),
+        codec: NUMERAL_CODEC.into(),
+        capacity: VALUES,
+        rows: Vec::new(),
+        continuation_score: 1000,
+        fit_config: [1, 0.1f64.to_bits(), 65536, 1],
+        training: model.construction.clone(),
+    });
+    model.refresh_identity().unwrap();
+    model
+}
+
+fn input(session: &mut Session, model: &Model, source: &[u8]) {
+    for &byte in source {
+        session.observe(model, u32::from(byte) + 2).unwrap();
+    }
+}
+
+fn emitting(model: &Model) -> Session {
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(model, BOS).unwrap();
+    input(&mut session, model, b"x = 13; y = 4; ");
+    session.begin_response(model).unwrap();
+    let values = session.values.as_mut().unwrap();
+    assert_eq!(values.sources.len(), 2);
+    values.pending = Some(ValueDecision {
+        action: ValueAction::Add,
+        operands: [values.sources[0], values.sources[1]],
+        value: 17,
+        write_id: values.next_id,
+        token: 51,
+        cursor: 0,
+        score: 1,
+        at_seen: values.seen,
+    });
+    session.observe(model, 51).unwrap();
+    assert_eq!(session.values.as_ref().unwrap().emission.unwrap().cursor, 1);
+    session
+}
+
+#[test]
+fn native_value_checkpoint_preserves_committed_emission_and_optional_response_state() {
+    for response in [false, true] {
+        let model = fixture(response);
+        let mut original = emitting(&model);
+        original.predict(&model).unwrap();
+        let bytes = original.checkpoint().unwrap();
+        let wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(wire["schema"], VALUE_SESSION_SCHEMA);
+        assert_eq!(wire.get("response_memory").is_some(), response);
+        assert!(wire["values"].get("pending").is_none());
+        let mut restored = model.restore_session(&bytes).unwrap();
+        assert!(restored.values.as_ref().unwrap().pending.is_none());
+        assert_eq!(restored.checkpoint().unwrap(), bytes);
+        let expected = original.predict(&model).unwrap();
+        let actual = restored.predict(&model).unwrap();
+        assert_eq!(actual, expected);
+        assert_eq!(actual.token, 57);
+        original.observe(&model, expected.token).unwrap();
+        restored.observe(&model, actual.token).unwrap();
+        assert_eq!(
+            serde_json::to_value(&restored.values).unwrap(),
+            serde_json::to_value(&original.values).unwrap()
+        );
+        assert!(restored.values.as_ref().unwrap().emission.is_none());
+    }
+}
+
+#[test]
+fn native_value_checkpoint_retains_numeric_records_and_open_scanner_after_token_eviction() {
+    let model = fixture(false);
+    let mut original = model.session(Control::Full).unwrap();
+    original.observe(&model, BOS).unwrap();
+    input(&mut original, &model, b"x = 13; y = 4; ");
+    input(&mut original, &model, &b"z ".repeat(40));
+    input(&mut original, &model, b"-922337203685477580");
+    let bytes = original.checkpoint().unwrap();
+    let mut restored = model.restore_session(&bytes).unwrap();
+    assert_eq!(restored.checkpoint().unwrap(), bytes);
+    assert!(restored.values.as_ref().unwrap().records.capacity() >= VALUES);
+    assert!(restored.values.as_ref().unwrap().sources.capacity() >= VALUES);
+    input(&mut original, &model, b"8; ");
+    input(&mut restored, &model, b"8; ");
+    assert_eq!(
+        restored
+            .values
+            .as_ref()
+            .unwrap()
+            .records
+            .last()
+            .unwrap()
+            .value,
+        i64::MIN
+    );
+    assert_eq!(
+        serde_json::to_value(&restored.values).unwrap(),
+        serde_json::to_value(&original.values).unwrap()
+    );
+    original.begin_response(&model).unwrap();
+    restored.begin_response(&model).unwrap();
+    assert_eq!(restored.values.as_ref().unwrap().sources.len(), 3);
+    assert_eq!(
+        restored.checkpoint().unwrap(),
+        original.checkpoint().unwrap()
+    );
+}
+
+#[test]
+fn native_value_checkpoint_rejects_malformed_scanner_records_queries_and_derivations() {
+    let model = fixture(false);
+    let original = emitting(&model);
+    let value: serde_json::Value = serde_json::from_slice(&original.checkpoint().unwrap()).unwrap();
+    let mutations: [fn(&mut serde_json::Value); 12] = [
+        |v| v["values"]["seen"] = 999.into(),
+        |v| v["values"]["recent_cursor"] = 32.into(),
+        |v| v["values"]["records"][0]["value"] = 14.into(),
+        |v| v["values"]["records"][0]["end"] = 999.into(),
+        |v| v["values"]["queries"][0]["pose"] = 120.into(),
+        |v| v["values"]["queries"][0]["token"] = u32::MAX.into(),
+        |v| v["values"]["emission"]["decision"]["value"] = 18.into(),
+        |v| v["values"]["emission"]["decision"]["operands"][0]["value"] = 14.into(),
+        |v| v["values"]["emission"]["numeral"]["tokens"][0] = 52.into(),
+        |v| v["values"]["emission"]["cursor"] = 20.into(),
+        |v| v["values"]["scanner"]["digits"] = 255.into(),
+        |v| v["values"]["pending"] = serde_json::Value::Null,
+    ];
+    for mutate in mutations {
+        let mut invalid = value.clone();
+        mutate(&mut invalid);
+        assert!(model
+            .restore_session(&serde_json::to_vec(&invalid).unwrap())
+            .is_err());
+    }
+    let mut open = model.session(Control::Full).unwrap();
+    input(&mut open, &model, b"-17");
+    let mut invalid: serde_json::Value =
+        serde_json::from_slice(&open.checkpoint().unwrap()).unwrap();
+    invalid["values"]["scanner"]["accumulated"] = (-18).into();
+    assert!(model
+        .restore_session(&serde_json::to_vec(&invalid).unwrap())
+        .is_err());
+}
+
+#[test]
+fn native_value_checkpoint_preserves_old_schema_laws_and_rejects_cross_schema_values() {
+    for response in [false, true] {
+        let mut model = fixture(response);
+        model.values = None;
+        model.refresh_identity().unwrap();
+        let mut session = model.session(Control::Full).unwrap();
+        session.observe(&model, BOS).unwrap();
+        let bytes = session.checkpoint().unwrap();
+        let mut wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            wire["schema"],
+            if response {
+                RESPONSE_SESSION_SCHEMA
+            } else {
+                LEGACY_SESSION_SCHEMA
+            }
+        );
+        assert!(wire.get("values").is_none());
+        assert_eq!(
+            model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+            bytes
+        );
+        wire["values"] = serde_json::Value::Null;
+        assert!(model
+            .restore_session(&serde_json::to_vec(&wire).unwrap())
+            .is_err());
+    }
+    let model = fixture(false);
+    let session = emitting(&model);
+    let mut wire: serde_json::Value =
+        serde_json::from_slice(&session.checkpoint().unwrap()).unwrap();
+    wire["schema"] = LEGACY_SESSION_SCHEMA.into();
+    wire.as_object_mut().unwrap().remove("values");
+    assert!(model
+        .restore_session(&serde_json::to_vec(&wire).unwrap())
+        .is_err());
+}
+
+#[test]
+fn native_value_checkpoint_validates_old_derivation_after_operand_and_token_eviction() {
+    let model = fixture(false);
+    let mut session = emitting(&model);
+    let next = session.predict(&model).unwrap();
+    session.observe(&model, next.token).unwrap();
+    session.end_response(&model).unwrap();
+    // Retain result write 2 as the oldest of sixteen numeric records while
+    // evicting both operand records 0 and 1 and all their raw token metadata.
+    for value in 0..15 {
+        input(&mut session, &model, format!(" {value};").as_bytes());
+    }
+    input(&mut session, &model, &b"z ".repeat(40));
+    let bytes = session.checkpoint().unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(wire["values"]["records"][0]["id"], 2);
+    assert_eq!(
+        wire["values"]["records"][0]["derivation"]["operand_ids"],
+        serde_json::json!([0, 1])
+    );
+    assert_eq!(
+        wire["values"]["records"][0]["derivation"]["operand_values"],
+        serde_json::json!([13, 4])
+    );
+    assert_eq!(
+        model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+        bytes
+    );
+    let mutations: [fn(&mut serde_json::Value); 6] = [
+        |v| v["values"]["records"][0]["derivation"] = serde_json::Value::Null,
+        |v| v["values"]["records"][0]["derived"] = false.into(),
+        |v| v["values"]["records"][0]["derivation"]["operand_ids"][0] = 2.into(),
+        |v| v["values"]["records"][0]["derivation"]["operand_values"][1] = 5.into(),
+        |v| v["values"]["records"][0]["derivation"]["action"] = "copy".into(),
+        |v| {
+            v["values"]["records"][0]["derivation"]["operand_values"] =
+                serde_json::json!([i64::MAX, 1])
+        },
+    ];
+    for mutate in mutations {
+        let mut invalid = wire.clone();
+        mutate(&mut invalid);
+        assert!(model
+            .restore_session(&serde_json::to_vec(&invalid).unwrap())
+            .is_err());
+    }
+}
+
+#[test]
+fn native_value_word_checkpoint_preserves_split_word_and_frozen_query_emission() {
+    let mut model = fixture(false);
+    model.values.as_mut().unwrap().schema = LEXEME_VALUE_SCHEMA.into();
+    model.refresh_identity().unwrap();
+    // Response boundaries separate words without inserting a source byte.
+    let mut boundary = model.session(Control::Full).unwrap();
+    input(&mut boundary, &model, b"suri");
+    boundary.begin_response(&model).unwrap();
+    boundary.end_response(&model).unwrap();
+    input(&mut boundary, &model, b"tavi");
+    let bytes = boundary.checkpoint().unwrap();
+    assert_eq!(
+        model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+        bytes
+    );
+    boundary.begin_response(&model).unwrap();
+    let bytes = boundary.checkpoint().unwrap();
+    assert_eq!(
+        model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+        bytes
+    );
+    let mut original = model.session(Control::Full).unwrap();
+    original.observe(&model, BOS).unwrap();
+    input(&mut original, &model, b"left = 13; righ");
+    let bytes = original.checkpoint().unwrap();
+    let mut restored = model.restore_session(&bytes).unwrap();
+    assert_eq!(restored.checkpoint().unwrap(), bytes);
+    for session in [&mut original, &mut restored] {
+        input(session, &model, b"t = 4; total");
+        session.begin_response(&model).unwrap();
+        let values = session.values.as_mut().unwrap();
+        let words = values.lexemes.as_ref().unwrap();
+        assert_eq!(words.query_len, 3);
+        assert_eq!(&words.queries[0].bytes[..5], b"total");
+        assert_eq!(&values.sources[1].lexical.unwrap()[0].bytes[..5], b"right");
+        values.pending = Some(ValueDecision {
+            action: ValueAction::Add,
+            operands: [values.sources[0], values.sources[1]],
+            value: 17,
+            write_id: values.next_id,
+            token: 51,
+            cursor: 0,
+            score: 1,
+            at_seen: values.seen,
+        });
+        session.observe(&model, 51).unwrap();
+    }
+    assert_eq!(
+        original.checkpoint().unwrap(),
+        restored.checkpoint().unwrap()
+    );
+    let bytes = original.checkpoint().unwrap();
+    let mut restored = model.restore_session(&bytes).unwrap();
+    assert_eq!(restored.checkpoint().unwrap(), bytes);
+    let expected = original.predict(&model).unwrap();
+    let actual = restored.predict(&model).unwrap();
+    assert_eq!(actual, expected);
+    original.observe(&model, expected.token).unwrap();
+    restored.observe(&model, actual.token).unwrap();
+    assert_eq!(
+        original.values.as_ref().unwrap().lexemes,
+        restored.values.as_ref().unwrap().lexemes
+    );
+    for session in [&mut original, &mut restored] {
+        session.end_response(&model).unwrap();
+        input(session, &model, &b"padding ".repeat(40));
+    }
+    let bytes = original.checkpoint().unwrap();
+    assert_eq!(
+        model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+        bytes
+    );
+    // The inherited /4 snapshot rebuilds postings from retained tokens and
+    // omits obsolete posting rows. A later prediction can therefore record
+    // fewer stale rejections than uninterrupted execution. Preserve every
+    // other checkpoint field and cost counter, including the full typed
+    // state; only this physical-index diagnostic has a different replay law.
+    let mut original_wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let mut restored_wire: serde_json::Value =
+        serde_json::from_slice(&restored.checkpoint().unwrap()).unwrap();
+    let original_stale = original_wire["work"]
+        .as_object_mut()
+        .unwrap()
+        .remove("memory_stale_rejections")
+        .unwrap();
+    let restored_stale = restored_wire["work"]
+        .as_object_mut()
+        .unwrap()
+        .remove("memory_stale_rejections")
+        .unwrap();
+    assert!(restored_stale.as_u64().unwrap() <= original_stale.as_u64().unwrap());
+    assert_eq!(restored_wire, original_wire);
+    original.begin_response(&model).unwrap();
+    restored.begin_response(&model).unwrap();
+    assert_eq!(
+        restored.predict(&model).unwrap(),
+        original.predict(&model).unwrap()
+    );
+    assert_eq!(restored.value_decision(), original.value_decision());
+}
+
+#[test]
+fn native_value_word_checkpoint_rejects_missing_fields_and_malformed_atoms_without_changing_v1() {
+    let legacy = fixture(false);
+    let legacy_session = emitting(&legacy);
+    let legacy_bytes = legacy_session.checkpoint().unwrap();
+    let mut legacy_wire: serde_json::Value = serde_json::from_slice(&legacy_bytes).unwrap();
+    assert!(legacy_wire["values"].get("lexemes").is_none());
+    assert!(legacy_wire["values"]["records"][0].get("lexical").is_none());
+    assert_eq!(
+        legacy
+            .restore_session(&legacy_bytes)
+            .unwrap()
+            .checkpoint()
+            .unwrap(),
+        legacy_bytes
+    );
+    legacy_wire["values"]["lexemes"] = serde_json::Value::Null;
+    assert!(legacy
+        .restore_session(&serde_json::to_vec(&legacy_wire).unwrap())
+        .is_err());
+    let mut model = fixture(false);
+    model.values.as_mut().unwrap().schema = LEXEME_VALUE_SCHEMA.into();
+    model.refresh_identity().unwrap();
+    let original = emitting(&model);
+    let wire: serde_json::Value = serde_json::from_slice(&original.checkpoint().unwrap()).unwrap();
+    assert_eq!(
+        model
+            .restore_session(&serde_json::to_vec(&wire).unwrap())
+            .unwrap()
+            .checkpoint()
+            .unwrap(),
+        original.checkpoint().unwrap()
+    );
+    let mutations: [fn(&mut serde_json::Value); 9] = [
+        |v| {
+            v["values"].as_object_mut().unwrap().remove("lexemes");
+        },
+        |v| {
+            v["values"]["records"][0]
+                .as_object_mut()
+                .unwrap()
+                .remove("lexical");
+        },
+        |v| v["values"]["sources"][0]["lexical"] = serde_json::Value::Null,
+        |v| v["values"]["lexemes"]["source_bytes_seen"] = 999.into(),
+        |v| v["values"]["lexemes"]["recent"][0]["len"] = 33.into(),
+        |v| v["values"]["lexemes"]["recent"][0]["bytes"][31] = 1.into(),
+        |v| v["values"]["lexemes"]["queries"][0]["end"] = 999.into(),
+        |v| v["values"]["records"][0]["lexical"][0]["bytes"][0] = b'z'.into(),
+        |v| v["values"]["emission"]["decision"]["operands"][0]["lexical"] = serde_json::Value::Null,
+    ];
+    for mutate in mutations {
+        let mut invalid = wire.clone();
+        mutate(&mut invalid);
+        assert!(model
+            .restore_session(&serde_json::to_vec(&invalid).unwrap())
+            .is_err());
+    }
+    let mut pending = model.session(Control::Full).unwrap();
+    input(&mut pending, &model, b"left = 13; righ");
+    let mut invalid: serde_json::Value =
+        serde_json::from_slice(&pending.checkpoint().unwrap()).unwrap();
+    invalid["values"]["lexemes"]["scanner"]["pending"]["bytes"][0] = b'z'.into();
+    assert!(model
+        .restore_session(&serde_json::to_vec(&invalid).unwrap())
+        .is_err());
+}
+
+#[test]
+fn native_value_word_checkpoint_checks_early_whole_lexical_token_bytes() {
+    let mut model = fixture(false);
+    model.values.as_mut().unwrap().schema = LEXEME_VALUE_SCHEMA.into();
+    model.refresh_identity().unwrap();
+    let word_tokens = model.encode(" value").unwrap();
+    assert_eq!(word_tokens.len(), 1);
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(&model, BOS).unwrap();
+    session.observe(&model, word_tokens[0]).unwrap();
+    for token in model.encode(" 13").unwrap() {
+        session.observe(&model, token).unwrap();
+    }
+    session.begin_response(&model).unwrap();
+    let values = session.values.as_ref().unwrap();
+    let atom = values.lexemes.as_ref().unwrap().recent[0];
+    assert_eq!(atom.end, 1);
+    assert_eq!(atom.len, 5);
+    assert_eq!(values.recent_len as u64, values.seen);
+    let bytes = session.checkpoint().unwrap();
+    assert_eq!(
+        model.restore_session(&bytes).unwrap().checkpoint().unwrap(),
+        bytes
+    );
+
+    // Change all copies together so shape, frozen-state and source-cue
+    // equality still agree. The retained original token must reject them.
+    let mut invalid: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    invalid["values"]["lexemes"]["recent"][0]["bytes"][0] = b'w'.into();
+    invalid["values"]["lexemes"]["queries"][0]["bytes"][0] = b'w'.into();
+    invalid["values"]["records"][0]["lexical"][0]["bytes"][0] = b'w'.into();
+    invalid["values"]["sources"][0]["lexical"][0]["bytes"][0] = b'w'.into();
+    let error = model
+        .restore_session(&serde_json::to_vec(&invalid).unwrap())
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("word payload differs from retained source bytes"));
+}

--- a/crates/uor-r4-core/src/native_geometric/value_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_training.rs
@@ -1,0 +1,443 @@
+//! Offline Rust learning for the optional typed operand/action selector.
+//! Targets label output bytes only. Operand identity and operation are latent;
+//! all positive credit goes to naturally admitted complete-value alternatives.
+use super::numeral::NUMERAL_CODEC;
+use super::value_runtime::execute;
+use super::value_types::*;
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueExample {
+    pub id: String,
+    pub prompt: String,
+    pub response: String,
+}
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueFitConfig {
+    pub epochs: usize,
+    pub learning_rate: f64,
+    pub max_features: usize,
+}
+impl Default for ValueFitConfig {
+    fn default() -> Self {
+        Self {
+            epochs: 24,
+            learning_rate: 0.1,
+            max_features: 65_536,
+        }
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValueFitReport {
+    pub schema: String,
+    pub examples: usize,
+    pub eligible_examples: usize,
+    pub numeric_targets: usize,
+    pub reachable_numeric_targets: usize,
+    pub no_write_targets: usize,
+    pub learned_features: usize,
+    pub dropped_features: usize,
+    pub epochs: usize,
+    pub selected_epoch: usize,
+    pub fit_correct: usize,
+    pub continuation_positions: usize,
+    pub loss: f64,
+    pub config: ValueFitConfig,
+    pub artifact_cid: String,
+}
+struct Alternative {
+    features: Vec<usize>,
+    correct: bool,
+}
+struct Example {
+    alternatives: Vec<Alternative>,
+    baseline_correct: bool,
+}
+
+fn target_integer(text: &str) -> Option<(i64, usize)> {
+    let bytes = text.as_bytes();
+    let mut end = usize::from(matches!(bytes.first(), Some(b'+' | b'-')));
+    let start = end;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    if end == start
+        || bytes
+            .get(end)
+            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        || (bytes.get(end) == Some(&b'.')
+            && bytes.get(end + 1).is_some_and(|b| !b.is_ascii_whitespace()))
+    {
+        return None;
+    }
+    text[..end].parse().ok().map(|n| (n, end))
+}
+impl ValueModel {
+    pub(super) fn validate(&self) -> Result<()> {
+        if ![VALUE_SCHEMA, LEXEME_VALUE_SCHEMA].contains(&self.schema.as_str())
+            || self.codec != NUMERAL_CODEC
+            || self.capacity != VALUES
+            || self.rows.len() > 262_144
+            || self.rows.windows(2).any(|p| p[0].feature >= p[1].feature)
+            || self.rows.iter().any(|r| {
+                r.feature.kind
+                    > if self.schema == LEXEME_VALUE_SCHEMA {
+                        16
+                    } else {
+                        15
+                    }
+                    || !(-1_000_000..=1_000_000).contains(&r.weight)
+            })
+            || !(0..=1_000_000).contains(&self.continuation_score)
+            || self
+                .training
+                .iter()
+                .map(|r| &r.id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                != self.training.len()
+            || (!self.training.is_empty()
+                && (!(1..=256).contains(&self.fit_config[0])
+                    || !(0.0001..=1.0).contains(&f64::from_bits(self.fit_config[1]))
+                    || !(1..=262_144).contains(&self.fit_config[2])
+                    || self.fit_config[3] == 0
+                    || self.fit_config[3] > self.fit_config[0]))
+        {
+            return Err(Error("invalid typed-value operator artifact".into()));
+        }
+        Ok(())
+    }
+}
+impl Model {
+    pub fn value_operator_version(&self) -> Option<&str> {
+        self.values.as_ref().map(|v| v.schema.as_str())
+    }
+    pub fn value_training(&self) -> &[DocumentReceipt] {
+        self.values.as_ref().map_or(&[], |v| v.training.as_slice())
+    }
+    pub fn fit_values(
+        &self,
+        documents: &[ValueExample],
+        config: ValueFitConfig,
+    ) -> Result<(Model, ValueFitReport)> {
+        self.fit_values_impl(documents, config, false)
+    }
+    /// Learn the versioned whole-lexeme relation while preserving `/1` fitting.
+    pub fn fit_values_with_lexeme_cues(
+        &self,
+        documents: &[ValueExample],
+        config: ValueFitConfig,
+    ) -> Result<(Model, ValueFitReport)> {
+        self.fit_values_impl(documents, config, true)
+    }
+    fn fit_values_impl(
+        &self,
+        documents: &[ValueExample],
+        config: ValueFitConfig,
+        lexeme_cues: bool,
+    ) -> Result<(Model, ValueFitReport)> {
+        if self.values.is_some()
+            || documents.is_empty()
+            || documents.len() > 4096
+            || !(1..=256).contains(&config.epochs)
+            || !config.learning_rate.is_finite()
+            || !(0.0001..=1.0).contains(&config.learning_rate)
+            || !(1..=262_144).contains(&config.max_features)
+            || documents
+                .iter()
+                .map(|d| d.prompt.len() + d.response.len())
+                .sum::<usize>()
+                > 16 * 1024 * 1024
+        {
+            return Err(Error(
+                "invalid typed-value fit configuration/source or already fitted component".into(),
+            ));
+        }
+        let mut model = self.clone();
+        model.values = Some(ValueModel {
+            schema: if lexeme_cues {
+                LEXEME_VALUE_SCHEMA
+            } else {
+                VALUE_SCHEMA
+            }
+            .into(),
+            codec: NUMERAL_CODEC.into(),
+            capacity: VALUES,
+            rows: Vec::new(),
+            continuation_score: 0,
+            fit_config: [0; 4],
+            training: Vec::new(),
+        });
+        model.refresh_identity()?;
+        let mut registry = BTreeMap::<ValueFeature, usize>::new();
+        let mut weights = Vec::<f64>::new();
+        let mut examples = Vec::new();
+        let mut receipts = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut prompts = BTreeMap::new();
+        let mut numeric = 0;
+        let mut reachable = 0;
+        let mut no_write = 0;
+        let mut dropped = 0;
+        let mut continuation_positions = 0;
+        for document in documents {
+            if document.id.trim().is_empty()
+                || !ids.insert(&document.id)
+                || prompts
+                    .insert(&document.prompt, &document.response)
+                    .is_some_and(|prior| prior != &document.response)
+            {
+                return Err(Error(
+                    "typed-value source IDs or prompt targets conflict".into(),
+                ));
+            }
+            let combined = Document {
+                id: document.id.clone(),
+                text: serde_json::to_string(&(&document.prompt, &document.response))
+                    .map_err(|error| Error(error.to_string()))?,
+            };
+            let receipt = super::training::receipt(&combined);
+            let whole = super::training::receipt(&Document {
+                id: document.id.clone(),
+                text: format!("{}{}", document.prompt, document.response),
+            });
+            if self
+                .construction
+                .iter()
+                .chain(self.readout_training())
+                .chain(self.memory_read_training())
+                .any(|known| {
+                    known.id == document.id
+                        || known.text_cid == receipt.text_cid
+                        || known.text_cid == whole.text_cid
+                })
+            {
+                return Err(Error(
+                    "typed-value fitting source overlaps previous model training".into(),
+                ));
+            }
+            receipts.push(receipt);
+            let mut session = model.session(Control::Full)?;
+            session.observe(&model, BOS)?;
+            for token in model.encode(&document.prompt)? {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            let target = target_integer(&document.response);
+            numeric += usize::from(target.is_some());
+            no_write += usize::from(target.is_none());
+            let state = session
+                .values
+                .as_ref()
+                .ok_or_else(|| Error("typed state unavailable".into()))?;
+            let mut alternatives = Vec::new();
+            let mut any_correct = false;
+            for index in 0..272 {
+                let Some((action, a, b)) = state.proposal(index) else {
+                    continue;
+                };
+                let mut work = ValueWork::default();
+                let Some(value) = execute(action, a.value, b.value, &mut work) else {
+                    continue;
+                };
+                let correct = target.is_some_and(|t| {
+                    t.0 == value
+                        && super::numeral::Numeral::from_zphi(
+                            crate::prime_route_attention::ZPhi::new(value, 0),
+                        )
+                        .is_some_and(|n| {
+                            n.len as usize == t.1
+                                && n.as_tokens()
+                                    .iter()
+                                    .zip(document.response.as_bytes())
+                                    .all(|(token, byte)| *token == u32::from(*byte) + 2)
+                        })
+                });
+                any_correct |= correct;
+                let (features, len) =
+                    state.features(&model, action, a, b, Control::Full, &mut work);
+                let mut indices = Vec::with_capacity(len);
+                for &feature in &features[..len] {
+                    let index = if let Some(&index) = registry.get(&feature) {
+                        Some(index)
+                    } else if weights.len() < config.max_features {
+                        let index = weights.len();
+                        registry.insert(feature, index);
+                        weights.push(if feature.kind == 0 { -2.0 } else { 0.0 });
+                        Some(index)
+                    } else {
+                        dropped += 1;
+                        None
+                    };
+                    if let Some(index) = index {
+                        indices.push(index);
+                    }
+                }
+                alternatives.push(Alternative {
+                    features: indices,
+                    correct,
+                });
+            }
+            if target.is_some() && !any_correct {
+                continue;
+            }
+            if any_correct {
+                reachable += 1;
+                continuation_positions += target.map_or(0, |(_, n)| n.saturating_sub(1));
+            }
+            examples.push(Example {
+                alternatives,
+                baseline_correct: target.is_none(),
+            });
+        }
+        if examples.is_empty() {
+            return Err(Error(
+                "typed-value source has no admitted learning targets".into(),
+            ));
+        }
+        let mut best_weights = weights.clone();
+        let mut best_correct = 0;
+        let mut best_loss = f64::INFINITY;
+        let mut best_epoch = 0;
+        for epoch in 0..config.epochs {
+            for example in &examples {
+                let logits: Vec<f64> = example
+                    .alternatives
+                    .iter()
+                    .map(|a| a.features.iter().map(|&i| weights[i]).sum())
+                    .collect();
+                let maximum = logits.iter().copied().fold(0.0, f64::max);
+                let baseline = (-maximum).exp();
+                let exp: Vec<f64> = logits.iter().map(|&n| (n - maximum).exp()).collect();
+                let total = baseline + exp.iter().sum::<f64>();
+                let positive = if example.baseline_correct {
+                    baseline
+                } else {
+                    0.0
+                } + example
+                    .alternatives
+                    .iter()
+                    .zip(&exp)
+                    .filter(|(a, _)| a.correct)
+                    .map(|(_, p)| *p)
+                    .sum::<f64>();
+                for (alternative, p) in example.alternatives.iter().zip(exp) {
+                    let gradient = (if alternative.correct {
+                        p / positive
+                    } else {
+                        0.0
+                    }) - p / total;
+                    // Normalize update magnitude for a bounded feature list;
+                    // repeated cues retain their declared repeated contributions.
+                    let delta = config.learning_rate * gradient
+                        / (alternative.features.len().max(1) as f64).sqrt();
+                    for &index in &alternative.features {
+                        weights[index] = (weights[index] + delta).clamp(-3900.0, 3900.0);
+                    }
+                }
+            }
+            let (correct, loss) = measure(&examples, &weights);
+            if correct > best_correct || (correct == best_correct && loss < best_loss) {
+                best_correct = correct;
+                best_loss = loss;
+                best_epoch = epoch + 1;
+                best_weights.clone_from(&weights);
+            }
+        }
+        // Preserve actual SGD source order in the artifact; this order can
+        // change learned weights even when the source set is identical.
+        let mut continuation = 0.0_f64;
+        for _ in 0..config.epochs {
+            for _ in 0..continuation_positions {
+                continuation += config.learning_rate / (1.0 + continuation.exp());
+            }
+        }
+        let head = model
+            .values
+            .as_mut()
+            .ok_or_else(|| Error("typed head unavailable".into()))?;
+        head.rows = registry
+            .into_iter()
+            .map(|(feature, index)| ValueRow {
+                feature,
+                weight: (best_weights[index] * 256.0).round() as i32,
+            })
+            .collect();
+        head.continuation_score = (continuation * 256.0).round() as i32;
+        head.training = receipts;
+        head.fit_config = [
+            config.epochs as u64,
+            config.learning_rate.to_bits(),
+            config.max_features as u64,
+            best_epoch as u64,
+        ];
+        let quantized: Vec<f64> = best_weights
+            .iter()
+            .map(|w| (w * 256.0).round() / 256.0)
+            .collect();
+        let (best_correct, best_loss) = measure(&examples, &quantized);
+        model.refresh_identity()?;
+        model.validate()?;
+        let report = ValueFitReport {
+            schema: if lexeme_cues {
+                LEXEME_VALUE_SCHEMA
+            } else {
+                VALUE_SCHEMA
+            }
+            .into(),
+            examples: documents.len(),
+            eligible_examples: examples.len(),
+            numeric_targets: numeric,
+            reachable_numeric_targets: reachable,
+            no_write_targets: no_write,
+            learned_features: head_len(&model),
+            dropped_features: dropped,
+            epochs: config.epochs,
+            selected_epoch: best_epoch,
+            fit_correct: best_correct,
+            continuation_positions,
+            loss: best_loss,
+            config,
+            artifact_cid: model.artifact_cid.clone(),
+        };
+        Ok((model, report))
+    }
+}
+fn head_len(model: &Model) -> usize {
+    model.values.as_ref().map_or(0, |h| h.rows.len())
+}
+fn measure(examples: &[Example], weights: &[f64]) -> (usize, f64) {
+    let mut correct = 0;
+    let mut loss = 0.0;
+    for e in examples {
+        let mut best = 0.0;
+        let mut right = e.baseline_correct;
+        let logits: Vec<f64> = e
+            .alternatives
+            .iter()
+            .map(|a| a.features.iter().map(|&i| weights[i]).sum())
+            .collect();
+        for (a, &logit) in e.alternatives.iter().zip(&logits) {
+            if logit > best {
+                best = logit;
+                right = a.correct;
+            }
+        }
+        correct += usize::from(right);
+        let baseline = (-best).exp();
+        let mut total = baseline;
+        let mut positive = if e.baseline_correct { baseline } else { 0.0 };
+        for (a, logit) in e.alternatives.iter().zip(logits) {
+            let p = (logit - best).exp();
+            total += p;
+            if a.correct {
+                positive += p;
+            }
+        }
+        loss += (total / positive).ln();
+    }
+    (correct, loss / examples.len() as f64)
+}

--- a/crates/uor-r4-core/src/native_geometric/value_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_types.rs
@@ -1,0 +1,187 @@
+//! Artifact and fixed-capacity state for the optional typed-value operator.
+use super::numeral::{Numeral, Scanner};
+use super::value_lexemes::{LexemeState, WordAtom};
+use super::*;
+
+pub(super) const VALUE_SCHEMA: &str = "uor-r4.native-typed-value/1";
+pub(super) const LEXEME_VALUE_SCHEMA: &str = "uor-r4.native-typed-value/2";
+pub(super) const VALUES: usize = 16;
+pub(super) const QUERY: usize = 8;
+pub(super) const VALUE_FEATURES: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueAction {
+    Copy,
+    Add,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ValueWork {
+    pub input_bytes: u64,
+    pub literal_writes: u64,
+    pub record_evictions: u64,
+    pub proposals: u64,
+    pub additions: u64,
+    pub overflow_rejections: u64,
+    pub feature_lookups: u64,
+    pub feature_comparisons: u64,
+    pub cue_comparisons: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub lexical_comparisons: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub lexical_byte_comparisons: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub lexical_writes: u64,
+    pub h4_reads: u64,
+    pub phase_updates: u64,
+    pub numeral_steps: u64,
+    pub derived_writes: u64,
+    pub emission_commits: u64,
+    pub emission_mismatches: u64,
+}
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
+}
+impl ValueWork {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub(super) struct ValueFeature {
+    pub kind: u8,
+    pub a: u64,
+    pub b: u64,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ValueRow {
+    pub feature: ValueFeature,
+    pub weight: i32,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ValueModel {
+    pub schema: String,
+    pub codec: String,
+    pub capacity: usize,
+    pub rows: Vec<ValueRow>,
+    pub continuation_score: i32,
+    /// Epoch budget, exact f64 learning-rate bits, feature cap, selected epoch.
+    pub fit_config: [u64; 4],
+    pub training: Vec<DocumentReceipt>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ValueEntry {
+    pub sequence: u64,
+    pub token: u32,
+    pub cue: u32,
+    pub pose: u16,
+    pub phases: [u16; PHASE_CHANNELS],
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueDerivation {
+    pub action: ValueAction,
+    pub operand_ids: [u64; 2],
+    pub operand_values: [i64; 2],
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ValueRecord {
+    pub id: u64,
+    pub value: i64,
+    pub start: u64,
+    pub end: u64,
+    pub derived: bool,
+    pub derivation: Option<ValueDerivation>,
+    pub(super) cue: [u32; 4],
+    pub(super) pose: u16,
+    pub(super) phases: [u16; PHASE_CHANNELS],
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) lexical: Option<[WordAtom; 4]>,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueDecision {
+    pub action: ValueAction,
+    pub operands: [ValueRecord; 2],
+    pub value: i64,
+    pub write_id: u64,
+    pub token: u32,
+    pub cursor: u8,
+    pub score: i64,
+    pub at_seen: u64,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ValueEmission {
+    pub decision: ValueDecision,
+    pub numeral: Numeral,
+    pub cursor: u8,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ValueState {
+    pub scanner: Scanner,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lexemes: Option<LexemeState>,
+    pub recent: [ValueEntry; 32],
+    pub recent_len: usize,
+    pub recent_cursor: usize,
+    pub records: Vec<ValueRecord>,
+    pub sources: Vec<ValueRecord>,
+    pub next_id: u64,
+    pub seen: u64,
+    pub pose: u16,
+    pub phases: [u16; PHASE_CHANNELS],
+    pub active: bool,
+    pub consumed: bool,
+    pub started_at: u64,
+    pub queries: [ValueEntry; QUERY],
+    pub query_len: usize,
+    pub emission: Option<ValueEmission>,
+    #[serde(skip)]
+    pub pending: Option<ValueDecision>,
+}
+impl ValueState {
+    pub fn new(model: &Model) -> Self {
+        Self {
+            scanner: Scanner::default(),
+            lexemes: model
+                .values
+                .as_ref()
+                .filter(|head| head.schema == LEXEME_VALUE_SCHEMA)
+                .map(|_| LexemeState::default()),
+            recent: [ValueEntry::default(); 32],
+            recent_len: 0,
+            recent_cursor: 0,
+            records: Vec::with_capacity(VALUES),
+            sources: Vec::with_capacity(VALUES),
+            next_id: 0,
+            seen: 0,
+            pose: model.geometry.identity,
+            phases: [0; PHASE_CHANNELS],
+            active: false,
+            consumed: false,
+            started_at: 0,
+            queries: [ValueEntry::default(); QUERY],
+            query_len: 0,
+            emission: None,
+            pending: None,
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValueStateView {
+    pub active: bool,
+    pub retained_values: usize,
+    pub captured_values: usize,
+    pub committed_write: Option<u64>,
+    pub emission_cursor: Option<u8>,
+    pub storage_bytes: usize,
+}

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -7,7 +7,8 @@ use std::cell::Cell;
 
 use uor_r4_core::native_geometric::{
     Config, Control, Document, MemoryReadFitConfig, MemoryReadSchedule, MemoryReadSupervision,
-    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, Trainer, BOS, EOS,
+    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, Trainer, ValueExample,
+    ValueFitConfig, BOS, EOS,
 };
 
 struct CountingAllocator;
@@ -95,6 +96,7 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         "fn begin_response(",
         "fn end_response(",
         "fn response_decision(",
+        "fn value_decision(",
         "fn recent(",
         "fn features(",
         "fn score_candidate(",
@@ -155,11 +157,61 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "response kernel coverage includes {function}"
         );
     }
+    let value_runtime = include_str!("../src/native_geometric/value_runtime.rs");
+    for function in [
+        "fn observe(",
+        "fn begin(",
+        "fn end(",
+        "fn proposal(",
+        "fn features(",
+        "fn offer(",
+        "fn selected(",
+        "fn commit(",
+        "fn execute(",
+    ] {
+        assert_eq!(
+            value_runtime.matches(function).count(),
+            1,
+            "typed-value kernel coverage includes {function}"
+        );
+    }
+    let (_, numeral, _) = region(
+        include_str!("../src/native_geometric/numeral.rs"),
+        "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
+        "// NATIVE_GEOMETRIC_INTEGER_KERNEL_END",
+    );
+    let (_, lexemes, _) = region(
+        include_str!("../src/native_geometric/value_lexemes.rs"),
+        "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
+        "// NATIVE_GEOMETRIC_INTEGER_KERNEL_END",
+    );
+    for function in ["fn from_zphi(", "fn digit(", "fn feed(", "fn finish("] {
+        assert_eq!(
+            numeral.matches(function).count(),
+            1,
+            "numeral kernel coverage includes {function}"
+        );
+    }
+    // The only external project arithmetic called by typed execution is the
+    // existing exact checked coefficient addition; scan that actual method.
+    let zphi_source = include_str!("../src/prime_route_attention.rs");
+    let zphi = zphi_source.split_once("impl ZPhi {").unwrap().1;
+    let zphi_add = zphi
+        .split_once("pub fn checked_add(")
+        .unwrap()
+        .1
+        .split_once("/// Exact checked multiplication")
+        .unwrap()
+        .0;
     for (name, source) in [
         ("native runtime", kernel),
         ("native Feature helpers", features),
         ("native memory runtime", memory),
         ("native response runtime", response),
+        ("native typed-value runtime", value_runtime),
+        ("native numeral codec", numeral),
+        ("native whole-word codec", lexemes),
+        ("exact ZPhi checked addition", zphi_add),
     ] {
         assert!(
             !source.contains(ALLOW_MARKER),
@@ -176,6 +228,97 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "{name}: no kernel allowances are permitted"
         );
     }
+}
+
+#[test]
+fn native_typed_value_ingest_write_emission_and_eviction_are_allocation_free() {
+    typed_value_allocation_census(false);
+    typed_value_allocation_census(true);
+}
+
+fn typed_value_allocation_census(lexeme_cues: bool) {
+    let documents = [Document {
+        id: "typed-allocation-catalog".into(),
+        text: "left = 13; right = 4; total: 17 unknown".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 32,
+            candidate_limit: 8,
+            ..Config::default()
+        },
+        &documents,
+    )
+    .unwrap();
+    trainer.train_documents(&documents).unwrap();
+    let baseline = trainer.compile().unwrap();
+    let source = [ValueExample {
+        id: "typed-allocation-fit".into(),
+        prompt: "left = 13; right = 4; total:".into(),
+        response: "17".into(),
+    }];
+    let config = ValueFitConfig {
+        epochs: 64,
+        learning_rate: 0.25,
+        max_features: 4096,
+    };
+    let (model, _) = if lexeme_cues {
+        baseline.fit_values_with_lexeme_cues(&source, config)
+    } else {
+        baseline.fit_values(&source, config)
+    }
+    .unwrap();
+    let tokens = model.encode(&source[0].prompt).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    let before = session.state().values.unwrap().storage_bytes;
+
+    ALLOCATIONS.with(|count| count.set(0));
+    BYTES.with(|count| count.set(0));
+    MEASURING.with(|enabled| enabled.set(true));
+    let result = (|| {
+        session.observe(&model, BOS)?;
+        for &token in &tokens {
+            session.observe(&model, token)?;
+        }
+        session.begin_response(&model)?;
+        let first = session.predict(&model)?;
+        let selected = session.value_decision().is_some();
+        session.observe(&model, first.token)?;
+        // Interrupt a committed multi-byte value using a different teacher
+        // byte. It must clear the cursor without an allocating recovery path.
+        session.predict(&model)?;
+        session.observe(&model, u32::from(b'x') + 2)?;
+        session.end_response(&model)?;
+        for _ in 0..64 {
+            for &token in &tokens {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            for _ in 0..2 {
+                let prediction = session.predict(&model)?;
+                session.observe(&model, prediction.token)?;
+            }
+            session.end_response(&model)?;
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(selected)
+    })();
+    MEASURING.with(|enabled| enabled.set(false));
+    let allocations = ALLOCATIONS.with(Cell::get);
+    let bytes = BYTES.with(Cell::get);
+    assert!(result.unwrap(), "fixture must select a fitted typed result");
+    assert_eq!((allocations, bytes), (0, 0));
+    assert_eq!(session.state().values.unwrap().storage_bytes, before);
+    assert!(session.work.values.input_bytes > 0);
+    assert!(session.work.values.literal_writes > 16);
+    assert!(session.work.values.record_evictions > 0);
+    assert!(session.work.values.derived_writes > 0);
+    assert!(session.work.values.emission_commits > 0);
+    assert!(session.work.values.emission_mismatches > 0);
+    assert!(session.work.evictions > 0);
+    println!(
+        "typed-value census allocations={allocations} bytes={bytes} work={:?}",
+        session.work.values
+    );
 }
 
 #[test]

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -12,6 +12,28 @@ windows as instructions for new work. A negative binds its exact configuration;
 resource unavailability does not determine model quality. The recovered plan
 allows open development iteration under configurable cumulative machine budgets.
 
+## Native typed-value development (2026-09-05)
+
+The [typed-value record](native_geometric_typed_value_973.md) adds an optional
+bounded literal store, learned operand/action selection, exact integer-domain
+addition and causal decimal emission on the stronger `/4` model. Its first fit
+produces correct numerals on 12/12 prose and 8/12 Rust numeric development cases,
+versus zero with typed values disabled. Complete responses remain 2/16 prose
+and 0/16 Rust; all twenty inspected primary/control Rust sources fail compilation.
+All four paired source-name swaps fail. H4/zeta controls make the same primary
+typed selections, so these results establish no added typed-selection advantage
+from those features. The observed whole-word identity loss across byte fallback
+motivates the versioned `/2` lexical-cue correction recorded there. Its 192-case
+fit retains the original 128 examples and adds 64 construction name swaps.
+On reused open development it reaches 24/24 correct numeric targets and 4/4
+correct name-swap pairs; disabling whole-word scoring leaves 4/24 numerals.
+H4/zeta-disabled retain the same typed actions and operands as Full. Complete
+responses remain 2/16 prose and 0/16 Rust, with all 20 generated Rust sources
+still failing compilation. The remaining numeric failure begins after emission,
+where the scalar fitter has trained neither ordinary suffix nor EOS. These are
+bounded binding and feature-sensitivity results; final held-out qualification,
+general geometric advantage and both alpha capability groups remain unqualified.
+
 ## Native response-state development negatives (2026-09-05)
 
 The [response-state record](native_geometric_response_state_973.md) adds

--- a/docs/evidence/native_geometric_typed_value_973.json
+++ b/docs/evidence/native_geometric_typed_value_973.json
@@ -1,0 +1,2083 @@
+{
+  "schema": "uor-r4.native-geometric-typed-value-record/1",
+  "date": "2026-09-05",
+  "issue": 973,
+  "base_revision": "c5673901462017b5a07c18ef9f1f7d545b710f7f",
+  "status": "TYPED_VALUE_AND_WORD_BINDING_IMPLEMENTED_OPEN_DEVELOPMENT_NUMERALS_PASS_COMPLETE_GENERATION_NEGATIVE",
+  "scope": "Synthetic open development in prose and Rust on one native model path. Fit-2 reuses development feedback; no final held-out, alpha, general reasoning, general identity binding or geometric compute-advantage claim.",
+  "provenance": {
+    "worktree": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4",
+    "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+    "source_bound_at": "2026-09-05T07:27:19.376Z",
+    "record_frozen_at": "2026-09-05T07:39:32.559Z",
+    "identity_method": "SHA-256 of exact file bytes; artifact/data identities are recorded BLAKE3 identities. Source and final executable hashes independently rechecked at assembly. Base revision is not a protected-delivery head.",
+    "raw_files": [
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/source.json",
+        "bytes": 64388,
+        "sha256": "80a6e05e3a7e4f90d844cb471bf380440e492e74a589782724954f024bfe0b42"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/model.json",
+        "bytes": 9961101,
+        "sha256": "d846bf07ec7615eea047b419886d478904073a79560912a515df4194a908da24"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/fit-report.json",
+        "bytes": 539,
+        "sha256": "cac076fcd7717f66bc5eeb01361c7719b3cef8b916d7edb0f51870457c15cbfd"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/report.json",
+        "bytes": 1215932,
+        "sha256": "2f5fef4f9d6d8a708f369435f871bfa8465ca096d54df5bb7e229f59763a5bba"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/binding-controls-source.json",
+        "bytes": 4477,
+        "sha256": "01e53cf29521ae1c1ae67388ad759058ebf2651b2870e6b5718515ae47aabb64"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/binding-controls-report.json",
+        "bytes": 74670,
+        "sha256": "6b98accaab6f38dcd5f755a0708fc6c0209061ac66f511e33cfba32f4a2b09a8"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/source.json",
+        "bytes": 90946,
+        "sha256": "10b69bfbbd89161032d80905306247b8a2e72ee098ab8f487932827f45d90352"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/model.json",
+        "bytes": 10006344,
+        "sha256": "8ef59f711edc8af333613b95bd7d1725665f74dc6283fa26e09066ba22810034"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/options.json",
+        "bytes": 423,
+        "sha256": "367487bb57faa690b69d031655cd57ac1404dcbc47732c72c3ded89168863347"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/fit-report.json",
+        "bytes": 542,
+        "sha256": "73ed63b38241799471deea1469aea4d7ba238ec945700c983f12a2039126a731"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/report.json",
+        "bytes": 4649315,
+        "sha256": "63707ef98a386908d00c7b1731dccd980616b396d6bd11db79d136f12f18fad9"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/binding-controls-source.json",
+        "bytes": 4684,
+        "sha256": "1a858a3cde98c19ecab16be42a4315e8f15f9d85b24e36ebf5da8c9a527cef22"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/binding-controls-report.json",
+        "bytes": 332338,
+        "sha256": "ef355b9633505cbdf1530b3011bad2a34051aebf06101d4ef23255c86c20cbb0"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-final/source.json",
+        "bytes": 64388,
+        "sha256": "80a6e05e3a7e4f90d844cb471bf380440e492e74a589782724954f024bfe0b42"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-final/model.json",
+        "bytes": 9961101,
+        "sha256": "d846bf07ec7615eea047b419886d478904073a79560912a515df4194a908da24"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-final/report.json",
+        "bytes": 1216204,
+        "sha256": "61b606993973994b7975c8071ad017b79868d1eec57de3c8db04eaac7bb105da"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-final-preservation.json",
+        "bytes": 1089,
+        "sha256": "34c52eb58d00fb636000972b75940b7e8e9017d2c38de379e2cfee549e6a1c12"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2-analysis.json",
+        "bytes": 91292,
+        "sha256": "d18e7b94cffad1f8576b0dbfbf6190322ecbc263eb875d106e62ccd3875f738c"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-1/report.json",
+        "bytes": 17931,
+        "sha256": "1801c933dd838f8c985c20f1ca8bdfa7a815307e532285a43399537c7beb2f73"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-2/report.json",
+        "bytes": 17932,
+        "sha256": "aeda5c483d452f88c20a3def8609906611e2bf362412ce9ce7e170646534517a"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/final-rust-source-identities.json",
+        "bytes": 3381,
+        "sha256": "f0e1aae6b98af476deb3227685f2d2437940823064232c8c62f2f00ccc709ae5"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/final-binary-identities.json",
+        "bytes": 578,
+        "sha256": "14ff07e51cddb2fbe15d8a53f4b7ebab9355c2da34c76de8fb328a927cfd5d1f"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-binary-identities.json",
+        "bytes": 638,
+        "sha256": "00b0dc0e66f232469bd6495c070ff921cef01afff7342084a4cc14341bafac4d"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-cli-artifact-sample.stdout.log",
+        "bytes": 22098,
+        "sha256": "4e65624166c0fe19e12bf0a9f2d978fefac10665d69cc5088d4e4ec18196b50f"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/resource-accounting.mjs",
+        "bytes": 3753,
+        "sha256": "3e45e35142bd546712af9924c57ab8aa87d9e2ea86d94e26bfeadd105d7eef5c"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/run-command.mjs",
+        "bytes": 5118,
+        "sha256": "2594bc09c8240266d4ab9d62cf53115481591cddaf3280d4edb053c981454389"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-generated.mjs",
+        "bytes": 1532,
+        "sha256": "56b5407520ff889e06196501fc7091a7530ff7c8236078e1aeb1049fbc67f582"
+      }
+    ],
+    "extraction": "Read-only aggregation of completed JSON reports and exact source/output bytes; counters summed over the declared cases. No new model or compiler execution during evidence extraction."
+  },
+  "mechanisms": {
+    "inherited_path": "The stronger matched memory-read /4 artifact remains the base. Optional /5 response-state and its two earlier negative fits are retained independently; the typed head does not replace their evidence.",
+    "source_ingestion": "Rust byte scanner retains exact signed i64 payloads, occurrence IDs, source token endpoints, prime cue addresses, cumulative H4 pose and eight fixed-zeta phase channels. It does not parse assignments, execute statements eagerly, or receive evaluator task/pair/answer labels.",
+    "retention": {
+      "numeric_records": 16,
+      "response_captured_records": 16,
+      "recent_token_metadata": 32,
+      "query_token_entries": 8,
+      "source_token_cues_per_operand": 4,
+      "word_atom_max_bytes": 32,
+      "query_words": 16,
+      "source_words_per_operand": 4,
+      "law": "Fixed retention; oldest typed records are evicted when full. Typed records can outlive the /4 token window. Exact bounded values and word cues are not a semantic multiscale abstraction. Unbounded text, longer word identity and evicted records are lost; general dependency graphs are absent."
+    },
+    "learned_selection": "Sparse integer feature rows learn Copy/Add and ordered operand selection versus a zero no-write threshold, using occurrence rank, derived provenance, token cue equality, H4 relative state and phase differences. /2 adds kind-16 query-position/source-word equality masks over exact whole words. Retained word bytes are not learned embeddings or a hash semantic metric. Per-word H4/phase metadata is retained but is not an additional kind-16 scoring term.",
+    "executed_operator": "Copy or checked exact Z[phi] addition restricted here to a+0*phi. Every admitted Add executes before selection. Overflow rejects the proposal. A positive proposal competes with the already evaluated ordinary candidate; at most one derived write per explicit response.",
+    "write_and_emission": "Commit a derived record only when the selected first numeral token is observed. Persist operand IDs/values and Copy/Add provenance. Spell signed decimals through a bounded integer table/subtraction path and learned positive continuation bias. Generated numeral bytes are not ingested as duplicate source literals; ordinary /4 generation supplies punctuation, code closure and EOS.",
+    "snapshot": "Typed session schema /3 preserves literal/word scanner state, source/query captures, cumulative typed geometry, derived provenance and partial emission through token-window eviction. Restore checks bounds, retained byte/geometry evidence, arithmetic derivations and exact numeral/cursor consistency. Old no-values /1 and /2 bytes retain their law; value-head /1 remains loadable. Missing /2 lexical state is rejected. User-provided state beyond retained evidence is not authenticated historical truth.",
+    "inference_training_boundary": "Offline Rust fitting uses floating-point optimization; serving uses bounded integer/table operations without provider/source-model access. The new fitted head does not lower a transformer. Allocation-free hot-path tests exclude initialization.",
+    "routing_boundary": "Bounded N-squared operand enumeration is not compute-saving sparse expert dispatch. Learned multiscale abstraction and inference savings remain unimplemented; every admitted Add currently executes before learned selection."
+  },
+  "data_and_design": {
+    "fit1_cases": 128,
+    "fit2_cases": 192,
+    "fit2_additional_cases": 64,
+    "primary_development_cases": 32,
+    "primary_development_families": [
+      "prose",
+      "rust"
+    ],
+    "fit_worlds": 16,
+    "development_worlds": 4,
+    "shared_templates": true,
+    "world_and_document_ids_disjoint": true,
+    "fit2_reuses_development_after_design_feedback": true,
+    "final_held_out": "NOT_RUN",
+    "scope": "Small finite synthetic open development with shared templates, different names/values and disjoint world/document IDs. Counterfactual pairs change one relevant input literal. Both families share one fitted artifact. Task and pair labels are evaluator-only. The dependency examples test response-time original-occurrence binding; they do not demonstrate eager statement execution, arbitrary Rust interpretation, retention beyond eviction or alpha. Source /2 appends context-only copy/add name swaps to the unchanged /1 fit cases, with fixed numeric source order and query bytes but changed correct operands. Whole-word cues are an explicit model variant. The unchanged primary development cases and four binding controls have already informed this design and are reused OPEN development feedback, not sealed or final held-out evaluation.",
+    "tokenization_law": "Numeric responses begin with exact signed decimal bytes, without an implicit leading space. Their punctuation and closing code are ordinary generated output. Leading-numeral accuracy and complete byte equality are separate from canonical lexical-token accuracy. No suffix or answer template is appended to generated output.",
+    "source_comparison": {
+      "original128fit_identical": true,
+      "primary32_identical": true,
+      "binding_pairs_raw_rows_identical": true,
+      "fit_cases": 192,
+      "development_cases": 32,
+      "changed_model_keys_vs_fit1": [
+        "artifact_cid",
+        "uor_model_address",
+        "values"
+      ]
+    }
+  },
+  "fits": [
+    {
+      "name": "fit-1",
+      "artifact_cid": "blake3:b95c1a33dfc604864baf21a323233217eae26d0ffa0d2f0f4c5755ae53616aae",
+      "input_artifact_cid": "blake3:9bfcd5f46ced60dd70aff50637cde64ffd8312d9e10c1430bbc7f22761f78264",
+      "source_blake3": "5286c324b14ef481f4e750fba237e068b188aca75118bc6b18f248749287c0fd",
+      "source_schema": "uor-r4.native-typed-value-source/1",
+      "fit_report": {
+        "artifact_cid": "blake3:b95c1a33dfc604864baf21a323233217eae26d0ffa0d2f0f4c5755ae53616aae",
+        "config": {
+          "epochs": 24,
+          "learning_rate": 0.1,
+          "max_features": 65536
+        },
+        "continuation_positions": 128,
+        "dropped_features": 0,
+        "eligible_examples": 128,
+        "epochs": 24,
+        "examples": 128,
+        "fit_correct": 128,
+        "learned_features": 3263,
+        "loss": 0.01790088921074832,
+        "no_write_targets": 32,
+        "numeric_targets": 96,
+        "reachable_numeric_targets": 96,
+        "schema": "uor-r4.native-typed-value/1",
+        "selected_epoch": 24
+      },
+      "development_cases": 32,
+      "arms": [
+        {
+          "control": "full",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 2,
+            "generated_tokens": 424,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 8,
+            "exact_responses": 0,
+            "generated_tokens": 303,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 10,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "values_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 0,
+            "exact_responses": 0,
+            "generated_tokens": 467,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 0,
+            "exact_responses": 0,
+            "generated_tokens": 402,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 0,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "h4_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 0,
+            "generated_tokens": 512,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 8,
+            "exact_responses": 0,
+            "generated_tokens": 512,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 10,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "zeta_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 1,
+            "generated_tokens": 463,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 8,
+            "exact_responses": 0,
+            "generated_tokens": 366,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 10,
+          "numeric_pairs_total": 12
+        }
+      ],
+      "binding_pairs": [
+        {
+          "pair_id": "typed-value/binding/prose/copy_current",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": false,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": false,
+          "cases": [
+            {
+              "id": "typed-value/binding/prose/copy_current/original",
+              "expected_leading_numeral": "73",
+              "actual_leading_numeral": "73",
+              "first_selected": {
+                "action": "copy",
+                "value": 73,
+                "operand_ids": [
+                  2,
+                  2
+                ],
+                "operand_values": [
+                  73,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/prose/copy_current/source_names_swapped",
+              "expected_leading_numeral": "301",
+              "actual_leading_numeral": "73",
+              "first_selected": {
+                "action": "copy",
+                "value": 73,
+                "operand_ids": [
+                  2,
+                  2
+                ],
+                "operand_values": [
+                  73,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/prose/add",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": false,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": false,
+          "cases": [
+            {
+              "id": "typed-value/binding/prose/add/original",
+              "expected_leading_numeral": "77",
+              "actual_leading_numeral": "77",
+              "first_selected": {
+                "action": "add",
+                "value": 77,
+                "operand_ids": [
+                  1,
+                  0
+                ],
+                "operand_values": [
+                  4,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/prose/add/source_names_swapped",
+              "expected_leading_numeral": "374",
+              "actual_leading_numeral": "77",
+              "first_selected": {
+                "action": "add",
+                "value": 77,
+                "operand_ids": [
+                  1,
+                  0
+                ],
+                "operand_values": [
+                  4,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/rust/copy_current",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": false,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": true,
+          "cases": [
+            {
+              "id": "typed-value/binding/rust/copy_current/original",
+              "expected_leading_numeral": "73",
+              "actual_leading_numeral": "73",
+              "first_selected": {
+                "action": "copy",
+                "value": 73,
+                "operand_ids": [
+                  2,
+                  2
+                ],
+                "operand_values": [
+                  73,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+              "expected_leading_numeral": "301",
+              "actual_leading_numeral": "332",
+              "first_selected": {
+                "action": "add",
+                "value": 332,
+                "operand_ids": [
+                  1,
+                  0
+                ],
+                "operand_values": [
+                  301,
+                  31
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/rust/add",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": false,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": false,
+          "cases": [
+            {
+              "id": "typed-value/binding/rust/add/original",
+              "expected_leading_numeral": "77",
+              "actual_leading_numeral": null,
+              "first_selected": null
+            },
+            {
+              "id": "typed-value/binding/rust/add/source_names_swapped",
+              "expected_leading_numeral": "374",
+              "actual_leading_numeral": null,
+              "first_selected": null
+            }
+          ]
+        }
+      ],
+      "binding_runs": 8,
+      "fit_includes_binding_runs": false,
+      "primary_metrics_include_binding_runs": false
+    },
+    {
+      "name": "fit-2",
+      "artifact_cid": "blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5",
+      "input_artifact_cid": "blake3:9bfcd5f46ced60dd70aff50637cde64ffd8312d9e10c1430bbc7f22761f78264",
+      "source_blake3": "7d234438ef98c976ed8af624487b849c02fce86b65e028cee8a9fde35b961713",
+      "source_schema": "uor-r4.native-typed-value-source/2",
+      "fit_report": {
+        "artifact_cid": "blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5",
+        "config": {
+          "epochs": 24,
+          "learning_rate": 0.1,
+          "max_features": 65536
+        },
+        "continuation_positions": 256,
+        "dropped_features": 0,
+        "eligible_examples": 192,
+        "epochs": 24,
+        "examples": 192,
+        "fit_correct": 192,
+        "learned_features": 3966,
+        "loss": 0.041390246523128865,
+        "no_write_targets": 32,
+        "numeric_targets": 160,
+        "reachable_numeric_targets": 160,
+        "schema": "uor-r4.native-typed-value/2",
+        "selected_epoch": 24
+      },
+      "development_cases": 32,
+      "arms": [
+        {
+          "control": "full",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 2,
+            "generated_tokens": 424,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 0,
+            "generated_tokens": 263,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 12,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "values_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 0,
+            "exact_responses": 0,
+            "generated_tokens": 467,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 0,
+            "exact_responses": 0,
+            "generated_tokens": 402,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 0,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "h4_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 0,
+            "generated_tokens": 512,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 0,
+            "generated_tokens": 512,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 12,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "zeta_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 1,
+            "generated_tokens": 463,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 12,
+            "exact_responses": 0,
+            "generated_tokens": 318,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 12,
+          "numeric_pairs_total": 12
+        },
+        {
+          "control": "value_lexemes_disabled",
+          "prose": {
+            "cases": 16,
+            "correct_leading_numerals": 4,
+            "exact_responses": 0,
+            "generated_tokens": 434,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "rust": {
+            "cases": 16,
+            "correct_leading_numerals": 0,
+            "exact_responses": 0,
+            "generated_tokens": 310,
+            "nonnumeric_cases": 4,
+            "nonnumeric_cases_with_leading_numerals": 0,
+            "numeric_cases": 12
+          },
+          "numeric_pairs_both_correct": 2,
+          "numeric_pairs_total": 12
+        }
+      ],
+      "binding_pairs": [
+        {
+          "pair_id": "typed-value/binding/prose/copy_current",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": true,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": true,
+          "cases": [
+            {
+              "id": "typed-value/binding/prose/copy_current/original",
+              "expected_leading_numeral": "73",
+              "actual_leading_numeral": "73",
+              "first_selected": {
+                "action": "copy",
+                "value": 73,
+                "operand_ids": [
+                  2,
+                  2
+                ],
+                "operand_values": [
+                  73,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/prose/copy_current/source_names_swapped",
+              "expected_leading_numeral": "301",
+              "actual_leading_numeral": "301",
+              "first_selected": {
+                "action": "copy",
+                "value": 301,
+                "operand_ids": [
+                  1,
+                  1
+                ],
+                "operand_values": [
+                  301,
+                  301
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/prose/add",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": true,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": true,
+          "cases": [
+            {
+              "id": "typed-value/binding/prose/add/original",
+              "expected_leading_numeral": "77",
+              "actual_leading_numeral": "77",
+              "first_selected": {
+                "action": "add",
+                "value": 77,
+                "operand_ids": [
+                  1,
+                  0
+                ],
+                "operand_values": [
+                  4,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/prose/add/source_names_swapped",
+              "expected_leading_numeral": "374",
+              "actual_leading_numeral": "374",
+              "first_selected": {
+                "action": "add",
+                "value": 374,
+                "operand_ids": [
+                  2,
+                  0
+                ],
+                "operand_values": [
+                  301,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/rust/copy_current",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": true,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": true,
+          "cases": [
+            {
+              "id": "typed-value/binding/rust/copy_current/original",
+              "expected_leading_numeral": "73",
+              "actual_leading_numeral": "73",
+              "first_selected": {
+                "action": "copy",
+                "value": 73,
+                "operand_ids": [
+                  2,
+                  2
+                ],
+                "operand_values": [
+                  73,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+              "expected_leading_numeral": "301",
+              "actual_leading_numeral": "301",
+              "first_selected": {
+                "action": "copy",
+                "value": 301,
+                "operand_ids": [
+                  1,
+                  1
+                ],
+                "operand_values": [
+                  301,
+                  301
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        },
+        {
+          "pair_id": "typed-value/binding/rust/add",
+          "control": "full",
+          "numeric_byte_runs_equal": true,
+          "query_bytes_equal": true,
+          "both_leading_numerals_correct": true,
+          "both_responses_exact": false,
+          "generated_leading_numeral_changed": true,
+          "cases": [
+            {
+              "id": "typed-value/binding/rust/add/original",
+              "expected_leading_numeral": "77",
+              "actual_leading_numeral": "77",
+              "first_selected": {
+                "action": "add",
+                "value": 77,
+                "operand_ids": [
+                  1,
+                  0
+                ],
+                "operand_values": [
+                  4,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            },
+            {
+              "id": "typed-value/binding/rust/add/source_names_swapped",
+              "expected_leading_numeral": "374",
+              "actual_leading_numeral": "374",
+              "first_selected": {
+                "action": "add",
+                "value": 374,
+                "operand_ids": [
+                  2,
+                  0
+                ],
+                "operand_values": [
+                  301,
+                  73
+                ],
+                "write_id": 3,
+                "cursor": 0
+              }
+            }
+          ]
+        }
+      ],
+      "binding_runs": 8,
+      "fit_includes_binding_runs": false,
+      "primary_metrics_include_binding_runs": false
+    }
+  ],
+  "controls_and_limits": {
+    "fit2_h4_and_zeta_primary_typed_selections_identical_to_full": true,
+    "fit2_value_lexemes_disabled_primary_selection_changes": 20,
+    "interpretation": [
+      "Fit2 is reused OPEN development, including the four source-name-swap pairs that informed the revision. It is not sealed/final held-out evaluation.",
+      "All four paired binding controls now select the changed intended source IDs at fixed numeric order and query bytes. The tiny fixed-template scope does not establish general binding or Rust interpretation.",
+      "Full vs ValueLexemesDisabled establishes within-artifact sensitivity to learned kind-16 query-position/source-word equality features; it does not compare separately fitted matched baselines.",
+      "Full, H4Disabled and ZetaDisabled have identical primary typed selections. No new typed-selection accuracy increment is attributable to H4 or zeta in this scope.",
+      "Fit1 to fit2 jointly changes whole-word state, features and 64 additional fit examples. Their individual contributions are not isolated.",
+      "The selector enumerates N squared Copy/Add proposals and executes every admitted Add before selection; it is not yet compute-saving expert dispatch or multiscale context abstraction.",
+      "Aggregated counters count named operations; their totals depend on generated length and do not include every control-flow, copying, allocation or serialization cost. Parent resource ledger owns process totals.",
+      "Next concrete model cause: learn the transition from a committed typed value into ordinary prose/code completion and termination using actual emitted histories, preserving raw response targets and open-development separation."
+    ]
+  },
+  "fit1_final_preservation": {
+    "status": "PASS",
+    "scope": "Identical /1 refit with final source/binary; raw source and model bytes, fit report, all case labels/outputs/tokens/stops/value traces and generation state/work match except the two documented fields below.",
+    "checks": {
+      "artifact_identity": true,
+      "source_bytes": true,
+      "model_bytes": true,
+      "binding_source_bytes": true
+    },
+    "case_control_runs": 136,
+    "artifact_cid": "blake3:b95c1a33dfc604864baf21a323233217eae26d0ffa0d2f0f4c5755ae53616aae",
+    "allowed_differences": {
+      "typed_storage_bytes": [
+        [
+          5952,
+          19304
+        ]
+      ],
+      "emission_mismatches": {
+        "before": 3463,
+        "after": 0,
+        "reason": "Final telemetry counts only real pending/interrupted emission mismatches; prior version also counted ordinary no-pending response tokens."
+      }
+    },
+    "source_receipt": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/final-rust-source-identities.json",
+    "binary_receipt": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/final-binary-identities.json"
+  },
+  "output_failure_localization": {
+    "numeric_cases": 24,
+    "numeral_emission_mismatches": 0,
+    "rows_by_family": [
+      {
+        "family": "prose",
+        "numeric_cases": 12,
+        "first_post_numeral_byte_or_eos_wrong": 8,
+        "exact_complete": 2
+      },
+      {
+        "family": "rust",
+        "numeric_cases": 12,
+        "first_post_numeral_byte_or_eos_wrong": 12,
+        "exact_complete": 0
+      }
+    ],
+    "observed": "Every numeric target is fully committed before the remaining failure. All twelve Rust responses fail immediately at the first ordinary suffix byte or EOS; prose has eight immediate suffix failures, two later failures and two exact responses. All eight NoWrite examples avoid typed writes but fail complete response equality.",
+    "source_supported": "value_training.rs supervises scalar selection and positive numeral continuation only, never suffix/EOS. value_runtime.rs sets consumed after one derived write; once numeral emission finishes, ordinary inherited /4 generation supplies all remaining bytes. Model components other than values and artifact addresses are unchanged from fit1.",
+    "token_history_example": {
+      "canonical_piece_text": "77",
+      "canonical_piece_token": 578,
+      "actual_typed_tokens": [
+        57,
+        57
+      ],
+      "limitation": "A real token-history difference. No matched recoding intervention was run, so its contribution is not separated from weak ordinary readout/query state."
+    }
+  },
+  "representative_examples": [
+    {
+      "id": "typed-value/development/prose/copy_current/100002",
+      "family": "prose",
+      "task": "copy_current",
+      "prompt": "User: suri had 32 coins. tavi has 302 coins.\nUser: Update: suri now has -78 coins.\nUser: How many coins does suri have now?\nAssistant:",
+      "expected_response": "-78.\n",
+      "actual_response": "-78.\n",
+      "exact_response": true,
+      "leading_numeral_correct": true,
+      "stop": "end_of_document",
+      "typed_selection": {
+        "action": "copy",
+        "value": -78,
+        "operand_ids": [
+          2,
+          2
+        ],
+        "operand_values": [
+          -78,
+          -78
+        ],
+        "write_id": 3,
+        "cursor": 0
+      }
+    },
+    {
+      "id": "typed-value/development/rust/add/100001",
+      "family": "rust",
+      "task": "add",
+      "prompt": "fn main() {\n    let suri = 76;\n    let orin = 4;\n    let tavi = 301;\n    assert_eq!(suri + orin,",
+      "expected_response": "80);\n}\n",
+      "actual_response": "80.\n",
+      "exact_response": false,
+      "leading_numeral_correct": true,
+      "stop": "end_of_document",
+      "typed_selection": {
+        "action": "add",
+        "value": 80,
+        "operand_ids": [
+          1,
+          0
+        ],
+        "operand_values": [
+          4,
+          76
+        ],
+        "write_id": 3,
+        "cursor": 0
+      }
+    },
+    {
+      "id": "typed-value/development/rust/add/100003",
+      "family": "rust",
+      "task": "add",
+      "prompt": "fn main() {\n    let suri = -75;\n    let orin = 5;\n    let tavi = 302;\n    assert_eq!(suri + orin,",
+      "expected_response": "-70);\n}\n",
+      "actual_response": "-70;\n}\n",
+      "exact_response": false,
+      "leading_numeral_correct": true,
+      "stop": "end_of_document",
+      "typed_selection": {
+        "action": "add",
+        "value": -70,
+        "operand_ids": [
+          1,
+          0
+        ],
+        "operand_values": [
+          5,
+          -75
+        ],
+        "write_id": 3,
+        "cursor": 0
+      }
+    }
+  ],
+  "generated_rust": [
+    {
+      "fit": "fit-1",
+      "report": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-1/report.json",
+      "compiled": 0,
+      "total": 20,
+      "execution": "NOT_RUN",
+      "scope": "Original generated source inspected before compiling, without edits. No executable run by this command."
+    },
+    {
+      "fit": "fit-2",
+      "report": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-2/report.json",
+      "compiled": 0,
+      "total": 20,
+      "execution": "NOT_RUN",
+      "scope": "Original generated source inspected before compiling, without edits. No executable run by this command."
+    }
+  ],
+  "actual_cli_sample": {
+    "source": {
+      "family": "rust",
+      "id": "typed-value/development/rust/add/100000",
+      "pair_id": "typed-value/development/rust/add/pair-0",
+      "prompt": "fn main() {\n    let suri = 73;\n    let orin = 4;\n    let tavi = 301;\n    assert_eq!(suri + orin,",
+      "response": "77);\n}\n",
+      "task": "add",
+      "variant": 0,
+      "world": 100000
+    },
+    "artifact_cid": "blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5",
+    "actual_text": "77.. User... User: User. User:.. 100",
+    "stop": "end_of_document",
+    "token_ids": [
+      57,
+      57,
+      506,
+      506,
+      434,
+      506,
+      506,
+      506,
+      434,
+      594,
+      434,
+      506,
+      434,
+      594,
+      506,
+      506,
+      281
+    ],
+    "typed_trace": [
+      {
+        "action": "add",
+        "value": 77,
+        "operand_ids": [
+          1,
+          0
+        ],
+        "operand_values": [
+          4,
+          73
+        ],
+        "write_id": 3,
+        "cursor": 0
+      },
+      {
+        "action": "add",
+        "value": 77,
+        "operand_ids": [
+          1,
+          0
+        ],
+        "operand_values": [
+          4,
+          73
+        ],
+        "write_id": 3,
+        "cursor": 1
+      }
+    ],
+    "result": "Correct leading 77; remaining generated Rust suffix is incorrect."
+  },
+  "cost": {
+    "source_derived_bounds": {
+      "scope": "Named inner-operation bounds per initial or retry prediction at N=16, eight token query entries, sixteen word query entries and full features; not elapsed time or a complete scalar-instruction census. A NoWrite outcome leaves consumed=false, so later predictions repeat the full typed search; frozen response state does not cache this outcome.",
+      "proposal_address_slots": 272,
+      "valid_proposals": 256,
+      "copy_proposals": 16,
+      "ordered_add_proposals": 240,
+      "features_per_proposal_v1": 44,
+      "features_per_proposal_v2": 60,
+      "feature_buffer_capacity": 64,
+      "feature_table_lookups_v2": 15360,
+      "feature_table_comparisons_v2_fit2_upper_bound": 199680,
+      "comparison_bound_basis": "At most 13 binary-search comparisons per lookup for 3966 learned rows.",
+      "token_cue_comparisons": 16384,
+      "whole_word_comparisons": 32768,
+      "whole_word_byte_comparisons_upper_bound": 1048576,
+      "relative_h4_table_reads": 1024,
+      "phase_difference_updates": 4096,
+      "operand_rank_search_comparisons_upper_bound": 8192,
+      "numeral_visit_bound_per_format": 190,
+      "format_calls_for_committed_first_token": 2,
+      "maximum_emitted_numeral_bytes": 20,
+      "uncounted_work": "272 slot decoding and record lookups, fixed-capacity copies/shifts, scans and loop/control arithmetic, byte scanning, state updates, loading, allocation outside the hot path, snapshots and serialization. Appending at capacity shifts at most 15 records. Ordinary /4 candidate generation/scoring still executes before typed offers and during continued numeral emission; this computation is not replaced."
+    },
+    "measured_fit2_full_primary32": {
+      "typed": {
+        "additions": 572,
+        "cue_comparisons": 66048,
+        "derived_writes": 24,
+        "emission_commits": 60,
+        "emission_mismatches": 0,
+        "feature_comparisons": 784212,
+        "feature_lookups": 60324,
+        "h4_reads": 6914,
+        "input_bytes": 3772,
+        "lexical_byte_comparisons": 64600,
+        "lexical_comparisons": 119328,
+        "lexical_writes": 560,
+        "literal_writes": 96,
+        "numeral_steps": 9120,
+        "overflow_rejections": 0,
+        "phase_updates": 38800,
+        "proposals": 1032,
+        "record_evictions": 0
+      },
+      "ordinary_decoder": {
+        "anchor_table_reads": 3488,
+        "candidate_evaluations": 153797,
+        "candidate_offers": 266329,
+        "evictions": 0,
+        "feature_queries": 18252,
+        "h4_table_reads": 2786,
+        "matched_rows": 16788,
+        "memory_candidates": 51987,
+        "memory_composed_candidates": 15204,
+        "memory_composition_comparisons": 6543385,
+        "memory_composition_duplicate_features": 384376,
+        "memory_composition_feature_moves": 6267298,
+        "memory_composition_feature_offers": 935766,
+        "memory_cue_reads": 100680,
+        "memory_h4_reads": 366695,
+        "memory_index_reads": 122328,
+        "memory_index_writes": 43296,
+        "memory_phase_updates": 1269976,
+        "memory_score_lookups": 551390,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 702,
+        "observed_tokens": 2786,
+        "orientation_table_reads": 702,
+        "phase_additions": 22288,
+        "radial_square_reads": 33432,
+        "score_lookups": 3707783
+      },
+      "typed_storage_bytes": 19304,
+      "typed_storage_scope": "Reported fixed-capacity typed state and buffers; excludes artifact/model tables, ordinary /4 state, serialization and process overhead.",
+      "ordinary_state_buffer_bytes": 257280,
+      "ordinary_plus_typed_state_buffer_bytes": 276584,
+      "scope": "Full primary32 only. Totals depend on generated length; controls are not matched total-work/latency comparisons."
+    },
+    "per_control_typed_work": [
+      {
+        "control": "full",
+        "work": {
+          "additions": 572,
+          "cue_comparisons": 66048,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 784212,
+          "feature_lookups": 60324,
+          "h4_reads": 6914,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 64600,
+          "lexical_comparisons": 119328,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 38800,
+          "proposals": 1032,
+          "record_evictions": 0
+        }
+      },
+      {
+        "control": "values_disabled",
+        "work": {
+          "additions": 0,
+          "cue_comparisons": 0,
+          "derived_writes": 0,
+          "emission_commits": 0,
+          "emission_mismatches": 0,
+          "feature_comparisons": 0,
+          "feature_lookups": 0,
+          "h4_reads": 2962,
+          "input_bytes": 3772,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 0,
+          "overflow_rejections": 0,
+          "phase_updates": 23696,
+          "proposals": 0,
+          "record_evictions": 0
+        }
+      },
+      {
+        "control": "h4_disabled",
+        "work": {
+          "additions": 704,
+          "cue_comparisons": 82944,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 966420,
+          "feature_lookups": 74340,
+          "h4_reads": 3108,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 76216,
+          "lexical_comparisons": 148896,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 45600,
+          "proposals": 1296,
+          "record_evictions": 0
+        }
+      },
+      {
+        "control": "zeta_disabled",
+        "work": {
+          "additions": 678,
+          "cue_comparisons": 79616,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 814684,
+          "feature_lookups": 62668,
+          "h4_reads": 7852,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 73928,
+          "lexical_comparisons": 143072,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 23008,
+          "proposals": 1244,
+          "record_evictions": 0
+        }
+      },
+      {
+        "control": "value_lexemes_disabled",
+        "work": {
+          "additions": 1058,
+          "cue_comparisons": 112704,
+          "derived_writes": 20,
+          "emission_commits": 50,
+          "emission_mismatches": 0,
+          "feature_comparisons": 1007292,
+          "feature_lookups": 77484,
+          "h4_reads": 9887,
+          "input_bytes": 3772,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 7600,
+          "overflow_rejections": 0,
+          "phase_updates": 50920,
+          "proposals": 1761,
+          "record_evictions": 0
+        }
+      }
+    ],
+    "allocation_census": {
+      "schemas": [
+        "uor-r4.native-typed-value/1",
+        "uor-r4.native-typed-value/2"
+      ],
+      "steady_state_allocations": [
+        0,
+        0
+      ],
+      "allocated_bytes": [
+        0,
+        0
+      ],
+      "scope": "After initialization, including ingestion, write, continued emission, interruption and record eviction. Snapshot load and fitting are excluded."
+    }
+  },
+  "verification": {
+    "tests": [
+      {
+        "label": "value-core-tests-4",
+        "passed": 72,
+        "failed": 0,
+        "scope": "Before final snapshot retained-word validation fix.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-core-tests-4.log",
+          "bytes": 9233,
+          "sha256": "86c01ed2594c9e3e4661166c905f164d0400a7577c3bcb60aa915975f3991e07"
+        },
+        "command": {
+          "label": "value-core-tests-4",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "-p",
+            "uor-r4-core",
+            "--lib",
+            "native_geometric"
+          ],
+          "elapsed_ms": 94511,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4082790400
+        }
+      },
+      {
+        "label": "value-snapshot-tests-final",
+        "passed": 16,
+        "failed": 0,
+        "scope": "After final snapshot fix, including complete-history lexical-byte mutation regression.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-snapshot-tests-final.log",
+          "bytes": 2489,
+          "sha256": "8b9fe1eced76f46d547468ce26aca8955b6b9227b1a3431fb87f945d55530519"
+        },
+        "command": {
+          "label": "value-snapshot-tests-final",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "-p",
+            "uor-r4-core",
+            "--lib",
+            "native_value_"
+          ],
+          "elapsed_ms": 90138,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4094156800
+        }
+      },
+      {
+        "label": "value-allocation-tests-1",
+        "passed": 3,
+        "failed": 0,
+        "scope": "Both value schemas exercised with zero allocation after initialization; inherited native path coverage retained.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-allocation-tests-1.log",
+          "bytes": 29249,
+          "sha256": "47020ee42cfbc88ac0fbe5af9cdbe6f0e58c951336278add4365de7a039ea11a"
+        },
+        "command": {
+          "label": "value-allocation-tests-1",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "-p",
+            "uor-r4-core",
+            "--test",
+            "native_geometric_allocations",
+            "--",
+            "--nocapture"
+          ],
+          "elapsed_ms": 128281,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4076314624
+        }
+      },
+      {
+        "label": "value-context-tests-1",
+        "passed": 3,
+        "failed": 0,
+        "scope": "Windowed context checks.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-context-tests-1.log",
+          "bytes": 665,
+          "sha256": "7a18dd32ee661230c7cf364c1ea37ad64311522185dc1769cc54c4d808d4dc2b"
+        },
+        "command": {
+          "label": "value-context-tests-1",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "-p",
+            "uor-r4-core",
+            "--test",
+            "windowed_geometric_context"
+          ],
+          "elapsed_ms": 10832,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4073570304
+        }
+      },
+      {
+        "label": "value-probe-tests-1",
+        "passed": 4,
+        "failed": 0,
+        "scope": "Source/probe checks.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-probe-tests-1.log",
+          "bytes": 771,
+          "sha256": "700cec3abfe8de8278b82b697a45ed7d3cc8912ce051fbd5fd6a27ce69f57216"
+        },
+        "command": {
+          "label": "value-probe-tests-1",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "-p",
+            "uor-r4-core",
+            "--example",
+            "native_geometric_value_probe"
+          ],
+          "elapsed_ms": 1839,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4074692608
+        }
+      },
+      {
+        "label": "value-cli-tests-2",
+        "passed": 16,
+        "failed": 0,
+        "scope": "CLI and HTTP/service checks, including split numeral across requests and snapshot for both value schemas.",
+        "log": {
+          "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-cli-tests-2.log",
+          "bytes": 2864,
+          "sha256": "2ab51281593e29bd4f644497fa28599dac84417eb0f46b11db58b9213a4bd9b7"
+        },
+        "command": {
+          "label": "value-cli-tests-2",
+          "command": "/Users/casey.allard/.cargo/bin/cargo",
+          "args": [
+            "test",
+            "--offline",
+            "--bin",
+            "r4",
+            "native_geometric_"
+          ],
+          "elapsed_ms": 166944,
+          "code": 0,
+          "signal": null,
+          "stopped": null,
+          "peak_sampled_known_bytes": 4106371072
+        }
+      }
+    ],
+    "format": {
+      "status": "PASS",
+      "command": {
+        "label": "value-fmt-final",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "fmt",
+          "--check"
+        ],
+        "elapsed_ms": 3230,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4110757888
+      },
+      "log": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-fmt-final.log",
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "final_release": {
+      "status": "PASS",
+      "command": {
+        "label": "value-release-v2",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "build",
+          "--release",
+          "--offline",
+          "-p",
+          "uor-r4-wasm-router",
+          "--bin",
+          "r4",
+          "-p",
+          "uor-r4-core",
+          "--example",
+          "native_geometric_value_probe"
+        ],
+        "elapsed_ms": 314990,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4106371072
+      },
+      "log": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-release-v2.log",
+        "bytes": 1011,
+        "sha256": "2b8f6dd7648d5e16017b36146d6baff60983f9a3557ef4203f59d67cc8af8da1"
+      }
+    },
+    "source_code": {
+      "at": "2026-09-05T07:27:19.376Z",
+      "worktree": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4",
+      "base": "c5673901462017b5a07c18ef9f1f7d545b710f7f",
+      "files": [
+        {
+          "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+          "bytes": 42430,
+          "sha256": "81387333fe9ff51743d36d9b5fc484e00a308020ffaedcfd78f433efc672ceef"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/memory_training.rs",
+          "bytes": 52527,
+          "sha256": "304d76de48a42c3d8ee0b4c626210cd95131a600c01f82c1c4ed34609484eb7d"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+          "bytes": 12898,
+          "sha256": "c0adda6abc4ec35253ee92d22e9c42963324bcc61031ba1fb0a673c02d215f0a"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/numeral.rs",
+          "bytes": 13768,
+          "sha256": "2c0012a595d87e653051b067d586d98e93fe1394f9651d75725144cf0ef330fb"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/runtime.rs",
+          "bytes": 20601,
+          "sha256": "6787f544e53f96130cef7c0dda0665051e4aec6f096ae4376fbd72263aee7296"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/snapshot.rs",
+          "bytes": 24957,
+          "sha256": "f8c13dd66566dbf90d08d2410da3173ba6758b2c6863cfd3037273fba44937df"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+          "bytes": 31129,
+          "sha256": "03b38a0765018da0158d8286511b9d587f756c095cb73145687ac019c73601a4"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_lexemes.rs",
+          "bytes": 12896,
+          "sha256": "dc79fa8e1c4f0fadb14af0d8153155b4e874a3178f8d33042b3515460467f5e9"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_runtime.rs",
+          "bytes": 17854,
+          "sha256": "0fab61b637c828bce9e11313e53419c404c427c4b7373c04c50ff822a6b122f1"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs",
+          "bytes": 13144,
+          "sha256": "5334bd20f90595932ac38fb18d8aad1d08c75c03af1ac14ae838c795b64c9ce9"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_snapshot.rs",
+          "bytes": 26189,
+          "sha256": "1d1c0e6a849cd82f8c79943915de7c28fcabefb8c6ba43f81efd9cc1e2a4ca7d"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_snapshot_tests.rs",
+          "bytes": 19506,
+          "sha256": "49a0cdd1ea033e32209594e4eaf2973c8e7c4a094ead42444b34a6dd7753babe"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_training.rs",
+          "bytes": 16601,
+          "sha256": "0b056cc7bc210e1201f84f09eae925752954db291aa0d4a095f64a595589602d"
+        },
+        {
+          "path": "crates/uor-r4-core/src/native_geometric/value_types.rs",
+          "bytes": 5749,
+          "sha256": "27854d550c5d3a5ab9c66af51ac664da76d93cd69ba18f8ed5b0728fc0b2919b"
+        },
+        {
+          "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+          "bytes": 25584,
+          "sha256": "a663d6707516dc4d26d21a16d29d01564e213c27d35c32aa758db378e7a753e5"
+        },
+        {
+          "path": "src/native_geometric_cli.rs",
+          "bytes": 62560,
+          "sha256": "2de7a6da2e7f885d3e3ef34e7b725e2849317e9f4b0b5d1ede915274b0b6c9ca"
+        },
+        {
+          "path": "src/native_geometric_service.rs",
+          "bytes": 63294,
+          "sha256": "e4d93fab2ecd9f4bac932283976d2ebd5aa7c786d267d3d68af91247754de8aa"
+        }
+      ]
+    },
+    "final_binaries": {
+      "at": "2026-09-05T07:33:34.491Z",
+      "source_receipt": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/final-rust-source-identities.json",
+      "files": [
+        {
+          "path": "/tmp/r4-native-geometric-target/release/r4",
+          "bytes": 22548032,
+          "sha256": "11d5d0e8cce549048976ae167493d6ddd0936ba77f7a4b0a7c22a1c0ea965049"
+        },
+        {
+          "path": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+          "bytes": 1865280,
+          "sha256": "69766d2d6db691afe046775a6b9b0ee9b8725ae7d9b3ec94a208a242f7590261"
+        }
+      ]
+    },
+    "earlier_failed_or_stopped_engineering_runs": [
+      {
+        "label": "core-check-1",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "check",
+          "--offline",
+          "-p",
+          "uor-r4-core",
+          "--example",
+          "native_geometric_value_probe"
+        ],
+        "elapsed_ms": 24209,
+        "code": 101,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4127789056,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/core-check-1.log"
+      },
+      {
+        "label": "value-release-1",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "build",
+          "--release",
+          "--offline",
+          "-p",
+          "uor-r4-core",
+          "--example",
+          "native_geometric_value_probe"
+        ],
+        "elapsed_ms": 13063,
+        "code": null,
+        "signal": "SIGTERM",
+        "stopped": "storage_margin",
+        "peak_sampled_known_bytes": 4163239936,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-release-1.log"
+      },
+      {
+        "label": "value-core-tests-1",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--offline",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric"
+        ],
+        "elapsed_ms": 93792,
+        "code": 101,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4081491968,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-core-tests-1.log"
+      },
+      {
+        "label": "value-core-tests-2",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--offline",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric"
+        ],
+        "elapsed_ms": 96212,
+        "code": 101,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4082454528,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-core-tests-2.log"
+      },
+      {
+        "label": "value-core-tests-3",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--offline",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric"
+        ],
+        "elapsed_ms": 95204,
+        "code": 101,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4083400704,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-core-tests-3.log"
+      },
+      {
+        "label": "value-cli-tests-1",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--offline",
+          "--bin",
+          "r4",
+          "native_geometric_"
+        ],
+        "elapsed_ms": 120194,
+        "code": null,
+        "signal": "SIGTERM",
+        "stopped": "storage_monitor_error: Command failed: /usr/bin/du -sk /tmp/r4-native-geometric-target\ndu: /tmp/r4-native-geometric-target/debug/deps/rmetaxYARYb: No such file or directory\n",
+        "peak_sampled_known_bytes": 4074696704,
+        "log": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-cli-tests-1.log"
+      }
+    ],
+    "failures_scope": "Failed/terminated commands remain preserved; later success does not erase them. CLI attempt1 stopped on transient du ENOENT. Monitoring retries at most three complete traversals of the affected root, accepts only successful output and preserves the margin. Snapshot replay can omit obsolete /4 posting rows; later memory_stale_rejections telemetry can differ while typed state, outputs and other checked state remain equal.",
+    "architecture_policy": {
+      "status": "PASS",
+      "command": {
+        "label": "value-policy-final",
+        "command": "/tmp/r4-native-geometric-target/debug/r4-policy-check",
+        "args": [
+          "."
+        ],
+        "elapsed_ms": 7,
+        "code": 0,
+        "signal": null,
+        "stopped": null
+      },
+      "log": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-policy-final.log",
+        "bytes": 73,
+        "sha256": "58dd9c24c33ba5ff6519ed3f5bea924d8fd10d93bcfaba529e2d8b0101be6ae7"
+      }
+    },
+    "claim_wording": {
+      "status": "PASS",
+      "command": {
+        "label": "value-claims-final",
+        "command": "python3",
+        "args": [
+          "scripts/check_claim_wording.py"
+        ],
+        "elapsed_ms": 211,
+        "code": 0,
+        "signal": null,
+        "stopped": null
+      },
+      "log": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/value-claims-final.log",
+        "bytes": 83,
+        "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+      }
+    }
+  },
+  "resources": {
+    "snapshot": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-05T07:39:32.557Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 1820667904,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 44564480,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 4110868480,
+      "storage_limit_bytes": 4294967296,
+      "remaining_storage_bytes": 184098816,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 49881088,
+      "model_ledger": {
+        "cumulative_ms": 894645,
+        "limit_ms": 1800000
+      },
+      "model_remaining_ms": 905355,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. Only documented current-run failed compiler outputs were removed; no inherited or user material was removed. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "inherited_model_ms": 884609,
+    "new_model_ms": 10036,
+    "model_commands": [
+      {
+        "label": "value-fit-1",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "fit",
+          "--model",
+          "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence.json",
+          "--output-dir",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1",
+          "--epochs",
+          "24",
+          "--learning-rate",
+          "0.1",
+          "--max-features",
+          "65536",
+          "--generated-tokens",
+          "32",
+          "--max-seconds",
+          "120"
+        ],
+        "elapsed_ms": 2659,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4068818944,
+        "peak_process_rss_sample_bytes": 254296064,
+        "process_rss_samples": 2,
+        "cumulative_ms": 887268
+      },
+      {
+        "label": "value-rust-compile-1",
+        "command": "node",
+        "args": [
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-generated.mjs",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-1"
+        ],
+        "elapsed_ms": 839,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4069351424,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": 0,
+        "cumulative_ms": 888107
+      },
+      {
+        "label": "value-fit-2",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "fit",
+          "--model",
+          "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence.json",
+          "--output-dir",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2",
+          "--epochs",
+          "24",
+          "--learning-rate",
+          "0.1",
+          "--max-features",
+          "65536",
+          "--generated-tokens",
+          "32",
+          "--max-seconds",
+          "120",
+          "--lexeme-cues",
+          "true"
+        ],
+        "elapsed_ms": 2544,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4098195456,
+        "peak_process_rss_sample_bytes": 280166400,
+        "process_rss_samples": 2,
+        "cumulative_ms": 890651
+      },
+      {
+        "label": "value-fit-1-final",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "fit",
+          "--model",
+          "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence.json",
+          "--output-dir",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1-final",
+          "--epochs",
+          "24",
+          "--learning-rate",
+          "0.1",
+          "--max-features",
+          "65536",
+          "--generated-tokens",
+          "32",
+          "--max-seconds",
+          "120"
+        ],
+        "elapsed_ms": 2495,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4110606336,
+        "peak_process_rss_sample_bytes": 278282240,
+        "process_rss_samples": 2,
+        "cumulative_ms": 893146
+      },
+      {
+        "label": "value-rust-compile-2",
+        "command": "node",
+        "args": [
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-generated.mjs",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-2"
+        ],
+        "elapsed_ms": 1069,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4110716928,
+        "peak_process_rss_sample_bytes": 53116928,
+        "process_rss_samples": 1,
+        "cumulative_ms": 894215
+      },
+      {
+        "label": "value-cli-artifact-sample",
+        "command": "/tmp/r4-native-geometric-target/release/r4",
+        "args": [
+          "geometric",
+          "generate",
+          "--model",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/model.json",
+          "--prompt",
+          "fn main() {\n    let suri = 73;\n    let orin = 4;\n    let tavi = 301;\n    assert_eq!(suri + orin,",
+          "--max-tokens",
+          "32",
+          "--json"
+        ],
+        "elapsed_ms": 430,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_sampled_known_bytes": 4110753792,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": 0,
+        "cumulative_ms": 894645
+      }
+    ],
+    "peak_sampled_fit_process_rss_bytes": 280166400,
+    "fit2_rss_samples": 2,
+    "accounting_method": "Inherited precleanup estimate minus only the audited obsolete target-growth credit; charge all current target allocation, both artifact roots, both measured worktree costs and 5 MiB source/metadata reserve. Preserve 128 MiB margin, one model process, 4 GiB RSS target and all inherited overages. No broad clone/free-disk credits or reset.",
+    "sampling_limits": "Periodic non-atomic du samples do not establish exact transient peaks or APFS unique extents. Direct child RSS excludes descendants: compile-2 sampled Node, not rustc; compile-1 and CLI had zero RSS samples and remain unavailable. Engineering RSS was not measured by this wrapper.",
+    "engineering_commands_path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/engineering-commands.jsonl",
+    "engineering_elapsed_ms": 2194194,
+    "current_run_disposable_compiler_cleanup_receipts": [
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/own-check-metadata-plan.json",
+        "bytes": 12393,
+        "sha256": "37dd1071ef4f403ae815864d9d63fa891bdd1f13ab6c114c7b3820b0485127be"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/own-check-metadata-result.json",
+        "bytes": 12414,
+        "sha256": "d8472c10736f9ddf8f0f28f44a4b024c1ac1f293add9c77cf7b73aa3cd7073ef"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/own-unified-feature-mismatch-cache-plan.json",
+        "bytes": 15010,
+        "sha256": "95a37fa39d15c3f387487d8b7f9e82ee5ef411491123ed34b0ac6186ef8532be"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/own-unified-feature-mismatch-cache-result.json",
+        "bytes": 15190,
+        "sha256": "6f184565e4bc54304ea30650ba0a0565134c3a885a6090cbf6532bead734b50d"
+      }
+    ],
+    "cleanup_scope": "Only documented newly generated failed compiler output files were removed. No inherited/user-material cleanup or new credit. Historical receipts and failures retained.",
+    "engineering_receipts_through": "value-claims-final"
+  },
+  "preservation": {
+    "checked_at": "2026-09-05T07:39:32.598Z",
+    "historical_files_checked": 15,
+    "historical_files": [
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/extract-response-evidence.py",
+        "bytes": 13650,
+        "sha256": "3d5c6f9902e410d1535ff6220cd5e7be996baee45bc6ee828243bacc42b63bd4"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/supervised-source/source.json",
+        "bytes": 523189,
+        "sha256": "7691238954be95cabda43c61cc5dc0be2f8a1459bed8481e463bf3e64ccd4eb7"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/supervised-source/fit.jsonl",
+        "bytes": 134814,
+        "sha256": "6d2388fc0d940113d484e3d27aa3eb90262229fa39e1161ec1fab1c94721b6a9"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/supervised-source/supervision.json",
+        "bytes": 145334,
+        "sha256": "a3a251009179b607ec3cba989fdee54b686629c4bce370a74b9a57e05a79a562"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence-fit-report.json",
+        "bytes": 158836,
+        "sha256": "987219c1d88f31ec7624d031b568cd17cb095a4a82dfd1b5f397a0aae5ad6b0d"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence-final-evaluation/report.json",
+        "bytes": 4033590,
+        "sha256": "f3a7b2ffbf5470279fb5dc371d82f311cc5490e4b9ea47c4c7253475e1b5f5b8"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-geometric-composition-2026-09-05/occurrence.json",
+        "bytes": 9780190,
+        "sha256": "e99884443e6b2f3cd0eb4600f7a6d485ec9d476b0a092571a764cad65399f68a"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/response-fit-report.json",
+        "bytes": 159610,
+        "sha256": "679b7281d9725215f78a6448a8c02d7f40ec906cb80c2eaff0aa18a652e440a1"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/response-evaluation/report.json",
+        "bytes": 9302286,
+        "sha256": "a87986c644f160fd409314ae251f89c4bbcf7a794dd834594e96f97a0355d2c8"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/response.json",
+        "bytes": 9498862,
+        "sha256": "1e4ee067396b474b04c8691f5ec943e775db7cb0f285865aa9b2de1b733b0878"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/response-regression-diagnosis.json",
+        "bytes": 40436,
+        "sha256": "efa68ac0c40a119ef5a344cea18ef9a5f7acc7633fe9cb872fa6cb8d23fa8240"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/reviewed-rust-execution.json",
+        "bytes": 1602,
+        "sha256": "2268ebe88261220ba3803003bc031511e6554029cd71d77d4c0e8f0685af33c5"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/advancing-fit-report.json",
+        "bytes": 159689,
+        "sha256": "fa775790c57b207a211284ff8822ea2ae815db65b1694428505145b82bd8c9f5"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/advancing-evaluation/report.json",
+        "bytes": 9275643,
+        "sha256": "c38c2664f880b6d5ed0780434da3ded741e15b19615f2be6d38c67ac4337ab0d"
+      },
+      {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-response-state-2026-09-05/advancing.json",
+        "bytes": 9626832,
+        "sha256": "2e11bb753af7111bf2a0670a4cd1ec17e31b50942c26cc0787eb099578d6317a"
+      }
+    ],
+    "worktrees": {
+      "predecessor_worktrees": 32,
+      "current_worktrees": 33,
+      "missing": [],
+      "added": [
+        "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4"
+      ]
+    },
+    "main_git_status": [
+      " D research/ai-research/ai-router/router-research/data/wikitext2_proxy/ppmi_proxy.npz",
+      " D research/archives/gemini-dev/wikitext2_proxy/ppmi_proxy.npz",
+      " M tools/r4-softmax-trainer/src/r4_softmax_trainer/prompt_conditioning_v4.py",
+      "?? .serena/",
+      "?? crates/uor-r4-core/tests/.uor-r4-recorded-corpus-producers/"
+    ],
+    "modified_user_python_git_blob": "e09e0c8eb6a4c97a4404d428825c87bc2dd45ce4",
+    "scope": "Selected historical file bindings, worktrees and main status verified; not every historical file hashed. Pre-existing deletions are preserved as existing user state."
+  },
+  "next_mechanism": "Investigate and learn the transition from committed typed emission into ordinary prose/code completion and termination using actual emitted histories. Retain raw targets and separate reused open development from future final held-out evaluation. No next fit is asserted.",
+  "delivery": {
+    "policy": "protected_pull_request_and_merge_queue",
+    "status": "PENDING",
+    "issue": 973,
+    "issue_must_remain_open": true,
+    "scope": "Frozen before protected PR submission; no CI success, PR head, approval or merge completion asserted. Live GitHub owns delivery status. Historical queue labels do not establish execution of all named legacy jobs."
+  }
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,6 +7,50 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
+## Typed value creation — 2026-09-05 development
+
+The native model now has an optional typed-value component on the stronger
+`/4` artifact. It lexes signed integer values, learns bounded operand/action
+selection, executes Copy or checked integer-domain `ZPhi::checked_add`, commits
+the result with causal provenance, and emits decimal byte tokens through the
+ordinary shortlist. It reuses the `/5` prediction/observation pattern while
+preserving both fitted `/5` negatives. Typed records survive token-ring eviction
+until their own sixteen-record store evicts them; this is deterministic retention.
+
+The first `/1` fit selects correctly on 128/128 raw training examples. On 32
+open-development cases it produces correct numerals on 12/12 prose and 8/12
+Rust numeric targets, versus 0/12 in each family with typed values disabled.
+Complete exact responses remain 2/16 prose and 0/16 Rust. All sixteen generated
+Rust sources and four Rust binding-control sources fail compilation unchanged.
+All four paired name swaps fail to select both correct results. H4/zeta-disabled
+arms make the same primary typed choices as Full, so this establishes no added
+typed-selection benefit from those features.
+
+The observed representation loss is specific: the six fit names are lexical
+tokens, while new development names split into bytes. Four-token source cues
+retain fragments and the eight-token query loses relevant words. The `/2`
+correction adds bounded exact whole-word cues across token splits and 64 varied
+raw construction bindings. It selects 192/192 fitting cases and all 24 numeric
+development targets; all four unchanged-query name-swap pairs now select both
+correct results. Whole-word scoring disabled falls to 4/24, while H4/zeta-disabled
+retain Full's typed actions and operands on all 32 cases. Complete responses
+remain 2/16 prose and 0/16 Rust, and all 20 generated Rust sources still fail
+compilation. Only the four previously failing Rust Add outputs change; the other
+28 primary outputs retain their exact bytes and tokens.
+
+The remaining numeric failures begin after completed numeral emission: every
+Rust case fails at its first suffix byte or EOS. The scalar fitter trains no
+suffix, and emitted byte-token history differs from canonical lexical encoding.
+The next concrete integration is learned response progress and continuation/stop
+selection at that value-to-completion boundary, using actual emitted histories.
+Keep the improved bounded operand/write mechanism and both prior `/5` negatives;
+do not substitute fixed response templates. The
+[typed-value record](../native_geometric_typed_value_973.md) binds outputs,
+controls, source/binary identities, preservation and focused checks. No general
+binding, geometric advantage or alpha claim follows. Final held-out qualification
+remains NOT_RUN. Cumulative model work is 894.645/1800 seconds; 905.355 seconds
+remain, with storage the tighter constraint.
+
 ## Persistent response state — 2026-09-05
 
 The native `/5` development option captures a bounded response query and its

--- a/docs/native_geometric_mechanism_map_973.md
+++ b/docs/native_geometric_mechanism_map_973.md
@@ -3,7 +3,7 @@
 This source map connects the native model to reusable mathematical and runtime
 components. Its baseline is the implementation delivered through PR #1127 at
 `3abf9d7e85f70416c95161863b4413cc42a6912c`; the versioned occurrence-selection
-and response-state successors are distinguished below. The [project plan](integration/project-track.md)
+response-state and typed-value successors are distinguished below. The [project plan](integration/project-track.md)
 owns the goal, and [current-state.md](integration/current-state.md) owns results
 and active work. This is not another roadmap or a claim that every architectural
 role is already assembled.
@@ -93,6 +93,47 @@ unsupervised context within a response. The
 [response-state record](native_geometric_response_state_973.md) binds the
 executed behavior, costs and checkpoint checks; mechanical continuity alone
 does not establish useful answer composition.
+
+The optional typed-value component adds `numeral.rs`, `value_runtime.rs`,
+`value_training.rs` and `value_snapshot.rs` to this same model. It uses the
+stronger `/4` fitted reader and reuses `/5`'s prediction/observation separation
+with distinct derived-write identity. A generic signed-integer byte lexer
+records numeric payloads, up to four preceding prime cues and cumulative
+H4/phase state. These payloads are separate from token-root coefficients.
+At a response boundary, the learned integer score table chooses Copy, checked
+`ZPhi::checked_add` in the integer subdomain, or no derived write. It examines
+up to sixteen records and 256 valid operand/action proposals. Relative H4,
+fixed-phase, prime-cue equality and occurrence-rank features influence selection.
+This is bounded exhaustive operand scoring, without sparse preselection.
+
+Typed schema `/2` additionally uses `value_lexemes.rs` to preserve complete
+ASCII word identity across tokenizer pieces. Sixteen recent words and sixteen
+captured query words are bounded to 32 bytes each; each numeric record retains
+four preceding words, source endpoints and their geometry. Learned query-position
+features consume exact source/query word-match masks. Word geometry is retained
+metadata, not a new scoring law. This preserves selected local identities while
+discarding most surrounding text; it supplies no entity-role parser, assignment
+graph, learned consolidation or multiscale semantic summary. Its 16 extra features
+per proposal can add up to 32,768 word comparisons and 1,048,576 byte comparisons
+at the sixteen-value limit, in addition to the existing path. Every admitted
+addition still executes before selection; sparse compute savings remain open.
+
+Only observing the selected decimal token commits the derived value and its
+operand IDs/values. A fixed twenty-byte buffer emits the remaining digits
+through the ordinary shortlist. Positive selection emits at the response
+boundary; the current gate cannot wait through generated text before inserting
+a numeral. It supplies no response suffix or learned stop classifier. Raw
+prompt/response training labels complete numeral bytes and leaves operand and
+action identities latent. Canonical lexical tokens and emitted byte tokens can
+differ while decoding to the same text.
+
+The sixteen-record store can retain numbers beyond ordinary token-ring
+eviction, including persistent derivation, but deterministically discards old
+records when full. Most surrounding source text and general assignment/dependency
+structure are not retained. Session schema `/3` validates this explicit state;
+older source payloads are user-provided state, not authenticated history.
+The [typed-value record](native_geometric_typed_value_973.md) supplies complete
+cost bounds, direct behavior, controls and remaining binding/emission limits.
 
 ## Historical pieces and what they can contribute
 

--- a/docs/native_geometric_typed_value_973.md
+++ b/docs/native_geometric_typed_value_973.md
@@ -1,0 +1,294 @@
+# Native typed-value creation and emission — #973
+
+Date: 2026-09-05. Status: `/1` negative retained; `/2` improves bounded numeric binding, while complete-response and Rust compilation failures remain.
+The [project plan](integration/project-track.md) owns the objective. This record does not establish conversation, coding, reasoning, alpha or geometric advantage.
+
+## Cause and integration choice
+
+The preceding diagnosis separated reachable-but-misselected copy targets from
+required numeric results absent from retained copy routes. A better copy reader
+cannot produce an absent arithmetic value. The stronger matched `/4` artifact
+is the integration baseline; both fitted `/5` response-state variants remain
+scoped development negatives in the [response-state record](native_geometric_response_state_973.md).
+
+The optional `uor-r4.native-typed-value/1` component adds typed literal ingestion,
+latent operand/action selection, checked addition, a committed result record and
+bounded numeral emission inside the existing native `Session`. It preserves the
+`/4` reader and ordinary shortlist. It reuses `/5`'s prediction-before-observation
+pattern without importing its regressed fitted response law.
+
+## Representation, learned selection and causal write
+
+`native_geometric/numeral.rs` recognizes signed ASCII decimal fragments through
+decoded token bytes, including byte fallback split across tokens. Literal
+admission uses no expression, assignment, entity-role or answer parser. Identifier
+suffixes, fractional/exponent forms and overflowing or oversized fragments are
+excluded. A period uses lookahead; sign interpretation is lexical, not a source
+language unary/binary-minus analysis. BOS/EOS close the scanner.
+
+The fixed recent metadata ring retains 32 tokens with sequence, lexical prime,
+H4 pose and eight fixed phases. The value store retains at most 16 records.
+Each literal preserves its integer, write ID, source interval, four preceding
+cue primes and endpoint geometry. Old source text can be evicted while its typed
+record survives. This is deterministic typed retention, not learned abstraction
+or a claim that arbitrary source meaning survives compression.
+
+An explicit response boundary captures at most 16 values and eight query tokens.
+The component enumerates Copy and ordered two-occurrence Add alternatives;
+equal-valued occurrences keep distinct IDs. Its learned rows consume operation,
+relative recency, literal/derived origin, query/cue primes and matches, relative
+H4 state and fixed-phase differences. `/4` learned read scores do not select the
+operands: `/4` supplies the ordinary token/memory baseline competing with this
+separate typed scorer. H4 order and signed root identity remain intact; phase
+differences are quantized features, not exact analytic zeta zeros.
+
+NoWrite has logit zero. A strictly positive typed score is added to the ordinary
+shortlist winner's score and offers one byte token through the existing merge.
+Zero ties retain NoWrite; equal positive derivations retain enumeration order.
+Scores use captured state, so a positive gate emits at the response boundary;
+a NoWrite gate cannot later activate after generated prose or code. Mid-response
+placement, eager dependency/assignment evaluation and general binding remain open.
+
+`prime_route_attention.rs::ZPhi::checked_add` executes exact coefficient addition
+on integer payloads with `b == 0`. These payloads are distinct from token-root
+coefficient sums. The selected result is spelled into at most 20 existing byte
+tokens using fixed decimal places and compare/subtract. No whitespace, punctuation,
+answer template, multiplication, division or floating point is added by emission.
+
+Prediction sets transient provenance without advancing the committed cursor.
+Only observing the selected token commits the derived value and advances emission.
+A mismatching observation cannot select a hidden target-matching operand pair;
+an interrupted committed emission clears its cursor. Completed records retain the operator, operand IDs and operand values, even after those operands are evicted.
+They can become later operands. This permits bounded cross-response composition,
+not general reasoning or a reconstructed full derivation tree after eviction.
+
+## Fitting, codec and persistence boundaries
+
+Offline Rust fitting receives raw prompt/response pairs. Host target processing
+labels canonical numeral-prefix bytes; operand IDs and actions remain latent.
+`+17`, `017` and `17` are different spellings. Punctuation after a supported
+numeral remains ordinary-model work. NoWrite accuracy measures the operator gate,
+not correctness of the baseline's unsupported-answer text. A global continuation
+score is fitted for remaining numeral bytes; buffer length ends typed emission.
+
+The artifact binds codec/schema, learned integer rows, continuation score, fit
+configuration and original-order structured prompt/response receipts. Reported fit selection metrics use exported quantized weights and serving tie rules.
+Unreachable numeric targets are reported separately from eligible fitting targets. Canonical lexical tokens and emitted byte tokens may decode identically while having different token counts; assess exact output bytes separately from token loss.
+
+The typed session snapshot preserves scanner, metadata, captured sources/query,
+committed derivation and emission cursor. Restoration validates bounded shapes,
+retained token/geometry evidence and checked derivation arithmetic, then restores
+preallocated capacity. Evicted source payloads are explicit persisted state;
+serialization integrity does not authenticate their original external truth.
+
+## Complete work bounds and attribution limits
+
+Let `K <= 16`, `Q <= 8`, `R <= 262144` learned rows. Every initial/retry decision
+visits 272 directory addresses and at most `K² <= 256` valid proposals: `K` Copy
+and `K(K-1) <= 240` Add. Arithmetic executes before proposal ranking. Each
+nonoverflow proposal has at most 44 active features, 32 rank comparisons,
+64 cue comparisons, four H4 reads and 16 phase subtractions. Full maxima are
+11264 feature lookups, 16384 cue comparisons, 1024 H4 reads and 4096 phase updates;
+feature lookup additionally uses bounded binary search in `R` rows.
+NoWrite leaves the gate unconsumed, so subsequent ordinary predictions repeat
+this captured-state search even though the selected gate cannot change. This
+redundant cost is measured, not removed or hidden by the per-decision bound.
+
+Ingestion scans each decoded byte and adds one H4 read/eight phase updates per
+token. Each literal may search 160 metadata entries; a full-store write moves
+15 records. Capture copies at most 16 records/eight query entries. Each numeral
+construction visits 19 places with at most 171 subtractions; initial offer and
+commit both construct it. Subsequent bytes use a cursor lookup and shortlist merge.
+Rank searches, metadata searches and record moves have these explicit bounds but are not all in `ValueWork`; `numeral_steps` records conservative allowances.
+
+These costs add to `/4`: 26 base feature queries, bounded prior/row posting offers
+and scoring, plus at most the configured memory-route limit of 128 in the matched
+artifact. `/4` local routes use 18 features, six H4 relation reads plus orientation,
+and 24 phase subtractions before occurrence feature union. Union/deduplication
+can require quadratic comparisons/moves; it is not constant-time attention.
+Ordinary observation, radial/square-table work and shortlist shifts also remain.
+
+This is bounded exhaustive operand routing followed by learned operator selection.
+It currently avoids no candidate arithmetic through pre-ranking. It has no dense experts; similarity to sparse routing or MoE functions is an investigation topic,
+not evidence of expert specialization or a transformer-compute advantage.
+
+## First fit and the whole-word correction
+
+The first `/1` fit reached **128/128 eligible construction examples**. Reused
+open development reached **12/12 prose** and **8/12 Rust numeric prefixes**, but
+only **2/16 prose** and **0/16 Rust complete responses** were exact. All four
+context-name-swap pairs failed pair correctness, and all **20 generated Rust
+programs failed compilation**. Successful number emission did not repair the
+ordinary model's continuation. These results establish neither general binding
+nor useful Rust generation.
+
+Artifacts are retained under
+`/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1`.
+The `/1` artifact and its implementation law remain available. The result is a
+negative for this fitted selector and dose, not for the complete architecture.
+
+Inspection localized a representation loss: construction names were complete
+lexical pieces, whereas development names `suri`, `orin` and `tavi` used byte
+fallback. Four source-token cues retained partial name suffixes; eight query
+tokens could omit names or operation context. For example, a source cue for
+`suri` retained `has`, `now`, `i`, `r`. Swapping context names while retaining
+numbers and query bytes left the selected numeric rank unchanged. Anonymous
+token-match masks also lost their association with a particular query position.
+
+The optional `uor-r4.native-typed-value/2` correction recognizes exact whole
+words through decoded bytes, independently of tokenizer segmentation. Words
+start with an ASCII letter or underscore and may contain later digits. The
+32-byte limit rejects an oversized run through its delimiter; numeric-leading
+and non-ASCII runs are excluded. Punctuation separates words without receiving
+task meaning. No entity, assignment, expression or answer parser is introduced.
+
+The component retains 16 completed words, captures the four preceding complete
+words when a numeral opens, and freezes 16 query words at the response boundary.
+Byte endpoints distinguish multiple words/numerals inside one lexical token.
+Each word retains exact bytes, token/byte endpoint, H4 pose and phases. Those
+per-word geometric fields are retained metadata, not new geometric scoring.
+Feature kind 16 binds the operator and query-word position to eight exact
+word-equality bits over the two operands' four source cues. Existing prime-token
+and relative-geometric features continue to execute. `/1` ignores this feature.
+
+The revised raw fitting source contains **192 pairs**: the original 128 plus
+64 context-name swaps using construction names. Query bytes and numeric order
+stay fixed in each swap while the correct occurrence changes. The same **32
+open-development examples** and four binding pairs are reused, with development
+names excluded from fitting; this is disclosed development reuse, not a new
+held-out result. The added `ValueLexemesDisabled` arm removes only kind 16 from
+the same `/2` artifact, retaining ingestion and state. It measures fitted-feature
+sensitivity; it is not a refitted causal comparison or geometric-advantage proof.
+
+The additional worst-case serving work is 16 features and 128 word comparisons
+per valid proposal. Each word comparison checks length and at most 32 bytes:
+4096 byte comparisons per proposal, or 32768 word comparisons and 1048576 byte
+comparisons over 256 proposals. Total active features are at most 60 per
+proposal, hence 15360 feature lookups plus their binary searches.
+At the maximum 262144 rows, a lookup needs at most 19 row-key comparisons,
+or 291840 across a full 256-proposal decision. The two recency-rank searches
+can additionally make 8192 comparisons. Ingestion
+adds bounded word-byte processing; each completed word moves at most 15 atoms.
+Numeric-start capture copies four atoms, and response capture copies 16 atoms.
+`ValueWork` counts word comparisons, actual byte comparisons and completed word
+writes, but not every fixed copy, rank search or metadata scan. All `/1` and
+ordinary `/4` costs above remain in the total serving path.
+
+Optional fields preserve `/1` serialization and feature behavior. Their inline
+Rust representation enlarges state and value records even when the options are
+empty; allocation-count equality does not imply equal storage or copy cost.
+Reports must use actual structure sizes. `/2` snapshots additionally validate
+word shapes, byte/token order, retained evidence and frozen query state; explicit
+response boundaries can separate adjacent source-byte intervals without an
+intervening source byte. Evicted source truth remains unauthenticated state.
+
+## Executed whole-word result and remaining cause
+
+The `/2` fit selects correctly on **192/192** eligible examples, including all
+160 reachable numeric targets and 32 NoWrite examples. It exports 3966 features
+with none dropped, selects epoch 24, and fits 256 remaining-numeral positions.
+Learning rate is 0.1 and feature limit 65536. Epoch choice uses floating weights;
+reported selection accuracy uses the exported integer weights.
+
+| Reused open-development arm | Prose numeric /12 | Rust numeric /12 | Prose exact /16 | Rust exact /16 |
+|---|---:|---:|---:|---:|
+| Full | 12 | 12 | 2 | 0 |
+| ValuesDisabled | 0 | 0 | 0 | 0 |
+| H4Disabled | 12 | 12 | 0 | 0 |
+| ZetaDisabled | 12 | 12 | 1 | 0 |
+| ValueLexemesDisabled | 4 | 0 | 0 | 0 |
+
+All four Full name-swap pairs now select both intended numerals. In each
+prose/Rust Copy pair the selected occurrence changes from ID 2/value 73 to
+ID 1/value 301. In each Add pair the operands change from IDs 1/0 (4 + 73)
+to IDs 2/0 (301 + 73), yielding 77 and 374. Numeric order and query bytes
+remain fixed within these pairs. `/1` failed all four pair-correctness checks.
+This is bounded source-binding evidence under the disclosed templates and
+local retention rule, not general assignment or entity understanding.
+
+Full commits 24 derived writes and all 60 numeral bytes, with zero emission
+mismatches or overflow rejections. All eight NoWrite cases make zero typed
+writes, but their ordinary text remains incorrect. Disabling whole-word scoring
+loses 20/24 numeric answers. H4Disabled and ZetaDisabled retain Full's typed
+actions, ordered operand IDs and values on all 32 cases. These runs establish
+fitted whole-word feature sensitivity, with no added typed-selection benefit
+from H4/zeta in this population. Their different ordinary suffixes do not isolate
+the typed geometry. `/1` to `/2` jointly changes state, features and fitting
+examples; it is not a single-variable intervention.
+
+Full output changes only for the four previously failing Rust Add cases; the
+other 28 primary outputs retain their exact `/1` bytes and tokens. All **20
+unchanged generated Rust files fail compilation**, including four binding-control
+files. No generated executable runs. Examples expose the boundary:
+
+- Prose Copy can emit exact `-78.\n`; prose Add emits `77..\n` for `77.\n`.
+- Rust dependency-before-update selects the correct old value plus increment,
+  emits `77`, then stops before the required `);\n}\n`.
+- Rust Add emits `77.. User... User: User. User:.. 100`; the ordinary CLI loaded
+  the same artifact and reproduced this output and typed trace.
+
+Every numeric Rust case fails at its first post-numeral byte or EOS. Eight of
+twelve prose numeric cases fail there; two fail later and two are exact. The
+scalar fitter never trains suffixes or EOS. Canonical encoding of `77` uses a
+learned lexical token, while typed emission uses two byte tokens. This different
+continuation history is observed; its causal share relative to ordinary query
+and readout weakness is not yet isolated.
+
+The next implementation target is the **typed-value to ordinary completion
+handoff**: teach response progress and continuation/stop selection using actual
+emitted byte-token history, retaining the learned operand/write path and
+comparing complete raw output. Reuse compatible response-state and fitting
+machinery; do not expand arithmetic, add automatic punctuation/templates or
+promote the regressed `/5` head merely because its schema is newer.
+
+## Artifact preservation, checks and resources
+
+The [compact evidence](evidence/native_geometric_typed_value_973.json) binds
+sources, changed Rust hashes, release binaries, outputs and command receipts.
+Under `/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05`:
+
+- `/1` is `fit-1/model.json`, CID
+  `blake3:b95c1a33dfc604864baf21a323233217eae26d0ffa0d2f0f4c5755ae53616aae`.
+- `/2` is `fit-2/model.json`, CID
+  `blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5`.
+- Fit directories retain raw sources, options, all outputs/control arms and
+  generated Rust; `compile-1` and `compile-2` retain compiler diagnostics.
+
+`fit-1-final` reproduces `/1` source/model bytes, metrics and all 136 case/control
+outputs, tokens, stops and traces with the final source/executable. The allowed
+differences are actual typed-state storage (5952 to 19304 bytes after the optional
+word layout) and corrected telemetry: 3463 ordinary no-pending tokens were
+formerly counted as emission mismatches; the final count is zero. All other
+generation state and work match. `/2` also reports 19304 typed-state bytes in
+addition to ordinary context, shortlist and `/4` memory storage.
+
+Pinned Rust 1.97.1 verification passed 72 native core tests before the final
+snapshot review fix, then all 16 affected typed tests including the new retained
+word-byte regression; three source/allocation tests; three context tests; four
+probe tests; and 16 CLI/service tests. The existing census covers 81920 decisions;
+both typed schemas separately exercise ingestion, derived writes, interrupted
+emission and repeated eviction with zero steady-state allocations. Final release,
+formatting, architecture policy and claim wording pass. A CLI build stopped on
+a transient `du`/Cargo rename race; a narrow complete-measurement retry corrected
+monitoring and the retry passed. Earlier failed engineering attempts remain logged.
+
+Through the actual CLI sample, cumulative model work is **894645/1800000 ms**,
+leaving **905355 ms**: inherited 884609 ms plus 10036 ms of fitting, evaluation,
+compilation and replay. Engineering builds/tests are logged separately. Maximum
+sampled direct model-process RSS is **280166400 bytes**, with two samples during
+`/2`. Unsampled short commands have unavailable RSS; the compilation wrapper's
+sampled Node RSS does not measure descendant `rustc` processes.
+
+At 07:35:34 UTC the inherited accounting records **4110757888/4294967296 bytes**,
+including a 5 MiB source/metadata reserve. After the 134217728-byte stop margin,
+**49991680 bytes** remain for growth. These periodic conservative readings are
+not exact peaks or APFS unique extents. The only inherited obsolete-target credit
+remains 671379456 bytes. Only documented newly generated failed compiler outputs
+were removed; inherited/user material and all 32 prior worktrees remain, with one
+new full worktree added.
+
+Protected PR/merge state belongs to live GitHub and the local delivery receipt.
+Actual queue steps determine test evidence; four historical required statuses
+only acknowledge deferred work. Clippy, broad release QA, `no_std`, κ, audit,
+fuzzing, WASM, Gate C and final held-out qualification are **NOT_RUN** in this
+development step. Issue #973 remains open for the broader native model objective.

--- a/docs/native_geometric_workflow.md
+++ b/docs/native_geometric_workflow.md
@@ -5,7 +5,8 @@ evaluation, sessions and generation use Rust. Its initial learner estimates
 conditional score tables over prime lexical identities and geometric context.
 Separate readout fitting learns bounded integer gates over seven feature groups
 and sufficiently supported last-prime query keys. It does not yet learn the
-state's memory-write law.
+ordinary token memory-write law. The optional typed-value component separately
+learns operand/action selection and whether to write its result.
 An optional learned memory reader retrieves actual retained token values through
 prime-addressed postings, query/source offsets and relative H4/zeta features.
 It is versioned separately in the artifact; the original fixed/readout-only
@@ -18,6 +19,46 @@ Build the CLI with `cargo build --release --bin r4`. The examples below use
 `target/release/r4`; set a different path when using a shared Cargo target.
 
 ## Prepare open development data
+
+The optional typed-value experiment is available through the same core
+`Model::fit_values` API and a bounded Rust example:
+
+```sh
+cargo build --release -p uor-r4-wasm-router --bin r4 -p uor-r4-core --example native_geometric_value_probe
+target/release/examples/native_geometric_value_probe fit \
+  --model /absolute/path/to/occurrence.json \
+  --output-dir /absolute/path/to/new-value-run \
+  --epochs 24 --learning-rate 0.1 --max-features 65536 \
+  --generated-tokens 32 --max-seconds 120
+```
+
+Use the inherited cumulative model/resource monitor around this command.
+Its inner time check is between bounded operations, not a hard interruption.
+The example writes raw fit/development source and name-swap controls before
+fitting, reloads the exported artifact, and saves actual output from Full,
+ValuesDisabled, H4Disabled and ZetaDisabled arms. It refuses an existing output
+directory and checks development against the artifact's training receipts.
+`evaluate --model ... --source ... --output-dir ...` replays a saved artifact.
+Generated Rust is saved unchanged; compilation/execution is a separate inspected
+step. This example uses numeral-first targets with exact decoded-byte metrics,
+not canonical first-token equivalence. See the
+[typed-value record](native_geometric_typed_value_973.md) for measured limits.
+
+`--lexeme-cues true` explicitly selects `Model::fit_values_with_lexeme_cues`
+and typed schema `/2`. It adds bounded whole-word identity cues and 64 raw
+construction name swaps to the original 128 fitting pairs. The same development
+cases are reused open feedback. The additional `ValueLexemesDisabled` arm removes
+only the new learned feature rows while retaining their state and ingestion cost.
+The default remains `/1`; source schema and this flag must agree on replay.
+
+The resulting model loads through ordinary `r4 geometric` generation and the
+native service. `--control values-disabled` suppresses typed candidates;
+`--control value-lexemes-disabled` suppresses `/2` whole-word scoring alone. Session
+schema `/3` preserves committed derived values and emission cursor, including
+empty HTTP continuation after export/import. `Session::begin_response` starts
+new value selection; a continuing response must retain its active state.
+
+The general corpus preparation command remains:
 
 ```sh
 target/release/r4 geometric prepare \

--- a/src/native_geometric_cli.rs
+++ b/src/native_geometric_cli.rs
@@ -256,6 +256,8 @@ enum ControlArg {
     HeatmapDisabled,
     MemoryDisabled,
     ResponseStateDisabled,
+    ValuesDisabled,
+    ValueLexemesDisabled,
 }
 impl From<ControlArg> for Control {
     fn from(value: ControlArg) -> Self {
@@ -270,6 +272,8 @@ impl From<ControlArg> for Control {
             ControlArg::HeatmapDisabled => Self::HeatmapDisabled,
             ControlArg::MemoryDisabled => Self::MemoryDisabled,
             ControlArg::ResponseStateDisabled => Self::ResponseStateDisabled,
+            ControlArg::ValuesDisabled => Self::ValuesDisabled,
+            ControlArg::ValueLexemesDisabled => Self::ValueLexemesDisabled,
         }
     }
 }
@@ -1228,7 +1232,8 @@ fn chat(a: &ChatArgs) -> Result<(), String> {
         for _ in 0..a.max_tokens {
             let token = session.predict(&model).map_err(err)?.token;
             if token == uor_r4_core::native_geometric::EOS {
-                if session.response_decision().is_some() {
+                if session.response_decision().is_some() || model.value_operator_version().is_some()
+                {
                     session.observe(&model, token).map_err(err)?;
                 }
                 break;

--- a/src/native_geometric_service.rs
+++ b/src/native_geometric_service.rs
@@ -403,12 +403,14 @@ impl Service {
                 || session
                     .state()
                     .response
-                    .is_none_or(|response| !response.active))
+                    .is_none_or(|response| !response.active)
+                    && session.state().values.is_none_or(|values| !values.active))
         {
             session.begin_response(&self.model).map_err(internal)?;
         }
         let mut output = Vec::new();
         let mut response_trace = Vec::new();
+        let mut value_trace = Vec::new();
         let mut output_bytes = 0;
         let mut stop = "token_limit";
         for _ in 0..request.max_tokens {
@@ -422,13 +424,20 @@ impl Service {
                 stop = "output_byte_limit";
                 break;
             }
+            if let Some(decision) = session.value_decision() {
+                if value_trace.len() < 96 {
+                    value_trace.push(decision);
+                }
+            }
             if let Some(decision) = session.response_decision() {
                 if response_trace.len() < 96 {
                     response_trace.push(decision);
                 }
             }
             if prediction.token == EOS {
-                if session.response_decision().is_some() {
+                if session.response_decision().is_some()
+                    || self.model.value_operator_version().is_some()
+                {
                     session.observe(&self.model, EOS).map_err(internal)?;
                 }
                 stop = "end_of_sequence";
@@ -451,7 +460,7 @@ impl Service {
             json!({"backend":BACKEND,"artifact_cid":self.model.artifact_cid(),"session_id":request.session_id,
             "memory_read_version":self.model.memory_read_version(),
             "text":text,"utf8_valid":utf8_valid,"bytes":bytes,"tokens":output,"stop":stop,
-            "response_trace":response_trace,
+            "response_trace":response_trace,"value_trace":value_trace,
             "prompt_tokens":prompt.len(),"observed_prompt_tokens":observed_prompt,
             "state":session.state(),"session_work":session.work,
             "persisted":self.session_directory.is_some() && persist_error.is_none(),"persistence_error":persist_error}),
@@ -1057,6 +1066,96 @@ mod tests {
         let isolated = isolated.session.lock().unwrap();
         assert_eq!(isolated.work.response_query_captures, 0);
         assert!(!isolated.state().response.unwrap().active);
+    }
+
+    #[test]
+    fn http_typed_numeral_continues_across_requests_and_imported_snapshot() {
+        typed_numeral_continuation(false);
+        typed_numeral_continuation(true);
+    }
+
+    fn typed_numeral_continuation(lexeme_cues: bool) {
+        use uor_r4_core::native_geometric::{ValueExample, ValueFitConfig};
+        // A tiny construction fit supplies the public values-enabled artifact.
+        // This test concerns HTTP/state continuity, not held-out arithmetic.
+        let examples = (0..4)
+            .map(|index| ValueExample {
+                id: format!("value-service-fit-{index}"),
+                prompt: format!("left = {}; right = 4; total:", 13 + index),
+                response: (17 + index).to_string(),
+            })
+            .collect::<Vec<_>>();
+        let baseline = model();
+        let config = ValueFitConfig {
+            epochs: 32,
+            learning_rate: 0.25,
+            max_features: 4096,
+        };
+        let (fitted, report) = if lexeme_cues {
+            baseline.fit_values_with_lexeme_cues(&examples, config)
+        } else {
+            baseline.fit_values(&examples, config)
+        }
+        .unwrap();
+        assert_eq!(report.reachable_numeric_targets, 4);
+        assert!(report.continuation_positions > 0);
+        let model = Model::from_bytes(&fitted.to_bytes().unwrap()).unwrap();
+        let service = Arc::new(Service::new(model, None).unwrap());
+        let complete_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let split_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let prompt = &examples[0].prompt;
+        let complete = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":complete_id,"prompt":prompt,"max_tokens":2}),
+        );
+        assert_eq!(complete["tokens"], json!([51, 57]));
+        assert_eq!(complete["bytes"], json!([b'1', b'7']));
+        assert_eq!(complete["text"], "17");
+        let first = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":split_id,"prompt":prompt,"max_tokens":1}),
+        );
+        assert_eq!(first["stop"], "token_limit");
+        assert_eq!(first["tokens"], json!([51]));
+        assert_eq!(first["state"]["values"]["active"], true);
+        assert_eq!(first["state"]["values"]["emission_cursor"], 1);
+        let write = first["state"]["values"]["committed_write"].clone();
+        let exported = post(
+            Arc::clone(&service),
+            "/api/export",
+            json!({"session_id":split_id}),
+        );
+        assert_eq!(
+            exported["checkpoint"]["schema"],
+            "uor-r4.native-geometric-session/3"
+        );
+        let restored_id = id(&post(
+            Arc::clone(&service),
+            "/api/import",
+            json!({"checkpoint":exported["checkpoint"]}),
+        ));
+        for session_id in [split_id, restored_id] {
+            let second = post(
+                Arc::clone(&service),
+                "/api/generate",
+                json!({"session_id":session_id,"prompt":"","max_tokens":1}),
+            );
+            assert_eq!(second["observed_prompt_tokens"], 0);
+            assert_eq!(second["tokens"], json!([57]));
+            assert_eq!(second["value_trace"][0]["write_id"], write);
+            assert_eq!(second["value_trace"][0]["cursor"], 1);
+            let mut tokens = first["tokens"].as_array().unwrap().clone();
+            tokens.extend(second["tokens"].as_array().unwrap().iter().cloned());
+            let mut trace = first["value_trace"].as_array().unwrap().clone();
+            trace.extend(second["value_trace"].as_array().unwrap().iter().cloned());
+            assert_eq!(json!(tokens), complete["tokens"]);
+            assert_eq!(json!(trace), complete["value_trace"]);
+            assert_eq!(second["state"], complete["state"]);
+            assert_eq!(second["session_work"], complete["session_work"]);
+            assert_eq!(second["session_work"]["values"]["derived_writes"], 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
The native reader can copy retained values but cannot produce an arithmetic result absent from those routes. This adds an optional typed-value component to the stronger `/4` artifact: bounded literal ingestion, learned operand/Copy/Add/NoWrite selection, checked integer-domain `ZPhi::checked_add`, a causal derived-value write, and allocation-free numeral byte emission through the ordinary shortlist. Predictions do not advance the write/cursor until the selected token is observed. CLI, HTTP continuation and versioned checkpoints use the same state law.

The first fitted selector exposed a specific binding failure across lexical-token versus byte-fallback names. Version `/2` retains bounded complete-word cues and learns query-position/source-word matches from additional raw construction name swaps. `/1`, the stronger ordinary `/4` reader and both earlier `/5` negatives remain preserved.

Measured reused OPEN development:

- `/1`: 20/24 numeric targets, 0/4 complete binding pairs; `/2`: 24/24 numeric targets and 4/4 binding pairs, with changed source occurrences verified.
- Disabling `/2` whole-word scoring leaves 4/24 correct numerals; disabling typed values leaves 0/24. H4/zeta-disabled retain Full's typed actions and operands, so no added typed-selection benefit from those features is established here.
- Complete responses remain 2/16 prose and 0/16 Rust. All 20 original generated Rust sources fail compilation in each fit. The remaining numeric failure begins after numeral emission; no punctuation or response template is appended to hide it.
- The final executable reproduces `/1` source/model bytes and 136 case/control outputs, tokens, stops and traces. Explicit differences are corrected mismatch telemetry and the larger optional-state layout. Artifact/source/binary identities and raw local receipt paths are in the compact evidence.

Validation: pinned release build; 72 native core tests, then 16 affected typed tests including the final retained-word snapshot regression; three source/allocation tests, three context tests, four probe tests, 16 CLI/service tests; formatting, architecture policy and claim wording. Both typed versions retain zero steady-state allocations through writes/emission/eviction. Historical queue status names must not be interpreted as release audit/fuzz/WASM/Gate-C results.

Cumulative model work is 894.645/1,800 seconds with the inherited storage law and safety margin unchanged. Engineering builds/tests and their failed attempts are recorded separately. All inherited artifacts, prior worktrees and unrelated main-checkout material are preserved. Only documented current-run failed compiler outputs were removed. This is bounded mechanism/binding progress, not conversation/coding alpha or expert-routing efficiency qualification.

Refs #973. Keep the parent objective open; the observed next cause is learned continuation and termination after a committed value.
