### PR TITLE
Complete native typed values through learned geometric byte transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,24 @@ results, remaining learned-operator work and capability limitations.
 
 The [native mechanism map](docs/native_geometric_mechanism_map_973.md) traces
 the implemented prime/zeta/R4 mechanisms from source to generated responses.
-The [response-state record](docs/native_geometric_response_state_973.md)
-adds explicit query persistence and model-selected source state. Both matched
-fits regress against the preceding occurrence reader: exact prose is 5/32
-versus 6/32, and Rust remains 0/32. They remain development options, with
-their controls, actual outputs and costs preserved. Useful response composition
-and coding remain unresolved. The subsequent
-[typed-value record](docs/native_geometric_typed_value_973.md) adds learned
-operand/action selection, checked value creation and causal decimal emission.
-Its whole-word correction reaches 24/24 numeric targets and all four binding
-pairs on reused open development, while complete responses remain 2/16 prose
-and 0/16 Rust and all 20 generated Rust sources fail compilation. It preserves
-the earlier binding negative and establishes no new H4/zeta selection benefit.
+The latest [typed-value completion record](docs/native_geometric_value_completion_973.md)
+combines bounded whole-word operand binding, checked value creation and decimal
+emission with learned geometric continuation and stopping. On the reused open
+development set it completes 12/16 prose and 12/16 Rust responses exactly;
+all 24 numeric targets and all four binding pairs are correct. Sixteen saved
+Rust records compile and pass their assertions (14 distinct successful sources);
+the eight nonnumeric cases remain incorrect. Removing this completion head's
+H4/orientation/phase features preserves the six-token candidate set and correct
+numerals but loses all complete numeric responses. This establishes combined
+geometric-score dependence in this fitted head, with no separately fitted
+comparison, new-response-form transfer or efficiency advantage yet measured.
+
+The [typed-value record](docs/native_geometric_typed_value_973.md) preserves the
+preceding binding negative and whole-word correction; the latter produced correct
+numerals but only 2/16 prose and 0/16 Rust complete responses. Both earlier
+[response-state fits](docs/native_geometric_response_state_973.md) remain scoped
+negatives against the stronger occurrence reader. General conversation, coding,
+reasoning and alpha capability remain unresolved.
 
 ## Preserved project entry points
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -9,16 +9,22 @@ use std::error::Error;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use uor_r4_core::native_geometric::{Control, Model, ValueExample, ValueFitConfig};
+use uor_r4_core::native_geometric::{
+    Control, Model, ValueCompletionFitConfig, ValueExample, ValueFitConfig,
+};
 
 type ProbeResult<T> = Result<T, Box<dyn Error>>;
 const SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/1";
 const LEXEME_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/2";
 const MAX_SOURCE_BYTES: u64 = 4 * 1024 * 1024;
+const COMPLETION_OUTPUT_BYTES: usize = 20 * 1024 * 1024;
+const PRESERVATION_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+static OUTPUT_BYTES_REMAINING: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 #[derive(Debug, Serialize)]
 struct Options {
@@ -34,6 +40,8 @@ struct Options {
     generated_tokens: usize,
     max_seconds: u64,
     lexeme_cues: bool,
+    controls: String,
+    completion_max_positions: usize,
 }
 
 impl Options {
@@ -57,18 +65,24 @@ impl Options {
             generated_tokens: 32,
             max_seconds: 120,
             lexeme_cues: false,
+            controls: "all".into(),
+            completion_max_positions: 4096,
         };
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "native_geometric_value_probe [prepare|fit|evaluate] --output-dir NEW_DIRECTORY\n\
+                    "native_geometric_value_probe [prepare|fit|completion|evaluate] --output-dir NEW_DIRECTORY\n\
                      fit: --model BASELINE [--source source.json]\n\
+                     completion: --model TYPED_MODEL --source SOURCE_V2 --lexeme-cues true\n\
                      evaluate: --model VALUE_MODEL --source source.json\n\
+                     evaluate --controls full: only Full, including the existing binding pairs\n\
                      --fit-worlds EVEN_NUMBER --development-worlds EVEN_NUMBER\n\
                      --epochs N --learning-rate F --max-features N\n\
+                     --completion-max-positions N (default 4096, completion fitting only)\n\
                      --generated-tokens N --max-seconds N\n\
                      --lexeme-cues true|false (default false; true appends 64 fit\n\
                      name swaps at default world count and uses source schema /2)\n\
+                     Completion output is capped at 20 MiB; Full-only preservation at 8 MiB.\n\
                      Defaults: 128 fit and 32 development cases across prose/Rust;\n\
                      paired worlds alter one numeric literal. Full byte exactness,\n\
                      leading numeral correctness and no-write behavior stay separate.\n\
@@ -92,13 +106,21 @@ impl Options {
                 "--generated-tokens" => result.generated_tokens = value.parse()?,
                 "--max-seconds" => result.max_seconds = value.parse()?,
                 "--lexeme-cues" => result.lexeme_cues = value.parse()?,
+                "--controls" => result.controls = value,
+                "--completion-max-positions" => result.completion_max_positions = value.parse()?,
                 _ => return Err(format!("unknown option {flag}").into()),
             }
         }
-        if !["prepare", "fit", "evaluate"].contains(&result.mode.as_str())
+        if !["prepare", "fit", "completion", "evaluate"].contains(&result.mode.as_str())
             || result.output_dir.as_os_str().is_empty()
             || (result.mode != "prepare" && result.model.as_os_str().is_empty())
-            || (result.mode == "evaluate" && result.source.is_none())
+            || (["completion", "evaluate"].contains(&result.mode.as_str())
+                && result.source.is_none())
+            || (result.mode == "completion" && !result.lexeme_cues)
+            || (result.mode == "completion" && result.epochs > 64)
+            || !(1..=4096).contains(&result.completion_max_positions)
+            || !["all", "full"].contains(&result.controls.as_str())
+            || (result.controls == "full" && result.mode != "evaluate")
             || !(2..=128).contains(&result.fit_worlds)
             || !(2..=32).contains(&result.development_worlds)
             || !result.fit_worlds.is_multiple_of(2)
@@ -516,6 +538,16 @@ struct Metrics {
 }
 
 fn write_new(path: &Path, bytes: &[u8]) -> ProbeResult<()> {
+    OUTPUT_BYTES_REMAINING
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+            remaining.checked_sub(bytes.len())
+        })
+        .map_err(|_| {
+            format!(
+                "output allowance exhausted before writing {}; retained partial files remain",
+                path.display()
+            )
+        })?;
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(bytes)?;
     Ok(())
@@ -547,6 +579,7 @@ fn reject_training_overlap(model: &Model, cases: &[Case]) -> ProbeResult<()> {
             .chain(model.readout_training())
             .chain(model.memory_read_training())
             .chain(model.value_training())
+            .chain(model.value_completion_training())
             .any(|known| {
                 known.id == case.id || known.text_cid == pair_cid || known.text_cid == whole_cid
             })
@@ -569,13 +602,25 @@ fn evaluate(
 ) -> ProbeResult<Value> {
     reject_training_overlap(model, &source.development)?;
     let mut arms = Vec::new();
-    let mut controls = vec![
-        Control::Full,
-        Control::ValuesDisabled,
-        Control::H4Disabled,
-        Control::ZetaDisabled,
-    ];
-    if options.lexeme_cues {
+    let completion = model.value_completion_version().is_some();
+    let mut controls = if options.controls == "full" {
+        vec![Control::Full]
+    } else if completion {
+        vec![
+            Control::Full,
+            Control::ValueCompletionDisabled,
+            Control::ValueCompletionGeometryDisabled,
+            Control::ValuesDisabled,
+        ]
+    } else {
+        vec![
+            Control::Full,
+            Control::ValuesDisabled,
+            Control::H4Disabled,
+            Control::ZetaDisabled,
+        ]
+    };
+    if options.lexeme_cues && options.controls == "all" && !completion {
         // Suppress kind-16 features in this fitted artifact while retaining its
         // state. This measures feature sensitivity, not a separately fitted
         // matched baseline.
@@ -645,10 +690,21 @@ fn evaluate(
         if control == Control::ValueLexemesDisabled {
             arm["scope"] = json!("Within-artifact lexical-feature sensitivity: kind-16 query-position/source-word match features disabled while retaining the same fitted artifact and state. This is not a separately fitted matched baseline.");
         }
-        write_json(
-            &options.output_dir.join(format!("arm-{}.json", arms.len())),
-            &arm,
-        )?;
+        if control == Control::ValueCompletionDisabled {
+            arm["scope"] = json!("Within-artifact completion-feature suppression. Typed operand selection and numeral emission remain enabled. This is not a separately fitted matched baseline.");
+        }
+        if control == Control::ValueCompletionGeometryDisabled {
+            arm["scope"] = json!("Within-artifact suppression of completion H4/orientation/phase feature contributions. The underlying typed-value and ordinary model geometry remain enabled. This measures feature sensitivity, not separately fitted matched training or general geometric advantage.");
+        }
+        // Completion reports retain the complete generation objects once in
+        // report.json to keep the model, exact outputs and traces within the
+        // configured output allowance. Historical typed-only files stay intact.
+        if !completion {
+            write_json(
+                &options.output_dir.join(format!("arm-{}.json", arms.len())),
+                &arm,
+            )?;
+        }
         arms.push(arm);
     }
     Ok(json!(arms))
@@ -724,6 +780,14 @@ fn evaluate_binding(
 
 fn main() -> ProbeResult<()> {
     let options = Options::parse()?;
+    let output_limit = if options.mode == "completion" {
+        Some(COMPLETION_OUTPUT_BYTES)
+    } else if options.controls == "full" {
+        Some(PRESERVATION_OUTPUT_BYTES)
+    } else {
+        None
+    };
+    OUTPUT_BYTES_REMAINING.store(output_limit.unwrap_or(usize::MAX), Ordering::Relaxed);
     let start = Instant::now();
     let source = source(&options)?;
     if let Some(parent) = options
@@ -764,32 +828,46 @@ fn main() -> ProbeResult<()> {
     within_limit(start, &options)?;
     let baseline = Model::from_bytes(&fs::read(&options.model)?)?;
     let input_artifact = baseline.artifact_cid().to_owned();
-    let (model, fit_report) = if options.mode == "fit" {
+    let (model, fit_report) = if ["fit", "completion"].contains(&options.mode.as_str()) {
         let examples: Vec<_> = source.fit.iter().map(Case::example).collect();
-        let config = ValueFitConfig {
-            epochs: options.epochs,
-            learning_rate: options.learning_rate,
-            max_features: options.max_features,
-        };
-        let (fitted, report) = if options.lexeme_cues {
-            baseline.fit_values_with_lexeme_cues(&examples, config)?
+        let (fitted, report) = if options.mode == "completion" {
+            let (fitted, report) = baseline.fit_value_completion(
+                &examples,
+                ValueCompletionFitConfig {
+                    epochs: options.epochs,
+                    learning_rate: options.learning_rate,
+                    max_positions: options.completion_max_positions,
+                },
+            )?;
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
         } else {
-            baseline.fit_values(&examples, config)?
+            let config = ValueFitConfig {
+                epochs: options.epochs,
+                learning_rate: options.learning_rate,
+                max_features: options.max_features,
+            };
+            let (fitted, report) = if options.lexeme_cues {
+                baseline.fit_values_with_lexeme_cues(&examples, config)?
+            } else {
+                baseline.fit_values(&examples, config)?
+            };
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
         };
-        write_json(&options.output_dir.join("fit-report.json"), &report)?;
         write_new(&options.output_dir.join("model.json"), &fitted.to_bytes()?)?;
         // Evaluate the serialized/reloaded artifact, not only the trainer's
         // in-memory object. Parent monitoring charges this loading/serialization.
         let reloaded = Model::from_bytes(&fs::read(options.output_dir.join("model.json"))?)?;
-        (reloaded, Some(serde_json::to_value(report)?))
+        (reloaded, Some(report))
     } else {
         (baseline, None)
     };
     within_limit(start, &options)?;
     let arms = evaluate(&model, &source, &options, start)?;
     let binding_controls = evaluate_binding(&model, &binding_source, &options, start)?;
-    let report = json!({
-        "schema":if options.lexeme_cues { "uor-r4.native-typed-value-probe/2" } else { "uor-r4.native-typed-value-probe/1" },
+    let mut report = json!({
+        "schema":if model.value_completion_version().is_some() { "uor-r4.native-value-completion-probe/1" } else if options.lexeme_cues { "uor-r4.native-typed-value-probe/2" } else { "uor-r4.native-typed-value-probe/1" },
         "status":"completed",
         "scope":source.scope,
         "tokenization_law":source.tokenization_law,
@@ -809,6 +887,18 @@ fn main() -> ProbeResult<()> {
         "compilation":"NOT_RUN: exact generated Rust saved for separate inspected-source assessment",
         "execution":"NOT_RUN",
     });
+    if let Some(version) = model.value_completion_version() {
+        report["completion_operator_version"] = json!(version);
+        report["completion_scope"] = json!("Same /2 raw source and unchanged OPEN development targets. Fitting follows actual upstream numeral rollouts, then supervises ordinary suffix bytes and EOS; no generated suffix or target template is appended. Completion traces describe the learned step transitions. Primary and binding controls remain reused design feedback, not final held-out evaluation.");
+    }
+    if options.controls != "all" {
+        report["controls_selection"] = json!(options.controls);
+    }
+    if let Some(limit) = output_limit {
+        report["resources"]["output_bytes_limit"] = json!(limit);
+        report["resources"]["output_bytes_before_report"] =
+            json!(limit - OUTPUT_BYTES_REMAINING.load(Ordering::Relaxed));
+    }
     write_json(&options.output_dir.join("report.json"), &report)?;
     println!(
         "{}",

--- a/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
@@ -1,0 +1,316 @@
+//! Integer/table next-token transitions after a causally completed numeral.
+//! No suffix string, answer buffer, task grammar or target lookup is stored.
+use super::completion_types::*;
+use super::value_types::{ValueAction, ValueState};
+use super::*;
+
+impl CompletionState {
+    /// Caller response boundaries clear completion state, preserving the two
+    /// actual observed tokens and their absolute observation count.
+    pub(super) fn reset(&mut self) {
+        self.anchor = None;
+        self.steps = 0;
+        self.active = false;
+        self.last_action = CompletionAction::Base;
+        self.pending = None;
+    }
+
+    /// Called after typed-value observation. The seed is taken from its prior
+    /// pending decision, never reconstructed from the observed token's value.
+    pub(super) fn observe(
+        &mut self,
+        _model: &Model,
+        values: &ValueState,
+        token: u32,
+        seed: Option<CompletionSeed>,
+        control: Control,
+        work: &mut CompletionWork,
+    ) {
+        work.observations = work.observations.saturating_add(1);
+        let pending = self.pending.take();
+        let was_active = self.active;
+        self.last_action = CompletionAction::Base;
+        if was_active {
+            self.steps = self.steps.saturating_add(1);
+            let matched =
+                pending.filter(|decision| decision.token == token && decision.at_seen == self.seen);
+            if let Some(decision) = matched {
+                self.last_action = decision.action;
+                work.commits = work.commits.saturating_add(1);
+            } else {
+                self.last_action = CompletionAction::Base;
+                work.base_steps = work.base_steps.saturating_add(1);
+                if pending.is_some() {
+                    work.mismatches = work.mismatches.saturating_add(1);
+                }
+            }
+        }
+        self.previous = self.last;
+        self.last = token;
+        self.seen = values.seen;
+        work.state_copies = work.state_copies.saturating_add(3);
+        if token == EOS {
+            if was_active {
+                work.stops = work.stops.saturating_add(1);
+            }
+            self.reset();
+            self.last_action = CompletionAction::Stop;
+            return;
+        }
+        if was_active {
+            if self.steps >= COMPLETION_STEPS {
+                let action = self.last_action;
+                self.reset();
+                self.last_action = action;
+                work.step_limits = work.step_limits.saturating_add(1);
+            }
+            return;
+        }
+        if matches!(control, Control::ValuesDisabled | Control::MemoryDisabled)
+            || !values.active
+            || !values.consumed
+            || values.emission.is_some()
+            || values.query_len == 0
+        {
+            return;
+        }
+        let Some(seed) = seed
+            .filter(|seed| seed.token == token && seed.at_seen.checked_add(1) == Some(values.seen))
+        else {
+            return;
+        };
+        work.metadata_reads = work.metadata_reads.saturating_add(2);
+        let Some(record) = values.records.last().filter(|record| {
+            record.id == seed.write_id
+                && record.derived
+                && record
+                    .derivation
+                    .is_some_and(|origin| origin.action == seed.action)
+        }) else {
+            return;
+        };
+        self.anchor = Some(CompletionAnchor {
+            write_id: record.id,
+            action: seed.action,
+            at_seen: values.seen,
+            pose: values.pose,
+            phases: values.phases,
+            query_prime: values.queries[0].cue,
+        });
+        self.steps = 0;
+        self.active = true;
+        self.last_action = CompletionAction::Base;
+        work.anchors = work.anchors.saturating_add(1);
+        // Five scalar fields and the eight-channel phase array are copied.
+        work.state_copies = work.state_copies.saturating_add(13);
+    }
+
+    pub(super) fn features(
+        &self,
+        model: &Model,
+        values: &ValueState,
+        control: Control,
+        work: &mut CompletionWork,
+    ) -> ([Feature; COMPLETION_FEATURES], usize) {
+        let mut features = [Feature { kind: 0, value: 0 }; COMPLETION_FEATURES];
+        let Some(anchor) = self.anchor else {
+            return (features, 0);
+        };
+        let last = u64::from(model.geometry.tokens[self.last as usize].prime);
+        let previous = u64::from(model.geometry.tokens[self.previous as usize].prime);
+        work.metadata_reads = work.metadata_reads.saturating_add(2);
+        let mut len = 0;
+        let mut add = |kind, value| {
+            features[len] = Feature { kind, value };
+            len += 1;
+        };
+        add(0, 0);
+        add(1, last);
+        add(2, (previous << 32) | last);
+        add(3, u64::from(anchor.query_prime));
+        add(4, (u64::from(anchor.query_prime) << 32) | last);
+        let op = match anchor.action {
+            ValueAction::Copy => 0,
+            ValueAction::Add => 1,
+        };
+        add(5, (op << 8) | u64::from(self.steps));
+        if !matches!(
+            control,
+            Control::GeometryDisabled
+                | Control::H4Disabled
+                | Control::ValueCompletionGeometryDisabled
+        ) {
+            let inverse = model.geometry.inverses[usize::from(anchor.pose)];
+            let relative = model.geometry.products
+                [model.geometry.row_bases[usize::from(inverse)] + usize::from(values.pose)];
+            work.h4_reads = work.h4_reads.saturating_add(2);
+            // The row-base addressing table is separate from the H4 entries.
+            work.metadata_reads = work.metadata_reads.saturating_add(1);
+            add(6, u64::from(relative));
+            if !matches!(
+                control,
+                Control::OrientationDisabled | Control::HeatmapDisabled
+            ) {
+                add(
+                    7,
+                    u64::from(model.geometry.orientation[usize::from(relative)]),
+                );
+                work.orientation_reads = work.orientation_reads.saturating_add(1);
+            }
+        }
+        if !matches!(
+            control,
+            Control::GeometryDisabled
+                | Control::ZetaDisabled
+                | Control::ValueCompletionGeometryDisabled
+        ) {
+            for channel in 0..PHASE_CHANNELS {
+                let phase = values.phases[channel].wrapping_sub(anchor.phases[channel]);
+                add(8 + channel as u8, u64::from(phase >> 12));
+                work.phase_subtractions = work.phase_subtractions.saturating_add(1);
+            }
+        }
+        (features, len)
+    }
+
+    pub(super) fn offer(
+        &mut self,
+        model: &Model,
+        values: &ValueState,
+        baseline: Candidate,
+        control: Control,
+        work: &mut CompletionWork,
+    ) -> Option<Candidate> {
+        self.pending = None;
+        if !self.active
+            || !values.active
+            || self.steps >= COMPLETION_STEPS
+            || matches!(
+                control,
+                Control::ValueCompletionDisabled
+                    | Control::ValuesDisabled
+                    | Control::MemoryDisabled
+            )
+        {
+            return None;
+        }
+        let head = model.completion.as_ref()?;
+        let anchor = self.anchor?;
+        let (features, len) = self.features(model, values, control, work);
+        let (tokens, count, rows, row_count) = candidates(head, &features[..len], work);
+        let mut best = None;
+        let mut best_score = 0_i64;
+        for token in tokens[..count].iter().copied() {
+            let score = score_candidate(head, token, &rows[..row_count], work);
+            if score > best_score
+                || (score == best_score && score > 0 && best.is_some_and(|known| token < known))
+            {
+                best = Some(token);
+                best_score = score;
+            }
+        }
+        let token = best?;
+        let score = baseline.score + best_score;
+        self.pending = Some(CompletionDecision {
+            token,
+            score,
+            write_id: anchor.write_id,
+            step: self.steps,
+            at_seen: self.seen,
+            action: if token == EOS {
+                CompletionAction::Stop
+            } else {
+                CompletionAction::Emit
+            },
+        });
+        Some(Candidate { token, score })
+    }
+
+    pub(super) fn selected(&mut self, best: Candidate) {
+        if self
+            .pending
+            .is_some_and(|decision| decision.token != best.token || decision.score != best.score)
+        {
+            self.pending = None;
+        }
+    }
+}
+
+pub(super) fn candidates(
+    head: &CompletionModel,
+    features: &[Feature],
+    work: &mut CompletionWork,
+) -> (
+    [u32; COMPLETION_CANDIDATES],
+    usize,
+    [usize; COMPLETION_FEATURES],
+    usize,
+) {
+    let mut tokens = [0; COMPLETION_CANDIDATES];
+    let mut count = 0;
+    let mut rows = [0; COMPLETION_FEATURES];
+    let mut row_count = 0;
+    for feature in features {
+        work.feature_queries = work.feature_queries.saturating_add(1);
+        if let Ok(index) = head.rows.binary_search_by(|row| {
+            work.row_comparisons = work.row_comparisons.saturating_add(1);
+            row.feature.cmp(feature)
+        }) {
+            rows[row_count] = index;
+            row_count += 1;
+            work.matched_rows = work.matched_rows.saturating_add(1);
+            for &token in &head.rows[index].postings {
+                offer_token(&mut tokens, &mut count, token, work);
+            }
+        }
+    }
+    for &token in &head.global_postings {
+        offer_token(&mut tokens, &mut count, token, work);
+    }
+    (tokens, count, rows, row_count)
+}
+
+fn offer_token(
+    tokens: &mut [u32; COMPLETION_CANDIDATES],
+    count: &mut usize,
+    token: u32,
+    work: &mut CompletionWork,
+) {
+    work.posting_offers = work.posting_offers.saturating_add(1);
+    for &known in &tokens[..*count] {
+        work.candidate_comparisons = work.candidate_comparisons.saturating_add(1);
+        if known == token {
+            return;
+        }
+    }
+    if *count == COMPLETION_CANDIDATES {
+        work.candidate_drops = work.candidate_drops.saturating_add(1);
+    } else {
+        tokens[*count] = token;
+        *count += 1;
+        work.candidate_writes = work.candidate_writes.saturating_add(1);
+    }
+}
+
+pub(super) fn score_candidate(
+    head: &CompletionModel,
+    token: u32,
+    rows: &[usize],
+    work: &mut CompletionWork,
+) -> i64 {
+    let mut score = 0;
+    for &index in rows {
+        let row = &head.rows[index];
+        work.score_lookups = work.score_lookups.saturating_add(1);
+        score += i64::from(
+            row.scores
+                .binary_search_by(|entry| {
+                    work.score_comparisons = work.score_comparisons.saturating_add(1);
+                    entry.token.cmp(&token)
+                })
+                .map_or(row.default_score, |index| row.scores[index].score),
+        );
+    }
+    work.candidate_evaluations = work.candidate_evaluations.saturating_add(1);
+    score
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_runtime_tests.rs
@@ -1,0 +1,293 @@
+//! Mechanical causal checks and separately learned raw-byte completion tests.
+use super::completion_runtime;
+use super::completion_types::*;
+use super::numeral::NUMERAL_CODEC;
+use super::value_types::{ValueFeature, ValueModel, ValueRow, LEXEME_VALUE_SCHEMA, VALUES};
+use super::*;
+
+fn baseline() -> Model {
+    let documents = [Document {
+        id: "completion-unit-count-construction".into(),
+        text: "source value query without a number 9 17 101 176 ; : , . ( ) { }\n".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 64,
+            candidate_limit: 16,
+            max_lexical_pieces: 128,
+            ..Config::default()
+        },
+        &documents,
+    )
+    .unwrap();
+    trainer.train_documents(&documents).unwrap();
+    let mut model = trainer.compile().unwrap();
+    // A fixed Copy gate establishes typed mechanics for these unit fixtures;
+    // the test below learns completion weights from raw responses separately.
+    model.values = Some(ValueModel {
+        schema: LEXEME_VALUE_SCHEMA.into(),
+        codec: NUMERAL_CODEC.into(),
+        capacity: VALUES,
+        rows: vec![ValueRow {
+            feature: ValueFeature {
+                kind: 0,
+                a: 0,
+                b: 0,
+            },
+            weight: 4096,
+        }],
+        continuation_score: 4096,
+        fit_config: [0; 4],
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    model
+}
+
+fn mechanical(token: u32, score: i32) -> Model {
+    let mut model = baseline();
+    let baseline_artifact = model.artifact_cid.clone();
+    model.completion = Some(CompletionModel {
+        schema: COMPLETION_SCHEMA.into(),
+        baseline_artifact,
+        rows: vec![ScoreRow {
+            feature: Feature { kind: 0, value: 0 },
+            default_score: 0,
+            scores: vec![TokenScore { token, score }],
+            postings: vec![token],
+        }],
+        global_postings: vec![token],
+        fit_config: [0; 4],
+        fit_positions: 0,
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    model
+}
+
+fn prefix(model: &Model, source: &str, control: Control) -> Session {
+    let mut session = model.session(control).unwrap();
+    session.observe(model, BOS).unwrap();
+    for token in model.encode(source).unwrap() {
+        session.observe(model, token).unwrap();
+    }
+    session.begin_response(model).unwrap();
+    session
+}
+
+#[test]
+fn native_completion_requires_the_observed_final_digit_and_uses_actual_suffix_history() {
+    let model = mechanical(u32::from(b'.') + 2, 1000);
+    let mut session = prefix(&model, "source 17; query:", Control::Full);
+    let first = session.predict(&model).unwrap();
+    assert_eq!(first.token, u32::from(b'1') + 2);
+    assert!(!session.completion.as_ref().unwrap().active);
+    assert_eq!(session.predict(&model).unwrap(), first);
+    session.observe(&model, first.token).unwrap();
+    assert!(!session.completion.as_ref().unwrap().active);
+    let final_digit = session.predict(&model).unwrap();
+    assert_eq!(final_digit.token, u32::from(b'7') + 2);
+    session.observe(&model, final_digit.token).unwrap();
+    let anchor = session.completion.as_ref().unwrap().anchor.unwrap();
+    let values = session.values.as_ref().unwrap();
+    assert_eq!(anchor.at_seen, values.seen);
+    assert_eq!(anchor.pose, values.pose);
+    assert_eq!(anchor.phases, values.phases);
+    let writes = session.work.values.derived_writes;
+    let state = *session.completion.as_ref().unwrap();
+    let next = session.predict(&model).unwrap();
+    assert_eq!(next.token, u32::from(b'.') + 2);
+    assert_eq!(session.completion.as_ref().unwrap().steps, state.steps);
+    assert_eq!(session.predict(&model).unwrap(), next);
+    let wrong = u32::from(b'?') + 2;
+    session.observe(&model, wrong).unwrap();
+    let completion = session.completion.as_ref().unwrap();
+    assert_eq!(completion.steps, 1);
+    assert_eq!(completion.last, wrong);
+    assert_eq!(completion.last_action, CompletionAction::Base);
+    assert_eq!(session.work.completion.mismatches, 1);
+    assert_eq!(session.work.values.derived_writes, writes);
+    let (features, len) = completion.features(
+        &model,
+        session.values.as_ref().unwrap(),
+        Control::Full,
+        &mut CompletionWork::default(),
+    );
+    assert!(features[..len].contains(&Feature {
+        kind: 1,
+        value: u64::from(model.geometry.tokens[wrong as usize].prime)
+    }));
+    session.observe(&model, EOS).unwrap();
+    assert!(!session.completion.as_ref().unwrap().active);
+    assert!(session.completion.as_ref().unwrap().anchor.is_none());
+    session.observe(&model, u32::from(b'x') + 2).unwrap();
+    assert_eq!(
+        session.completion.as_ref().unwrap().last_action,
+        CompletionAction::Base
+    );
+
+    let mut interrupted = prefix(&model, "source 17; query:", Control::Full);
+    let first = interrupted.predict(&model).unwrap();
+    interrupted.observe(&model, first.token).unwrap();
+    interrupted.predict(&model).unwrap();
+    interrupted.observe(&model, wrong).unwrap();
+    assert!(!interrupted.completion.as_ref().unwrap().active);
+    assert_eq!(interrupted.work.completion.anchors, 0);
+}
+
+#[test]
+fn native_completion_single_digit_stop_disabled_controls_and_step_cap_are_causal() {
+    let model = mechanical(EOS, 1000);
+    let mut session = prefix(&model, "source 9; query:", Control::Full);
+    let digit = session.predict(&model).unwrap();
+    session.observe(&model, digit.token).unwrap();
+    assert!(session.completion.as_ref().unwrap().active);
+    assert_eq!(session.work.completion.anchors, 1);
+    let stop = session.predict(&model).unwrap();
+    assert_eq!(stop.token, EOS);
+    assert_eq!(
+        session.completion.as_ref().unwrap().pending.unwrap().action,
+        CompletionAction::Stop
+    );
+    session.observe(&model, EOS).unwrap();
+    assert_eq!(session.work.completion.commits, 1);
+    assert_eq!(session.work.completion.stops, 1);
+    assert!(!session.completion.as_ref().unwrap().active);
+
+    let mut disabled = prefix(&model, "source 9; query:", Control::ValueCompletionDisabled);
+    let digit = disabled.predict(&model).unwrap();
+    disabled.observe(&model, digit.token).unwrap();
+    assert!(disabled.completion.as_ref().unwrap().active);
+    disabled.predict(&model).unwrap();
+    assert!(disabled.completion.as_ref().unwrap().pending.is_none());
+    assert_eq!(disabled.work.completion.feature_queries, 0);
+    let mut no_values = prefix(&model, "source 9; query:", Control::ValuesDisabled);
+    no_values.predict(&model).unwrap();
+    no_values.observe(&model, u32::from(b'9') + 2).unwrap();
+    assert!(!no_values.completion.as_ref().unwrap().active);
+
+    let model = mechanical(u32::from(b'.') + 2, 1000);
+    let mut bounded = prefix(&model, "source 9; query:", Control::Full);
+    let digit = bounded.predict(&model).unwrap();
+    bounded.observe(&model, digit.token).unwrap();
+    for _ in 0..COMPLETION_STEPS {
+        let next = bounded.predict(&model).unwrap();
+        assert_ne!(next.token, EOS);
+        bounded.observe(&model, next.token).unwrap();
+    }
+    assert!(!bounded.completion.as_ref().unwrap().active);
+    assert!(bounded.completion.as_ref().unwrap().anchor.is_none());
+    assert_eq!(bounded.work.completion.step_limits, 1);
+    assert_eq!(bounded.work.completion.commits, u64::from(COMPLETION_STEPS));
+}
+
+#[test]
+fn native_completion_postings_and_sparse_score_work_have_fixed_bounds() {
+    let features: [Feature; COMPLETION_FEATURES] = std::array::from_fn(|kind| Feature {
+        kind: kind as u8,
+        value: 0,
+    });
+    let head = CompletionModel {
+        schema: COMPLETION_SCHEMA.into(),
+        baseline_artifact: String::new(),
+        fit_config: [0; 4],
+        fit_positions: 0,
+        training: Vec::new(),
+        global_postings: (2..18).collect(),
+        rows: features
+            .iter()
+            .enumerate()
+            .map(|(index, feature)| {
+                let postings: Vec<_> = (0..4)
+                    .map(|offset| 2 + (index * 4 + offset) as u32)
+                    .collect();
+                ScoreRow {
+                    feature: *feature,
+                    default_score: 0,
+                    scores: postings
+                        .iter()
+                        .map(|&token| TokenScore { token, score: 1 })
+                        .collect(),
+                    postings,
+                }
+            })
+            .collect(),
+    };
+    let mut work = CompletionWork::default();
+    let (tokens, len, rows, row_count) =
+        completion_runtime::candidates(&head, &features, &mut work);
+    assert_eq!(len, COMPLETION_CANDIDATES);
+    assert_eq!(row_count, COMPLETION_FEATURES);
+    assert_eq!(work.posting_offers, 80);
+    assert_eq!(work.candidate_drops, 48);
+    assert!(work.candidate_comparisons <= 1280);
+    for &token in &tokens[..len] {
+        completion_runtime::score_candidate(&head, token, &rows[..row_count], &mut work);
+    }
+    assert_eq!(work.score_lookups, 256);
+    assert_eq!(work.candidate_evaluations, 16);
+}
+
+#[test]
+fn native_completion_raw_response_fit_learns_suffix_and_stop_without_repairing_wrong_numbers() {
+    let model = baseline();
+    let mut examples = Vec::new();
+    for index in 0..12 {
+        let number = 101 + index;
+        for (family, query, suffix) in [("prose", ':', ".\n"), ("rust", ',', ");\n}\n")] {
+            examples.push(ValueExample {
+                id: format!("completion-fit/{family}/{index}"),
+                prompt: format!("source {number}; query{query}"),
+                response: format!("{number}{suffix}"),
+            });
+        }
+    }
+    examples.push(ValueExample {
+        id: "completion-fit/no-write".into(),
+        prompt: "query without a number:".into(),
+        response: "unknown\n".into(),
+    });
+    for (name, response) in [("short", "176.\n"), ("plus", "+17.\n"), ("zero", "017.\n")] {
+        examples.push(ValueExample {
+            id: format!("completion-fit/upstream-{name}"),
+            prompt: format!("source 17; {name} query:"),
+            response: response.into(),
+        });
+    }
+    let original_values = serde_json::to_value(&model.values).unwrap();
+    let original_bytes = model.to_bytes().unwrap();
+    let (learned, report) = model
+        .fit_value_completion(
+            &examples,
+            ValueCompletionFitConfig {
+                epochs: 24,
+                learning_rate: 0.1,
+                max_positions: 4096,
+            },
+        )
+        .unwrap();
+    assert_eq!(report.matched_numeric, 24);
+    assert_eq!(report.skipped_no_write, 1);
+    assert_eq!(report.upstream_failures, 3);
+    assert_eq!(report.positions, 108);
+    assert_eq!(report.target_in_candidates, report.positions);
+    assert_eq!(report.fit_correct, report.positions);
+    assert_eq!(
+        serde_json::to_value(&learned.values).unwrap(),
+        original_values
+    );
+    assert_eq!(model.to_bytes().unwrap(), original_bytes);
+    for example in &examples[..24] {
+        let generated = learned
+            .generate(&example.prompt, 32, Control::Full)
+            .unwrap();
+        assert_eq!(
+            generated.bytes,
+            example.response.as_bytes(),
+            "{}",
+            example.id
+        );
+        assert_eq!(generated.stop, "end_of_document");
+        assert_eq!(generated.work.completion.stops, 1);
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_snapshot.rs
@@ -1,0 +1,230 @@
+//! Host validation of observed post-numeral state. The anchor is derived from
+//! a checked typed write, then compared with the retained actual token path.
+//! This authenticates consistency with retained evidence, not evicted history.
+use super::*;
+use crate::native_geometric::completion_types::{CompletionAction, CompletionState};
+use crate::native_geometric::numeral::Numeral;
+use crate::prime_route_attention::ZPhi;
+
+fn invalid(message: &str) -> Error {
+    Error(format!("session value completion {message}"))
+}
+
+/// Presence is versioned separately from serde's optional-field default.
+/// Historical models must reject even an explicit null completion field.
+pub(super) fn validate_field_presence(model: &Model, wire: &serde_json::Value) -> Result<()> {
+    let field = wire.get("completion");
+    if model.completion.is_some() {
+        if !field.is_some_and(serde_json::Value::is_object) {
+            return Err(invalid("state is required by this artifact"));
+        }
+    } else if field.is_some() {
+        return Err(invalid("state is foreign to this artifact"));
+    }
+    if field.is_some_and(|state| state.get("pending").is_some()) {
+        return Err(invalid("checkpoint contains a transient prediction"));
+    }
+    Ok(())
+}
+
+impl Session {
+    /// Call only after restoring and validating ValueState. The completion
+    /// candidate workspace is a fixed local array, so no serialized capacity
+    /// or allocation is accepted from a checkpoint.
+    pub(super) fn restore_completion_state(
+        &mut self,
+        model: &Model,
+        saved: CompletionState,
+        retained: &[u32],
+        observed: u64,
+    ) -> Result<()> {
+        if model.completion.is_none() {
+            return Err(invalid("requires a completion artifact"));
+        }
+        let values = self
+            .values
+            .as_ref()
+            .ok_or_else(|| invalid("requires restored typed state"))?;
+        if saved.seen != observed
+            || values.seen != observed
+            || saved.pending.is_some()
+            || saved.active != saved.anchor.is_some()
+            || saved.steps >= 32
+            || (!saved.active && saved.steps != 0)
+            || (saved.active && saved.steps == 0 && saved.last_action != CompletionAction::Base)
+            || saved.last as usize >= model.vocabulary_size()
+            || saved.previous as usize >= model.vocabulary_size()
+            || (saved.last_action == CompletionAction::Stop && saved.last != EOS)
+            || (saved.last_action == CompletionAction::Emit && saved.last == EOS)
+            || observed < retained.len() as u64
+            || values.recent_len != observed.min(32) as usize
+        {
+            return Err(invalid("shape, action or observation counters are invalid"));
+        }
+        let recent = |sequence: u64| {
+            (sequence < observed && observed - sequence <= values.recent_len as u64)
+                .then(|| values.recent[(sequence & 31) as usize])
+        };
+        let token_at = |sequence: u64| -> Result<u32> {
+            let entry =
+                recent(sequence).ok_or_else(|| invalid("actual token history is absent"))?;
+            if entry.sequence != sequence || entry.token as usize >= model.vocabulary_size() {
+                return Err(invalid("actual token history is invalid"));
+            }
+            let oldest = observed - retained.len() as u64;
+            if sequence >= oldest && retained[(sequence - oldest) as usize] != entry.token {
+                return Err(invalid(
+                    "actual token history differs from the session window",
+                ));
+            }
+            Ok(entry.token)
+        };
+        if observed == 0 {
+            if saved.last != BOS
+                || saved.previous != BOS
+                || saved.last_action != CompletionAction::Base
+                || saved.active
+            {
+                return Err(invalid("empty observation state is invalid"));
+            }
+        } else if saved.last != token_at(observed - 1)?
+            || saved.previous
+                != if observed > 1 {
+                    token_at(observed - 2)?
+                } else {
+                    BOS
+                }
+        {
+            return Err(invalid("last tokens differ from actual observations"));
+        }
+        // Emit survives automatic deactivation only on the exact cap step.
+        // A later source observation or explicit response reset clears it.
+        if !saved.active && saved.last_action == CompletionAction::Emit {
+            let record = values
+                .records
+                .last()
+                .filter(|record| {
+                    values.active
+                        && values.consumed
+                        && values.emission.is_none()
+                        && record.derived
+                        && record.start >= values.started_at
+                })
+                .ok_or_else(|| invalid("inactive emit lacks a capped typed response"))?;
+            let numeral = Numeral::from_zphi(ZPhi::new(record.value, 0))
+                .ok_or_else(|| invalid("capped write has no exact numeral"))?;
+            if record
+                .start
+                .checked_add(u64::from(numeral.len))
+                .and_then(|seen| seen.checked_add(32))
+                != Some(observed)
+            {
+                return Err(invalid("inactive emit does not end at the completion cap"));
+            }
+        }
+        if let Some(anchor) = saved.anchor {
+            if !values.active
+                || !values.consumed
+                || values.emission.is_some()
+                || values.query_len == 0
+                || anchor.at_seen == 0
+                || anchor.at_seen > observed
+                || observed - anchor.at_seen != u64::from(saved.steps)
+                || usize::from(anchor.pose) >= model.geometry.inverses.len()
+                || anchor.query_prime != values.queries[0].cue
+                || saved.last == EOS
+                || matches!(
+                    self.control,
+                    Control::ValuesDisabled | Control::MemoryDisabled
+                )
+            {
+                return Err(invalid("anchor or response boundary is invalid"));
+            }
+            let record = values
+                .records
+                .last()
+                .filter(|record| {
+                    record.id == anchor.write_id
+                        && record.derived
+                        && record.id.checked_add(1) == Some(values.next_id)
+                        && record.start >= values.started_at
+                        && record.start == record.end
+                })
+                .ok_or_else(|| invalid("anchor does not identify the current derived write"))?;
+            let derivation = record
+                .derivation
+                .as_ref()
+                .ok_or_else(|| invalid("anchor write lacks checked provenance"))?;
+            if derivation.action != anchor.action
+                || usize::from(record.pose) >= model.geometry.inverses.len()
+            {
+                return Err(invalid("anchor action or write frame is invalid"));
+            }
+            let numeral = Numeral::from_zphi(ZPhi::new(record.value, 0))
+                .ok_or_else(|| invalid("anchor write has no exact numeral"))?;
+            if record.start.checked_add(u64::from(numeral.len)) != Some(anchor.at_seen) {
+                return Err(invalid(
+                    "anchor precedes or exceeds completed numeral emission",
+                ));
+            }
+            let advance = |pose: &mut u16, phases: &mut [u16; PHASE_CHANNELS], token: u32| {
+                let geometry = &model.geometry.tokens[token as usize];
+                *pose = model.geometry.products
+                    [model.geometry.row_bases[usize::from(*pose)] + usize::from(geometry.leaf)];
+                for (phase, delta) in phases.iter_mut().zip(geometry.phases) {
+                    *phase = phase.wrapping_add(delta);
+                }
+            };
+            // Derived record geometry is the state before its first observed
+            // numeral byte. Reconstruct the complete, fixed spelling and check
+            // every part of that spelling which remains in token evidence.
+            let mut pose = record.pose;
+            let mut phases = record.phases;
+            for (offset, &token) in numeral.tokens[..usize::from(numeral.len)]
+                .iter()
+                .enumerate()
+            {
+                let sequence = record.start + offset as u64;
+                if recent(sequence).is_some() && token_at(sequence)? != token {
+                    return Err(invalid("anchor numeral differs from observed bytes"));
+                }
+                advance(&mut pose, &mut phases, token);
+            }
+            if pose != anchor.pose || phases != anchor.phases {
+                return Err(invalid(
+                    "anchor frame differs from the completed typed write",
+                ));
+            }
+            // Active completion has fewer than 32 following observations. Its
+            // endpoint and full actual suffix therefore fit in ValueState's
+            // independently validated 32-entry token/geometry ring, even when
+            // the ordinary context window is smaller.
+            let endpoint = recent(anchor.at_seen - 1)
+                .ok_or_else(|| invalid("anchor endpoint evidence is absent"))?;
+            if endpoint.pose != anchor.pose || endpoint.phases != anchor.phases {
+                return Err(invalid(
+                    "anchor frame differs from retained endpoint evidence",
+                ));
+            }
+            for sequence in anchor.at_seen..observed {
+                let token = token_at(sequence)?;
+                if token == EOS {
+                    return Err(invalid("active suffix crosses an observed end token"));
+                }
+                advance(&mut pose, &mut phases, token);
+                let entry =
+                    recent(sequence).ok_or_else(|| invalid("suffix frame evidence is absent"))?;
+                if pose != entry.pose || phases != entry.phases {
+                    return Err(invalid(
+                        "actual suffix frame differs from retained evidence",
+                    ));
+                }
+            }
+            if pose != values.pose || phases != values.phases {
+                return Err(invalid("current frame differs from the actual suffix"));
+            }
+        }
+        self.completion = Some(saved);
+        Ok(())
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_snapshot_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_snapshot_tests.rs
@@ -1,0 +1,291 @@
+//! Persistence tests use the public fit APIs on a tiny construction fixture.
+//! They establish causal state/serialization behavior, not held-out quality.
+use super::*;
+use crate::native_geometric::completion_training::ValueCompletionFitConfig;
+use crate::native_geometric::completion_types::CompletionAction;
+use std::sync::OnceLock;
+
+const PROMPT: &str = "left = 13; right = 4; total:";
+
+fn fixture() -> &'static Model {
+    static MODEL: OnceLock<Model> = OnceLock::new();
+    MODEL.get_or_init(|| {
+        let catalog = [Document {
+            id: "completion-snapshot-catalog".into(),
+            text: "left right total copy none 13 4 17 18 answer unknown result ;\n".into(),
+        }];
+        let mut trainer = Trainer::new(
+            Config {
+                context_tokens: 8,
+                candidate_limit: 16,
+                max_lexical_pieces: 128,
+                ..Config::default()
+            },
+            &catalog,
+        )
+        .unwrap();
+        trainer.train_documents(&catalog).unwrap();
+        let baseline = trainer.compile().unwrap();
+        let examples = [
+            ValueExample {
+                id: "completion-snapshot-fit-17".into(),
+                prompt: PROMPT.into(),
+                response: "17;\n".into(),
+            },
+            ValueExample {
+                id: "completion-snapshot-fit-18".into(),
+                prompt: "left = 14; right = 4; total:".into(),
+                response: "18;\n".into(),
+            },
+        ];
+        let (typed, report) = baseline
+            .fit_values_with_lexeme_cues(
+                &examples,
+                ValueFitConfig {
+                    epochs: 64,
+                    learning_rate: 0.25,
+                    max_features: 4096,
+                },
+            )
+            .unwrap();
+        assert_eq!(report.fit_correct, 2);
+        let (learned, report) = typed
+            .fit_value_completion(
+                &examples,
+                ValueCompletionFitConfig {
+                    epochs: 32,
+                    learning_rate: 0.25,
+                    max_positions: 32,
+                },
+            )
+            .unwrap();
+        assert_eq!(report.matched_numeric, 2);
+        assert_eq!(report.upstream_failures, 0);
+        assert_eq!(report.positions, 6);
+        Model::from_bytes(&learned.to_bytes().unwrap()).unwrap()
+    })
+}
+
+fn before_numeral(model: &Model) -> Session {
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(model, BOS).unwrap();
+    for token in model.encode(PROMPT).unwrap() {
+        session.observe(model, token).unwrap();
+    }
+    session.begin_response(model).unwrap();
+    session
+}
+
+fn emit_digit(session: &mut Session, model: &Model, byte: u8) {
+    let prediction = session.predict(model).unwrap();
+    assert_eq!(prediction.token, u32::from(byte) + 2);
+    assert!(session.value_decision().is_some());
+    session.observe(model, prediction.token).unwrap();
+}
+
+fn anchored(model: &Model) -> Session {
+    let mut session = before_numeral(model);
+    emit_digit(&mut session, model, b'1');
+    assert!(!session.completion.as_ref().unwrap().active);
+    emit_digit(&mut session, model, b'7');
+    assert!(session.completion.as_ref().unwrap().active);
+    assert_eq!(session.completion.as_ref().unwrap().steps, 0);
+    session
+}
+
+fn restored(model: &Model, wire: &serde_json::Value) -> Result<Session> {
+    model.restore_session(&serde_json::to_vec(wire).unwrap())
+}
+
+#[test]
+fn native_completion_checkpoint_preserves_mid_suffix_and_empty_input_continuation() {
+    let model = fixture();
+    let mut original = anchored(model);
+    original.observe(model, u32::from(b';') + 2).unwrap();
+    original.predict(model).unwrap();
+    assert!(original.completion.as_ref().unwrap().pending.is_some());
+    let bytes = original.checkpoint().unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(wire["schema"], "uor-r4.native-geometric-session/4");
+    assert!(wire["completion"].get("pending").is_none());
+    let mut resumed = model.restore_session(&bytes).unwrap();
+    assert!(resumed.completion.as_ref().unwrap().pending.is_none());
+    assert_eq!(resumed.checkpoint().unwrap(), bytes);
+    // The core continuation contract consumes an empty input without another
+    // response boundary; the HTTP request boundary is tested in the service.
+    for token in model.encode("").unwrap() {
+        resumed.observe(model, token).unwrap();
+    }
+    assert!(resumed.completion.as_ref().unwrap().active);
+    assert_eq!(resumed.completion.as_ref().unwrap().steps, 1);
+    for _ in 0..4 {
+        let left = original.predict(model).unwrap();
+        let right = resumed.predict(model).unwrap();
+        assert_eq!(left, right);
+        assert_eq!(original.completion, resumed.completion);
+        original.observe(model, left.token).unwrap();
+        resumed.observe(model, right.token).unwrap();
+        assert_eq!(original.completion, resumed.completion);
+        assert_eq!(
+            serde_json::to_value(&original.values).unwrap(),
+            serde_json::to_value(&resumed.values).unwrap()
+        );
+        if left.token == EOS {
+            assert!(!resumed.completion.as_ref().unwrap().active);
+            return;
+        }
+    }
+    panic!("tiny fitted completion fixture did not terminate");
+}
+
+#[test]
+fn native_completion_checkpoint_rejects_missing_foreign_and_transient_state() {
+    let model = fixture();
+    let original = anchored(model);
+    let wire: serde_json::Value = serde_json::from_slice(&original.checkpoint().unwrap()).unwrap();
+    let mut missing = wire.clone();
+    missing.as_object_mut().unwrap().remove("completion");
+    assert!(restored(model, &missing).is_err());
+    let mut null = wire.clone();
+    null["completion"] = serde_json::Value::Null;
+    assert!(restored(model, &null).is_err());
+    let mut transient = wire.clone();
+    transient["completion"]["pending"] = serde_json::Value::Null;
+    assert!(restored(model, &transient).is_err());
+    let mut old_schema = wire.clone();
+    old_schema["schema"] = "uor-r4.native-geometric-session/3".into();
+    assert!(restored(model, &old_schema).is_err());
+
+    let mut historical = model.clone();
+    historical.completion = None;
+    historical.refresh_identity().unwrap();
+    let session = historical.session(Control::Full).unwrap();
+    let bytes = session.checkpoint().unwrap();
+    let mut old_wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(old_wire["schema"], "uor-r4.native-geometric-session/3");
+    assert!(old_wire.get("completion").is_none());
+    assert_eq!(
+        historical
+            .restore_session(&bytes)
+            .unwrap()
+            .checkpoint()
+            .unwrap(),
+        bytes
+    );
+    old_wire["completion"] = serde_json::Value::Null;
+    assert!(restored(&historical, &old_wire).is_err());
+}
+
+#[test]
+fn native_completion_checkpoint_rejects_reforged_anchor_and_actual_history() {
+    let model = fixture();
+    let mut original = anchored(model);
+    original.observe(model, u32::from(b';') + 2).unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&original.checkpoint().unwrap()).unwrap();
+    let mutations = [
+        ("/completion/anchor/write_id", serde_json::json!(u64::MAX)),
+        ("/completion/anchor/action", serde_json::json!("copy")),
+        ("/completion/anchor/at_seen", serde_json::json!(0)),
+        ("/completion/anchor/pose", serde_json::json!(u16::MAX)),
+        ("/completion/anchor/query_prime", serde_json::json!(0)),
+        ("/completion/steps", serde_json::json!(32)),
+        ("/completion/active", serde_json::json!(false)),
+        ("/completion/last", serde_json::json!(EOS)),
+        ("/completion/previous", serde_json::json!(BOS)),
+        ("/completion/seen", serde_json::json!(0)),
+        ("/work/completion/observations", serde_json::json!(0)),
+    ];
+    for (pointer, value) in mutations {
+        let mut changed = wire.clone();
+        *changed.pointer_mut(pointer).unwrap() = value;
+        assert!(restored(model, &changed).is_err(), "accepted {pointer}");
+    }
+    let mut phase = wire.clone();
+    let old = phase["completion"]["anchor"]["phases"][0].as_u64().unwrap();
+    phase["completion"]["anchor"]["phases"][0] = ((old + 1) & 65535).into();
+    assert!(restored(model, &phase).is_err());
+}
+
+#[test]
+fn native_completion_checkpoint_cannot_anchor_an_unfinished_numeral() {
+    let model = fixture();
+    let complete = anchored(model);
+    let complete_wire: serde_json::Value =
+        serde_json::from_slice(&complete.checkpoint().unwrap()).unwrap();
+    let mut partial = before_numeral(model);
+    emit_digit(&mut partial, model, b'1');
+    let mut wire: serde_json::Value =
+        serde_json::from_slice(&partial.checkpoint().unwrap()).unwrap();
+    assert!(wire["completion"]["anchor"].is_null());
+    wire["completion"]["anchor"] = complete_wire["completion"]["anchor"].clone();
+    wire["completion"]["active"] = true.into();
+    wire["completion"]["anchor"]["at_seen"] = wire["completion"]["seen"].clone();
+    assert!(restored(model, &wire).is_err());
+}
+
+#[test]
+fn native_completion_checkpoint_follows_mismatched_actual_byte() {
+    let model = fixture();
+    let mut original = anchored(model);
+    let offered = original.predict(model).unwrap();
+    assert!(original.completion.as_ref().unwrap().pending.is_some());
+    let actual = if offered.token != u32::from(b'?') + 2 {
+        u32::from(b'?') + 2
+    } else {
+        u32::from(b'!') + 2
+    };
+    let prior_commits = original.work.completion.commits;
+    original.observe(model, actual).unwrap();
+    assert_eq!(original.work.completion.commits, prior_commits);
+    assert_eq!(
+        original.completion.as_ref().unwrap().last_action,
+        CompletionAction::Base
+    );
+    assert_eq!(original.completion.as_ref().unwrap().last, actual);
+    assert_eq!(original.completion.as_ref().unwrap().steps, 1);
+    let bytes = original.checkpoint().unwrap();
+    let mut resumed = model.restore_session(&bytes).unwrap();
+    assert_eq!(resumed.checkpoint().unwrap(), bytes);
+    assert_eq!(
+        original.predict(model).unwrap(),
+        resumed.predict(model).unwrap()
+    );
+    assert_eq!(original.completion, resumed.completion);
+}
+
+#[test]
+fn native_completion_checkpoint_uses_retained_suffix_through_step_cap() {
+    let model = fixture();
+    let mut original = anchored(model);
+    for _ in 0..31 {
+        original.observe(model, u32::from(b'?') + 2).unwrap();
+    }
+    assert_eq!(original.state().retained_tokens, 8);
+    assert_eq!(original.completion.as_ref().unwrap().steps, 31);
+    let bytes = original.checkpoint().unwrap();
+    let mut resumed = model.restore_session(&bytes).unwrap();
+    assert_eq!(resumed.checkpoint().unwrap(), bytes);
+    original.observe(model, u32::from(b'!') + 2).unwrap();
+    resumed.observe(model, u32::from(b'!') + 2).unwrap();
+    for state in [&original, &resumed] {
+        let completion = state.completion.as_ref().unwrap();
+        assert!(!completion.active);
+        assert!(completion.anchor.is_none());
+        assert_eq!(completion.steps, 0);
+        assert_ne!(completion.last, EOS);
+        assert_eq!(state.work.completion.step_limits, 1);
+    }
+    assert_eq!(original.completion, resumed.completion);
+    assert!(model
+        .restore_session(&resumed.checkpoint().unwrap())
+        .is_ok());
+    resumed.observe(model, EOS).unwrap();
+    resumed.observe(model, u32::from(b'x') + 2).unwrap();
+    assert_eq!(
+        resumed.completion.as_ref().unwrap().last_action,
+        CompletionAction::Base
+    );
+    assert!(model
+        .restore_session(&resumed.checkpoint().unwrap())
+        .is_ok());
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_training.rs
@@ -1,0 +1,648 @@
+//! Offline sparse completion learning from actual frozen typed-value rollouts.
+//! Only individual next-byte/EOS associations enter learned rows and postings.
+use super::completion_runtime;
+use super::completion_types::*;
+use super::value_types::LEXEME_VALUE_SCHEMA;
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueCompletionFitConfig {
+    pub epochs: usize,
+    pub learning_rate: f64,
+    pub max_positions: usize,
+}
+impl Default for ValueCompletionFitConfig {
+    fn default() -> Self {
+        Self {
+            epochs: 24,
+            learning_rate: 0.1,
+            max_positions: COMPLETION_POSITIONS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValueCompletionFitReport {
+    pub schema: String,
+    pub baseline_artifact: String,
+    pub artifact_cid: String,
+    pub examples: usize,
+    pub matched_numeric: usize,
+    pub skipped_no_write: usize,
+    pub upstream_failures: usize,
+    pub position_limit_skips: usize,
+    pub overlong_responses: usize,
+    pub positions: usize,
+    pub target_in_candidates: usize,
+    pub eligible_positions: usize,
+    pub learned_rows: usize,
+    pub learned_associations: usize,
+    pub dropped_row_events: usize,
+    pub dropped_association_events: usize,
+    pub fit_correct: usize,
+    pub fit_loss: f64,
+    pub selected_epoch: usize,
+    pub config: ValueCompletionFitConfig,
+}
+
+struct Frame {
+    features: [Feature; COMPLETION_FEATURES],
+    len: usize,
+    target: u32,
+    baseline: u32,
+}
+struct Alternative {
+    token: u32,
+    weights: Vec<usize>,
+    correct: bool,
+}
+struct Example {
+    alternatives: Vec<Alternative>,
+    baseline_correct: bool,
+}
+
+fn valid_token(token: u32) -> bool {
+    token == EOS || (2..LEXICAL_BASE).contains(&token)
+}
+
+/// Host-only exact numeric-prefix label. It never chooses an inference value
+/// or operand; a shorter emitted number cannot be repaired as a suffix.
+fn canonical_prefix_len(response: &str) -> Option<usize> {
+    let bytes = response.as_bytes();
+    let mut end = usize::from(matches!(bytes.first(), Some(b'+' | b'-')));
+    let first_digit = end;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    if end == first_digit
+        || bytes
+            .get(end)
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+        || (bytes.get(end) == Some(&b'.')
+            && bytes
+                .get(end + 1)
+                .is_some_and(|byte| !byte.is_ascii_whitespace()))
+    {
+        return None;
+    }
+    let value = response[..end].parse::<i64>().ok()?;
+    let numeral =
+        super::numeral::Numeral::from_zphi(crate::prime_route_attention::ZPhi::new(value, 0))?;
+    (usize::from(numeral.len) == end
+        && numeral
+            .as_tokens()
+            .iter()
+            .zip(bytes)
+            .all(|(token, byte)| *token == u32::from(*byte) + 2))
+    .then_some(end)
+}
+
+impl CompletionModel {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        let associations = self.rows.iter().map(|row| row.scores.len()).sum::<usize>();
+        if self.schema != COMPLETION_SCHEMA
+            || !model
+                .values
+                .as_ref()
+                .is_some_and(|values| values.schema == LEXEME_VALUE_SCHEMA)
+            || self.rows.len() > COMPLETION_ROWS
+            || associations > COMPLETION_ASSOCIATIONS
+            || self.global_postings.len() > COMPLETION_CANDIDATES
+            || self
+                .global_postings
+                .iter()
+                .any(|&token| !valid_token(token))
+            || self.global_postings.iter().collect::<BTreeSet<_>>().len()
+                != self.global_postings.len()
+            || self
+                .rows
+                .windows(2)
+                .any(|pair| pair[0].feature >= pair[1].feature)
+            || self.rows.iter().any(|row| {
+                row.feature.kind >= COMPLETION_FEATURES as u8
+                    || row.default_score != 0
+                    || row.postings.len() > COMPLETION_POSTINGS
+                    || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
+                    || row
+                        .scores
+                        .windows(2)
+                        .any(|pair| pair[0].token >= pair[1].token)
+                    || row.scores.iter().any(|entry| {
+                        !valid_token(entry.token)
+                            || !(-1_000_000..=1_000_000).contains(&entry.score)
+                    })
+                    || row.postings.iter().any(|token| {
+                        row.scores
+                            .binary_search_by_key(token, |entry| entry.token)
+                            .is_err()
+                    })
+            })
+            || self.fit_positions > COMPLETION_POSITIONS
+            || self
+                .training
+                .iter()
+                .any(|receipt| receipt.id.trim().is_empty())
+            || self
+                .training
+                .iter()
+                .map(|receipt| &receipt.id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                != self.training.len()
+            || (!self.training.is_empty()
+                && (self.fit_positions == 0
+                    || !(1..=64).contains(&self.fit_config[0])
+                    || !(0.0001..=1.0).contains(&f64::from_bits(self.fit_config[1]))
+                    || !(1..=COMPLETION_POSITIONS as u64).contains(&self.fit_config[2])
+                    || self.fit_config[3] == 0
+                    || self.fit_config[3] > self.fit_config[0]))
+        {
+            return Err(Error("invalid sparse value-completion artifact".into()));
+        }
+        let mut baseline = model.clone();
+        baseline.completion = None;
+        baseline.refresh_identity()?;
+        if baseline.artifact_cid != self.baseline_artifact {
+            return Err(Error(
+                "completion artifact differs from its frozen typed baseline".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Model {
+    pub fn value_completion_version(&self) -> Option<&str> {
+        self.completion.as_ref().map(|head| head.schema.as_str())
+    }
+
+    pub fn value_completion_training(&self) -> &[DocumentReceipt] {
+        self.completion
+            .as_ref()
+            .map_or(&[], |head| head.training.as_slice())
+    }
+
+    pub fn fit_value_completion(
+        &self,
+        documents: &[ValueExample],
+        config: ValueCompletionFitConfig,
+    ) -> Result<(Model, ValueCompletionFitReport)> {
+        let source_bytes = documents.iter().try_fold(0_usize, |sum, document| {
+            sum.checked_add(document.prompt.len())?
+                .checked_add(document.response.len())
+        });
+        if self.completion.is_some()
+            || !self
+                .values
+                .as_ref()
+                .is_some_and(|values| values.schema == LEXEME_VALUE_SCHEMA)
+            || documents.is_empty()
+            || documents.len() > 4096
+            || source_bytes.is_none_or(|bytes| bytes > 16 * 1024 * 1024)
+            || !(1..=64).contains(&config.epochs)
+            || !config.learning_rate.is_finite()
+            || !(0.0001..=1.0).contains(&config.learning_rate)
+            || !(1..=COMPLETION_POSITIONS).contains(&config.max_positions)
+        {
+            return Err(Error(
+                "invalid completion source, configuration or frozen value baseline".into(),
+            ));
+        }
+        let mut model = self.clone();
+        model.completion = Some(CompletionModel {
+            schema: COMPLETION_SCHEMA.into(),
+            baseline_artifact: self.artifact_cid.clone(),
+            rows: Vec::new(),
+            global_postings: Vec::new(),
+            fit_config: [0; 4],
+            fit_positions: 0,
+            training: Vec::new(),
+        });
+        model.refresh_identity()?;
+        let mut frames = Vec::new();
+        let mut receipts = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut prompts = BTreeMap::new();
+        let mut matched_numeric = 0;
+        let mut skipped_no_write = 0;
+        let mut upstream_failures = 0;
+        let mut position_limit_skips = 0;
+        let mut overlong_responses = 0;
+        for document in documents {
+            if document.id.trim().is_empty()
+                || !ids.insert(&document.id)
+                || prompts
+                    .insert(&document.prompt, &document.response)
+                    .is_some_and(|known| known != &document.response)
+            {
+                return Err(Error(
+                    "completion source IDs or raw prompt targets conflict".into(),
+                ));
+            }
+            let receipt = super::training::receipt(&Document {
+                id: document.id.clone(),
+                text: serde_json::to_string(&(&document.prompt, &document.response))
+                    .map_err(|error| Error(error.to_string()))?,
+            });
+            let whole = super::training::receipt(&Document {
+                id: document.id.clone(),
+                text: format!("{}{}", document.prompt, document.response),
+            });
+            if self
+                .construction
+                .iter()
+                .chain(self.readout_training())
+                .chain(self.memory_read_training())
+                .any(|known| {
+                    known.id == receipt.id
+                        || known.text_cid == receipt.text_cid
+                        || known.text_cid == whole.text_cid
+                })
+            {
+                return Err(Error(
+                    "completion source overlaps ordinary model construction".into(),
+                ));
+            }
+            receipts.push(receipt);
+            let target_prefix_len = canonical_prefix_len(&document.response);
+            let mut session = model.session(Control::Full)?;
+            session.observe(&model, BOS)?;
+            for token in model.encode(&document.prompt)? {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            let mut offset = 0;
+            let mut upstream_ok = false;
+            let mut no_write = false;
+            for _ in 0..20 {
+                let prediction = session.predict(&model)?;
+                if session.value_decision().is_none() {
+                    no_write = offset == 0;
+                    break;
+                }
+                let expected = document
+                    .response
+                    .as_bytes()
+                    .get(offset)
+                    .map(|byte| u32::from(*byte) + 2);
+                if expected != Some(prediction.token) {
+                    break;
+                }
+                session.observe(&model, prediction.token)?;
+                offset += 1;
+                if session
+                    .completion
+                    .as_ref()
+                    .is_some_and(|state| state.active)
+                {
+                    upstream_ok = target_prefix_len == Some(offset);
+                    break;
+                }
+            }
+            if !upstream_ok {
+                let numeric_start = document
+                    .response
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|byte| byte.is_ascii_digit() || matches!(*byte, b'+' | b'-'));
+                if no_write && !numeric_start {
+                    skipped_no_write += 1;
+                } else {
+                    upstream_failures += 1;
+                }
+                continue;
+            }
+            matched_numeric += 1;
+            let remaining = &document.response.as_bytes()[offset..];
+            if remaining.len().saturating_add(1) > usize::from(COMPLETION_STEPS) {
+                overlong_responses += 1;
+            }
+            for target in remaining
+                .iter()
+                .map(|byte| u32::from(*byte) + 2)
+                .chain(std::iter::once(EOS))
+                .take(usize::from(COMPLETION_STEPS))
+            {
+                if frames.len() == config.max_positions {
+                    position_limit_skips += 1;
+                    break;
+                }
+                let baseline = session.predict(&model)?.token;
+                let state = session.completion.as_ref().ok_or_else(|| {
+                    Error("completion state missing during actual rollout".into())
+                })?;
+                let values = session
+                    .values
+                    .as_ref()
+                    .ok_or_else(|| Error("typed state missing during completion rollout".into()))?;
+                if !state.active {
+                    return Err(Error(
+                        "completion frame ended before its declared step bound".into(),
+                    ));
+                }
+                let (features, len) = state.features(
+                    &model,
+                    values,
+                    Control::Full,
+                    &mut CompletionWork::default(),
+                );
+                frames.push(Frame {
+                    features,
+                    len,
+                    target,
+                    baseline,
+                });
+                session.observe(&model, target)?;
+            }
+        }
+        if frames.is_empty() {
+            return Err(Error(
+                "completion source has no matched emitted numeral and suffix positions".into(),
+            ));
+        }
+        let mut counts = BTreeMap::<Feature, BTreeMap<u32, u64>>::new();
+        let mut global = BTreeMap::<u32, u64>::new();
+        let mut association_count = 0;
+        let mut dropped_row_events = 0;
+        let mut dropped_association_events = 0;
+        for frame in &frames {
+            *global.entry(frame.target).or_default() += 1;
+            for &feature in &frame.features[..frame.len] {
+                if !counts.contains_key(&feature) && counts.len() == COMPLETION_ROWS {
+                    dropped_row_events += 1;
+                    continue;
+                }
+                let row = counts.entry(feature).or_default();
+                if !row.contains_key(&frame.target) {
+                    if association_count == COMPLETION_ASSOCIATIONS {
+                        dropped_association_events += 1;
+                        continue;
+                    }
+                    association_count += 1;
+                }
+                *row.entry(frame.target).or_default() += 1;
+            }
+        }
+        let mut registry = BTreeMap::<(Feature, u32), usize>::new();
+        let mut weights = Vec::new();
+        let rows = counts
+            .into_iter()
+            .map(|(feature, counts)| {
+                let postings = top_counts(&counts, COMPLETION_POSTINGS);
+                let scores = counts
+                    .keys()
+                    .map(|&token| {
+                        registry.insert((feature, token), weights.len());
+                        let weight = if feature.kind == 0 { -2.0 } else { 0.0 };
+                        weights.push(weight);
+                        TokenScore {
+                            token,
+                            score: (weight * 256.0) as i32,
+                        }
+                    })
+                    .collect();
+                ScoreRow {
+                    feature,
+                    default_score: 0,
+                    scores,
+                    postings,
+                }
+            })
+            .collect();
+        let head = model
+            .completion
+            .as_mut()
+            .ok_or_else(|| Error("completion component unavailable".into()))?;
+        head.rows = rows;
+        head.global_postings = top_counts(&global, COMPLETION_CANDIDATES);
+        let mut examples = Vec::new();
+        let mut target_in_candidates = 0;
+        for frame in &frames {
+            let (tokens, len, _, _) = completion_runtime::candidates(
+                head,
+                &frame.features[..frame.len],
+                &mut CompletionWork::default(),
+            );
+            let target_present = tokens[..len].contains(&frame.target);
+            target_in_candidates += usize::from(target_present);
+            if !target_present && frame.baseline != frame.target {
+                continue;
+            }
+            let alternatives = tokens[..len]
+                .iter()
+                .map(|&token| Alternative {
+                    token,
+                    correct: token == frame.target,
+                    weights: frame.features[..frame.len]
+                        .iter()
+                        .filter_map(|&feature| registry.get(&(feature, token)).copied())
+                        .collect(),
+                })
+                .collect();
+            examples.push(Example {
+                alternatives,
+                baseline_correct: frame.baseline == frame.target,
+            });
+        }
+        if examples.is_empty() {
+            return Err(Error(
+                "completion postings admit no fitting target or correct Base action".into(),
+            ));
+        }
+        let mut best_weights = weights.clone();
+        let mut best_correct = 0;
+        let mut best_loss = f64::INFINITY;
+        let mut selected_epoch = 0;
+        for epoch in 0..config.epochs {
+            for example in &examples {
+                update(example, &mut weights, config.learning_rate)?;
+            }
+            let quantized: Vec<f64> = weights
+                .iter()
+                .map(|weight| (weight * 256.0).round() / 256.0)
+                .collect();
+            let (correct, loss) = measure(&examples, &quantized);
+            if !loss.is_finite() {
+                return Err(Error(
+                    "completion fitting produced a nonfinite objective".into(),
+                ));
+            }
+            if correct > best_correct || (correct == best_correct && loss < best_loss) {
+                best_correct = correct;
+                best_loss = loss;
+                selected_epoch = epoch + 1;
+                best_weights = quantized;
+            }
+        }
+        for row in &mut head.rows {
+            for entry in &mut row.scores {
+                let index = registry
+                    .get(&(row.feature, entry.token))
+                    .ok_or_else(|| Error("completion export association missing".into()))?;
+                entry.score = (best_weights[*index] * 256.0).round() as i32;
+            }
+        }
+        head.fit_positions = frames.len();
+        head.fit_config = [
+            config.epochs as u64,
+            config.learning_rate.to_bits(),
+            config.max_positions as u64,
+            selected_epoch as u64,
+        ];
+        head.training = receipts;
+        let learned_rows = head.rows.len();
+        model.refresh_identity()?;
+        model.validate()?;
+        let report = ValueCompletionFitReport {
+            schema: COMPLETION_SCHEMA.into(),
+            baseline_artifact: self.artifact_cid.clone(),
+            artifact_cid: model.artifact_cid.clone(),
+            examples: documents.len(),
+            matched_numeric,
+            skipped_no_write,
+            upstream_failures,
+            position_limit_skips,
+            overlong_responses,
+            positions: frames.len(),
+            target_in_candidates,
+            eligible_positions: examples.len(),
+            learned_rows,
+            learned_associations: weights.len(),
+            dropped_row_events,
+            dropped_association_events,
+            fit_correct: best_correct,
+            fit_loss: best_loss,
+            selected_epoch,
+            config,
+        };
+        Ok((model, report))
+    }
+}
+
+fn top_counts(counts: &BTreeMap<u32, u64>, cap: usize) -> Vec<u32> {
+    let mut ranked: Vec<_> = counts
+        .iter()
+        .map(|(&token, &count)| (token, count))
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked.truncate(cap);
+    ranked.into_iter().map(|(token, _)| token).collect()
+}
+
+fn logits(example: &Example, weights: &[f64]) -> Vec<f64> {
+    example
+        .alternatives
+        .iter()
+        .map(|alternative| {
+            alternative
+                .weights
+                .iter()
+                .map(|&index| weights[index])
+                .sum()
+        })
+        .collect()
+}
+
+fn update(example: &Example, weights: &mut [f64], rate: f64) -> Result<()> {
+    let scores = logits(example, weights);
+    let maximum = scores.iter().copied().fold(0.0, f64::max);
+    let total = (-maximum).exp()
+        + scores
+            .iter()
+            .map(|score| (score - maximum).exp())
+            .sum::<f64>();
+    let positive_max = example
+        .alternatives
+        .iter()
+        .zip(&scores)
+        .filter(|(alternative, _)| alternative.correct)
+        .map(|(_, score)| *score)
+        .fold(
+            if example.baseline_correct {
+                0.0
+            } else {
+                f64::NEG_INFINITY
+            },
+            f64::max,
+        );
+    let positive = (if example.baseline_correct {
+        (-positive_max).exp()
+    } else {
+        0.0
+    }) + example
+        .alternatives
+        .iter()
+        .zip(&scores)
+        .filter(|(alternative, _)| alternative.correct)
+        .map(|(_, score)| (score - positive_max).exp())
+        .sum::<f64>();
+    for (alternative, score) in example.alternatives.iter().zip(scores) {
+        let desired = if alternative.correct {
+            (score - positive_max).exp() / positive
+        } else {
+            0.0
+        };
+        let gradient = desired - (score - maximum).exp() / total;
+        let delta = rate * gradient / (alternative.weights.len().max(1) as f64).sqrt();
+        if !delta.is_finite() {
+            return Err(Error("completion gradient is nonfinite".into()));
+        }
+        for &index in &alternative.weights {
+            weights[index] = (weights[index] + delta).clamp(-3900.0, 3900.0);
+        }
+    }
+    Ok(())
+}
+
+fn measure(examples: &[Example], weights: &[f64]) -> (usize, f64) {
+    let mut correct = 0;
+    let mut loss = 0.0;
+    for example in examples {
+        let scores = logits(example, weights);
+        let mut best = 0.0;
+        let mut selected = None;
+        let mut right = example.baseline_correct;
+        for (alternative, &score) in example.alternatives.iter().zip(&scores) {
+            if score > best
+                || (score == best
+                    && score > 0.0
+                    && selected.is_some_and(|token| alternative.token < token))
+            {
+                best = score;
+                selected = Some(alternative.token);
+                right = alternative.correct;
+            }
+        }
+        correct += usize::from(right);
+        let positive_max = example
+            .alternatives
+            .iter()
+            .zip(&scores)
+            .filter(|(alternative, _)| alternative.correct)
+            .map(|(_, score)| *score)
+            .fold(
+                if example.baseline_correct {
+                    0.0
+                } else {
+                    f64::NEG_INFINITY
+                },
+                f64::max,
+            );
+        let total = (-best).exp() + scores.iter().map(|score| (score - best).exp()).sum::<f64>();
+        let positive = (if example.baseline_correct {
+            (-positive_max).exp()
+        } else {
+            0.0
+        }) + example
+            .alternatives
+            .iter()
+            .zip(&scores)
+            .filter(|(alternative, _)| alternative.correct)
+            .map(|(_, score)| (score - positive_max).exp())
+            .sum::<f64>();
+        loss += best + total.ln() - positive_max - positive.ln();
+    }
+    (correct, loss / examples.len() as f64)
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_types.rs
@@ -1,0 +1,134 @@
+//! Optional bounded next-byte completion after an observed typed numeral.
+use super::value_types::{ValueAction, ValueDecision};
+use super::*;
+
+pub(super) const COMPLETION_SCHEMA: &str = "uor-r4.native-value-completion/1";
+pub(super) const COMPLETION_FEATURES: usize = 16;
+pub(super) const COMPLETION_CANDIDATES: usize = 16;
+pub(super) const COMPLETION_POSTINGS: usize = 4;
+pub(super) const COMPLETION_ROWS: usize = 4096;
+pub(super) const COMPLETION_ASSOCIATIONS: usize = 32768;
+pub(super) const COMPLETION_POSITIONS: usize = 4096;
+pub(super) const COMPLETION_STEPS: u8 = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CompletionModel {
+    pub schema: String,
+    pub baseline_artifact: String,
+    pub rows: Vec<ScoreRow>,
+    pub global_postings: Vec<u32>,
+    /// Epoch budget, exact learning-rate bits, position cap, selected epoch.
+    pub fit_config: [u64; 4],
+    pub fit_positions: usize,
+    pub training: Vec<DocumentReceipt>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CompletionWork {
+    pub observations: u64,
+    pub anchors: u64,
+    pub metadata_reads: u64,
+    pub state_copies: u64,
+    pub feature_queries: u64,
+    pub row_comparisons: u64,
+    pub matched_rows: u64,
+    pub posting_offers: u64,
+    pub candidate_comparisons: u64,
+    pub candidate_writes: u64,
+    pub candidate_drops: u64,
+    pub candidate_evaluations: u64,
+    pub score_lookups: u64,
+    pub score_comparisons: u64,
+    pub h4_reads: u64,
+    pub orientation_reads: u64,
+    pub phase_subtractions: u64,
+    pub commits: u64,
+    pub base_steps: u64,
+    pub mismatches: u64,
+    pub stops: u64,
+    pub step_limits: u64,
+}
+impl CompletionWork {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionAction {
+    #[default]
+    Base,
+    Emit,
+    Stop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompletionDecision {
+    pub token: u32,
+    pub score: i64,
+    pub write_id: u64,
+    pub step: u8,
+    pub at_seen: u64,
+    pub action: CompletionAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CompletionAnchor {
+    pub write_id: u64,
+    pub action: ValueAction,
+    /// Observation count immediately after the final numeric byte.
+    pub at_seen: u64,
+    pub pose: u16,
+    pub phases: [u16; PHASE_CHANNELS],
+    pub query_prime: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CompletionSeed {
+    pub token: u32,
+    pub write_id: u64,
+    pub action: ValueAction,
+    pub at_seen: u64,
+}
+impl From<ValueDecision> for CompletionSeed {
+    fn from(decision: ValueDecision) -> Self {
+        Self::from(&decision)
+    }
+}
+impl From<&ValueDecision> for CompletionSeed {
+    fn from(decision: &ValueDecision) -> Self {
+        Self {
+            token: decision.token,
+            write_id: decision.write_id,
+            action: decision.action,
+            at_seen: decision.at_seen,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CompletionState {
+    pub anchor: Option<CompletionAnchor>,
+    pub last: u32,
+    pub previous: u32,
+    pub seen: u64,
+    pub steps: u8,
+    pub active: bool,
+    pub last_action: CompletionAction,
+    #[serde(skip)]
+    pub pending: Option<CompletionDecision>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionStateView {
+    pub active: bool,
+    pub write_id: Option<u64>,
+    pub steps: u8,
+    pub last_action: CompletionAction,
+    pub storage_bytes: usize,
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -8,6 +8,9 @@
 //! tokenization, serialization, fitting and diagnostic rendering are host work.
 
 mod anchors;
+mod completion_runtime;
+mod completion_training;
+mod completion_types;
 mod memory_runtime;
 mod memory_training;
 mod memory_types;
@@ -24,6 +27,10 @@ mod value_types;
 
 use serde::{Deserialize, Serialize};
 
+pub use completion_training::{ValueCompletionFitConfig, ValueCompletionFitReport};
+pub use completion_types::{
+    CompletionAction, CompletionDecision, CompletionStateView, CompletionWork,
+};
 pub use memory_training::{
     MemoryReadDiagnostic, MemoryReadDocumentExposure, MemoryReadDocumentSupervision,
     MemoryReadResponseStateReport, MemoryReadSchedule, MemoryReadStreamProgress,
@@ -126,6 +133,8 @@ pub enum Control {
     ResponseStateDisabled,
     ValuesDisabled,
     ValueLexemesDisabled,
+    ValueCompletionDisabled,
+    ValueCompletionGeometryDisabled,
 }
 
 /// Explicit feature addresses, never content digests. Kinds 0/1 are full
@@ -165,7 +174,9 @@ impl Feature {
             | Control::MemoryDisabled
             | Control::ResponseStateDisabled
             | Control::ValuesDisabled
-            | Control::ValueLexemesDisabled => true,
+            | Control::ValueLexemesDisabled
+            | Control::ValueCompletionDisabled
+            | Control::ValueCompletionGeometryDisabled => true,
             Control::GeometryDisabled => self.kind < 2,
             Control::ZetaDisabled => !(8..=15).contains(&self.kind) && self.kind != 5,
             Control::H4Disabled => self.kind < 2 || (8..=15).contains(&self.kind),
@@ -251,6 +262,8 @@ pub struct Model {
     memory_read: Option<memory_types::MemoryModel>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     values: Option<value_types::ValueModel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completion: Option<completion_types::CompletionModel>,
 }
 
 #[derive(Deserialize)]
@@ -273,6 +286,8 @@ struct ModelWire {
     memory_read: Option<memory_types::MemoryModel>,
     #[serde(default)]
     values: Option<value_types::ValueModel>,
+    #[serde(default)]
+    completion: Option<completion_types::CompletionModel>,
 }
 impl TryFrom<ModelWire> for Model {
     type Error = Error;
@@ -293,6 +308,7 @@ impl TryFrom<ModelWire> for Model {
             readout_training: wire.readout_training,
             memory_read: wire.memory_read,
             values: wire.values,
+            completion: wire.completion,
         };
         model.validate()?;
         Ok(model)
@@ -301,6 +317,8 @@ impl TryFrom<ModelWire> for Model {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Work {
+    #[serde(default, skip_serializing_if = "CompletionWork::is_empty")]
+    pub completion: CompletionWork,
     #[serde(default, skip_serializing_if = "ValueWork::is_empty")]
     pub values: ValueWork,
     #[serde(default, skip_serializing_if = "zero_work")]
@@ -381,6 +399,8 @@ pub struct Prediction {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Generation {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completion_trace: Vec<CompletionDecision>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub value_trace: Vec<ValueDecision>,
     /// First at most 96 decisions, recorded outside the allocation-free kernel.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -414,3 +434,6 @@ mod tests;
 
 #[cfg(test)]
 mod value_runtime_tests;
+
+#[cfg(test)]
+mod completion_runtime_tests;

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -11,6 +11,8 @@ pub(super) const FEATURE_COUNT: usize = 26;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion: Option<super::CompletionStateView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<super::ValueStateView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response: Option<super::ResponseStateView>,
@@ -33,6 +35,7 @@ pub struct StateView {
 
 #[derive(Debug, Clone)]
 pub struct Session {
+    pub(super) completion: Option<super::completion_types::CompletionState>,
     pub(super) values: Option<super::value_types::ValueState>,
     pub(super) memory: Option<super::memory_types::MemoryState>,
     pub(super) artifact_cid: String,
@@ -61,6 +64,7 @@ impl Session {
             .capacity()
             .saturating_mul(std::mem::size_of::<Candidate>());
         Self {
+            completion: model.completion.as_ref().map(|_| Default::default()),
             values: model
                 .values
                 .as_ref()
@@ -88,6 +92,16 @@ impl Session {
 
     pub fn state(&self) -> StateView {
         StateView {
+            completion: self
+                .completion
+                .as_ref()
+                .map(|s| super::CompletionStateView {
+                    active: s.active,
+                    write_id: s.anchor.map(|a| a.write_id),
+                    steps: s.steps,
+                    last_action: s.last_action,
+                    storage_bytes: std::mem::size_of::<super::completion_types::CompletionState>(),
+                }),
             values: self.values.as_ref().map(|s| super::ValueStateView {
                 active: s.active,
                 retained_values: s.records.len(),
@@ -131,6 +145,10 @@ impl Session {
         self.values.as_ref().and_then(|s| s.pending)
     }
 
+    pub fn completion_decision(&self) -> Option<super::CompletionDecision> {
+        self.completion.as_ref().and_then(|s| s.pending)
+    }
+
     fn check_model(&self, model: &Model) -> Result<()> {
         if self.artifact_cid != model.artifact_cid {
             return Err(Error(
@@ -142,6 +160,9 @@ impl Session {
 
     pub fn begin_response(&mut self, model: &Model) -> Result<()> {
         self.check_model(model)?;
+        if let Some(state) = &mut self.completion {
+            state.reset();
+        }
         if let Some(state) = &mut self.values {
             state.begin(&mut self.work.values);
         }
@@ -156,6 +177,9 @@ impl Session {
 
     pub fn end_response(&mut self, model: &Model) -> Result<()> {
         self.check_model(model)?;
+        if let Some(state) = &mut self.completion {
+            state.reset();
+        }
         if let Some(state) = &mut self.values {
             state.end();
         }
@@ -237,7 +261,21 @@ impl Session {
             state.observe(model, memory, token, &mut self.work);
         }
         if let Some(state) = &mut self.values {
+            let seed = state
+                .pending
+                .as_ref()
+                .map(super::completion_types::CompletionSeed::from);
             state.observe(model, token, &mut self.work.values);
+            if let Some(completion) = &mut self.completion {
+                completion.observe(
+                    model,
+                    state,
+                    token,
+                    seed,
+                    self.control,
+                    &mut self.work.completion,
+                );
+            }
         }
         Ok(())
     }
@@ -449,6 +487,22 @@ impl Session {
                 self.offer_memory(model, candidate);
             }
         }
+        if let (Some(baseline), Some(state), Some(values)) = (
+            self.candidates.first().copied(),
+            &mut self.completion,
+            &self.values,
+        ) {
+            let offer = state.offer(
+                model,
+                values,
+                baseline,
+                self.control,
+                &mut self.work.completion,
+            );
+            if let Some(candidate) = offer {
+                self.offer_memory(model, candidate);
+            }
+        }
         let best = *self
             .candidates
             .first()
@@ -457,6 +511,9 @@ impl Session {
             state.select_response(model, best, &mut self.work);
         }
         if let Some(state) = &mut self.values {
+            state.selected(best);
+        }
+        if let Some(state) = &mut self.completion {
             state.selected(best);
         }
         Ok(Prediction {

--- a/crates/uor-r4-core/src/native_geometric/snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/snapshot.rs
@@ -1,5 +1,6 @@
 //! Host-only, artifact-bound persistence of a bounded conversation context.
 
+use super::completion_types::CompletionState;
 use super::memory_types::{MemoryEntry, MemoryReference, ResponseAction, RESPONSE_MEMORY_SCHEMA};
 use super::value_types::ValueState;
 use super::*;
@@ -8,6 +9,7 @@ use serde::{Deserialize, Serialize};
 const LEGACY_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/1";
 const RESPONSE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/2";
 const VALUE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/3";
+const COMPLETION_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/4";
 const LEGACY_CHECKPOINT_LIMIT: usize = 1024 * 1024;
 const RESPONSE_CHECKPOINT_LIMIT: usize = 8 * 1024 * 1024;
 // Bound allocation before collecting the sparse index. A tuple has two
@@ -65,6 +67,8 @@ struct Checkpoint {
     response_memory: Option<ResponseMemorySnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     values: Option<ValueState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completion: Option<CompletionState>,
 }
 
 impl Session {
@@ -81,7 +85,9 @@ impl Session {
             self.ring[..self.length].to_vec()
         };
         let response_memory = self.response_memory_snapshot()?;
-        let schema = if self.values.is_some() {
+        let schema = if self.completion.is_some() {
+            COMPLETION_SESSION_SCHEMA
+        } else if self.values.is_some() {
             VALUE_SESSION_SCHEMA
         } else if response_memory.is_some() {
             RESPONSE_SESSION_SCHEMA
@@ -100,6 +106,7 @@ impl Session {
             work: self.work,
             response_memory,
             values: self.values.clone(),
+            completion: self.completion,
         })
         .map_err(|error| Error(error.to_string()))?;
         let limit = if schema != LEGACY_SESSION_SCHEMA {
@@ -128,7 +135,9 @@ impl Session {
             .memory_read
             .as_ref()
             .is_some_and(|memory| memory.schema == RESPONSE_MEMORY_SCHEMA);
-        let expected_schema = if model.values.is_some() {
+        let expected_schema = if model.completion.is_some() {
+            COMPLETION_SESSION_SCHEMA
+        } else if model.values.is_some() {
             VALUE_SESSION_SCHEMA
         } else if response_model {
             RESPONSE_SESSION_SCHEMA
@@ -138,6 +147,7 @@ impl Session {
         let object: serde_json::Value =
             serde_json::from_slice(bytes).map_err(|error| Error(error.to_string()))?;
         value_snapshot::validate_lexeme_field_presence(model, &object)?;
+        completion_snapshot::validate_field_presence(model, &object)?;
         // The additive /2 field must remain an unknown field for historical
         // /1 inputs, including an explicit JSON null. Keep their old loader
         // law as well as their byte serialization unchanged.
@@ -146,7 +156,11 @@ impl Session {
                 return Err(Error("historical session contains response state".into()));
             }
         }
-        if checkpoint.schema != VALUE_SESSION_SCHEMA && object.get("values").is_some() {
+        if !matches!(
+            checkpoint.schema.as_str(),
+            VALUE_SESSION_SCHEMA | COMPLETION_SESSION_SCHEMA
+        ) && object.get("values").is_some()
+        {
             return Err(Error(
                 "historical session contains typed value state".into(),
             ));
@@ -163,6 +177,9 @@ impl Session {
         if checkpoint.schema != expected_schema
             || checkpoint.response_memory.is_some() != response_model
             || checkpoint.values.is_some() != model.values.is_some()
+            || checkpoint.completion.is_some() != model.completion.is_some()
+            || (model.completion.is_some()
+                && checkpoint.work.completion.observations != checkpoint.work.observed_tokens)
             || (checkpoint.schema == LEGACY_SESSION_SCHEMA && bytes.len() > LEGACY_CHECKPOINT_LIMIT)
             || checkpoint.artifact_cid != model.artifact_cid()
             || checkpoint.retained_tokens.len() > model.config().context_tokens
@@ -251,6 +268,14 @@ impl Session {
                 &checkpoint.retained_tokens,
                 checkpoint.work.observed_tokens,
                 checkpoint.work.values.input_bytes,
+            )?;
+        }
+        if let Some(completion) = checkpoint.completion {
+            restored.restore_completion_state(
+                model,
+                completion,
+                &checkpoint.retained_tokens,
+                checkpoint.work.observed_tokens,
             )?;
         }
         restored.work = checkpoint.work;
@@ -593,3 +618,10 @@ mod value_snapshot;
 #[cfg(test)]
 #[path = "value_snapshot_tests.rs"]
 mod value_snapshot_tests;
+
+#[path = "completion_snapshot.rs"]
+mod completion_snapshot;
+
+#[cfg(test)]
+#[path = "completion_snapshot_tests.rs"]
+mod completion_snapshot_tests;

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -188,6 +188,7 @@ impl Trainer {
             readout: super::mixture::Readout::default(),
             readout_training: Vec::new(),
             values: None,
+            completion: None,
             memory_read: None,
         };
         template.refresh_identity()?;
@@ -507,6 +508,9 @@ impl Model {
         if let Some(values) = &self.values {
             values.validate()?;
         }
+        if let Some(completion) = &self.completion {
+            completion.validate(self)?;
+        }
         self.readout.validate(self)?;
         if let Some(memory) = &self.memory_read {
             memory.validate(self)?;
@@ -642,9 +646,15 @@ impl Model {
         let mut token_ids = Vec::new();
         let mut response_trace = Vec::new();
         let mut value_trace = Vec::new();
+        let mut completion_trace = Vec::new();
         let mut stop = "token_budget".to_owned();
         for _ in 0..max_new_tokens {
             let token = session.predict(self)?.token;
+            if let Some(decision) = session.completion_decision() {
+                if completion_trace.len() < 96 {
+                    completion_trace.push(decision);
+                }
+            }
             if let Some(decision) = session.value_decision() {
                 if value_trace.len() < 96 {
                     value_trace.push(decision);
@@ -674,6 +684,7 @@ impl Model {
             token_ids,
             response_trace,
             value_trace,
+            completion_trace,
             stop,
             work: session.work,
             state: session.state(),
@@ -697,6 +708,7 @@ impl Model {
                     .chain(&self.readout_training)
                     .chain(self.memory_read_training())
                     .chain(self.value_training())
+                    .chain(self.value_completion_training())
                     .any(|known| known.id == candidate.id || known.text_cid == candidate.text_cid)
             {
                 return Err(Error(format!(

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -7,8 +7,8 @@ use std::cell::Cell;
 
 use uor_r4_core::native_geometric::{
     Config, Control, Document, MemoryReadFitConfig, MemoryReadSchedule, MemoryReadSupervision,
-    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, Trainer, ValueExample,
-    ValueFitConfig, BOS, EOS,
+    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, Trainer, ValueCompletionFitConfig,
+    ValueExample, ValueFitConfig, BOS, EOS,
 };
 
 struct CountingAllocator;
@@ -97,6 +97,7 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         "fn end_response(",
         "fn response_decision(",
         "fn value_decision(",
+        "fn completion_decision(",
         "fn recent(",
         "fn features(",
         "fn score_candidate(",
@@ -175,6 +176,31 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "typed-value kernel coverage includes {function}"
         );
     }
+    let completion = include_str!("../src/native_geometric/completion_runtime.rs");
+    for function in [
+        "fn reset(",
+        "fn observe(",
+        "fn features(",
+        "fn offer(",
+        "fn selected(",
+        "fn candidates(",
+        "fn offer_token(",
+        "fn score_candidate(",
+    ] {
+        assert_eq!(
+            completion.matches(function).count(),
+            1,
+            "completion kernel coverage includes {function}"
+        );
+    }
+    let completion_types = include_str!("../src/native_geometric/completion_types.rs");
+    let seed = completion_types
+        .split_once("impl From<&ValueDecision> for CompletionSeed {")
+        .unwrap()
+        .1
+        .split_once("#[derive")
+        .unwrap()
+        .0;
     let (_, numeral, _) = region(
         include_str!("../src/native_geometric/numeral.rs"),
         "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
@@ -209,6 +235,8 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         ("native memory runtime", memory),
         ("native response runtime", response),
         ("native typed-value runtime", value_runtime),
+        ("native completion runtime", completion),
+        ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
         ("exact ZPhi checked addition", zphi_add),
@@ -319,6 +347,84 @@ fn typed_value_allocation_census(lexeme_cues: bool) {
         "typed-value census allocations={allocations} bytes={bytes} work={:?}",
         session.work.values
     );
+}
+
+#[test]
+fn native_value_completion_commit_mismatch_and_limit_are_allocation_free() {
+    let documents = [Document {
+        id: "completion-allocation-catalog".into(),
+        text: "left = 13; right = 4; total: 17.\n".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 32,
+            candidate_limit: 8,
+            ..Config::default()
+        },
+        &documents,
+    )
+    .unwrap();
+    trainer.train_documents(&documents).unwrap();
+    let baseline = trainer.compile().unwrap();
+    let source = [ValueExample {
+        id: "completion-allocation-fit".into(),
+        prompt: "left = 13; right = 4; total:".into(),
+        response: "17.\n".into(),
+    }];
+    let (typed, _) = baseline
+        .fit_values_with_lexeme_cues(
+            &source,
+            ValueFitConfig {
+                epochs: 64,
+                learning_rate: 0.25,
+                max_features: 4096,
+            },
+        )
+        .unwrap();
+    let (model, report) = typed
+        .fit_value_completion(&source, ValueCompletionFitConfig::default())
+        .unwrap();
+    assert_eq!(report.matched_numeric, 1);
+    let prompt = model.encode(&source[0].prompt).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    let storage = session.state().completion.unwrap().storage_bytes;
+    ALLOCATIONS.with(|count| count.set(0));
+    BYTES.with(|count| count.set(0));
+    MEASURING.with(|enabled| enabled.set(true));
+    let result = (|| {
+        session.observe(&model, BOS)?;
+        for _ in 0..4 {
+            session.end_response(&model)?;
+            for &token in &prompt {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            for _ in 0..2 {
+                let next = session.predict(&model)?.token;
+                session.observe(&model, next)?;
+            }
+            // Commit one learned suffix token, then deliberately observe a
+            // different byte and exercise the finite progress limit.
+            let next = session.predict(&model)?.token;
+            session.observe(&model, next)?;
+            session.predict(&model)?;
+            session.observe(&model, u32::from(b'x') + 2)?;
+            for _ in 0..31 {
+                session.predict(&model)?;
+                session.observe(&model, u32::from(b'x') + 2)?;
+            }
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(())
+    })();
+    MEASURING.with(|enabled| enabled.set(false));
+    result.unwrap();
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    assert_eq!(session.state().completion.unwrap().storage_bytes, storage);
+    assert_eq!(session.work.completion.anchors, 4);
+    assert!(session.work.completion.commits > 0);
+    assert!(session.work.completion.mismatches > 0);
+    assert_eq!(session.work.completion.step_limits, 4);
+    assert!(session.work.evictions > 0);
 }
 
 #[test]

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -12,6 +12,29 @@ windows as instructions for new work. A negative binds its exact configuration;
 resource unavailability does not determine model quality. The recovered plan
 allows open development iteration under configurable cumulative machine budgets.
 
+## Native typed-value completion (2026-09-05)
+
+The [completion record](native_geometric_value_completion_973.md) adds a learned
+continuation/stop head after actual typed numeral emission, preserving the stronger
+occurrence reader and typed-value `/2` weights. It fits 720/720 eligible positions
+from the unchanged 192 raw construction pairs. On reused open development, Full
+completes 12/16 prose and 12/16 Rust responses, versus 2/16 and 0/16 with this
+head disabled. Both retain 24/24 correct numeric targets. All four name-binding
+pairs complete correctly on both sides. Sixteen of twenty inspected, unchanged
+Rust records compile, execute and pass their assertions; fourteen successful
+source hashes are distinct. Eight nonnumeric primary responses remain failures.
+
+Removing only the completion H4/orientation/phase features preserves all six
+candidate tokens and correct numerals, but fails subsequent progression or
+termination: 0/16 exact responses in each family. This is a within-artifact
+combined geometric scoring result at equal candidate support, not separate-term
+attribution or an equal-training comparison. Shared response templates and reused
+development remain explicit limitations; final held-out transfer, broad geometric
+advantage and compute savings are NOT_RUN. The prior typed artifacts reproduce
+all 80 complete primary/control Generation objects under the new binary. Their
+dated results below remain intact. Current work checkpoints at the remaining
+storage margin before another checked implementation cycle.
+
 ## Native typed-value development (2026-09-05)
 
 The [typed-value record](native_geometric_typed_value_973.md) adds an optional

--- a/docs/evidence/native_geometric_value_completion_973.json
+++ b/docs/evidence/native_geometric_value_completion_973.json
@@ -1,0 +1,1823 @@
+{
+  "schema": "uor-r4.native-value-completion-evidence/1",
+  "at": "2026-09-05T08:26:41.846Z",
+  "status": "OPEN_DEVELOPMENT_NUMERIC_COMPLETION_RETAINED_STORAGE_CHECKPOINT",
+  "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "artifact_cid": "blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff",
+  "baseline_artifact": "blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5",
+  "operator": "uor-r4.native-value-completion/1",
+  "scope": "Same /2 raw source and unchanged OPEN development targets. Fitting follows actual upstream numeral rollouts, then supervises ordinary suffix bytes and EOS; no generated suffix or target template is appended. Completion traces describe the learned step transitions. Primary and binding controls remain reused design feedback, not final held-out evaluation.",
+  "population_scope": "Small finite synthetic open development with shared templates, different names/values and disjoint world/document IDs. Counterfactual pairs change one relevant input literal. Both families share one fitted artifact. Task and pair labels are evaluator-only. The dependency examples test response-time original-occurrence binding; they do not demonstrate eager statement execution, arbitrary Rust interpretation, retention beyond eviction or alpha. Source /2 appends context-only copy/add name swaps to the unchanged /1 fit cases, with fixed numeric source order and query bytes but changed correct operands. Whole-word cues are an explicit model variant. The unchanged primary development cases and four binding controls have already informed this design and are reused OPEN development feedback, not sealed or final held-out evaluation.",
+  "fit": {
+    "artifact_cid": "blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff",
+    "baseline_artifact": "blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5",
+    "config": {
+      "epochs": 24,
+      "learning_rate": 0.1,
+      "max_positions": 4096
+    },
+    "dropped_association_events": 0,
+    "dropped_row_events": 0,
+    "eligible_positions": 720,
+    "examples": 192,
+    "fit_correct": 720,
+    "fit_loss": 0.007023032880161844,
+    "learned_associations": 289,
+    "learned_rows": 192,
+    "matched_numeric": 160,
+    "overlong_responses": 0,
+    "position_limit_skips": 0,
+    "positions": 720,
+    "schema": "uor-r4.native-value-completion/1",
+    "selected_epoch": 24,
+    "skipped_no_write": 32,
+    "target_in_candidates": 720,
+    "upstream_failures": 0
+  },
+  "arms": [
+    {
+      "control": "full",
+      "prose": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 12,
+        "generated_tokens": 182,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "rust": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 12,
+        "generated_tokens": 148,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "work": {
+        "anchor_table_reads": 2800,
+        "candidate_evaluations": 67079,
+        "candidate_offers": 137109,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 0,
+          "candidate_comparisons": 10120,
+          "candidate_drops": 0,
+          "candidate_evaluations": 648,
+          "candidate_writes": 648,
+          "commits": 108,
+          "feature_queries": 1728,
+          "h4_reads": 216,
+          "matched_rows": 1708,
+          "metadata_reads": 372,
+          "mismatches": 0,
+          "observations": 2442,
+          "orientation_reads": 108,
+          "phase_subtractions": 864,
+          "posting_offers": 3728,
+          "row_comparisons": 15552,
+          "score_comparisons": 18480,
+          "score_lookups": 10248,
+          "state_copies": 7638,
+          "step_limits": 0,
+          "stops": 24
+        },
+        "evictions": 0,
+        "feature_queries": 9308,
+        "h4_table_reads": 2442,
+        "matched_rows": 8576,
+        "memory_candidates": 24070,
+        "memory_composed_candidates": 8650,
+        "memory_composition_comparisons": 2928048,
+        "memory_composition_duplicate_features": 169626,
+        "memory_composition_feature_moves": 1902137,
+        "memory_composition_feature_offers": 433260,
+        "memory_cue_reads": 55272,
+        "memory_h4_reads": 170932,
+        "memory_index_reads": 74168,
+        "memory_index_writes": 37792,
+        "memory_phase_updates": 597216,
+        "memory_score_lookups": 263634,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 358,
+        "observed_tokens": 2442,
+        "orientation_table_reads": 358,
+        "phase_additions": 19536,
+        "radial_square_reads": 29304,
+        "score_lookups": 1637751,
+        "values": {
+          "additions": 572,
+          "cue_comparisons": 66048,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 784212,
+          "feature_lookups": 60324,
+          "h4_reads": 6570,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 64600,
+          "lexical_comparisons": 119328,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 36048,
+          "proposals": 1032,
+          "record_evictions": 0
+        }
+      },
+      "completion_storage_bytes": [
+        96
+      ]
+    },
+    {
+      "control": "value_completion_disabled",
+      "prose": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 2,
+        "generated_tokens": 424,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "rust": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 0,
+        "generated_tokens": 263,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "work": {
+        "anchor_table_reads": 3488,
+        "candidate_evaluations": 153797,
+        "candidate_offers": 266329,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 452,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 48,
+          "mismatches": 0,
+          "observations": 2786,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 8670,
+          "step_limits": 0,
+          "stops": 11
+        },
+        "evictions": 0,
+        "feature_queries": 18252,
+        "h4_table_reads": 2786,
+        "matched_rows": 16788,
+        "memory_candidates": 51987,
+        "memory_composed_candidates": 15204,
+        "memory_composition_comparisons": 6543385,
+        "memory_composition_duplicate_features": 384376,
+        "memory_composition_feature_moves": 6267298,
+        "memory_composition_feature_offers": 935766,
+        "memory_cue_reads": 100680,
+        "memory_h4_reads": 366695,
+        "memory_index_reads": 122328,
+        "memory_index_writes": 43296,
+        "memory_phase_updates": 1269976,
+        "memory_score_lookups": 551390,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 702,
+        "observed_tokens": 2786,
+        "orientation_table_reads": 702,
+        "phase_additions": 22288,
+        "radial_square_reads": 33432,
+        "score_lookups": 3707783,
+        "values": {
+          "additions": 572,
+          "cue_comparisons": 66048,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 784212,
+          "feature_lookups": 60324,
+          "h4_reads": 6914,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 64600,
+          "lexical_comparisons": 119328,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 38800,
+          "proposals": 1032,
+          "record_evictions": 0
+        }
+      },
+      "completion_storage_bytes": [
+        96
+      ]
+    },
+    {
+      "control": "value_completion_geometry_disabled",
+      "prose": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 0,
+        "generated_tokens": 512,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "rust": {
+        "cases": 16,
+        "correct_leading_numerals": 12,
+        "exact_responses": 0,
+        "generated_tokens": 442,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "work": {
+        "anchor_table_reads": 4000,
+        "candidate_evaluations": 119443,
+        "candidate_offers": 338576,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 0,
+          "candidate_comparisons": 29116,
+          "candidate_drops": 0,
+          "candidate_evaluations": 4248,
+          "candidate_writes": 4248,
+          "commits": 708,
+          "feature_queries": 4248,
+          "h4_reads": 0,
+          "matched_rows": 3004,
+          "metadata_reads": 1464,
+          "mismatches": 0,
+          "observations": 3042,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 11246,
+          "row_comparisons": 38232,
+          "score_comparisons": 41988,
+          "score_lookups": 18024,
+          "state_copies": 9438,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "evictions": 0,
+        "feature_queries": 24908,
+        "h4_table_reads": 3042,
+        "matched_rows": 20943,
+        "memory_candidates": 97628,
+        "memory_composed_candidates": 11726,
+        "memory_composition_comparisons": 13657884,
+        "memory_composition_duplicate_features": 998610,
+        "memory_composition_feature_moves": 27279894,
+        "memory_composition_feature_offers": 1757304,
+        "memory_cue_reads": 134472,
+        "memory_h4_reads": 686438,
+        "memory_index_reads": 158168,
+        "memory_index_writes": 47392,
+        "memory_phase_updates": 2367408,
+        "memory_score_lookups": 758694,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 958,
+        "observed_tokens": 3042,
+        "orientation_table_reads": 958,
+        "phase_additions": 24336,
+        "radial_square_reads": 36504,
+        "score_lookups": 2727336,
+        "values": {
+          "additions": 572,
+          "cue_comparisons": 66048,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 784212,
+          "feature_lookups": 60324,
+          "h4_reads": 7170,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 64600,
+          "lexical_comparisons": 119328,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 40848,
+          "proposals": 1032,
+          "record_evictions": 0
+        }
+      },
+      "completion_storage_bytes": [
+        96
+      ]
+    },
+    {
+      "control": "values_disabled",
+      "prose": {
+        "cases": 16,
+        "correct_leading_numerals": 0,
+        "exact_responses": 0,
+        "generated_tokens": 467,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "rust": {
+        "cases": 16,
+        "correct_leading_numerals": 0,
+        "exact_responses": 0,
+        "generated_tokens": 402,
+        "nonnumeric_cases": 4,
+        "nonnumeric_cases_with_leading_numerals": 0,
+        "numeric_cases": 12
+      },
+      "work": {
+        "anchor_table_reads": 3840,
+        "candidate_evaluations": 197208,
+        "candidate_offers": 333510,
+        "completion": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 2962,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 8886,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "evictions": 0,
+        "feature_queries": 22828,
+        "h4_table_reads": 2962,
+        "matched_rows": 21145,
+        "memory_candidates": 71677,
+        "memory_composed_candidates": 20594,
+        "memory_composition_comparisons": 9212896,
+        "memory_composition_duplicate_features": 522236,
+        "memory_composition_feature_moves": 9361345,
+        "memory_composition_feature_offers": 1290186,
+        "memory_cue_reads": 123912,
+        "memory_h4_reads": 504701,
+        "memory_index_reads": 146968,
+        "memory_index_writes": 46112,
+        "memory_phase_updates": 1743944,
+        "memory_score_lookups": 767950,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 878,
+        "observed_tokens": 2962,
+        "orientation_table_reads": 878,
+        "phase_additions": 23696,
+        "radial_square_reads": 35544,
+        "score_lookups": 4782362,
+        "values": {
+          "additions": 0,
+          "cue_comparisons": 0,
+          "derived_writes": 0,
+          "emission_commits": 0,
+          "emission_mismatches": 0,
+          "feature_comparisons": 0,
+          "feature_lookups": 0,
+          "h4_reads": 2962,
+          "input_bytes": 3772,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 0,
+          "overflow_rejections": 0,
+          "phase_updates": 23696,
+          "proposals": 0,
+          "record_evictions": 0
+        }
+      },
+      "completion_storage_bytes": [
+        96
+      ]
+    }
+  ],
+  "binding": [
+    {
+      "pair_id": "typed-value/binding/prose/copy_current",
+      "both_leading_numerals_correct": true,
+      "both_responses_exact": true,
+      "cases": [
+        {
+          "id": "typed-value/binding/prose/copy_current/original",
+          "expected": "73.\n",
+          "actual": "73.\n",
+          "exact": true
+        },
+        {
+          "id": "typed-value/binding/prose/copy_current/source_names_swapped",
+          "expected": "301.\n",
+          "actual": "301.\n",
+          "exact": true
+        }
+      ]
+    },
+    {
+      "pair_id": "typed-value/binding/prose/add",
+      "both_leading_numerals_correct": true,
+      "both_responses_exact": true,
+      "cases": [
+        {
+          "id": "typed-value/binding/prose/add/original",
+          "expected": "77.\n",
+          "actual": "77.\n",
+          "exact": true
+        },
+        {
+          "id": "typed-value/binding/prose/add/source_names_swapped",
+          "expected": "374.\n",
+          "actual": "374.\n",
+          "exact": true
+        }
+      ]
+    },
+    {
+      "pair_id": "typed-value/binding/rust/copy_current",
+      "both_leading_numerals_correct": true,
+      "both_responses_exact": true,
+      "cases": [
+        {
+          "id": "typed-value/binding/rust/copy_current/original",
+          "expected": "73);\n}\n",
+          "actual": "73);\n}\n",
+          "exact": true
+        },
+        {
+          "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+          "expected": "301);\n}\n",
+          "actual": "301);\n}\n",
+          "exact": true
+        }
+      ]
+    },
+    {
+      "pair_id": "typed-value/binding/rust/add",
+      "both_leading_numerals_correct": true,
+      "both_responses_exact": true,
+      "cases": [
+        {
+          "id": "typed-value/binding/rust/add/original",
+          "expected": "77);\n}\n",
+          "actual": "77);\n}\n",
+          "exact": true
+        },
+        {
+          "id": "typed-value/binding/rust/add/source_names_swapped",
+          "expected": "374);\n}\n",
+          "actual": "374);\n}\n",
+          "exact": true
+        }
+      ]
+    }
+  ],
+  "candidate_support": {
+    "global_token_ids": [
+      12,
+      1,
+      43,
+      48,
+      61,
+      127
+    ],
+    "tokens": [
+      "newline",
+      "EOS",
+      ")",
+      ".",
+      ";",
+      "}"
+    ],
+    "all_row_postings_subset_of_global": true,
+    "capacity": 16,
+    "candidate_drops": 0,
+    "full_and_geometry_disabled_same_candidate_set": true,
+    "ties": "smaller token ID; positive scores versus zero Base",
+    "interpretation": "Combined completion geometric features affect continuation progression/termination in this fitted artifact at equal candidate support; separate term attribution, matched-refit advantage, response-form transfer and efficiency advantage NOT_RUN."
+  },
+  "generated_rust": {
+    "records": 20,
+    "compiled": 16,
+    "executed": 16,
+    "passed": 16,
+    "primary_numeric_passed": 12,
+    "binding_passed": 4,
+    "distinct_successful_sources": 14,
+    "unchanged_no_write_compile_failures": 4,
+    "source_law": "Each file equals original prompt plus saved generated bytes, inspected before compile/execute; exact file hashes, compiler diagnostics, temporary binary identities and execution outputs retained. No source repair or answer harness.",
+    "scope": "Exact reviewed generated Rust, unchanged; executable cases run directly including their generated assertions. Libraries compile only. Newly created reproducible compiler products removed one at a time after retaining identity, diagnostics and execution output. No source, model, evidence or inherited material removed."
+  },
+  "preservation": {
+    "prior_typed_artifacts": {
+      "scope": "Full control only, 32primary+8binding generations per prior typed artifact. Compare complete Generation bytes,tokens,traces,state and all work counters under current compiled source. /1 comparison uses its final prior-source replay so earlier documented layout/telemetry corrections are not relabeled as a new change.",
+      "results": [
+        {
+          "version": 1,
+          "reference": "fit-1-final",
+          "artifact_cid_equal": true,
+          "source_blake3_equal": true,
+          "primary": [
+            {
+              "id": "typed-value/development/prose/copy_current/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100003",
+              "generation_equal": true
+            }
+          ],
+          "pairs": [
+            {
+              "id": "typed-value/binding/prose/copy_current/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/copy_current/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/add/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/add/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/add/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/add/source_names_swapped",
+              "generation_equal": true
+            }
+          ],
+          "all_generations_equal": true
+        },
+        {
+          "version": 2,
+          "reference": "fit-2",
+          "artifact_cid_equal": true,
+          "source_blake3_equal": true,
+          "primary": [
+            {
+              "id": "typed-value/development/prose/copy_current/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100000",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100001",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100002",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/copy_current/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/add/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/dependency_before_update/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/prose/no_write/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/copy_current/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/add/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/dependency_before_update/100003",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/development/rust/no_write/100003",
+              "generation_equal": true
+            }
+          ],
+          "pairs": [
+            {
+              "id": "typed-value/binding/prose/copy_current/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/copy_current/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/add/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/prose/add/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/add/original",
+              "generation_equal": true
+            },
+            {
+              "id": "typed-value/binding/rust/add/source_names_swapped",
+              "generation_equal": true
+            }
+          ],
+          "all_generations_equal": true
+        }
+      ]
+    },
+    "completion_disabled": {
+      "scope": "Supplement to strict first analysis. CompletionDisabled is expected to change the state.control label; every other noncompletion Generation field is compared exactly.",
+      "differences": [
+        {
+          "id": "typed-value/development/prose/copy_current/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/add/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/dependency_before_update/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/add/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100000",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/copy_current/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/add/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/dependency_before_update/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/add/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100001",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/copy_current/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/add/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/dependency_before_update/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/add/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100002",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/copy_current/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/add/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/dependency_before_update/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/add/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100003",
+          "path": "generation.state.control",
+          "new": "value_completion_disabled",
+          "old": "full"
+        }
+      ],
+      "only_declared_control_label_differs": true
+    },
+    "cli": {
+      "scope": "Compare every probe Generation field against CLI output. CLI also emits artifact_cid,uor_model_address,memory_read_version and readout_version metadata. The earlier whole-object comparison retained a shape difference rather than a model-output difference.",
+      "generation_keys": [
+        "bytes",
+        "completion_trace",
+        "state",
+        "stop",
+        "text",
+        "token_ids",
+        "utf8_valid",
+        "value_trace",
+        "work"
+      ],
+      "generation_equal": true,
+      "artifact_cid": "blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff",
+      "artifact_matches": true,
+      "text": "77);\n}\n"
+    },
+    "source_unchanged_sha256": "10b69bfbbd89161032d80905306247b8a2e72ee098ab8f487932827f45d90352",
+    "model_changes": [
+      "completion",
+      "artifact_cid",
+      "uor_model_address"
+    ],
+    "large_integers": "Independent source-aware JSON numeric audit and native baseline CID validation preserve exact integers.",
+    "unchanged_primary_value_traces": 32,
+    "unchanged_binding_value_traces": 8
+  },
+  "source_identities": {
+    "at": "2026-09-05T08:14:12.911Z",
+    "worktree": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4",
+    "base_commit": "2f6c080c266d01683771b84f405c8c353cc7653b",
+    "base_tree": "9a019b7bcfcf27180bc74d17f2cfff007e3846fc",
+    "source_parent": "7aec2cf5978628134108d1b4fcb5f8c3b1b34c73",
+    "source_parent_tree": "9a019b7bcfcf27180bc74d17f2cfff007e3846fc",
+    "note": "Base and reviewed predecessor trees are identical. These source changes were uncommitted during the measured build; source bytes are bound explicitly. Documentation is not included in this Rust-source identity list.",
+    "files": [
+      {
+        "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+        "bytes": 47520,
+        "sha256": "582759a286a9920a85c93bc0b6e544bb88905108a6336fcf667706721c7ba899"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_runtime.rs",
+        "bytes": 11154,
+        "sha256": "7e8aafd952e0a049b95fec2e2021e2167368cfaa1778f4d58bb0b0e10d2b2cb1"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_runtime_tests.rs",
+        "bytes": 11404,
+        "sha256": "00a6678f7c4f9db1cdd78598e4e63e2219ef3ccb86dcd07b716b07b2df4f3a68"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_snapshot.rs",
+        "bytes": 10558,
+        "sha256": "0701775ec18cc2c2efe4d9c916cba51cbc49100f6bf07f4921812278d0729edf"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_snapshot_tests.rs",
+        "bytes": 11711,
+        "sha256": "b11acf8d489c9c9fa15f428f1b3fd0d56b91180e624142e6ba6d77459695090c"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_training.rs",
+        "bytes": 23844,
+        "sha256": "36c0e9358dfae45ccb1d44fd828c5fd809a387febd4d307d0c0fc9d34fad3e5c"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/completion_types.rs",
+        "bytes": 3886,
+        "sha256": "f27c88bf1d8f359ff1e40a56fd241144f7b032a55e379fc5f2e1bb06694446ca"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+        "bytes": 13838,
+        "sha256": "cdd179b007742467c5f3dfc26385e7e92f118dc4630a10dab32d3f5941ece4cb"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/runtime.rs",
+        "bytes": 22698,
+        "sha256": "184cbfaed5ff522aea4606cb6240c655caa7313e2767dc4686d3451e11177219"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/snapshot.rs",
+        "bytes": 26191,
+        "sha256": "4ec8e42dd6ed50f572335121118c481c4826de0ab3ae99b0ed4c79c3c3b64651"
+      },
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+        "bytes": 31602,
+        "sha256": "859fde5529babee0a7fbcbd2f7c592aa426814253ded7289c4dd70dd707970cf"
+      },
+      {
+        "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+        "bytes": 29428,
+        "sha256": "90e37c5d248c9acc585c8b9ae5ce03dce3b07e9506e73a35d4ef02e60c66b093"
+      },
+      {
+        "path": "src/native_geometric_cli.rs",
+        "bytes": 62806,
+        "sha256": "db6e3446ffba60d1650a0036c58a7b7a306f7cd9efb258a520d9d0f0c2eb0abb"
+      },
+      {
+        "path": "src/native_geometric_service.rs",
+        "bytes": 67352,
+        "sha256": "b1d98cb6dcce722dd86ed2c5d83d51e74d8c2bbeb1d67a1dda6a352035a9add5"
+      }
+    ]
+  },
+  "binaries": {
+    "at": "2026-09-05T08:18:55.939Z",
+    "rust_source": "completion-rust-source-identities.json",
+    "source_still_equal": true,
+    "files": [
+      {
+        "path": "/tmp/r4-native-geometric-target/release/r4",
+        "bytes": 22588832,
+        "sha256": "7e7d88bbc9daf32eb25d7b3d62fb9f963bebcb89cbe4fb4c2ce2c38b00479fd6"
+      },
+      {
+        "path": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "bytes": 1975808,
+        "sha256": "239d52c4f1815f7d285e2d6f6194c3cc41854d2ee34f0ec56ca3ab36407386cd"
+      }
+    ]
+  },
+  "model_commands": [
+    {
+      "label": "completion-fit-1",
+      "started": "2026-09-05T08:18:56.115Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "completion",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/source.json",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1",
+        "--lexeme-cues",
+        "true",
+        "--epochs",
+        "24",
+        "--learning-rate",
+        "0.1",
+        "--completion-max-positions",
+        "4096",
+        "--generated-tokens",
+        "32",
+        "--max-seconds",
+        "120"
+      ],
+      "elapsed_ms": 3485,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": false,
+      "peak_process_rss_sample_bytes": 314228736,
+      "process_rss_samples": 3,
+      "peak_sampled_known_bytes": 4132675584,
+      "initial_known_bytes": 4118081536,
+      "final_known_bytes": 4132675584,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-compile-execute",
+      "started": "2026-09-05T08:20:06.708Z",
+      "command": "node",
+      "args": [
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/compile-execute-generated.mjs",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-generated-source-review.json",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-compile-execute"
+      ],
+      "elapsed_ms": 3149,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": false,
+      "peak_process_rss_sample_bytes": 56721408,
+      "process_rss_samples": 3,
+      "peak_sampled_known_bytes": 4133187584,
+      "initial_known_bytes": 4132765696,
+      "final_known_bytes": 4132876288,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-preserve-v1",
+      "started": "2026-09-05T08:20:56.793Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-1/source.json",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-preserve-v1",
+        "--lexeme-cues",
+        "false",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "32",
+        "--max-seconds",
+        "120"
+      ],
+      "elapsed_ms": 573,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": false,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": 0,
+      "peak_sampled_known_bytes": 4133761024,
+      "initial_known_bytes": 4132880384,
+      "final_known_bytes": 4133761024,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-preserve-v2",
+      "started": "2026-09-05T08:21:07.424Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fit-2/source.json",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-preserve-v2",
+        "--lexeme-cues",
+        "true",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "32",
+        "--max-seconds",
+        "120"
+      ],
+      "elapsed_ms": 562,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": false,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": 0,
+      "peak_sampled_known_bytes": 4136611840,
+      "initial_known_bytes": 4133765120,
+      "final_known_bytes": 4136611840,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-cli-artifact-sample",
+      "started": "2026-09-05T08:21:08.210Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json",
+        "--prompt",
+        "fn main() {\n    let suri = 73;\n    let orin = 4;\n    let tavi = 301;\n    assert_eq!(suri + orin,",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 1112,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": false,
+      "peak_process_rss_sample_bytes": 114655232,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4136669184,
+      "initial_known_bytes": 4136644608,
+      "final_known_bytes": 4136669184,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    }
+  ],
+  "engineering_commands": [
+    {
+      "label": "completion-core-tests",
+      "started": "2026-09-05T08:01:37.538Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "native_geometric",
+        "--offline"
+      ],
+      "elapsed_ms": 100755,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4125487104,
+      "initial_known_bytes": 4111122432,
+      "final_known_bytes": 4111343616,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-runtime-tests",
+      "started": "2026-09-05T08:04:01.407Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "native_geometric::completion_runtime_tests",
+        "--offline"
+      ],
+      "elapsed_ms": 92062,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4127121408,
+      "initial_known_bytes": 4111486976,
+      "final_known_bytes": 4111609856,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-boundary-tests",
+      "started": "2026-09-05T08:05:40.290Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "-p",
+        "uor-r4-core",
+        "--test",
+        "native_geometric_allocations",
+        "--test",
+        "windowed_geometric_context",
+        "--example",
+        "native_geometric_value_probe",
+        "--offline"
+      ],
+      "elapsed_ms": 144514,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4113793024,
+      "initial_known_bytes": 4111609856,
+      "final_known_bytes": 4113604608,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-cli-tests",
+      "started": "2026-09-05T08:08:21.985Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--bin",
+        "r4",
+        "native_geometric_",
+        "--offline"
+      ],
+      "elapsed_ms": 285846,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4144316416,
+      "initial_known_bytes": 4113608704,
+      "final_known_bytes": 4115718144,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-release",
+      "started": "2026-09-05T08:13:25.153Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe"
+      ],
+      "elapsed_ms": 316032,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4145467392,
+      "initial_known_bytes": 4115783680,
+      "final_known_bytes": 4118081536,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-policy-final",
+      "started": "2026-09-05T08:26:52.182Z",
+      "command": "/tmp/r4-native-geometric-target/debug/r4-policy-check",
+      "args": [
+        "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4"
+      ],
+      "elapsed_ms": 163,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4136722432,
+      "initial_known_bytes": 4136718336,
+      "final_known_bytes": 4136722432,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-claims-final",
+      "started": "2026-09-05T08:26:56.767Z",
+      "command": "python3",
+      "args": [
+        "scripts/check_claim_wording.py"
+      ],
+      "elapsed_ms": 207,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4136726528,
+      "initial_known_bytes": 4136722432,
+      "final_known_bytes": 4136726528,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-fmt-final",
+      "started": "2026-09-05T08:27:15.725Z",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--check"
+      ],
+      "elapsed_ms": 3461,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4136726528,
+      "initial_known_bytes": 4136726528,
+      "final_known_bytes": 4136726528,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    },
+    {
+      "label": "completion-claims-docs-frozen",
+      "started": "2026-09-05T08:27:31.415Z",
+      "command": "python3",
+      "args": [
+        "scripts/check_claim_wording.py"
+      ],
+      "elapsed_ms": 325,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "engineering_only": true,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": null,
+      "peak_sampled_known_bytes": 4136730624,
+      "initial_known_bytes": 4136726528,
+      "final_known_bytes": 4136730624,
+      "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+    }
+  ],
+  "local_validation": {
+    "core_tests": 83,
+    "core_scope": "79 initial tests plus four added completion runtime tests; 83 distinct tests across two runs.",
+    "allocation_source_tests": 4,
+    "context_tests": 3,
+    "probe_tests": 4,
+    "cli_service_tests": 17,
+    "release_build": "PASS",
+    "format": "PASS final",
+    "not_run": [
+      "blanket full workspace suite",
+      "Clippy",
+      "no_std",
+      "kappa reproduction",
+      "audit",
+      "fuzz",
+      "WASM",
+      "Gate C",
+      "release QA",
+      "final held-out evaluation"
+    ],
+    "architecture_policy": "PASS",
+    "claim_wording": "PASS after all prose changes"
+  },
+  "resources": {
+    "at": "2026-09-05T08:26:41.837Z",
+    "status": "CHECKPOINT_STORAGE_PROJECTION",
+    "resource": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-05T08:26:41.836Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 1827282944,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 63791104,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 4136710144,
+      "storage_limit_bytes": 4294967296,
+      "remaining_storage_bytes": 158257152,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 24039424,
+      "model_ledger": {
+        "cumulative_ms": 903526,
+        "limit_ms": 1800000
+      },
+      "model_remaining_ms": 896474,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. Only documented current-run failed compiler outputs were removed; no inherited or user material was removed. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "latest_release_peak_growth_bytes": 29683712,
+    "next_checked_implementation_admitted": false,
+    "next_decision": "Same-budget geometry-free completion fit and independent response-form transfer; then cause-directed nonnumeric development. Another checked source implementation cycle is not admitted under remaining storage. Keep existing artifacts and user material; no budget increase or broad cleanup.",
+    "scope": "This is a resource checkpoint, not model-quality evidence. Metadata/protected delivery uses the existing reserve; model ledger is unchanged."
+  },
+  "limitations": [
+    "Eight nonnumeric primary cases remain incorrect and unchanged.",
+    "Only six completion token candidates; shared fit/development response templates; development informed design.",
+    "Typed proposal execution and ordinary decoding precede completion, so no sparse-expert compute saving is established.",
+    "One-second RSS samples measure direct child only. Generated compiler process descendants are unmeasured; subsecond replays have no RSS samples.",
+    "Counters enumerate named work, not a complete machine instruction census."
+  ],
+  "files": [
+    {
+      "path": "completion-fit-1/model.json",
+      "bytes": 10058579,
+      "sha256": "79e023469b1bd07dff1879c9bc3b00316a30be2ef4e5c7a44624758851851e44"
+    },
+    {
+      "path": "completion-fit-1/source.json",
+      "bytes": 90946,
+      "sha256": "10b69bfbbd89161032d80905306247b8a2e72ee098ab8f487932827f45d90352"
+    },
+    {
+      "path": "completion-fit-1/report.json",
+      "bytes": 3991857,
+      "sha256": "9b3871ff2c3ab0a315de7a3c65c128f3fb15d145e64e99c7df78cb35e783cce1"
+    },
+    {
+      "path": "completion-fit-analysis.json",
+      "bytes": 68713,
+      "sha256": "a8a1c05d7cae694028a201e0edf993ea23eade5e4033b0917e34bffe6025c7db"
+    },
+    {
+      "path": "completion-compile-execute/report.json",
+      "bytes": 21914,
+      "sha256": "33900b7cca418f330d409666fc184a2fda2d61808e2f976476fe4a0ea56aa66b"
+    },
+    {
+      "path": "completion-generated-source-review.json",
+      "bytes": 5127,
+      "sha256": "009246c8f686dead67f19eb2c6160ab1923abec1abdfe8e7dd9be6569d4a1ac9"
+    },
+    {
+      "path": "completion-prior-artifact-preservation.json",
+      "bytes": 10732,
+      "sha256": "f4b80fb088a07c593ab2b3e71d260e2a4acb664a4aff7df67fe8ef692a4401c5"
+    },
+    {
+      "path": "completion-disabled-preservation.json",
+      "bytes": 6054,
+      "sha256": "6aac06b4492d3f0a10bf58cdbe2b9eadf872cce62f1c0674f4743990c9425ad1"
+    },
+    {
+      "path": "completion-cli-generation-preservation.json",
+      "bytes": 612,
+      "sha256": "a3fc403e5074475e57e98bd9227aa9f951cbd9d302490a5b1134a626471ea455"
+    },
+    {
+      "path": "completion-independent-audit.json",
+      "bytes": 8892,
+      "sha256": "d88a7b7911c08282a5c2f2d3defb70b0fb5498c90b8d186ad37ef2b9a099683c"
+    },
+    {
+      "path": "completion-storage-checkpoint.json",
+      "bytes": 2046,
+      "sha256": "3fdcfc5cf2506cf34df5c3f0467db3d74be781c7924082c09b247781dea351a4"
+    },
+    {
+      "path": "completion-binary-identities.json",
+      "bytes": 541,
+      "sha256": "c036ff0ca7f8a66acfc19b27beaad3c365e23a4d1e9cab141ab7071f6e18ff9c"
+    },
+    {
+      "path": "completion-rust-source-identities.json",
+      "bytes": 3265,
+      "sha256": "16ce07fca110e9486074efec2eda3959b08bf7250c15cf73fe1c17dbf733aa30"
+    },
+    {
+      "path": "completion-fit-1.stdout.log",
+      "bytes": 7786,
+      "sha256": "9fa326dfa33cd88019de152611ab4fb9a12097ebe06e1cd75e45a823f267eac5"
+    },
+    {
+      "path": "completion-fit-1.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-compile-execute.stdout.log",
+      "bytes": 53,
+      "sha256": "9e7ff12c73da5c84ec333fcf5a8305613020bf8aecd626c944d1de7593e9df28"
+    },
+    {
+      "path": "completion-compile-execute.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-preserve-v1.stdout.log",
+      "bytes": 2117,
+      "sha256": "b3c008354f6bb30eeaba50fa57a3b5f7fb48b4b882de52bc970ab3a6b2a7ad3b"
+    },
+    {
+      "path": "completion-preserve-v1.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-preserve-v2.stdout.log",
+      "bytes": 2118,
+      "sha256": "1fc42b2c79a323db972a757122240e70c4d6c8983cde30c36842c5fb7df99b2c"
+    },
+    {
+      "path": "completion-preserve-v2.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-cli-artifact-sample.stdout.log",
+      "bytes": 23321,
+      "sha256": "826bf9680d29c746b25f779bd83edb9055b45b33c1680345a8a59157ed138ed7"
+    },
+    {
+      "path": "completion-cli-artifact-sample.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-core-tests.log",
+      "bytes": 10182,
+      "sha256": "bba2d0519b29bdcb25bcc806138942c8ffc97fd7375ffff9213b0ce6e4fd19e0"
+    },
+    {
+      "path": "completion-runtime-tests.log",
+      "bytes": 939,
+      "sha256": "e5103447d5496aafa90c3b627b4cad75c2ccfaf20232ca7ed7347427100549e9"
+    },
+    {
+      "path": "completion-boundary-tests.log",
+      "bytes": 1838,
+      "sha256": "8aa263f606da70197c7585ba79ccce4da035e929206c815269616543ddf10d79"
+    },
+    {
+      "path": "completion-cli-tests.log",
+      "bytes": 3085,
+      "sha256": "155ad5b9366d43ca43b39b4d19b24998e74cf6532398b871632d4d3e3fa8c9e9"
+    },
+    {
+      "path": "completion-release.log",
+      "bytes": 1011,
+      "sha256": "f956f385c2d97a31de57e8f25cc3658598935146c433a3dbf3864924e02b9e72"
+    },
+    {
+      "path": "completion-policy-final.log",
+      "bytes": 73,
+      "sha256": "58dd9c24c33ba5ff6519ed3f5bea924d8fd10d93bcfaba529e2d8b0101be6ae7"
+    },
+    {
+      "path": "completion-claims-final.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    },
+    {
+      "path": "completion-fmt-final.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "completion-claims-docs-frozen.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    }
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,7 +7,61 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
-## Typed value creation — 2026-09-05 development
+## Typed values with geometric completion — 2026-09-05
+
+The current development artifact adds optional `uor-r4.native-value-completion/1`
+to the stronger occurrence-memory `/4` reader and typed-value `/2` component.
+After an actually observed final numeral byte, it retains the derived write and
+post-numeral H4/zeta anchor, compares current relative geometry and short ordered
+context, and learns bounded byte/EOS selection. Its sparse scores, observation
+law, integer/table serving path and session schema `/4` are implemented in Rust.
+The baseline reader, tokenizer, geometry and typed weights remain unchanged.
+
+| Reused open development (32 cases) | Correct numeric targets | Exact prose | Exact Rust |
+| --- | ---: | ---: | ---: |
+| Full | 24/24 | 12/16 | 12/16 |
+| Completion disabled | 24/24 | 2/16 | 0/16 |
+| Completion geometry disabled | 24/24 | 0/16 | 0/16 |
+| Typed values disabled | 0/24 | 0/16 | 0/16 |
+
+All four name-binding pairs now complete correctly on both sides (8/8 outputs).
+Sixteen of twenty saved Rust records compile, execute and pass their assertions:
+twelve primary numeric cases and four binding cases, with fourteen distinct
+successful source hashes. The eight NoWrite primary cases remain unchanged and
+incorrect. Neither arbitrary Rust execution by the model nor general conversation
+or reasoning follows from this result.
+
+All geometric-control candidates are the same six byte/EOS tokens; capacity is
+sixteen with no drops. Suppressing only completion H4/orientation/phase features
+preserves the first suffix byte but loses progression/termination. This supports
+combined geometric-score dependence in this fitted artifact at equal support.
+Individual-term effects, a same-budget geometry-free refit, independent response
+forms and efficiency advantage remain unmeasured. Ordinary decoder work and typed
+proposal execution still precede this head; no expert-compute saving is claimed.
+
+The [completion record](../native_geometric_value_completion_973.md) and
+[compact evidence](../evidence/native_geometric_value_completion_973.json) bind
+source, binaries, all outputs, costs and preservation. The local artifact is
+`.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json`, CID
+`blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff`.
+Prior typed `/1` and `/2` reproduce all eighty Full primary/binding Generation
+objects under the current binary; both prior `/5` negatives remain preserved.
+
+The next decision is a matched geometry-free fit and independent response-form
+transfer for this small completion head, followed by cause-directed development
+of the remaining nonnumeric cases. It is **checkpointed for storage**: cumulative
+model work is 903.526/1800 seconds (896.474 seconds remain), but the 08:22 UTC
+snapshot leaves 24,055,808 bytes of growth before the 128 MiB stop margin within
+the 4 GiB allocation. The last release build alone added a measured peak of
+29,683,712 bytes. Another checked implementation cycle is not admitted; preserve
+all artifacts and user material, with no silent budget increase. Metadata and
+protected delivery continue within the existing reserve. Final held-out
+qualification and both alpha capability groups remain unqualified.
+
+The following sections preserve earlier checkpoints and their then-current
+next actions. They do not override the active pointer above.
+
+## Preceding typed value creation — 2026-09-05 development
 
 The native model now has an optional typed-value component on the stronger
 `/4` artifact. It lexes signed integer values, learns bounded operand/action

--- a/docs/native_geometric_mechanism_map_973.md
+++ b/docs/native_geometric_mechanism_map_973.md
@@ -2,8 +2,8 @@
 
 This source map connects the native model to reusable mathematical and runtime
 components. Its baseline is the implementation delivered through PR #1127 at
-`3abf9d7e85f70416c95161863b4413cc42a6912c`; the versioned occurrence-selection
-response-state and typed-value successors are distinguished below. The [project plan](integration/project-track.md)
+`3abf9d7e85f70416c95161863b4413cc42a6912c`; the versioned occurrence-selection,
+response-state, typed-value and completion successors are distinguished below. The [project plan](integration/project-track.md)
 owns the goal, and [current-state.md](integration/current-state.md) owns results
 and active work. This is not another roadmap or a claim that every architectural
 role is already assembled.
@@ -122,7 +122,8 @@ Only observing the selected decimal token commits the derived value and its
 operand IDs/values. A fixed twenty-byte buffer emits the remaining digits
 through the ordinary shortlist. Positive selection emits at the response
 boundary; the current gate cannot wait through generated text before inserting
-a numeral. It supplies no response suffix or learned stop classifier. Raw
+a numeral. Typed schemas `/1` and `/2` alone supply no response suffix or learned
+stop classifier; the separate completion component below adds that operation. Raw
 prompt/response training labels complete numeral bytes and leaves operand and
 action identities latent. Canonical lexical tokens and emitted byte tokens can
 differ while decoding to the same text.
@@ -134,6 +135,65 @@ structure are not retained. Session schema `/3` validates this explicit state;
 older source payloads are user-provided state, not authenticated history.
 The [typed-value record](native_geometric_typed_value_973.md) supplies complete
 cost bounds, direct behavior, controls and remaining binding/emission limits.
+
+## Committed-value completion — 2026-09-05
+
+The optional `uor-r4.native-value-completion/1` component adds
+`completion_types.rs`, `completion_runtime.rs`, `completion_training.rs` and
+`completion_snapshot.rs`. It preserves the fitted `/4` reader and typed `/2`
+parameters. A completion anchor exists only after the final predicted numeral
+byte has actually been observed and the derived write committed. It retains
+the write identity/action, endpoint H4 pose and eight phases, frozen query-end
+prime, last two actual token identities and at most 32 observed suffix steps.
+It does not retain a suffix template or whole-answer key. Prediction is
+transient; observed bytes alone advance the state, including mismatches.
+
+Sixteen feature addresses combine prime/token history, action/progress,
+relative H4, signed orientation and phase-difference bins. Construction-only
+postings admit byte/EOS candidates; signed integer scores select a positive
+candidate against zero-score Base. Rust fitting learns these next-byte scores
+from actual frozen `/2` numeral rollouts and raw response suffixes plus EOS.
+It rejects upstream incorrect, noncanonical or incomplete numerals instead of
+teaching suffix repair. NoWrite cases never activate completion. Session schema
+`/4` validates the committed anchor and actual suffix history; schemas `/1`–`/3`
+and absent-component model serialization retain their earlier laws.
+
+The first fit used the existing 192 raw pairs: 160 matched numerals, 32 skipped
+NoWrite cases, no upstream failures, and 720/720 correct exported fit positions.
+On the same reused open development, Full produces 12/16 exact prose and 12/16
+exact Rust responses: all 24 numeric responses complete correctly. The eight
+NoWrite responses remain incorrect. Completion-disabled retains the earlier
+2/16 prose and 0/16 Rust exact results with 24/24 correct leading numerals.
+Suppressing only completion geometry gives 0/16 exact in each family while
+preserving the same six completion candidates. This is within-artifact feature
+sensitivity, not a separately fitted comparator or general geometric advantage.
+The typed-only negative and both `/5` negatives remain preserved evidence.
+
+The current local artifact is
+`/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json`,
+CID `blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff`.
+Its preserved baseline is `fit-2/model.json` under the same root, CID
+`blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5`.
+Sibling `fit-report.json` and `report.json` bind the fit and generated outputs;
+the [completion record](native_geometric_value_completion_973.md) and
+[compact evidence](evidence/native_geometric_value_completion_973.json) retain
+their measured scope and controls.
+Exact authored numeric completions do not establish general conversation,
+dependency execution or Rust coding capability; compiler/execution evidence
+is recorded separately in [current state](integration/current-state.md).
+
+Added serving work per active completion prediction is bounded by 16 row
+queries, 80 posting offers, 1,280 candidate equality comparisons, 16 candidates
+and 256 token-score lookups. At the format maxima of 4,096 rows and 257 byte/EOS
+IDs per row, binary searches use at most 13 row comparisons and 10 token
+comparisons per lookup. Features add two H4 table reads, one orientation read
+and eight phase subtractions. The fitted head has 192 rows/289 associations;
+observed completion state occupies 96 bytes on this host. Fixed feature,
+candidate and row-index buffers also occupy stack space. Observation/history
+copies, ordinary `/4` prediction, numeric scanning and `/2` selection remain
+additional work; counters name operations, not every machine instruction.
+There are no runtime floats, matrix products or steady-state allocations in
+this component. Fitting, serialization and initialization are separate host work.
 
 ## Historical pieces and what they can contribute
 
@@ -153,6 +213,21 @@ what its learned selection consumes, the operator applied, information lost and
 the complete execution cost. An operator that creates a value also needs a
 typed result and causal write/read path; a better copy selector alone cannot
 supply it.
+
+The inspected sparse-expert reference makes the ordering concrete:
+Mesh TensorFlow's [`_switch_gating`](https://github.com/tensorflow/mesh/blob/master/mesh_tensorflow/transformer/moe.py#L1200-L1323)
+learns input-to-expert scores, selects one expert and applies capacity filtering
+before [`transformer_moe_layer_v1`](https://github.com/tensorflow/mesh/blob/master/mesh_tensorflow/transformer/moe.py#L405-L534)
+dispatches inputs and executes dense experts. Overflow skips that expert branch;
+extra capacity adds padded computation, memory and communication. The router,
+dispatch, combine and padding costs remain part of total work. See the
+[Switch paper, sections 2.1–2.2](https://jmlr.org/papers/volume23/21-0998/21-0998.pdf).
+Our `/4` and completion postings restrict later candidate scoring; `/2` executes
+up to 240 checked additions before ranking, so its gate currently avoids no
+operator arithmetic. These native heads are not MoE expert networks. A future
+geometric gate could select operands/operators before expensive execution, but
+must preserve reachability and count its own cost. Sparse dispatch also does
+not by itself specify what a multiscale context summary retains or loses.
 
 The [recovery](native_geometric_recovery_973.md),
 [query-context](native_geometric_query_context_973.md) and

--- a/docs/native_geometric_typed_value_973.md
+++ b/docs/native_geometric_typed_value_973.md
@@ -292,3 +292,14 @@ Actual queue steps determine test evidence; four historical required statuses
 only acknowledge deferred work. Clippy, broad release QA, `no_std`, κ, audit,
 fuzzing, WASM, Gate C and final held-out qualification are **NOT_RUN** in this
 development step. Issue #973 remains open for the broader native model objective.
+
+## Completion follow-through — 2026-09-05
+
+The subsequent [learned completion head](native_geometric_value_completion_973.md)
+preserves both typed artifacts and the exact `/2` baseline. It learns suffix
+progression and EOS after actual numeral emission, completing all 24 numeric
+open-development cases and both sides of all four binding pairs. Sixteen of
+twenty saved Rust records compile and execute with passing assertions (fourteen
+distinct successful source hashes); the eight NoWrite primary cases remain
+incorrect. These later results do not rewrite the two preceding fits or their
+then-untrained suffix failures.

--- a/docs/native_geometric_value_completion_973.md
+++ b/docs/native_geometric_value_completion_973.md
@@ -1,0 +1,147 @@
+# Native completion after typed-value emission — #973
+
+Date: 2026-09-05. Status: bounded numeric-response completion improves on reused open development; general capability and matched-refit geometry comparison remain unqualified. The [project
+plan](integration/project-track.md) owns the objective.
+
+## Observed cause and inherited checkpoint
+
+The preceding typed-value step merged through protected [PR #1130](https://github.com/UOR-Foundation/uor-r4/pull/1130) at
+[2f6c080c266d01683771b84f405c8c353cc7653b](https://github.com/UOR-Foundation/uor-r4/commit/2f6c080c266d01683771b84f405c8c353cc7653b). Its [record](native_geometric_typed_value_973.md) and [bound
+evidence](evidence/native_geometric_typed_value_973.json) preserve both fits. The `/2` artifact selects all 24 tested numeric prefixes and all four binding pairs correctly, but only 2/16 prose and 0/16
+Rust responses are complete. All twelve numeric Rust cases fail at the first post-numeral byte or EOS; eight numeric prose cases fail there, two later, and two are exact. Both sets of twenty saved
+generated Rust files fail compilation. These are reused open-development results, not general conversation, coding, reasoning or geometric advantage.
+
+The typed fitter supervises operands and numeral continuation; the ordinary decoder handles punctuation, code closure and stopping. Typed `77` emits two byte tokens; the ordinary tokenizer can encode the
+same bytes as one lexical token. This history difference is observed, but its causal share relative to ordinary readout weakness has not been isolated. The implemented component learns continuation from
+the history actually produced by typed emission. It preserves the stronger `/4` memory reader and the `/2` value head. Earlier `/5` response-state fits remain separately scoped negatives.
+
+## Representation and causal execution
+
+`completion_types.rs` defines optional `uor-r4.native-value-completion/1` state. An anchor is created only after the final selected numeral byte is actually observed, using the preceding typed prediction's
+matching provenance. It retains the derived write ID, Copy/Add action, post-numeral observation count, cumulative typed H4 pose, eight fixed-zeta phase channels and frozen query-end cue prime. The state
+also retains the last two actual token IDs, current observation count, completion step, active flag and last observed action. Predictions are transient.
+
+The relative H4 feature is `inverse(anchor.pose) * current_typed_pose`, with a separate signed-orientation lookup. Eight phase differences use wrapping u16 subtraction and their upper four bits. Other keys
+represent a bias, last-token prime, ordered last-two-token primes, query-end prime, query/last-prime pair, and operator/step. At most sixteen keys address learned rows. Prime identities are addresses, not
+a semantic distance. The inherited paired-H4/icosian, exact `Z[phi]`, radial and UOR identity fields retain their existing roles; this head adds no new paired-coordinate or radial ranking term.
+
+The bounded state retains an exact anchor and recent ordered observations; its score features deliberately quantize phase differences and compress the suffix to two token identities, relative geometry and
+a step. It does not retain an arbitrary suffix transcript, syntax tree, semantic summary or dependency graph. The typed store still retains at most sixteen exact values and bounded word cues; eviction
+loses older records and unbounded source detail. This is not learned multiscale semantic compression or evidence of general reasoning.
+
+`completion_runtime.rs` unions up to four postings from each matched feature row with sixteen global postings, retaining at most sixteen distinct candidates in deterministic offer order. Candidates are
+individual byte tokens or EOS. Sparse integer row scores compete with a zero Base action: a positive winner offers its token at the already computed baseline score plus the learned score. Equal positive
+scores choose the smaller token ID; nonpositive scores retain Base. No serving suffix string, answer template, target lookup or provider response exists.
+
+Observation always updates the actual token history. A matching pending decision credits Emit/Stop; a mismatching byte credits Base and advances from that byte, without committing an unobserved prediction.
+EOS clears the response anchor. After 32 actual completion observations the head clears its anchor and disables itself without forcing EOS; ordinary generation can continue. Explicit response boundaries
+reset progress while preserving actual token history. Empty request continuation must retain the active response rather than start a new one.
+
+## Offline fitting and declared comparison scope
+
+The bounded run uses the unchanged `/2` source: 192 fit pairs, the same 32 development examples, and four source-name binding pairs/eight Full runs. Those development cases informed design and remain
+**OPEN development**. Configuration is 24 epochs, learning rate 0.1 and at most 4096 fitting positions; the artifact caps feature rows at 4096 and token associations at 32768. Shared templates and disjoint
+document/world IDs do not establish held-out transfer.
+
+`fit_value_completion` runs the frozen value model to its actual numeral end. The emitted bytes must match the entire canonical integer prefix of the raw response. Wrong, partial or differently spelled
+numbers are recorded as upstream failures; `17` cannot be repaired into target `176` by learning an extra suffix digit. NoWrite examples are skipped separately. Only then does offline fitting observe
+authored suffix bytes and EOS, recording individual next-byte frames. Position limits, overlong responses and unavailable candidate targets are reported.
+
+Postings come from bounded training frequency counts; floating-point sparse optimization learns token scores versus Base. Epoch selection evaluates quantized weights with serving tie rules. The artifact
+binds its frozen baseline identity, configuration and ordered source receipts. Ordinary tokenizer, geometry, readout, memory rows and typed weights remain unchanged. Offline floating point, gradients and
+exponentials are permitted training operations; inference remains integer/table.
+
+Full is compared with completion disabled, completion geometry disabled, and values disabled. Completion-disabled retains state but offers no completion token; the geometry control removes only this head's
+H4/orientation/phase features. These are within-artifact controls, not separately fitted matched baselines. Their generated lengths and total work can differ. Final held-out evaluation, broader grammar
+coverage and a geometric speed/quality advantage remain unclaimed.
+
+## Complete work and persistence boundaries
+
+The following are conservative **per active prediction** source bounds, not measured latency:
+
+| Completion operation | Bound |
+|---|---:|
+| Feature queries / row-key comparisons | 16 / 208 at 4096 rows |
+| H4 / orientation reads; phase subtractions | 2 / 1; 8 |
+| Token-prime and H4 row-base metadata reads | 3 |
+| Posting offers / distinct retained candidates | 80 / 16 |
+| Candidate duplicate comparisons / writes | 1280 / 16 |
+| Candidate evaluations / score lookups | 16 / 256 |
+| Score-token comparisons | 2560: at most 10 per lookup over 257 byte/EOS tokens |
+
+Each observation updates three history scalars; anchoring copies five scalar fields and eight phases after two record/provenance metadata reads. Fixed local arrays hold sixteen features, sixteen candidate
+tokens and sixteen row indices (448 bytes of logical array storage on the current 64-bit layout), in addition to persistent state, locals and caller frames. `StateView` reports persistent `CompletionState`
+size separately. Neither number includes model tables or RSS. Counters cover named operations, not every branch, fixed-array initialization, copy, lookup address calculation, shortlist insertion or
+serialization instruction.
+
+All ordinary decoder work still executes before the completion offer: 26 base feature queries, posting/scoring work and at most 128 memory routes in the matched `/4` artifact, with occurrence-feature
+union/deduplication, H4/orientation/phase, radial tables and shortlist moves. Typed ingestion and numeral work also remain: initial/retry selection visits 272 slots, up to 256 valid Copy/Add proposals and
+240 checked additions, with up to 60 features, 64 token-cue and 128 whole-word comparisons per proposal. Every admitted Add executes before ranking. At full occupancy this includes 15360 feature lookups
+and up to 1048576 word-byte comparisons. NoWrite repeats the typed search on later predictions; a completed write avoids that search, but keeps ordinary prediction work. The [typed
+record](native_geometric_typed_value_973.md) details remaining ingestion, rank, copy and numeral bounds. Postings admit tokens; they do not select which arithmetic expert executes. No expert or transformer
+compute saving is established. Host tokenization, artifact loading and snapshots are outside the serving-kernel operation counts and still contribute to total cost.
+
+Session schema `/4` requires completion state only for completion artifacts; older `/1`–`/3` field/serialization laws remain. Restore first validates typed state, then checks derived provenance, exact
+numeral completion, anchor/query identity, actual token history, counters and relative frames. While active, its endpoint and fewer than 32 suffix observations fit the typed 32-entry ring even after
+ordinary-window eviction. Transient predictions are omitted; candidate workspaces are fixed arrays. Evicted external source truth remains unauthenticated. Focused tests cover real-fit persistence,
+malformed snapshots, mismatching bytes, empty continuation, allocation boundaries and EOS/cap behavior. Report actual test/storage/RSS scope.
+
+## Measured open-development result
+
+The unchanged 192 fit pairs produced 160 matched numeric rollouts and 32 skipped NoWrite examples, with no upstream failures, truncations or dropped row/association events. All 720 suffix/EOS targets
+entered the candidate set and all 720 were selected correctly using exported weights. The fit exported 192 rows and 289 individual token associations at epoch 24, learning rate 0.1; loss was
+0.007023032880161844. These are construction and reused-development results.
+
+| Same-artifact development arm | Correct numerals /24 | Prose exact /16 | Rust exact /16 |
+|---|---:|---:|---:|
+| Full | 24 | 12 | 12 |
+| Completion disabled | 24 | 2 | 0 |
+| Completion geometry disabled | 24 | 0 | 0 |
+| Values disabled | 0 | 0 | 0 |
+
+Full completes every numeric primary response and both complete responses in all four binding pairs. All eight NoWrite primary cases still fail complete equality: this head activates only after a typed
+write. The CLI loads the same artifact and emits exact `77);\n}\n`; every probe Generation field, including tokens, stop, state, value/completion traces and work, matches the CLI. Extra CLI metadata is
+outside that shared object comparison.
+
+All twenty generated Rust records were inspected and compiled without source repair. Sixteen compile, execute and pass their generated assertions; the four NoWrite records fail compilation. The sixteen
+successful records contain fourteen distinct source hashes because two original binding cases duplicate primary cases. This is finite generated-program evidence, not sixteen independent novel programs or
+general Rust competence.
+
+Full creates 24 anchors and commits 108 completion tokens, including 24 stops, with zero mismatches, Base suffix steps or step-limit events. Its head performs 1728 feature queries, 648 candidate
+evaluations and 10248 score lookups; persistent completion state is 96 bytes, separately from the 448-byte logical local arrays and all inherited state. Ordinary work still includes 67079 candidate
+evaluations and 1637751 base score lookups, plus the separately counted memory work. Shorter correct outputs change aggregate work; these totals establish no matched-latency or per-token speed advantage.
+
+The independent source/report audit finds the same six candidates in both Full and completion-geometry-disabled at every active decision: newline, EOS, right parenthesis, period, semicolon and closing
+brace. All six are in global postings, the candidate limit is sixteen, and no candidate is dropped. Removing the jointly fitted H4/orientation/phase terms therefore changes scoring without losing these
+candidates; numeric selection remains intact. Full's suffix success and the control's 0/32 complete responses establish that those terms are load-bearing in this fitted head. They do not isolate H4 from
+orientation or phases, compare separately refitted competitors, or establish geometric superiority. Only two authored suffix forms are learned in this population, so unseen response-form transfer is
+untested.
+
+## Preservation, checks and resource stop
+
+Artifacts remain under `/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05`. The model is `completion-fit-1/model.json`, CID
+`blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff`, bound to the prior `/2` artifact. Its directory retains source, options, fit report, all control outputs, binding outputs and
+generated Rust. `completion-rust-source-identities.json` and `completion-binary-identities.json` bind code and executables; `completion-compile-execute/report.json` retains compiler/execution identities
+and outcomes. Newly created per-case compiler products were removed after their identities, diagnostics and execution output were retained; source, model, evidence and inherited material were preserved.
+
+The source is byte-identical to the prior source. Model fields change only for completion and artifact identities. Completion-disabled reproduces every prior Full noncompletion Generation field on all 32
+primary cases except the explicitly different control label. Replaying each prior value artifact under the new executable preserves full Generation objects on 32 primary plus eight binding runs per
+artifact, including bytes, tokens, traces, state and work. The `/1` reference is its prior final-source replay, preserving the already documented older layout/telemetry correction. The first strict
+comparison's CLI metadata/control-label differences remain recorded; they are not relabeled as output failures or silently discarded.
+
+Actual checks passed 79 native core tests, then four newly wired completion runtime tests; four source/allocation checks, three context tests, four probe tests and seventeen CLI/service tests. The release
+build passed in 316032 ms. These counts retain their actual invocation scope, rather than claiming a single 83-test run. The completion allocation check covers commit, mismatch and cap behavior after
+initialization. Final formatting, architecture-policy and claim-wording checks pass. Broad release QA and final held-out qualification remain NOT_RUN; successor protected delivery is a separate live GitHub result.
+
+Through the CLI sample, cumulative model work is **903526/1800000 ms**, leaving **896474 ms**: 894645 inherited plus 8881 for completion fitting/evaluation, generated-program compilation/execution,
+prior-artifact preservation and CLI replay. Engineering builds/tests remain separately logged. Fit RSS peaks at a sampled **314228736 bytes**, from three direct-process samples. Compile-wrapper RSS
+measures Node rather than descendant compiler/program peaks; short preservation commands have no RSS samples. Periodic sampling is not an exact-peak guarantee.
+
+At **08:22:21 UTC**, accounted storage is **4136693760/4294967296 bytes**. After the unchanged **134217728-byte** stop margin, only **24055808 bytes** remain for growth. The inherited accounting still
+charges current target allocation, both artifact roots, measured worktrees and the source/metadata reserve, using only the previously audited obsolete-target credit. The latest measured build peak
+increment is **29683712 bytes**, exceeding available growth by **5627904 bytes** before additional outputs. The next implementation/build is therefore blocked under the current storage envelope despite
+remaining model time; no limit increase or new cleanup credit is assumed.
+
+The next bounded decision is a separately fitted comparison with the completion geometry terms removed, using the same source, candidate constraints and fitting budget, followed by response-form transfer
+checks with authored targets kept separate from fitting. This distinguishes dependence of the present fit from a relative geometric benefit and tests whether completion extends beyond the two existing
+forms. Both are NOT_RUN at this checkpoint and must wait for an explicitly viable resource envelope. The existing successful mechanism and the failed controls remain preserved.

--- a/docs/native_geometric_workflow.md
+++ b/docs/native_geometric_workflow.md
@@ -7,6 +7,8 @@ Separate readout fitting learns bounded integer gates over seven feature groups
 and sufficiently supported last-prime query keys. It does not yet learn the
 ordinary token memory-write law. The optional typed-value component separately
 learns operand/action selection and whether to write its result.
+An optional completion component learns byte/EOS transitions after a committed
+typed numeral, while preserving that upstream model.
 An optional learned memory reader retrieves actual retained token values through
 prime-addressed postings, query/source offsets and relative H4/zeta features.
 It is versioned separately in the artifact; the original fixed/readout-only
@@ -57,6 +59,84 @@ native service. `--control values-disabled` suppresses typed candidates;
 schema `/3` preserves committed derived values and emission cursor, including
 empty HTTP continuation after export/import. `Session::begin_response` starts
 new value selection; a continuing response must retain its active state.
+
+### Complete committed typed values — 2026-09-05
+
+`Model::fit_value_completion` adds the optional
+`uor-r4.native-value-completion/1` component to a fitted typed `/2` model. It
+uses the same raw `ValueExample` prompt/response pairs; it first follows the
+frozen upstream model's actual numeral-byte decisions, then learns individual
+suffix bytes and EOS. It accepts a training suffix only after the emitted
+number matches the complete canonical leading numeral. It cannot repair an
+incorrect number, choose target operands or append a stored answer template.
+NoWrite cases are reported and skipped because they have no committed numeral.
+
+```sh
+target/release/examples/native_geometric_value_probe completion \
+  --model /absolute/path/to/typed-fit-2/model.json \
+  --source /absolute/path/to/typed-fit-2/source.json \
+  --lexeme-cues true --output-dir /absolute/path/to/new-completion-run \
+  --epochs 24 --learning-rate 0.1 --completion-max-positions 4096 \
+  --generated-tokens 32 --max-seconds 120
+```
+
+Admit a run only when its projected work fits the remaining cumulative limits.
+Preserve the existing `/2` artifact and use the inherited resource monitor and
+a new output directory. The component bounds fitting to 4,096 positions, 4,096
+rows and 32,768 associations; rows and token postings are learned only from
+construction frames. Floating-point fitting exports integer scores and chooses
+the epoch using the quantized serving rule. The report separates skipped
+NoWrite, upstream failures, capacity drops, candidate coverage and fit accuracy.
+
+The completed first fit is at
+`/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json`,
+CID `blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff`.
+Its baseline remains `fit-2/model.json` under that root, CID
+`blake3:af5f892e7f10680266911e2f5f6fb0aa96a5f25b1894d2f191f0a6b1179843f5`.
+The fit used 160 numeric and 32 skipped NoWrite examples from the existing 192
+pairs, reaching 720/720 exported fit positions with 192 rows/289 associations.
+Full produces 12/16 exact prose and 12/16 exact Rust responses on the reused
+open development: all 24 numeric responses now complete, while the eight
+NoWrite responses remain incorrect. This does not replace the prior typed-only
+negative or qualify general conversation, dependency execution or coding.
+
+The same artifact supports `value-completion-disabled` and
+`value-completion-geometry-disabled` in `r4 geometric --control` operations.
+The former restores the 2/16 prose and 0/16 Rust exact results; the latter gives
+0/16 in each family with the same six completion candidates. Both preserve
+24/24 correct leading numerals. These are within-artifact interventions, not
+independently fitted controls. The probe's completion mode includes Full,
+both completion controls and ValuesDisabled. `evaluate --controls full` selects
+only Full, including its separate binding pairs, for a bounded preservation
+replay; it must use the existing source and `--lexeme-cues true`.
+
+Generation exposes `completion_trace` from the actual rollout. Low-level
+callers use the existing predict/observe and response-boundary methods; the
+component anchors only after the last predicted numeral byte is observed.
+Session schema `/4` persists that anchor and actual suffix history, with pending
+predictions recomputed after restore. It supports empty HTTP continuation after
+checkpoint import. New input closes the active response. At most 32 observed
+suffix steps are retained; EOS closes the state, and mismatches advance actual
+history without selecting a hidden target transition. Models without the
+component retain their prior serialized bytes and behavior.
+
+Per active prediction, the added bound is 16 feature queries, 80 posting offers,
+1,280 candidate equality comparisons, 16 candidate scores and 256 score lookups,
+plus two H4 reads, one orientation read and eight phase differences. Binary
+search, fixed buffers, observation copies and all ordinary `/4` and typed `/2`
+work remain in the cost; this is not a replacement for their computation.
+The [mechanism map](native_geometric_mechanism_map_973.md#committed-value-completion--2026-09-05)
+gives format/search/storage bounds and the primary-source routing comparison.
+Token postings restrict scoring; `/2` still executes all valid checked Adds
+before ranking. Sparse MoE routes before costly expert execution, including
+capacity/drop and dispatch costs. The native heads contain no dense experts,
+and no speed advantage or learned multiscale abstraction follows from these
+bounded routing mechanisms alone.
+The [completion record](native_geometric_value_completion_973.md) and
+[compact evidence](evidence/native_geometric_value_completion_973.json) bind
+the artifact, direct outputs, controls and separate compiler/execution results.
+
+### General corpus preparation
 
 The general corpus preparation command remains:
 

--- a/src/native_geometric_cli.rs
+++ b/src/native_geometric_cli.rs
@@ -258,6 +258,8 @@ enum ControlArg {
     ResponseStateDisabled,
     ValuesDisabled,
     ValueLexemesDisabled,
+    ValueCompletionDisabled,
+    ValueCompletionGeometryDisabled,
 }
 impl From<ControlArg> for Control {
     fn from(value: ControlArg) -> Self {
@@ -274,6 +276,8 @@ impl From<ControlArg> for Control {
             ControlArg::ResponseStateDisabled => Self::ResponseStateDisabled,
             ControlArg::ValuesDisabled => Self::ValuesDisabled,
             ControlArg::ValueLexemesDisabled => Self::ValueLexemesDisabled,
+            ControlArg::ValueCompletionDisabled => Self::ValueCompletionDisabled,
+            ControlArg::ValueCompletionGeometryDisabled => Self::ValueCompletionGeometryDisabled,
         }
     }
 }

--- a/src/native_geometric_service.rs
+++ b/src/native_geometric_service.rs
@@ -411,6 +411,7 @@ impl Service {
         let mut output = Vec::new();
         let mut response_trace = Vec::new();
         let mut value_trace = Vec::new();
+        let mut completion_trace = Vec::new();
         let mut output_bytes = 0;
         let mut stop = "token_limit";
         for _ in 0..request.max_tokens {
@@ -427,6 +428,11 @@ impl Service {
             if let Some(decision) = session.value_decision() {
                 if value_trace.len() < 96 {
                     value_trace.push(decision);
+                }
+            }
+            if let Some(decision) = session.completion_decision() {
+                if completion_trace.len() < 96 {
+                    completion_trace.push(decision);
                 }
             }
             if let Some(decision) = session.response_decision() {
@@ -456,15 +462,17 @@ impl Service {
             .persist(&request.session_id, &session)
             .err()
             .map(|error| error.to_string());
-        Ok(
-            json!({"backend":BACKEND,"artifact_cid":self.model.artifact_cid(),"session_id":request.session_id,
+        let mut response = json!({"backend":BACKEND,"artifact_cid":self.model.artifact_cid(),"session_id":request.session_id,
             "memory_read_version":self.model.memory_read_version(),
             "text":text,"utf8_valid":utf8_valid,"bytes":bytes,"tokens":output,"stop":stop,
             "response_trace":response_trace,"value_trace":value_trace,
             "prompt_tokens":prompt.len(),"observed_prompt_tokens":observed_prompt,
             "state":session.state(),"session_work":session.work,
-            "persisted":self.session_directory.is_some() && persist_error.is_none(),"persistence_error":persist_error}),
-        )
+            "persisted":self.session_directory.is_some() && persist_error.is_none(),"persistence_error":persist_error});
+        if self.model.value_completion_version().is_some() {
+            response["completion_trace"] = json!(completion_trace);
+        }
+        Ok(response)
     }
     fn info(&self) -> Value {
         json!({"backend":BACKEND,"artifact_cid":self.model.artifact_cid(),
@@ -1152,6 +1160,92 @@ mod tests {
             trace.extend(second["value_trace"].as_array().unwrap().iter().cloned());
             assert_eq!(json!(tokens), complete["tokens"]);
             assert_eq!(json!(trace), complete["value_trace"]);
+            assert_eq!(second["state"], complete["state"]);
+            assert_eq!(second["session_work"], complete["session_work"]);
+            assert_eq!(second["session_work"]["values"]["derived_writes"], 1);
+        }
+    }
+
+    #[test]
+    fn native_geometric_completion_http_resumes_actual_suffix_and_stop() {
+        use uor_r4_core::native_geometric::{
+            ValueCompletionFitConfig, ValueExample, ValueFitConfig,
+        };
+        let examples = (0..4)
+            .map(|index| ValueExample {
+                id: format!("completion-service-fit-{index}"),
+                prompt: format!("left = {}; right = 4; total:", 13 + index),
+                response: format!("{}.\n", 17 + index),
+            })
+            .collect::<Vec<_>>();
+        let (typed, _) = model()
+            .fit_values_with_lexeme_cues(
+                &examples,
+                ValueFitConfig {
+                    epochs: 32,
+                    learning_rate: 0.25,
+                    max_features: 4096,
+                },
+            )
+            .unwrap();
+        let (fitted, report) = typed
+            .fit_value_completion(&examples, ValueCompletionFitConfig::default())
+            .unwrap();
+        assert_eq!(report.matched_numeric, 4);
+        let restored_model = Model::from_bytes(&fitted.to_bytes().unwrap()).unwrap();
+        let service = Arc::new(Service::new(restored_model, None).unwrap());
+        let complete_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let split_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let complete = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":complete_id,"prompt":examples[0].prompt,"max_tokens":16}),
+        );
+        assert_eq!(complete["text"], "17.\n");
+        assert_eq!(complete["stop"], "end_of_sequence");
+        let first = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":split_id,"prompt":examples[0].prompt,"max_tokens":3}),
+        );
+        assert_eq!(first["text"], "17.");
+        assert_eq!(first["state"]["completion"]["active"], true);
+        assert_eq!(first["state"]["completion"]["steps"], 1);
+        let exported = post(
+            Arc::clone(&service),
+            "/api/export",
+            json!({"session_id":split_id}),
+        );
+        assert_eq!(
+            exported["checkpoint"]["schema"],
+            "uor-r4.native-geometric-session/4"
+        );
+        let imported_id = id(&post(
+            Arc::clone(&service),
+            "/api/import",
+            json!({"checkpoint":exported["checkpoint"]}),
+        ));
+        for session_id in [split_id, imported_id] {
+            let second = post(
+                Arc::clone(&service),
+                "/api/generate",
+                json!({"session_id":session_id,"prompt":"","max_tokens":16}),
+            );
+            assert_eq!(second["observed_prompt_tokens"], 0);
+            assert_eq!(second["text"], "\n");
+            assert_eq!(second["stop"], "end_of_sequence");
+            let mut tokens = first["tokens"].as_array().unwrap().clone();
+            tokens.extend(second["tokens"].as_array().unwrap().iter().cloned());
+            let mut trace = first["completion_trace"].as_array().unwrap().clone();
+            trace.extend(
+                second["completion_trace"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .cloned(),
+            );
+            assert_eq!(json!(tokens), complete["tokens"]);
+            assert_eq!(json!(trace), complete["completion_trace"]);
             assert_eq!(second["state"], complete["state"]);
             assert_eq!(second["session_work"], complete["session_work"]);
             assert_eq!(second["session_work"]["values"]["derived_writes"], 1);


### PR DESCRIPTION
The preserved typed-value /2 model selects correct operands and emits all 24 numeric development targets, but its ordinary decoder leaves most answers unfinished. This adds a learned, bounded geometric byte/EOS head after the final observed numeral byte, preserving the /4 reader and /2 weights. It now emits complete numeric prose and Rust assertion suffixes through the actual native generation path.

Full completes 12/16 prose and 12/16 Rust cases versus 2/16 and 0/16 with completion disabled. All four source-name binding pairs complete correctly on both sides. Sixteen of twenty inspected generated Rust records compile, execute and pass their assertions (14 distinct successful source hashes); the eight nonnumeric primary cases remain incorrect.

Removing completion H4/orientation/phase features preserves the same six candidates and correct numbers but loses progression/termination. This is combined geometric-score dependence within the fitted artifact; separately fitted comparison, unseen response-form transfer, efficiency advantage and final held-out qualification remain NOT_RUN. Training uses the unchanged 192 raw pairs and fits 720/720 eligible suffix/EOS positions. No runtime suffix template or provider supplies outputs.

The implementation includes causal observation/provenance, bounded candidates and scoring, schema /4 persistence, mismatch/EOS/step-cap behavior, controls and CLI/HTTP continuation. Both older typed artifacts reproduce all 80 saved Generation objects. README, research/current-state, mechanism map and the compact artifact/source/output/resource record are updated.

Validation: 79 core tests plus four new completion runtime tests; four allocation/source, three context, four probe and seventeen CLI/service tests; combined pinned offline release build; formatting, architecture policy and claim wording. Full workspace/release QA, Clippy, no_std, kappa, audit, fuzz, WASM and Gate C were not run locally. Required queue acknowledgements are not substituted for those checks.

Cumulative model work is 903526/1800000 ms. Storage leaves about 24 MB before the unchanged 128 MiB margin in the 4 GiB allocation, below the last build peak increment of 29683712 bytes. Model development checkpoints for storage after delivery; retained artifacts/user material and existing limits remain intact.

Continues #973. Builds on merged #1130; does not close the native-model objective.
