### PR TITLE
Learn NoWrite response entry and reuse its typed decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,24 @@ results, remaining learned-operator work and capability limitations.
 
 The [native mechanism map](docs/native_geometric_mechanism_map_973.md) traces
 the implemented prime/zeta/R4 mechanisms from source to generated responses.
-The latest [typed-value completion record](docs/native_geometric_value_completion_973.md)
-combines bounded whole-word operand binding, checked value creation and decimal
-emission with learned geometric continuation and stopping. On the reused open
-development set it completes 12/16 prose and 12/16 Rust responses exactly;
-all 24 numeric targets and all four binding pairs are correct. Sixteen saved
-Rust records compile and pass their assertions (14 distinct successful sources);
-the eight nonnumeric cases remain incorrect. Removing this completion head's
-H4/orientation/phase features preserves the six-token candidate set and correct
-numerals but loses all complete numeric responses. This establishes combined
-geometric-score dependence in this fitted head, with no separately fitted
-comparison, new-response-form transfer or efficiency advantage yet measured.
+The latest [response-entry record](docs/native_geometric_response_entry_973.md)
+adds learned lexical entry and continuation corrections when the typed selector
+chooses NoWrite. On the same reused OPEN development set it completes **16/16
+prose and 16/16 Rust responses**, preserving all 24 numeric targets and eight
+binding outputs from the preceding [numeric completion model](docs/native_geometric_value_completion_973.md).
+All twenty saved Rust records compile and pass execution checks, including
+four identity functions tested by separate callers (eighteen distinct sources).
+Removing the new head's H4/orientation/phase scores preserves its thirteen-token
+support and correct first entry but loses all eight new complete responses.
+Ordinary decoding supplies parts of those responses, including every EOS.
+
+A separate four-case content-transfer diagnostic fails: explicit city facts
+still receive the learned Unknown sentence, and renamed parameters still produce
+`value`, which fails compilation. The current learned forms do not establish
+grounded abstention or general content binding. The record distinguishes this
+boundary, the final runtime's reuse of an invariant NoWrite decision, complete
+work costs and preserved historical results. A matched geometry-free refit,
+multiscale semantic abstraction and whole-model efficiency advantage remain open.
 
 The [typed-value record](docs/native_geometric_typed_value_973.md) preserves the
 preceding binding negative and whole-word correction; the latter produced correct

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uor_r4_core::native_geometric::{
-    Control, Model, ValueCompletionFitConfig, ValueExample, ValueFitConfig,
+    Control, Model, ResponseEntryFitConfig, ValueCompletionFitConfig, ValueExample, ValueFitConfig,
 };
 
 type ProbeResult<T> = Result<T, Box<dyn Error>>;
@@ -71,14 +71,15 @@ impl Options {
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "native_geometric_value_probe [prepare|fit|completion|evaluate] --output-dir NEW_DIRECTORY\n\
+                    "native_geometric_value_probe [prepare|fit|completion|entry|evaluate] --output-dir NEW_DIRECTORY\n\
                      fit: --model BASELINE [--source source.json]\n\
                      completion: --model TYPED_MODEL --source SOURCE_V2 --lexeme-cues true\n\
+                     entry: --model COMPLETION_MODEL --source SOURCE_V2 --lexeme-cues true --generated-tokens 64\n\
                      evaluate: --model VALUE_MODEL --source source.json\n\
                      evaluate --controls full: only Full, including the existing binding pairs\n\
                      --fit-worlds EVEN_NUMBER --development-worlds EVEN_NUMBER\n\
                      --epochs N --learning-rate F --max-features N\n\
-                     --completion-max-positions N (default 4096, completion fitting only)\n\
+                     --completion-max-positions N (default 4096, completion or entry fitting)\n\
                      --generated-tokens N --max-seconds N\n\
                      --lexeme-cues true|false (default false; true appends 64 fit\n\
                      name swaps at default world count and uses source schema /2)\n\
@@ -107,17 +108,19 @@ impl Options {
                 "--max-seconds" => result.max_seconds = value.parse()?,
                 "--lexeme-cues" => result.lexeme_cues = value.parse()?,
                 "--controls" => result.controls = value,
-                "--completion-max-positions" => result.completion_max_positions = value.parse()?,
+                "--completion-max-positions" | "--entry-max-positions" => {
+                    result.completion_max_positions = value.parse()?
+                }
                 _ => return Err(format!("unknown option {flag}").into()),
             }
         }
-        if !["prepare", "fit", "completion", "evaluate"].contains(&result.mode.as_str())
+        if !["prepare", "fit", "completion", "entry", "evaluate"].contains(&result.mode.as_str())
             || result.output_dir.as_os_str().is_empty()
             || (result.mode != "prepare" && result.model.as_os_str().is_empty())
-            || (["completion", "evaluate"].contains(&result.mode.as_str())
+            || (["completion", "entry", "evaluate"].contains(&result.mode.as_str())
                 && result.source.is_none())
-            || (result.mode == "completion" && !result.lexeme_cues)
-            || (result.mode == "completion" && result.epochs > 64)
+            || (["completion", "entry"].contains(&result.mode.as_str()) && !result.lexeme_cues)
+            || (["completion", "entry"].contains(&result.mode.as_str()) && result.epochs > 64)
             || !(1..=4096).contains(&result.completion_max_positions)
             || !["all", "full"].contains(&result.controls.as_str())
             || (result.controls == "full" && result.mode != "evaluate")
@@ -580,6 +583,7 @@ fn reject_training_overlap(model: &Model, cases: &[Case]) -> ProbeResult<()> {
             .chain(model.memory_read_training())
             .chain(model.value_training())
             .chain(model.value_completion_training())
+            .chain(model.response_entry_training())
             .any(|known| {
                 known.id == case.id || known.text_cid == pair_cid || known.text_cid == whole_cid
             })
@@ -603,8 +607,15 @@ fn evaluate(
     reject_training_overlap(model, &source.development)?;
     let mut arms = Vec::new();
     let completion = model.value_completion_version().is_some();
+    let entry = model.response_entry_version().is_some();
     let mut controls = if options.controls == "full" {
         vec![Control::Full]
+    } else if entry {
+        vec![
+            Control::Full,
+            Control::ResponseEntryDisabled,
+            Control::ResponseEntryGeometryDisabled,
+        ]
     } else if completion {
         vec![
             Control::Full,
@@ -696,10 +707,16 @@ fn evaluate(
         if control == Control::ValueCompletionGeometryDisabled {
             arm["scope"] = json!("Within-artifact suppression of completion H4/orientation/phase feature contributions. The underlying typed-value and ordinary model geometry remain enabled. This measures feature sensitivity, not separately fitted matched training or general geometric advantage.");
         }
+        if control == Control::ResponseEntryDisabled {
+            arm["scope"] = json!("Within-artifact suppression of response-entry offers while retaining ordinary, typed and numeral-completion components. State remains bounded; this is not a separately fitted baseline.");
+        }
+        if control == Control::ResponseEntryGeometryDisabled {
+            arm["scope"] = json!("Within-artifact suppression of only response-entry H4/orientation/phase score features. Other components remain enabled. Candidate support and complete work must be checked separately; this is not a refitted geometry comparator.");
+        }
         // Completion reports retain the complete generation objects once in
         // report.json to keep the model, exact outputs and traces within the
         // configured output allowance. Historical typed-only files stay intact.
-        if !completion {
+        if !completion && !entry {
             write_json(
                 &options.output_dir.join(format!("arm-{}.json", arms.len())),
                 &arm,
@@ -780,7 +797,7 @@ fn evaluate_binding(
 
 fn main() -> ProbeResult<()> {
     let options = Options::parse()?;
-    let output_limit = if options.mode == "completion" {
+    let output_limit = if ["completion", "entry"].contains(&options.mode.as_str()) {
         Some(COMPLETION_OUTPUT_BYTES)
     } else if options.controls == "full" {
         Some(PRESERVATION_OUTPUT_BYTES)
@@ -828,9 +845,20 @@ fn main() -> ProbeResult<()> {
     within_limit(start, &options)?;
     let baseline = Model::from_bytes(&fs::read(&options.model)?)?;
     let input_artifact = baseline.artifact_cid().to_owned();
-    let (model, fit_report) = if ["fit", "completion"].contains(&options.mode.as_str()) {
+    let (model, fit_report) = if ["fit", "completion", "entry"].contains(&options.mode.as_str()) {
         let examples: Vec<_> = source.fit.iter().map(Case::example).collect();
-        let (fitted, report) = if options.mode == "completion" {
+        let (fitted, report) = if options.mode == "entry" {
+            let (fitted, report) = baseline.fit_response_entry(
+                &examples,
+                ResponseEntryFitConfig {
+                    epochs: options.epochs,
+                    learning_rate: options.learning_rate,
+                    max_positions: options.completion_max_positions,
+                },
+            )?;
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
+        } else if options.mode == "completion" {
             let (fitted, report) = baseline.fit_value_completion(
                 &examples,
                 ValueCompletionFitConfig {
@@ -867,7 +895,7 @@ fn main() -> ProbeResult<()> {
     let arms = evaluate(&model, &source, &options, start)?;
     let binding_controls = evaluate_binding(&model, &binding_source, &options, start)?;
     let mut report = json!({
-        "schema":if model.value_completion_version().is_some() { "uor-r4.native-value-completion-probe/1" } else if options.lexeme_cues { "uor-r4.native-typed-value-probe/2" } else { "uor-r4.native-typed-value-probe/1" },
+        "schema":if model.response_entry_version().is_some() { "uor-r4.native-response-entry-probe/1" } else if model.value_completion_version().is_some() { "uor-r4.native-value-completion-probe/1" } else if options.lexeme_cues { "uor-r4.native-typed-value-probe/2" } else { "uor-r4.native-typed-value-probe/1" },
         "status":"completed",
         "scope":source.scope,
         "tokenization_law":source.tokenization_law,
@@ -887,6 +915,10 @@ fn main() -> ProbeResult<()> {
         "compilation":"NOT_RUN: exact generated Rust saved for separate inspected-source assessment",
         "execution":"NOT_RUN",
     });
+    if let Some(version) = model.response_entry_version() {
+        report["response_entry_operator_version"] = json!(version);
+        report["response_entry_scope"] = json!("Same raw /2 source and reused OPEN development. Nonnumeric response entry learns canonical token IDs and EOS after actual model-selected NoWrite. Continuation follows only a quantized selected Enter that was observed; no target creates a hidden anchor. Whole responses over 32 canonical-token/EOS positions are skipped, not truncated. Numeric typed/completion behavior remains the upstream path. Same-artifact entry and entry-geometry controls retain all other components.");
+    }
     if let Some(version) = model.value_completion_version() {
         report["completion_operator_version"] = json!(version);
         report["completion_scope"] = json!("Same /2 raw source and unchanged OPEN development targets. Fitting follows actual upstream numeral rollouts, then supervises ordinary suffix bytes and EOS; no generated suffix or target template is appended. Completion traces describe the learned step transitions. Primary and binding controls remain reused design feedback, not final held-out evaluation.");

--- a/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
@@ -246,25 +246,39 @@ pub(super) fn candidates(
     [usize; COMPLETION_FEATURES],
     usize,
 ) {
+    candidate_rows(&head.rows, &head.global_postings, features, work)
+}
+
+pub(super) fn candidate_rows(
+    score_rows: &[ScoreRow],
+    global_postings: &[u32],
+    features: &[Feature],
+    work: &mut CompletionWork,
+) -> (
+    [u32; COMPLETION_CANDIDATES],
+    usize,
+    [usize; COMPLETION_FEATURES],
+    usize,
+) {
     let mut tokens = [0; COMPLETION_CANDIDATES];
     let mut count = 0;
     let mut rows = [0; COMPLETION_FEATURES];
     let mut row_count = 0;
     for feature in features {
         work.feature_queries = work.feature_queries.saturating_add(1);
-        if let Ok(index) = head.rows.binary_search_by(|row| {
+        if let Ok(index) = score_rows.binary_search_by(|row| {
             work.row_comparisons = work.row_comparisons.saturating_add(1);
             row.feature.cmp(feature)
         }) {
             rows[row_count] = index;
             row_count += 1;
             work.matched_rows = work.matched_rows.saturating_add(1);
-            for &token in &head.rows[index].postings {
+            for &token in &score_rows[index].postings {
                 offer_token(&mut tokens, &mut count, token, work);
             }
         }
     }
-    for &token in &head.global_postings {
+    for &token in global_postings {
         offer_token(&mut tokens, &mut count, token, work);
     }
     (tokens, count, rows, row_count)
@@ -298,9 +312,18 @@ pub(super) fn score_candidate(
     rows: &[usize],
     work: &mut CompletionWork,
 ) -> i64 {
+    score_rows(&head.rows, token, rows, work)
+}
+
+pub(super) fn score_rows(
+    score_rows: &[ScoreRow],
+    token: u32,
+    rows: &[usize],
+    work: &mut CompletionWork,
+) -> i64 {
     let mut score = 0;
     for &index in rows {
-        let row = &head.rows[index];
+        let row = &score_rows[index];
         work.score_lookups = work.score_lookups.saturating_add(1);
         score += i64::from(
             row.scores

--- a/crates/uor-r4-core/src/native_geometric/completion_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_training.rs
@@ -47,11 +47,11 @@ pub struct ValueCompletionFitReport {
     pub config: ValueCompletionFitConfig,
 }
 
-struct Frame {
-    features: [Feature; COMPLETION_FEATURES],
-    len: usize,
-    target: u32,
-    baseline: u32,
+pub(super) struct Frame {
+    pub(super) features: [Feature; COMPLETION_FEATURES],
+    pub(super) len: usize,
+    pub(super) target: u32,
+    pub(super) baseline: u32,
 }
 struct Alternative {
     token: u32,
@@ -163,6 +163,7 @@ impl CompletionModel {
         }
         let mut baseline = model.clone();
         baseline.completion = None;
+        baseline.response_entry = None;
         baseline.refresh_identity()?;
         if baseline.artifact_cid != self.baseline_artifact {
             return Err(Error(
@@ -362,128 +363,14 @@ impl Model {
                 "completion source has no matched emitted numeral and suffix positions".into(),
             ));
         }
-        let mut counts = BTreeMap::<Feature, BTreeMap<u32, u64>>::new();
-        let mut global = BTreeMap::<u32, u64>::new();
-        let mut association_count = 0;
-        let mut dropped_row_events = 0;
-        let mut dropped_association_events = 0;
-        for frame in &frames {
-            *global.entry(frame.target).or_default() += 1;
-            for &feature in &frame.features[..frame.len] {
-                if !counts.contains_key(&feature) && counts.len() == COMPLETION_ROWS {
-                    dropped_row_events += 1;
-                    continue;
-                }
-                let row = counts.entry(feature).or_default();
-                if !row.contains_key(&frame.target) {
-                    if association_count == COMPLETION_ASSOCIATIONS {
-                        dropped_association_events += 1;
-                        continue;
-                    }
-                    association_count += 1;
-                }
-                *row.entry(frame.target).or_default() += 1;
-            }
-        }
-        let mut registry = BTreeMap::<(Feature, u32), usize>::new();
-        let mut weights = Vec::new();
-        let rows = counts
-            .into_iter()
-            .map(|(feature, counts)| {
-                let postings = top_counts(&counts, COMPLETION_POSTINGS);
-                let scores = counts
-                    .keys()
-                    .map(|&token| {
-                        registry.insert((feature, token), weights.len());
-                        let weight = if feature.kind == 0 { -2.0 } else { 0.0 };
-                        weights.push(weight);
-                        TokenScore {
-                            token,
-                            score: (weight * 256.0) as i32,
-                        }
-                    })
-                    .collect();
-                ScoreRow {
-                    feature,
-                    default_score: 0,
-                    scores,
-                    postings,
-                }
-            })
-            .collect();
+        let fit = fit_sparse_frames(&frames, config, COMPLETION_ROWS, COMPLETION_ASSOCIATIONS, 0)?;
         let head = model
             .completion
             .as_mut()
             .ok_or_else(|| Error("completion component unavailable".into()))?;
-        head.rows = rows;
-        head.global_postings = top_counts(&global, COMPLETION_CANDIDATES);
-        let mut examples = Vec::new();
-        let mut target_in_candidates = 0;
-        for frame in &frames {
-            let (tokens, len, _, _) = completion_runtime::candidates(
-                head,
-                &frame.features[..frame.len],
-                &mut CompletionWork::default(),
-            );
-            let target_present = tokens[..len].contains(&frame.target);
-            target_in_candidates += usize::from(target_present);
-            if !target_present && frame.baseline != frame.target {
-                continue;
-            }
-            let alternatives = tokens[..len]
-                .iter()
-                .map(|&token| Alternative {
-                    token,
-                    correct: token == frame.target,
-                    weights: frame.features[..frame.len]
-                        .iter()
-                        .filter_map(|&feature| registry.get(&(feature, token)).copied())
-                        .collect(),
-                })
-                .collect();
-            examples.push(Example {
-                alternatives,
-                baseline_correct: frame.baseline == frame.target,
-            });
-        }
-        if examples.is_empty() {
-            return Err(Error(
-                "completion postings admit no fitting target or correct Base action".into(),
-            ));
-        }
-        let mut best_weights = weights.clone();
-        let mut best_correct = 0;
-        let mut best_loss = f64::INFINITY;
-        let mut selected_epoch = 0;
-        for epoch in 0..config.epochs {
-            for example in &examples {
-                update(example, &mut weights, config.learning_rate)?;
-            }
-            let quantized: Vec<f64> = weights
-                .iter()
-                .map(|weight| (weight * 256.0).round() / 256.0)
-                .collect();
-            let (correct, loss) = measure(&examples, &quantized);
-            if !loss.is_finite() {
-                return Err(Error(
-                    "completion fitting produced a nonfinite objective".into(),
-                ));
-            }
-            if correct > best_correct || (correct == best_correct && loss < best_loss) {
-                best_correct = correct;
-                best_loss = loss;
-                selected_epoch = epoch + 1;
-                best_weights = quantized;
-            }
-        }
-        for row in &mut head.rows {
-            for entry in &mut row.scores {
-                let index = registry
-                    .get(&(row.feature, entry.token))
-                    .ok_or_else(|| Error("completion export association missing".into()))?;
-                entry.score = (best_weights[*index] * 256.0).round() as i32;
-            }
-        }
+        head.rows = fit.rows;
+        head.global_postings = fit.global_postings;
+        let selected_epoch = fit.selected_epoch;
         head.fit_positions = frames.len();
         head.fit_config = [
             config.epochs as u64,
@@ -506,14 +393,14 @@ impl Model {
             position_limit_skips,
             overlong_responses,
             positions: frames.len(),
-            target_in_candidates,
-            eligible_positions: examples.len(),
+            target_in_candidates: fit.target_in_candidates,
+            eligible_positions: fit.eligible_positions,
             learned_rows,
-            learned_associations: weights.len(),
-            dropped_row_events,
-            dropped_association_events,
-            fit_correct: best_correct,
-            fit_loss: best_loss,
+            learned_associations: fit.learned_associations,
+            dropped_row_events: fit.dropped_row_events,
+            dropped_association_events: fit.dropped_association_events,
+            fit_correct: fit.correct,
+            fit_loss: fit.loss,
             selected_epoch,
             config,
         };
@@ -521,7 +408,162 @@ impl Model {
     }
 }
 
-fn top_counts(counts: &BTreeMap<u32, u64>, cap: usize) -> Vec<u32> {
+/// Shared host sparse optimizer. A baseline ID absent from the token domain
+/// makes Base ineligible when learning a state-creating action.
+pub(super) struct SparseFit {
+    pub(super) rows: Vec<ScoreRow>,
+    pub(super) global_postings: Vec<u32>,
+    pub(super) target_in_candidates: usize,
+    pub(super) eligible_positions: usize,
+    pub(super) learned_associations: usize,
+    pub(super) dropped_row_events: usize,
+    pub(super) dropped_association_events: usize,
+    pub(super) correct: usize,
+    pub(super) loss: f64,
+    pub(super) selected_epoch: usize,
+}
+
+pub(super) fn fit_sparse_frames(
+    frames: &[Frame],
+    config: ValueCompletionFitConfig,
+    max_rows: usize,
+    max_associations: usize,
+    bias_kind: u8,
+) -> Result<SparseFit> {
+    let mut counts = BTreeMap::<Feature, BTreeMap<u32, u64>>::new();
+    let mut global = BTreeMap::<u32, u64>::new();
+    let mut association_count = 0;
+    let mut dropped_row_events = 0;
+    let mut dropped_association_events = 0;
+    for frame in frames {
+        *global.entry(frame.target).or_default() += 1;
+        for &feature in &frame.features[..frame.len] {
+            if !counts.contains_key(&feature) && counts.len() == max_rows {
+                dropped_row_events += 1;
+                continue;
+            }
+            let row = counts.entry(feature).or_default();
+            if !row.contains_key(&frame.target) {
+                if association_count == max_associations {
+                    dropped_association_events += 1;
+                    continue;
+                }
+                association_count += 1;
+            }
+            *row.entry(frame.target).or_default() += 1;
+        }
+    }
+    let mut registry = BTreeMap::<(Feature, u32), usize>::new();
+    let mut weights = Vec::new();
+    let rows = counts
+        .into_iter()
+        .map(|(feature, counts)| {
+            let postings = top_counts(&counts, COMPLETION_POSTINGS);
+            let scores = counts
+                .keys()
+                .map(|&token| {
+                    registry.insert((feature, token), weights.len());
+                    let weight = if feature.kind == bias_kind { -2.0 } else { 0.0 };
+                    weights.push(weight);
+                    TokenScore {
+                        token,
+                        score: (weight * 256.0) as i32,
+                    }
+                })
+                .collect();
+            ScoreRow {
+                feature,
+                default_score: 0,
+                scores,
+                postings,
+            }
+        })
+        .collect();
+    let mut rows: Vec<ScoreRow> = rows;
+    let global_postings = top_counts(&global, COMPLETION_CANDIDATES);
+    let mut examples = Vec::new();
+    let mut target_in_candidates = 0;
+    for frame in frames {
+        let (tokens, len, _, _) = completion_runtime::candidate_rows(
+            &rows,
+            &global_postings,
+            &frame.features[..frame.len],
+            &mut CompletionWork::default(),
+        );
+        let target_present = tokens[..len].contains(&frame.target);
+        target_in_candidates += usize::from(target_present);
+        if !target_present && frame.baseline != frame.target {
+            continue;
+        }
+        let alternatives = tokens[..len]
+            .iter()
+            .map(|&token| Alternative {
+                token,
+                correct: token == frame.target,
+                weights: frame.features[..frame.len]
+                    .iter()
+                    .filter_map(|&feature| registry.get(&(feature, token)).copied())
+                    .collect(),
+            })
+            .collect();
+        examples.push(Example {
+            alternatives,
+            baseline_correct: frame.baseline == frame.target,
+        });
+    }
+    if examples.is_empty() {
+        return Err(Error(
+            "completion postings admit no fitting target or correct Base action".into(),
+        ));
+    }
+    let mut best_weights = weights.clone();
+    let mut best_correct = 0;
+    let mut best_loss = f64::INFINITY;
+    let mut selected_epoch = 0;
+    for epoch in 0..config.epochs {
+        for example in &examples {
+            update(example, &mut weights, config.learning_rate)?;
+        }
+        let quantized: Vec<f64> = weights
+            .iter()
+            .map(|weight| (weight * 256.0).round() / 256.0)
+            .collect();
+        let (correct, loss) = measure(&examples, &quantized);
+        if !loss.is_finite() {
+            return Err(Error(
+                "completion fitting produced a nonfinite objective".into(),
+            ));
+        }
+        if correct > best_correct || (correct == best_correct && loss < best_loss) {
+            best_correct = correct;
+            best_loss = loss;
+            selected_epoch = epoch + 1;
+            best_weights = quantized;
+        }
+    }
+    for row in &mut rows {
+        for entry in &mut row.scores {
+            let index = registry
+                .get(&(row.feature, entry.token))
+                .ok_or_else(|| Error("completion export association missing".into()))?;
+            entry.score = (best_weights[*index] * 256.0).round() as i32;
+        }
+    }
+    Ok(SparseFit {
+        rows,
+        global_postings,
+        target_in_candidates,
+        eligible_positions: examples.len(),
+        learned_associations: weights.len(),
+        dropped_row_events,
+        dropped_association_events,
+        correct: best_correct,
+        loss: best_loss,
+        selected_epoch,
+    })
+}
+
+pub(super) fn top_counts(counts: &BTreeMap<u32, u64>, cap: usize) -> Vec<u32> {
     let mut ranked: Vec<_> = counts
         .iter()
         .map(|(&token, &count)| (token, count))

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -16,6 +16,9 @@ mod memory_training;
 mod memory_types;
 mod mixture;
 mod numeral;
+mod response_entry_runtime;
+mod response_entry_training;
+mod response_entry_types;
 mod response_runtime;
 mod runtime;
 mod snapshot;
@@ -31,6 +34,11 @@ pub use completion_training::{ValueCompletionFitConfig, ValueCompletionFitReport
 pub use completion_types::{
     CompletionAction, CompletionDecision, CompletionStateView, CompletionWork,
 };
+pub use response_entry_training::{ResponseEntryFitConfig, ResponseEntryFitReport};
+pub use response_entry_types::{
+    ResponseEntryAction, ResponseEntryDecision, ResponseEntryStateView,
+};
+pub type ResponseEntryWork = CompletionWork;
 pub use memory_training::{
     MemoryReadDiagnostic, MemoryReadDocumentExposure, MemoryReadDocumentSupervision,
     MemoryReadResponseStateReport, MemoryReadSchedule, MemoryReadStreamProgress,
@@ -135,6 +143,8 @@ pub enum Control {
     ValueLexemesDisabled,
     ValueCompletionDisabled,
     ValueCompletionGeometryDisabled,
+    ResponseEntryDisabled,
+    ResponseEntryGeometryDisabled,
 }
 
 /// Explicit feature addresses, never content digests. Kinds 0/1 are full
@@ -176,7 +186,9 @@ impl Feature {
             | Control::ValuesDisabled
             | Control::ValueLexemesDisabled
             | Control::ValueCompletionDisabled
-            | Control::ValueCompletionGeometryDisabled => true,
+            | Control::ValueCompletionGeometryDisabled
+            | Control::ResponseEntryDisabled
+            | Control::ResponseEntryGeometryDisabled => true,
             Control::GeometryDisabled => self.kind < 2,
             Control::ZetaDisabled => !(8..=15).contains(&self.kind) && self.kind != 5,
             Control::H4Disabled => self.kind < 2 || (8..=15).contains(&self.kind),
@@ -264,6 +276,8 @@ pub struct Model {
     values: Option<value_types::ValueModel>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     completion: Option<completion_types::CompletionModel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    response_entry: Option<response_entry_types::ResponseEntryModel>,
 }
 
 #[derive(Deserialize)]
@@ -288,6 +302,8 @@ struct ModelWire {
     values: Option<value_types::ValueModel>,
     #[serde(default)]
     completion: Option<completion_types::CompletionModel>,
+    #[serde(default)]
+    response_entry: Option<response_entry_types::ResponseEntryModel>,
 }
 impl TryFrom<ModelWire> for Model {
     type Error = Error;
@@ -309,6 +325,7 @@ impl TryFrom<ModelWire> for Model {
             memory_read: wire.memory_read,
             values: wire.values,
             completion: wire.completion,
+            response_entry: wire.response_entry,
         };
         model.validate()?;
         Ok(model)
@@ -317,6 +334,8 @@ impl TryFrom<ModelWire> for Model {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Work {
+    #[serde(default, skip_serializing_if = "CompletionWork::is_empty")]
+    pub response_entry: CompletionWork,
     #[serde(default, skip_serializing_if = "CompletionWork::is_empty")]
     pub completion: CompletionWork,
     #[serde(default, skip_serializing_if = "ValueWork::is_empty")]
@@ -399,6 +418,8 @@ pub struct Prediction {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Generation {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub response_entry_trace: Vec<ResponseEntryDecision>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_trace: Vec<CompletionDecision>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub value_trace: Vec<ValueDecision>,
@@ -437,3 +458,8 @@ mod value_runtime_tests;
 
 #[cfg(test)]
 mod completion_runtime_tests;
+
+#[cfg(test)]
+mod response_entry_runtime_tests;
+#[cfg(test)]
+mod response_entry_training_tests;

--- a/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
@@ -1,0 +1,274 @@
+//! Integer/table response transitions anchored to an actual query boundary.
+//! Entry commits only when its selected token is observed; no answer buffer,
+//! numeric write or target-derived state is synthesized.
+use super::completion_runtime::{candidate_rows, score_rows};
+use super::completion_types::CompletionWork;
+use super::response_entry_types::*;
+use super::value_types::ValueState;
+use super::*;
+
+pub(super) fn eligible(values: &ValueState, control: Control) -> bool {
+    !matches!(
+        control,
+        Control::ResponseEntryDisabled | Control::ValuesDisabled | Control::MemoryDisabled
+    ) && values.active
+        && !values.consumed
+        && values.emission.is_none()
+        && values.query_len > 0
+        && !values.sources.is_empty()
+        && values.next_id != u64::MAX
+}
+
+impl ResponseEntryState {
+    /// Response boundaries clear selection while preserving actual history.
+    pub(super) fn reset(&mut self) {
+        self.boundary = None;
+        self.steps = 0;
+        self.active = false;
+        self.last_action = ResponseEntryAction::Base;
+        self.pending = None;
+    }
+
+    pub(super) fn begin(
+        &mut self,
+        values: &ValueState,
+        control: Control,
+        work: &mut CompletionWork,
+    ) {
+        self.reset();
+        if !eligible(values, control)
+            || values.pending.is_some()
+            || values.started_at != values.seen
+            || self.seen != values.seen
+        {
+            return;
+        }
+        self.boundary = Some(ResponseEntryAnchor {
+            at_seen: values.seen,
+            pose: values.pose,
+            phases: values.phases,
+            query_prime: values.queries[0].cue,
+        });
+        work.anchors = work.anchors.saturating_add(1);
+        work.metadata_reads = work.metadata_reads.saturating_add(1);
+        work.state_copies = work.state_copies.saturating_add(11);
+    }
+
+    pub(super) fn observe(
+        &mut self,
+        _model: &Model,
+        values: &ValueState,
+        token: u32,
+        control: Control,
+        work: &mut CompletionWork,
+    ) {
+        work.observations = work.observations.saturating_add(1);
+        let pending = self.pending.take();
+        let was_active = self.active;
+        let boundary = self.boundary;
+        let matched = pending.filter(|decision| {
+            decision.token == token
+                && decision.at_seen == self.seen
+                && decision.step == self.steps
+                && boundary.is_some_and(|anchor| anchor.at_seen == decision.boundary_seen)
+                && decision.at_seen.checked_add(1) == Some(values.seen)
+        });
+        self.previous = self.last;
+        self.last = token;
+        self.seen = values.seen;
+        self.last_action = ResponseEntryAction::Base;
+        work.state_copies = work.state_copies.saturating_add(3);
+
+        // EOS updates typed state before this call, so its active bit is
+        // already false. Commit the actual selected stop before gate checks.
+        if token == EOS {
+            if matched.is_some() {
+                work.commits = work.commits.saturating_add(1);
+            } else if boundary.is_some() {
+                work.base_steps = work.base_steps.saturating_add(1);
+                if pending.is_some() {
+                    work.mismatches = work.mismatches.saturating_add(1);
+                }
+            }
+            if was_active || matched.is_some() {
+                work.stops = work.stops.saturating_add(1);
+            }
+            self.reset();
+            self.last_action = ResponseEntryAction::Stop;
+            return;
+        }
+        if !eligible(values, control) {
+            self.reset();
+            return;
+        }
+        if was_active {
+            self.steps = self.steps.saturating_add(1);
+            if let Some(decision) = matched {
+                self.last_action = decision.action;
+                work.commits = work.commits.saturating_add(1);
+            } else {
+                work.base_steps = work.base_steps.saturating_add(1);
+                if pending.is_some() {
+                    work.mismatches = work.mismatches.saturating_add(1);
+                }
+            }
+            if self.steps >= RESPONSE_ENTRY_STEPS {
+                // A cap ends the component without fabricating EOS. Clearing
+                // the action makes inactive state independent of stale origin.
+                self.reset();
+                work.step_limits = work.step_limits.saturating_add(1);
+            }
+        } else if let Some(decision) = matched.filter(|decision| {
+            decision.action == ResponseEntryAction::Enter
+                && decision.step == 0
+                && boundary.is_some_and(|anchor| anchor.at_seen == decision.at_seen)
+        }) {
+            self.active = true;
+            self.steps = 1;
+            self.last_action = decision.action;
+            work.commits = work.commits.saturating_add(1);
+        } else {
+            if boundary.is_some() {
+                work.base_steps = work.base_steps.saturating_add(1);
+                if pending.is_some() {
+                    work.mismatches = work.mismatches.saturating_add(1);
+                }
+            }
+            // An unselected or mismatched first observation closes eligibility
+            // until the caller begins another response.
+            self.reset();
+        }
+    }
+
+    pub(super) fn features(
+        &self,
+        model: &Model,
+        values: &ValueState,
+        control: Control,
+        work: &mut CompletionWork,
+    ) -> ([Feature; RESPONSE_ENTRY_FEATURES], usize) {
+        let mut features = [Feature { kind: 0, value: 0 }; RESPONSE_ENTRY_FEATURES];
+        let Some(anchor) = self.boundary else {
+            return (features, 0);
+        };
+        let last = u64::from(model.geometry.tokens[self.last as usize].prime);
+        let previous = u64::from(model.geometry.tokens[self.previous as usize].prime);
+        work.metadata_reads = work.metadata_reads.saturating_add(2);
+        let offset = if self.active { 16 } else { 0 };
+        let mut len = 0;
+        let mut add = |kind, value| {
+            features[len] = Feature {
+                kind: kind + offset,
+                value,
+            };
+            len += 1;
+        };
+        add(0, 0);
+        add(1, last);
+        add(2, (previous << 32) | last);
+        add(3, u64::from(anchor.query_prime));
+        add(4, (u64::from(anchor.query_prime) << 32) | last);
+        add(5, u64::from(self.steps));
+        if !matches!(
+            control,
+            Control::GeometryDisabled
+                | Control::H4Disabled
+                | Control::ResponseEntryGeometryDisabled
+        ) {
+            let inverse = model.geometry.inverses[usize::from(anchor.pose)];
+            let relative = model.geometry.products
+                [model.geometry.row_bases[usize::from(inverse)] + usize::from(values.pose)];
+            work.h4_reads = work.h4_reads.saturating_add(2);
+            work.metadata_reads = work.metadata_reads.saturating_add(1);
+            add(6, u64::from(relative));
+            if !matches!(
+                control,
+                Control::OrientationDisabled | Control::HeatmapDisabled
+            ) {
+                add(
+                    7,
+                    u64::from(model.geometry.orientation[usize::from(relative)]),
+                );
+                work.orientation_reads = work.orientation_reads.saturating_add(1);
+            }
+        }
+        if !matches!(
+            control,
+            Control::GeometryDisabled
+                | Control::ZetaDisabled
+                | Control::ResponseEntryGeometryDisabled
+        ) {
+            for channel in 0..PHASE_CHANNELS {
+                let phase = values.phases[channel].wrapping_sub(anchor.phases[channel]);
+                add(8 + channel as u8, u64::from(phase >> 12));
+                work.phase_subtractions = work.phase_subtractions.saturating_add(1);
+            }
+        }
+        (features, len)
+    }
+
+    pub(super) fn offer(
+        &mut self,
+        model: &Model,
+        values: &ValueState,
+        baseline: Candidate,
+        control: Control,
+        work: &mut CompletionWork,
+    ) -> Option<Candidate> {
+        self.pending = None;
+        if !eligible(values, control)
+            || values.pending.is_some()
+            || self.steps >= RESPONSE_ENTRY_STEPS
+            || self.seen != values.seen
+        {
+            return None;
+        }
+        let head = model.response_entry.as_ref()?;
+        let anchor = self.boundary?;
+        if anchor.at_seen != values.started_at
+            || (!self.active && (self.steps != 0 || self.seen != anchor.at_seen))
+        {
+            return None;
+        }
+        let (features, len) = self.features(model, values, control, work);
+        let (tokens, count, rows, row_count) =
+            candidate_rows(&head.rows, &head.global_postings, &features[..len], work);
+        let mut best = None;
+        let mut best_score = 0_i64;
+        for token in tokens[..count].iter().copied() {
+            let score = score_rows(&head.rows, token, &rows[..row_count], work);
+            if score > best_score
+                || (score == best_score && score > 0 && best.is_some_and(|known| token < known))
+            {
+                best = Some(token);
+                best_score = score;
+            }
+        }
+        let token = best?;
+        let score = baseline.score + best_score;
+        self.pending = Some(ResponseEntryDecision {
+            token,
+            score,
+            boundary_seen: anchor.at_seen,
+            step: self.steps,
+            at_seen: self.seen,
+            action: if token == EOS {
+                ResponseEntryAction::Stop
+            } else if self.active {
+                ResponseEntryAction::Emit
+            } else {
+                ResponseEntryAction::Enter
+            },
+        });
+        Some(Candidate { token, score })
+    }
+
+    pub(super) fn selected(&mut self, best: Candidate) {
+        if self
+            .pending
+            .is_some_and(|decision| decision.token != best.token || decision.score != best.score)
+        {
+            self.pending = None;
+        }
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs
@@ -1,0 +1,450 @@
+//! Mechanical entry, observation, numeric precedence and persistence checks.
+//! Fixed rows here establish state laws, not fitted model capability.
+use super::completion_types::{CompletionModel, COMPLETION_SCHEMA};
+use super::numeral::NUMERAL_CODEC;
+use super::response_entry_types::*;
+use super::value_types::{ValueFeature, ValueModel, ValueRow, LEXEME_VALUE_SCHEMA, VALUES};
+use super::*;
+
+const EMIT: u32 = b'!' as u32 + 2;
+const OTHER: u32 = b'?' as u32 + 2;
+
+fn mechanical(copy: bool, continuation: u32) -> Model {
+    let documents = [Document {
+        id: "response-entry-mechanical-catalog".into(),
+        text: "source value query unknown reply 9 17 101 ; : ! ?\n".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 8,
+            candidate_limit: 16,
+            max_lexical_pieces: 128,
+            ..Config::default()
+        },
+        &documents,
+    )
+    .unwrap();
+    trainer.train_documents(&documents).unwrap();
+    let mut model = trainer.compile().unwrap();
+    model.values = Some(ValueModel {
+        schema: LEXEME_VALUE_SCHEMA.into(),
+        codec: NUMERAL_CODEC.into(),
+        capacity: VALUES,
+        rows: if copy {
+            vec![ValueRow {
+                feature: ValueFeature {
+                    kind: 0,
+                    a: 0,
+                    b: 0,
+                },
+                weight: 4096,
+            }]
+        } else {
+            Vec::new()
+        },
+        continuation_score: 4096,
+        fit_config: [0; 4],
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    model.completion = Some(CompletionModel {
+        schema: COMPLETION_SCHEMA.into(),
+        baseline_artifact: model.artifact_cid.clone(),
+        rows: Vec::new(),
+        global_postings: Vec::new(),
+        fit_config: [0; 4],
+        fit_positions: 0,
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    model.response_entry = Some(ResponseEntryModel {
+        schema: RESPONSE_ENTRY_SCHEMA.into(),
+        baseline_artifact: model.artifact_cid.clone(),
+        rows: [(0, EMIT), (16, continuation)]
+            .into_iter()
+            .map(|(kind, token)| ScoreRow {
+                feature: Feature { kind, value: 0 },
+                default_score: 0,
+                scores: vec![TokenScore { token, score: 1000 }],
+                postings: vec![token],
+            })
+            .collect(),
+        global_postings: if continuation == EMIT {
+            vec![EMIT]
+        } else {
+            vec![EMIT, continuation]
+        },
+        fit_config: [0; 5],
+        fit_positions: 0,
+        training: Vec::new(),
+    });
+    model.refresh_identity().unwrap();
+    Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
+}
+
+fn prefix(model: &Model, control: Control, source: &str) -> Session {
+    let mut session = model.session(control).unwrap();
+    session.observe(model, BOS).unwrap();
+    for token in model.encode(source).unwrap() {
+        session.observe(model, token).unwrap();
+    }
+    session.begin_response(model).unwrap();
+    session
+}
+
+#[test]
+fn native_response_entry_commits_only_selected_observation_and_tracks_actual_mismatch() {
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    let boundary = session.response_entry.as_ref().unwrap().boundary.unwrap();
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    let first = session.predict(&model).unwrap();
+    assert_eq!(first.token, EMIT);
+    let decision = session.response_entry_decision().unwrap();
+    assert_eq!(decision.action, ResponseEntryAction::Enter);
+    assert_eq!(decision.boundary_seen, boundary.at_seen);
+    assert_eq!(session.predict(&model).unwrap(), first);
+    assert_eq!(session.response_entry.as_ref().unwrap().steps, 0);
+    assert_eq!(session.work.values.derived_writes, 0);
+    session.observe(&model, first.token).unwrap();
+    assert!(session.response_entry.as_ref().unwrap().active);
+    assert_eq!(session.response_entry.as_ref().unwrap().steps, 1);
+    assert_eq!(
+        session.response_entry.as_ref().unwrap().last_action,
+        ResponseEntryAction::Enter
+    );
+    session.predict(&model).unwrap();
+    session.observe(&model, OTHER).unwrap();
+    let entry = session.response_entry.as_ref().unwrap();
+    assert_eq!(entry.steps, 2);
+    assert_eq!(entry.last, OTHER);
+    assert_eq!(entry.last_action, ResponseEntryAction::Base);
+    assert_eq!(session.work.response_entry.mismatches, 1);
+    let (features, count) = entry.features(
+        &model,
+        session.values.as_ref().unwrap(),
+        Control::Full,
+        &mut CompletionWork::default(),
+    );
+    assert_eq!(count, 16);
+    assert!(features[..count].iter().all(|feature| feature.kind >= 16));
+    assert!(features[..count].contains(&Feature {
+        kind: 17,
+        value: u64::from(model.geometry.tokens[OTHER as usize].prime),
+    }));
+    let restored = model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+    assert_eq!(restored.state(), session.state());
+    assert_eq!(session.work.values.derived_writes, 0);
+}
+
+#[test]
+fn native_response_entry_first_unselected_or_mismatched_observation_closes_boundary() {
+    let model = mechanical(false, EMIT);
+    for predict in [false, true] {
+        let mut session = prefix(&model, Control::Full, "source 17; query:");
+        if predict {
+            assert_eq!(session.predict(&model).unwrap().token, EMIT);
+        }
+        session.observe(&model, OTHER).unwrap();
+        assert!(session.response_entry.as_ref().unwrap().boundary.is_none());
+        assert!(!session.response_entry.as_ref().unwrap().active);
+        session.predict(&model).unwrap();
+        assert!(session.response_entry_decision().is_none());
+        model
+            .restore_session(&session.checkpoint().unwrap())
+            .unwrap();
+    }
+}
+
+#[test]
+fn native_response_entry_respects_typed_precedence_and_valid_gate_boundaries() {
+    let model = mechanical(true, EMIT);
+    let mut numeric = prefix(&model, Control::Full, "source 17; query:");
+    let first = numeric.predict(&model).unwrap();
+    assert_eq!(first.token, b'1' as u32 + 2);
+    assert!(numeric.value_decision().is_some());
+    assert!(numeric.response_entry_decision().is_none());
+    numeric.observe(&model, first.token).unwrap();
+    assert!(numeric.response_entry.as_ref().unwrap().boundary.is_none());
+    let model = mechanical(false, EMIT);
+    for control in [
+        Control::ResponseEntryDisabled,
+        Control::ValuesDisabled,
+        Control::MemoryDisabled,
+    ] {
+        let mut session = prefix(&model, control, "source 17; query:");
+        session.predict(&model).unwrap();
+        assert!(session.response_entry_decision().is_none());
+        assert!(session.response_entry.as_ref().unwrap().boundary.is_none());
+    }
+    let mut empty = prefix(&model, Control::Full, "source without value query:");
+    empty.predict(&model).unwrap();
+    assert!(empty.response_entry_decision().is_none());
+    let mut exhausted = prefix(&model, Control::Full, "source 17; query:");
+    exhausted.values.as_mut().unwrap().next_id = u64::MAX;
+    exhausted.predict(&model).unwrap();
+    assert!(exhausted.response_entry_decision().is_none());
+}
+
+#[test]
+fn native_response_entry_eos_and_observation_cap_end_without_invented_tokens() {
+    let model = mechanical(false, EOS);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    let first = session.predict(&model).unwrap();
+    session.observe(&model, first.token).unwrap();
+    let stop = session.predict(&model).unwrap();
+    assert_eq!(stop.token, EOS);
+    assert_eq!(
+        session.response_entry_decision().unwrap().action,
+        ResponseEntryAction::Stop
+    );
+    session.observe(&model, EOS).unwrap();
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    assert_eq!(session.work.response_entry.stops, 1);
+    model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    for step in 1..=RESPONSE_ENTRY_STEPS {
+        let next = session.predict(&model).unwrap();
+        assert_eq!(next.token, EMIT);
+        session.observe(&model, next.token).unwrap();
+        if step == RESPONSE_ENTRY_STEPS - 1 {
+            let restored = model
+                .restore_session(&session.checkpoint().unwrap())
+                .unwrap();
+            assert_eq!(restored.state(), session.state());
+        }
+    }
+    let entry = session.response_entry.as_ref().unwrap();
+    assert!(!entry.active);
+    assert!(entry.boundary.is_none());
+    assert_eq!(entry.last, EMIT);
+    assert_eq!(entry.steps, 0);
+    assert_eq!(session.work.response_entry.step_limits, 1);
+    assert_eq!(session.work.response_entry.stops, 0);
+    model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+}
+
+#[test]
+fn native_response_entry_snapshot_rejects_foreign_origin_history_and_transient_fields() {
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    let initial = session.checkpoint().unwrap();
+    model.restore_session(&initial).unwrap();
+    let first = session.predict(&model).unwrap();
+    session.observe(&model, first.token).unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&session.checkpoint().unwrap()).unwrap();
+    let mut bad = wire.clone();
+    bad["response_entry"]["boundary"]["query_prime"] = serde_json::json!(u32::MAX);
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    let mut bad = wire.clone();
+    bad["response_entry"]["last"] = serde_json::json!(OTHER);
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    let mut bad = wire.clone();
+    bad["response_entry"]["pending"] = serde_json::Value::Null;
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    let mut bad = wire.clone();
+    bad["response_entry"] = serde_json::Value::Null;
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    let mut bad = wire.clone();
+    bad["response_entry"]["boundary"]["pose"] = serde_json::json!(u16::MAX);
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+
+    // A changed, valid model with the same upstream baseline must not accept
+    // a forged origin merely by replacing the outer artifact identity.
+    let mut no_entry = model.clone();
+    no_entry.response_entry.as_mut().unwrap().rows[0].scores[0].score = -1000;
+    no_entry.refresh_identity().unwrap();
+    let no_entry = Model::from_bytes(&no_entry.to_bytes().unwrap()).unwrap();
+    let mut bad = wire;
+    bad["response_entry"]["last_action"] = serde_json::json!("base");
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    bad["response_entry"]["last_action"] = serde_json::json!("enter");
+    bad["artifact_cid"] = serde_json::json!(no_entry.artifact_cid);
+    assert!(no_entry
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+}
+
+#[test]
+fn native_response_entry_uses_disjoint_entry_and_continuation_geometry_namespaces() {
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    let (entry_features, entry_count) = session.response_entry.as_ref().unwrap().features(
+        &model,
+        session.values.as_ref().unwrap(),
+        Control::Full,
+        &mut CompletionWork::default(),
+    );
+    assert_eq!(entry_count, RESPONSE_ENTRY_FEATURES);
+    assert!(entry_features[..entry_count]
+        .iter()
+        .all(|feature| feature.kind < 16));
+    let first = session.predict(&model).unwrap();
+    session.observe(&model, first.token).unwrap();
+    let (features, count) = session.response_entry.as_ref().unwrap().features(
+        &model,
+        session.values.as_ref().unwrap(),
+        Control::ResponseEntryGeometryDisabled,
+        &mut CompletionWork::default(),
+    );
+    assert_eq!(count, 6);
+    assert!(features[..count]
+        .iter()
+        .all(|feature| (16..22).contains(&feature.kind)));
+}
+
+#[test]
+fn native_response_entry_counts_unselected_eos_and_restores_a_new_boundary_after_eos() {
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; query:");
+    assert_eq!(session.predict(&model).unwrap().token, EMIT);
+    session.observe(&model, EOS).unwrap();
+    assert_eq!(session.work.response_entry.base_steps, 1);
+    assert_eq!(session.work.response_entry.mismatches, 1);
+    assert_eq!(session.work.response_entry.commits, 0);
+    assert_eq!(session.work.response_entry.stops, 0);
+    model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+
+    // The existing begin_response law can establish a new response after an
+    // actual EOS. That ready, zero-step boundary is distinct from an active
+    // response attempting to cross an EOS in its committed history.
+    session.begin_response(&model).unwrap();
+    let ready = session.response_entry.as_ref().unwrap();
+    assert!(ready.boundary.is_some());
+    assert!(!ready.active);
+    assert_eq!(ready.last, EOS);
+    assert_eq!(ready.steps, 0);
+    let mut restored = model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+    assert_eq!(restored.state(), session.state());
+    assert_eq!(
+        restored.predict(&model).unwrap(),
+        session.predict(&model).unwrap()
+    );
+
+    let first = session.predict(&model).unwrap();
+    session.observe(&model, first.token).unwrap();
+    // Without another prediction, the next EOS is a Base observation ending
+    // the active component, not a committed Stop decision.
+    session.observe(&model, EOS).unwrap();
+    assert_eq!(session.work.response_entry.base_steps, 2);
+    assert_eq!(session.work.response_entry.mismatches, 1);
+    assert_eq!(session.work.response_entry.commits, 1);
+    assert_eq!(session.work.response_entry.stops, 1);
+    model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+}
+
+#[test]
+fn native_response_entry_reuses_no_write_only_during_committed_response() {
+    use super::value_types::ValueWork;
+
+    let model = mechanical(false, EMIT);
+    let mut session = prefix(&model, Control::Full, "source 17; source 9; query:");
+    assert_eq!(session.values.as_ref().unwrap().sources.len(), 2);
+    let first = session.predict(&model).unwrap();
+    assert!(session.work.values.proposals > 0);
+    assert!(session.work.values.additions > 0);
+    assert!(session.work.values.feature_lookups > 0);
+    session.observe(&model, first.token).unwrap();
+    assert!(session.response_entry.as_ref().unwrap().active);
+    assert!(session.value_decision().is_none());
+    // Restoration rechecks the original selector and retains the same right
+    // to reuse NoWrite; it does not serialize a pending prediction or cache.
+    session = model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+
+    for step in 0..6 {
+        let mut reference = session.values.as_ref().unwrap().clone();
+        let mut hypothetical_work = ValueWork::default();
+        assert!(reference
+            .offer(
+                &model,
+                Candidate {
+                    token: OTHER,
+                    score: 1234 + step
+                },
+                Control::Full,
+                &mut hypothetical_work,
+            )
+            .is_none());
+        assert!(hypothetical_work.proposals > 0);
+        assert!(hypothetical_work.additions > 0);
+        assert!(hypothetical_work.feature_lookups > 0);
+
+        let before = session.work.values;
+        let prediction = session.predict(&model).unwrap();
+        assert_eq!(prediction.token, EMIT);
+        assert_eq!(session.predict(&model).unwrap(), prediction);
+        assert_eq!(session.work.values, before);
+        assert!(session.value_decision().is_none());
+        session
+            .observe(&model, if step & 1 == 0 { EMIT } else { OTHER })
+            .unwrap();
+        assert!(session.response_entry.as_ref().unwrap().active);
+    }
+    assert!(session.work.response_entry.mismatches > 0);
+    assert!(session.work.response_entry.commits > 1);
+
+    for _ in 0..RESPONSE_ENTRY_STEPS {
+        if !session.response_entry.as_ref().unwrap().active {
+            break;
+        }
+        let before = session.work.values;
+        session.predict(&model).unwrap();
+        assert_eq!(session.work.values, before);
+        session.observe(&model, OTHER).unwrap();
+    }
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    assert_eq!(session.work.response_entry.step_limits, 1);
+    let after_cap = session.work.values;
+    session.predict(&model).unwrap();
+    assert!(session.work.values.proposals > after_cap.proposals);
+    assert!(session.work.values.additions > after_cap.additions);
+    assert!(session.work.values.feature_lookups > after_cap.feature_lookups);
+    assert!(session.response_entry_decision().is_none());
+
+    session.end_response(&model).unwrap();
+    for token in model.encode("source 101; query:").unwrap() {
+        session.observe(&model, token).unwrap();
+    }
+    session.begin_response(&model).unwrap();
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    let before_new_query = session.work.values;
+    let first = session.predict(&model).unwrap();
+    assert!(session.work.values.proposals > before_new_query.proposals);
+    assert!(session.work.values.additions > before_new_query.additions);
+    assert!(session.work.values.feature_lookups > before_new_query.feature_lookups);
+    assert_eq!(
+        session.response_entry_decision().unwrap().action,
+        ResponseEntryAction::Enter
+    );
+    session.observe(&model, first.token).unwrap();
+    assert!(session.response_entry.as_ref().unwrap().active);
+    assert!(session.value_decision().is_none());
+}

--- a/crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs
@@ -1,0 +1,205 @@
+//! Host-only restoration of a distinct response-boundary origin and its actual
+//! observed path. Retained evidence is validated; evicted source truth is not
+//! authenticated by this checkpoint.
+use super::completion_types::CompletionWork;
+use super::response_entry_runtime::eligible;
+use super::response_entry_types::*;
+use super::value_types::ValueWork;
+use super::*;
+
+fn invalid(message: &str) -> Error {
+    Error(format!("session response entry {message}"))
+}
+
+pub(super) fn validate_field_presence(model: &Model, wire: &serde_json::Value) -> Result<()> {
+    let field = wire.get("response_entry");
+    if model.response_entry.is_some() {
+        if !field.is_some_and(serde_json::Value::is_object) {
+            return Err(invalid("state is required by this artifact"));
+        }
+    } else if field.is_some() {
+        return Err(invalid("state is foreign to this artifact"));
+    }
+    if field.is_some_and(|state| state.get("pending").is_some()) {
+        return Err(invalid("checkpoint contains a transient prediction"));
+    }
+    Ok(())
+}
+
+impl Session {
+    /// Restore only after typed state and optional numeric completion state
+    /// have been validated. Candidate workspace is never checkpoint data.
+    pub(super) fn restore_response_entry_state(
+        &mut self,
+        model: &Model,
+        saved: ResponseEntryState,
+        retained: &[u32],
+        observed: u64,
+    ) -> Result<()> {
+        if model.response_entry.is_none() {
+            return Err(invalid("requires a response-entry artifact"));
+        }
+        let values = self
+            .values
+            .as_ref()
+            .ok_or_else(|| invalid("requires restored typed state"))?;
+        if saved.seen != observed
+            || values.seen != observed
+            || saved.pending.is_some()
+            || saved.steps >= RESPONSE_ENTRY_STEPS
+            || (saved.active && (saved.boundary.is_none() || saved.steps == 0))
+            || (saved.active && saved.steps == 1 && saved.last_action != ResponseEntryAction::Enter)
+            || (!saved.active && saved.steps != 0)
+            || (!saved.active
+                && matches!(
+                    saved.last_action,
+                    ResponseEntryAction::Enter | ResponseEntryAction::Emit
+                ))
+            || (saved.last_action == ResponseEntryAction::Enter && saved.steps != 1)
+            || (saved.last_action == ResponseEntryAction::Emit && saved.steps <= 1)
+            || (saved.last_action == ResponseEntryAction::Stop && saved.last != EOS)
+            || saved.last as usize >= model.vocabulary_size()
+            || saved.previous as usize >= model.vocabulary_size()
+            || observed < retained.len() as u64
+            || values.recent_len != observed.min(32) as usize
+        {
+            return Err(invalid("shape, action or observation counters are invalid"));
+        }
+        let recent = |sequence: u64| {
+            (sequence < observed && observed - sequence <= values.recent_len as u64)
+                .then(|| values.recent[(sequence & 31) as usize])
+        };
+        let token_at = |sequence: u64| -> Result<u32> {
+            let entry =
+                recent(sequence).ok_or_else(|| invalid("actual token history is absent"))?;
+            if entry.sequence != sequence || entry.token as usize >= model.vocabulary_size() {
+                return Err(invalid("actual token history is invalid"));
+            }
+            let oldest = observed - retained.len() as u64;
+            if sequence >= oldest && retained[(sequence - oldest) as usize] != entry.token {
+                return Err(invalid(
+                    "actual token history differs from the session window",
+                ));
+            }
+            Ok(entry.token)
+        };
+        if observed == 0 {
+            if saved.last != BOS
+                || saved.previous != BOS
+                || saved.last_action != ResponseEntryAction::Base
+                || saved.boundary.is_some()
+            {
+                return Err(invalid("empty observation state is invalid"));
+            }
+        } else if saved.last != token_at(observed - 1)?
+            || saved.previous
+                != if observed > 1 {
+                    token_at(observed - 2)?
+                } else {
+                    BOS
+                }
+        {
+            return Err(invalid("last tokens differ from actual observations"));
+        }
+        if let Some(anchor) = saved.boundary {
+            if !eligible(values, self.control)
+                || values.pending.is_some()
+                || anchor.at_seen == 0
+                || anchor.at_seen != values.started_at
+                || anchor.at_seen > observed
+                || observed - anchor.at_seen != u64::from(saved.steps)
+                || usize::from(anchor.pose) >= model.geometry.inverses.len()
+                || anchor.query_prime != values.queries[0].cue
+                || anchor.pose != values.queries[0].pose
+                || anchor.phases != values.queries[0].phases
+                || values.queries[0].sequence.checked_add(1) != Some(anchor.at_seen)
+                || (saved.active && saved.last == EOS)
+                || (!saved.active && saved.last_action != ResponseEntryAction::Base)
+                || self.completion.as_ref().is_some_and(|state| state.active)
+            {
+                return Err(invalid("query origin or response boundary is invalid"));
+            }
+            let endpoint = recent(anchor.at_seen - 1)
+                .ok_or_else(|| invalid("boundary endpoint evidence is absent"))?;
+            if endpoint.pose != anchor.pose || endpoint.phases != anchor.phases {
+                return Err(invalid(
+                    "boundary frame differs from actual endpoint evidence",
+                ));
+            }
+            let mut pose = anchor.pose;
+            let mut phases = anchor.phases;
+            for sequence in anchor.at_seen..observed {
+                let token = token_at(sequence)?;
+                if token == EOS {
+                    return Err(invalid("active response crosses an observed end token"));
+                }
+                let geometry = &model.geometry.tokens[token as usize];
+                pose = model.geometry.products
+                    [model.geometry.row_bases[usize::from(pose)] + usize::from(geometry.leaf)];
+                for (phase, delta) in phases.iter_mut().zip(geometry.phases) {
+                    *phase = phase.wrapping_add(delta);
+                }
+                let actual = recent(sequence).ok_or_else(|| invalid("response frame is absent"))?;
+                if pose != actual.pose || phases != actual.phases {
+                    return Err(invalid(
+                        "actual response frame differs from retained evidence",
+                    ));
+                }
+            }
+            if pose != values.pose || phases != values.phases {
+                return Err(invalid(
+                    "current frame differs from actual response history",
+                ));
+            }
+            if saved.active {
+                // Reconstruct only the first selector from its saved query and
+                // source state. Host restoration may allocate this clone and
+                // execute the bounded typed gate; none is steady-state work.
+                // The future/actual response never supplies the entry score.
+                let mut boundary_values = values.clone();
+                boundary_values.seen = anchor.at_seen;
+                boundary_values.pose = anchor.pose;
+                boundary_values.phases = anchor.phases;
+                boundary_values.pending = None;
+                let baseline = Candidate {
+                    token: BOS,
+                    score: 0,
+                };
+                if boundary_values
+                    .offer(model, baseline, self.control, &mut ValueWork::default())
+                    .is_some()
+                {
+                    return Err(invalid("origin is superseded by a typed value selection"));
+                }
+                let mut origin = ResponseEntryState {
+                    boundary: Some(anchor),
+                    last: values.queries[0].token,
+                    previous: if values.query_len > 1 {
+                        values.queries[1].token
+                    } else {
+                        BOS
+                    },
+                    seen: anchor.at_seen,
+                    ..ResponseEntryState::default()
+                };
+                let selection = origin.offer(
+                    model,
+                    &boundary_values,
+                    baseline,
+                    self.control,
+                    &mut CompletionWork::default(),
+                );
+                if !selection.is_some_and(|candidate| {
+                    token_at(anchor.at_seen).is_ok_and(|token| token == candidate.token)
+                }) || !origin
+                    .pending
+                    .is_some_and(|decision| decision.action == ResponseEntryAction::Enter)
+                {
+                    return Err(invalid("origin is not an observed selected entry"));
+                }
+            }
+        }
+        self.response_entry = Some(saved);
+        Ok(())
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/response_entry_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_training.rs
@@ -1,0 +1,445 @@
+//! Offline response entry and continuation over actual native model state.
+//! Raw targets supervise token scores; they never create a serving anchor.
+use super::completion_training::{fit_sparse_frames, top_counts, Frame, ValueCompletionFitConfig};
+use super::completion_types::CompletionWork;
+use super::response_entry_types::*;
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseEntryFitConfig {
+    pub epochs: usize,
+    pub learning_rate: f64,
+    pub max_positions: usize,
+}
+impl Default for ResponseEntryFitConfig {
+    fn default() -> Self {
+        Self {
+            epochs: 24,
+            learning_rate: 0.1,
+            max_positions: RESPONSE_ENTRY_POSITIONS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseEntryFitReport {
+    pub schema: String,
+    pub baseline_artifact: String,
+    pub artifact_cid: String,
+    pub examples: usize,
+    pub numeric_examples: usize,
+    pub matched_numeric: usize,
+    pub upstream_failures: usize,
+    pub no_write_examples: usize,
+    pub unexpected_value_writes: usize,
+    pub overlong_responses: usize,
+    pub position_limit_skips: usize,
+    pub entry_positions: usize,
+    pub entry_target_in_candidates: usize,
+    pub entry_fit_correct: usize,
+    pub entered_rollouts: usize,
+    pub entry_rollout_failures: usize,
+    pub continuation_positions: usize,
+    pub continuation_target_in_candidates: usize,
+    pub continuation_fit_correct: usize,
+    pub final_entry_correct: usize,
+    pub final_exact_responses: usize,
+    pub learned_rows: usize,
+    pub learned_associations: usize,
+    pub dropped_row_events: usize,
+    pub dropped_association_events: usize,
+    pub entry_fit_loss: f64,
+    pub continuation_fit_loss: Option<f64>,
+    pub selected_entry_epoch: usize,
+    pub selected_continuation_epoch: usize,
+    pub config: ResponseEntryFitConfig,
+    pub tokenization_law: String,
+}
+
+impl ResponseEntryModel {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        let associations = self.rows.iter().map(|row| row.scores.len()).sum::<usize>();
+        let valid_token =
+            |token: u32| token != BOS && (token as usize) < model.geometry.tokens.len();
+        if self.schema != RESPONSE_ENTRY_SCHEMA
+            || model.completion.is_none()
+            || self.rows.len() > RESPONSE_ENTRY_ROWS
+            || associations > RESPONSE_ENTRY_ASSOCIATIONS
+            || self.global_postings.len() > RESPONSE_ENTRY_CANDIDATES
+            || self
+                .global_postings
+                .iter()
+                .any(|&token| !valid_token(token))
+            || self.global_postings.iter().collect::<BTreeSet<_>>().len()
+                != self.global_postings.len()
+            || self
+                .rows
+                .windows(2)
+                .any(|pair| pair[0].feature >= pair[1].feature)
+            || self.rows.iter().any(|row| {
+                row.feature.kind >= (RESPONSE_ENTRY_FEATURES * 2) as u8
+                    || row.default_score != 0
+                    || row.postings.len() > RESPONSE_ENTRY_POSTINGS
+                    || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
+                    || row
+                        .scores
+                        .windows(2)
+                        .any(|pair| pair[0].token >= pair[1].token)
+                    || row.scores.iter().any(|entry| {
+                        !valid_token(entry.token)
+                            || !(-1_000_000..=1_000_000).contains(&entry.score)
+                    })
+                    || row.postings.iter().any(|token| {
+                        row.scores
+                            .binary_search_by_key(token, |entry| entry.token)
+                            .is_err()
+                    })
+            })
+            || self.fit_positions > RESPONSE_ENTRY_POSITIONS
+            || self
+                .training
+                .iter()
+                .any(|receipt| receipt.id.trim().is_empty())
+            || self
+                .training
+                .iter()
+                .map(|receipt| &receipt.id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                != self.training.len()
+            || (!self.training.is_empty()
+                && (self.fit_positions == 0
+                    || !(1..=64).contains(&self.fit_config[0])
+                    || !(0.0001..=1.0).contains(&f64::from_bits(self.fit_config[1]))
+                    || !(1..=RESPONSE_ENTRY_POSITIONS as u64).contains(&self.fit_config[2])
+                    || self.fit_config[3] == 0
+                    || self.fit_config[3] > self.fit_config[0]
+                    || self.fit_config[4] > self.fit_config[0]))
+        {
+            return Err(Error("invalid learned response-entry artifact".into()));
+        }
+        let mut baseline = model.clone();
+        baseline.response_entry = None;
+        baseline.refresh_identity()?;
+        if baseline.artifact_cid != self.baseline_artifact {
+            return Err(Error(
+                "response-entry artifact differs from its frozen completion baseline".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn response_session(model: &Model, prompt: &str) -> Result<Session> {
+    let mut session = model.session(Control::Full)?;
+    session.observe(model, BOS)?;
+    for token in model.encode(prompt)? {
+        session.observe(model, token)?;
+    }
+    session.begin_response(model)?;
+    Ok(session)
+}
+
+fn frame(session: &Session, model: &Model, target: u32, baseline: u32) -> Result<Frame> {
+    let state = session
+        .response_entry
+        .as_ref()
+        .ok_or_else(|| Error("response entry state absent during fit".into()))?;
+    let values = session
+        .values
+        .as_ref()
+        .ok_or_else(|| Error("typed state absent during entry fit".into()))?;
+    let (features, len) =
+        state.features(model, values, Control::Full, &mut CompletionWork::default());
+    if len == 0 {
+        return Err(Error("response entry frame has no causal boundary".into()));
+    }
+    Ok(Frame {
+        features,
+        len,
+        target,
+        baseline,
+    })
+}
+
+impl Model {
+    pub fn response_entry_version(&self) -> Option<&str> {
+        self.response_entry
+            .as_ref()
+            .map(|head| head.schema.as_str())
+    }
+    pub fn response_entry_training(&self) -> &[DocumentReceipt] {
+        self.response_entry
+            .as_ref()
+            .map_or(&[], |head| head.training.as_slice())
+    }
+
+    pub fn fit_response_entry(
+        &self,
+        documents: &[ValueExample],
+        config: ResponseEntryFitConfig,
+    ) -> Result<(Model, ResponseEntryFitReport)> {
+        let source_bytes = documents.iter().try_fold(0_usize, |sum, document| {
+            sum.checked_add(document.prompt.len())?
+                .checked_add(document.response.len())
+        });
+        if self.response_entry.is_some()
+            || self.completion.is_none()
+            || documents.is_empty()
+            || documents.len() > 4096
+            || source_bytes.is_none_or(|bytes| bytes > 16 * 1024 * 1024)
+            || !(1..=64).contains(&config.epochs)
+            || !config.learning_rate.is_finite()
+            || !(0.0001..=1.0).contains(&config.learning_rate)
+            || !(1..=RESPONSE_ENTRY_POSITIONS).contains(&config.max_positions)
+        {
+            return Err(Error(
+                "invalid response-entry source, configuration or baseline".into(),
+            ));
+        }
+        let mut model = self.clone();
+        model.response_entry = Some(ResponseEntryModel {
+            schema: RESPONSE_ENTRY_SCHEMA.into(),
+            baseline_artifact: self.artifact_cid.clone(),
+            rows: Vec::new(),
+            global_postings: Vec::new(),
+            fit_config: [0; 5],
+            fit_positions: 0,
+            training: Vec::new(),
+        });
+        model.refresh_identity()?;
+        let mut receipts = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut prompts = BTreeMap::new();
+        let mut entry_frames = Vec::new();
+        let mut admitted = Vec::new();
+        let mut reserved_positions = 0_usize;
+        let mut numeric_examples = 0;
+        let mut matched_numeric = 0;
+        let mut upstream_failures = 0;
+        let mut no_write_examples = 0;
+        let mut unexpected_value_writes = 0;
+        let mut overlong_responses = 0;
+        let mut position_limit_skips = 0;
+        for (index, document) in documents.iter().enumerate() {
+            if document.id.trim().is_empty()
+                || !ids.insert(&document.id)
+                || prompts
+                    .insert(&document.prompt, &document.response)
+                    .is_some_and(|known| known != &document.response)
+            {
+                return Err(Error(
+                    "response-entry source IDs or raw targets conflict".into(),
+                ));
+            }
+            let receipt = super::training::receipt(&Document {
+                id: document.id.clone(),
+                text: serde_json::to_string(&(&document.prompt, &document.response))
+                    .map_err(|error| Error(error.to_string()))?,
+            });
+            let whole = super::training::receipt(&Document {
+                id: document.id.clone(),
+                text: format!("{}{}", document.prompt, document.response),
+            });
+            if self
+                .construction
+                .iter()
+                .chain(self.readout_training())
+                .chain(self.memory_read_training())
+                .any(|known| {
+                    known.id == receipt.id
+                        || known.text_cid == receipt.text_cid
+                        || known.text_cid == whole.text_cid
+                })
+            {
+                return Err(Error(
+                    "entry source overlaps ordinary model construction".into(),
+                ));
+            }
+            receipts.push(receipt);
+            // Classification is training-only raw numeral syntax. All supplied
+            // numeric examples are checked through the actual frozen full path.
+            let numeric = document
+                .response
+                .as_bytes()
+                .first()
+                .is_some_and(|byte| byte.is_ascii_digit() || matches!(*byte, b'+' | b'-'));
+            if numeric {
+                numeric_examples += 1;
+                let generated = self.generate(&document.prompt, 64, Control::Full)?;
+                if generated.bytes == document.response.as_bytes() {
+                    matched_numeric += 1;
+                } else {
+                    upstream_failures += 1;
+                }
+                continue;
+            }
+            no_write_examples += 1;
+            let mut session = response_session(&model, &document.prompt)?;
+            session.predict(&model)?;
+            if session.value_decision().is_some() {
+                unexpected_value_writes += 1;
+                continue;
+            }
+            let mut targets = model.encode(&document.response)?;
+            targets.push(EOS);
+            if targets.len() > usize::from(RESPONSE_ENTRY_STEPS) {
+                overlong_responses += 1;
+                continue;
+            }
+            if reserved_positions.saturating_add(targets.len()) > config.max_positions {
+                position_limit_skips += 1;
+                continue;
+            }
+            if session
+                .response_entry
+                .as_ref()
+                .is_none_or(|state| state.boundary.is_none())
+            {
+                upstream_failures += 1;
+                continue;
+            }
+            // Correct ordinary Base output must still learn Enter, because
+            // observation of Base cannot create an entry anchor.
+            entry_frames.push(frame(&session, &model, targets[0], u32::MAX)?);
+            reserved_positions += targets.len();
+            admitted.push((index, targets));
+        }
+        if entry_frames.is_empty() {
+            return Err(Error(
+                "entry fit has no bounded no-write response targets".into(),
+            ));
+        }
+        let optimizer_config = ValueCompletionFitConfig {
+            epochs: config.epochs,
+            learning_rate: config.learning_rate,
+            max_positions: config.max_positions,
+        };
+        let entry_fit = fit_sparse_frames(
+            &entry_frames,
+            optimizer_config,
+            RESPONSE_ENTRY_ROWS,
+            RESPONSE_ENTRY_ASSOCIATIONS,
+            0,
+        )?;
+        let entry_row_count = entry_fit.rows.len();
+        let entry_association_count = entry_fit.learned_associations;
+        let head = model
+            .response_entry
+            .as_mut()
+            .ok_or_else(|| Error("entry component missing".into()))?;
+        head.rows = entry_fit.rows;
+        head.global_postings = entry_fit.global_postings;
+        model.refresh_identity()?;
+        let mut continuation_frames = Vec::new();
+        let mut entered_rollouts = 0;
+        let mut entry_rollout_failures = 0;
+        for (index, targets) in &admitted {
+            let mut session = response_session(&model, &documents[*index].prompt)?;
+            let prediction = session.predict(&model)?;
+            let entered = session.response_entry_decision().is_some_and(|decision| {
+                decision.action == ResponseEntryAction::Enter && decision.token == targets[0]
+            });
+            if prediction.token != targets[0] || !entered {
+                entry_rollout_failures += 1;
+                continue;
+            }
+            session.observe(&model, prediction.token)?;
+            entered_rollouts += 1;
+            for &target in &targets[1..] {
+                let baseline = session.predict(&model)?.token;
+                if session
+                    .response_entry
+                    .as_ref()
+                    .is_none_or(|state| !state.active)
+                {
+                    return Err(Error(
+                        "entry anchor ended before whole training response".into(),
+                    ));
+                }
+                continuation_frames.push(frame(&session, &model, target, baseline)?);
+                // Teacher forcing starts only after a real selected Enter was
+                // observed. Later mismatches update actual state without hidden
+                // target provenance; all targets and EOS stay trainer-side.
+                session.observe(&model, target)?;
+            }
+        }
+        let continuation_fit = if continuation_frames.is_empty() {
+            None
+        } else {
+            Some(fit_sparse_frames(
+                &continuation_frames,
+                optimizer_config,
+                RESPONSE_ENTRY_ROWS.saturating_sub(entry_row_count),
+                RESPONSE_ENTRY_ASSOCIATIONS.saturating_sub(entry_association_count),
+                RESPONSE_ENTRY_FEATURES as u8,
+            )?)
+        };
+        let mut globals = BTreeMap::<u32, u64>::new();
+        for item in entry_frames.iter().chain(&continuation_frames) {
+            *globals.entry(item.target).or_default() += 1;
+        }
+        let head = model
+            .response_entry
+            .as_mut()
+            .ok_or_else(|| Error("entry component missing".into()))?;
+        if let Some(fit) = &continuation_fit {
+            head.rows.extend(fit.rows.clone());
+        }
+        head.rows.sort_by_key(|row| row.feature);
+        head.global_postings = top_counts(&globals, RESPONSE_ENTRY_CANDIDATES);
+        head.fit_positions = entry_frames.len() + continuation_frames.len();
+        head.fit_config = [
+            config.epochs as u64,
+            config.learning_rate.to_bits(),
+            config.max_positions as u64,
+            entry_fit.selected_epoch as u64,
+            continuation_fit
+                .as_ref()
+                .map_or(0, |fit| fit.selected_epoch as u64),
+        ];
+        head.training = receipts;
+        let learned_rows = head.rows.len();
+        let learned_associations = head.rows.iter().map(|row| row.scores.len()).sum();
+        model.refresh_identity()?;
+        model.validate()?;
+        // Shared global postings can change admission. Recheck actual entry
+        // decisions and complete free-running bytes using the exported model.
+        let mut final_entry_correct = 0;
+        let mut final_exact_responses = 0;
+        for (index, targets) in &admitted {
+            let document = &documents[*index];
+            let mut session = response_session(&model, &document.prompt)?;
+            let prediction = session.predict(&model)?;
+            final_entry_correct += usize::from(
+                prediction.token == targets[0]
+                    && session
+                        .response_entry_decision()
+                        .is_some_and(|decision| decision.action == ResponseEntryAction::Enter),
+            );
+            let output = model.generate(
+                &document.prompt,
+                usize::from(RESPONSE_ENTRY_STEPS),
+                Control::Full,
+            )?;
+            final_exact_responses += usize::from(output.bytes == document.response.as_bytes());
+        }
+        let report = ResponseEntryFitReport {
+            schema: RESPONSE_ENTRY_SCHEMA.into(), baseline_artifact: self.artifact_cid.clone(), artifact_cid: model.artifact_cid.clone(), examples: documents.len(),
+            numeric_examples, matched_numeric, upstream_failures, no_write_examples, unexpected_value_writes, overlong_responses, position_limit_skips,
+            entry_positions: entry_frames.len(), entry_target_in_candidates: entry_fit.target_in_candidates, entry_fit_correct: entry_fit.correct,
+            entered_rollouts, entry_rollout_failures, continuation_positions: continuation_frames.len(),
+            continuation_target_in_candidates: continuation_fit.as_ref().map_or(0, |fit| fit.target_in_candidates),
+            continuation_fit_correct: continuation_fit.as_ref().map_or(0, |fit| fit.correct), final_entry_correct, final_exact_responses,
+            learned_rows, learned_associations,
+            dropped_row_events: entry_fit.dropped_row_events + continuation_fit.as_ref().map_or(0, |fit| fit.dropped_row_events),
+            dropped_association_events: entry_fit.dropped_association_events + continuation_fit.as_ref().map_or(0, |fit| fit.dropped_association_events),
+            entry_fit_loss: entry_fit.loss, continuation_fit_loss: continuation_fit.as_ref().map(|fit| fit.loss),
+            selected_entry_epoch: entry_fit.selected_epoch, selected_continuation_epoch: continuation_fit.as_ref().map_or(0, |fit| fit.selected_epoch), config,
+            tokenization_law: "Canonical frozen model.encode(response) plus EOS; an overlong response is skipped whole. Entry action is supervised separately from equal-token Base; continuation frames require actual quantized Enter selection and observation. Final shared-posting entry and free-running response checks are reported.".into(),
+        };
+        Ok((model, report))
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/response_entry_training_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_training_tests.rs
@@ -1,0 +1,236 @@
+//! Real fitting tests distinguish learned Enter from equal-token Base output.
+use super::completion_types::{CompletionModel, COMPLETION_SCHEMA};
+use super::numeral::NUMERAL_CODEC;
+use super::response_entry_types::*;
+use super::value_types::{ValueModel, LEXEME_VALUE_SCHEMA, VALUES};
+use super::*;
+use std::sync::OnceLock;
+
+fn no_write_baseline() -> Model {
+    let catalog = [Document {
+        id: "entry-fit-catalog".into(),
+        text: "source value query reply total done unknown 13 4 17 18 ; : .\n".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 32,
+            candidate_limit: 16,
+            max_lexical_pieces: 128,
+            ..Config::default()
+        },
+        &catalog,
+    )
+    .unwrap();
+    trainer.train_documents(&catalog).unwrap();
+    let mut baseline = trainer.compile().unwrap();
+    baseline.values = Some(ValueModel {
+        schema: LEXEME_VALUE_SCHEMA.into(),
+        codec: NUMERAL_CODEC.into(),
+        capacity: VALUES,
+        rows: Vec::new(),
+        continuation_score: 0,
+        fit_config: [0; 4],
+        training: Vec::new(),
+    });
+    baseline.refresh_identity().unwrap();
+    baseline.completion = Some(CompletionModel {
+        schema: COMPLETION_SCHEMA.into(),
+        baseline_artifact: baseline.artifact_cid.clone(),
+        rows: Vec::new(),
+        global_postings: Vec::new(),
+        fit_config: [0; 4],
+        fit_positions: 0,
+        training: Vec::new(),
+    });
+    baseline.refresh_identity().unwrap();
+    baseline.validate().unwrap();
+    baseline
+}
+
+fn example(id: &str, prompt: &str, response: &str) -> ValueExample {
+    ValueExample {
+        id: id.into(),
+        prompt: prompt.into(),
+        response: response.into(),
+    }
+}
+
+#[test]
+fn native_response_entry_fitting_bootstraps_actual_selected_entry_and_freezes_numeric_baseline() {
+    let baseline = no_write_baseline();
+    let examples = [example("entry-fit-short", "source 17; query:", " done.\n")];
+    let (model, report) = baseline
+        .fit_response_entry(&examples, ResponseEntryFitConfig::default())
+        .unwrap();
+    assert_eq!(report.entry_positions, 1);
+    assert_eq!(report.entry_fit_correct, 1);
+    assert_eq!(report.entered_rollouts, 1);
+    assert_eq!(report.entry_rollout_failures, 0);
+    assert_eq!(report.final_entry_correct, 1);
+    assert!(report.continuation_positions > 0);
+    assert_eq!(report.final_exact_responses, 1);
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(&model, BOS).unwrap();
+    for token in model.encode(&examples[0].prompt).unwrap() {
+        session.observe(&model, token).unwrap();
+    }
+    session.begin_response(&model).unwrap();
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    let first = session.predict(&model).unwrap();
+    assert_eq!(
+        session.response_entry_decision().unwrap().action,
+        ResponseEntryAction::Enter
+    );
+    assert!(!session.response_entry.as_ref().unwrap().active);
+    session.observe(&model, first.token).unwrap();
+    assert!(session.response_entry.as_ref().unwrap().active);
+    assert_eq!(session.work.values.derived_writes, 0);
+    let mut restored_baseline = model.clone();
+    restored_baseline.response_entry = None;
+    restored_baseline.refresh_identity().unwrap();
+    assert_eq!(
+        restored_baseline.to_bytes().unwrap(),
+        baseline.to_bytes().unwrap()
+    );
+}
+
+#[test]
+fn native_response_entry_fitting_skips_overlong_and_overbudget_responses_whole() {
+    let baseline = no_write_baseline();
+    let first = example("entry-bound-short", "source 17; query:", " done.\n");
+    let positions = baseline.encode(&first.response).unwrap().len() + 1;
+    let examples = [
+        first,
+        example("entry-bound-long", "source 18; query:", &"🚀".repeat(20)),
+        example("entry-bound-budget", "source 19; query:", " unknown.\n"),
+    ];
+    let (_, report) = baseline
+        .fit_response_entry(
+            &examples,
+            ResponseEntryFitConfig {
+                max_positions: positions,
+                ..ResponseEntryFitConfig::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(report.examples, 3);
+    assert_eq!(report.overlong_responses, 1);
+    assert_eq!(report.position_limit_skips, 1);
+    assert_eq!(report.entry_positions, 1);
+    assert_eq!(
+        report.entry_positions + report.continuation_positions,
+        positions
+    );
+}
+
+#[test]
+fn native_response_entry_artifact_rejects_foreign_baseline_and_malformed_rows() {
+    let (model, _) = no_write_baseline()
+        .fit_response_entry(
+            &[example("entry-shape", "source 17; query:", " done.\n")],
+            ResponseEntryFitConfig::default(),
+        )
+        .unwrap();
+    let mut bad = model.clone();
+    bad.response_entry.as_mut().unwrap().baseline_artifact = "blake3:foreign".into();
+    bad.refresh_identity().unwrap();
+    assert!(bad.validate().is_err());
+    let mut bad = model.clone();
+    bad.response_entry.as_mut().unwrap().rows[0].feature.kind = 32;
+    bad.refresh_identity().unwrap();
+    assert!(bad.validate().is_err());
+    let mut bad = model.clone();
+    bad.response_entry
+        .as_mut()
+        .unwrap()
+        .global_postings
+        .push(BOS);
+    bad.refresh_identity().unwrap();
+    assert!(bad.validate().is_err());
+    let mut bad = model.clone();
+    bad.response_entry.as_mut().unwrap().fit_config[4] = 65;
+    bad.refresh_identity().unwrap();
+    assert!(bad.validate().is_err());
+    assert!(Model::from_bytes(&model.to_bytes().unwrap()).is_ok());
+}
+
+fn numeric_fixture() -> &'static (Model, Model) {
+    static MODELS: OnceLock<(Model, Model)> = OnceLock::new();
+    MODELS.get_or_init(|| {
+        let catalog = [Document {
+            id: "entry-numeric-catalog".into(),
+            text: "left = 13; right = 4; total: 17.\nreply: Unknown.\n Unknown.\n".into(),
+        }];
+        let mut trainer = Trainer::new(
+            Config {
+                context_tokens: 32,
+                candidate_limit: 8,
+                max_lexical_pieces: 128,
+                ..Config::default()
+            },
+            &catalog,
+        )
+        .unwrap();
+        trainer.train_documents(&catalog).unwrap();
+        let count = trainer.compile().unwrap();
+        let mut examples = Vec::new();
+        for index in 0..4 {
+            examples.push(example(
+                &format!("entry-number-{index}"),
+                &format!("left = {}; right = 4; total:", 13 + index),
+                &format!("{}.\n", 17 + index),
+            ));
+            examples.push(example(
+                &format!("entry-unknown-{index}"),
+                &format!("left = {}; right = 4; reply:", 13 + index),
+                " Unknown.\n",
+            ));
+        }
+        let (typed, _) = count
+            .fit_values_with_lexeme_cues(
+                &examples,
+                ValueFitConfig {
+                    epochs: 64,
+                    learning_rate: 0.25,
+                    max_features: 4096,
+                },
+            )
+            .unwrap();
+        let (completion, _) = typed
+            .fit_value_completion(&examples, ValueCompletionFitConfig::default())
+            .unwrap();
+        let (entry, report) = completion
+            .fit_response_entry(&examples, ResponseEntryFitConfig::default())
+            .unwrap();
+        assert_eq!(report.numeric_examples, 4);
+        assert_eq!(report.matched_numeric, 4);
+        assert_eq!(report.upstream_failures, 0);
+        assert_eq!(report.final_entry_correct, 4);
+        (completion, entry)
+    })
+}
+
+#[test]
+fn native_response_entry_keeps_complete_numeric_output_and_both_prior_heads() {
+    let (completion, entry) = numeric_fixture();
+    for index in 0..4 {
+        let prompt = format!("left = {}; right = 4; total:", 13 + index);
+        let before = completion.generate(&prompt, 16, Control::Full).unwrap();
+        let after = entry.generate(&prompt, 16, Control::Full).unwrap();
+        assert_eq!(before.bytes, after.bytes);
+        assert_eq!(before.token_ids, after.token_ids);
+        assert_eq!(before.stop, after.stop);
+        assert_eq!(
+            serde_json::to_value(before.value_trace).unwrap(),
+            serde_json::to_value(after.value_trace).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(before.completion_trace).unwrap(),
+            serde_json::to_value(after.completion_trace).unwrap()
+        );
+    }
+    let mut stripped = entry.clone();
+    stripped.response_entry = None;
+    stripped.refresh_identity().unwrap();
+    assert_eq!(stripped.to_bytes().unwrap(), completion.to_bytes().unwrap());
+}

--- a/crates/uor-r4-core/src/native_geometric/response_entry_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_types.rs
@@ -1,0 +1,81 @@
+//! Optional learned lexical-token entry and continuation at a response boundary.
+use super::*;
+
+pub(super) const RESPONSE_ENTRY_SCHEMA: &str = "uor-r4.native-response-entry/1";
+pub(super) const RESPONSE_ENTRY_FEATURES: usize = 16;
+pub(super) const RESPONSE_ENTRY_CANDIDATES: usize = 16;
+pub(super) const RESPONSE_ENTRY_POSTINGS: usize = 4;
+pub(super) const RESPONSE_ENTRY_ROWS: usize = 4096;
+pub(super) const RESPONSE_ENTRY_ASSOCIATIONS: usize = 32768;
+pub(super) const RESPONSE_ENTRY_POSITIONS: usize = 4096;
+pub(super) const RESPONSE_ENTRY_STEPS: u8 = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ResponseEntryModel {
+    pub schema: String,
+    pub baseline_artifact: String,
+    pub rows: Vec<ScoreRow>,
+    pub global_postings: Vec<u32>,
+    /// Epoch budget, exact learning-rate bits, position cap, selected entry
+    /// epoch and selected continuation epoch. The schema fixes canonical
+    /// model.encode(response) tokens followed by EOS as the target token law.
+    pub fit_config: [u64; 5],
+    pub fit_positions: usize,
+    pub training: Vec<DocumentReceipt>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseEntryAction {
+    #[default]
+    Base,
+    Enter,
+    Emit,
+    Stop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseEntryDecision {
+    pub token: u32,
+    pub score: i64,
+    /// Absolute observation count at the actual response boundary. This is
+    /// distinct from a numeric write identity.
+    pub boundary_seen: u64,
+    pub step: u8,
+    pub at_seen: u64,
+    pub action: ResponseEntryAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ResponseEntryAnchor {
+    pub at_seen: u64,
+    pub pose: u16,
+    pub phases: [u16; PHASE_CHANNELS],
+    pub query_prime: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ResponseEntryState {
+    pub boundary: Option<ResponseEntryAnchor>,
+    pub last: u32,
+    pub previous: u32,
+    pub seen: u64,
+    pub steps: u8,
+    pub active: bool,
+    pub last_action: ResponseEntryAction,
+    #[serde(skip)]
+    pub pending: Option<ResponseEntryDecision>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResponseEntryStateView {
+    pub active: bool,
+    pub boundary_seen: Option<u64>,
+    pub steps: u8,
+    pub last_action: ResponseEntryAction,
+    pub storage_bytes: usize,
+}

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -11,6 +11,8 @@ pub(super) const FEATURE_COUNT: usize = 26;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_entry: Option<super::ResponseEntryStateView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion: Option<super::CompletionStateView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<super::ValueStateView>,
@@ -35,6 +37,7 @@ pub struct StateView {
 
 #[derive(Debug, Clone)]
 pub struct Session {
+    pub(super) response_entry: Option<super::response_entry_types::ResponseEntryState>,
     pub(super) completion: Option<super::completion_types::CompletionState>,
     pub(super) values: Option<super::value_types::ValueState>,
     pub(super) memory: Option<super::memory_types::MemoryState>,
@@ -64,6 +67,7 @@ impl Session {
             .capacity()
             .saturating_mul(std::mem::size_of::<Candidate>());
         Self {
+            response_entry: model.response_entry.as_ref().map(|_| Default::default()),
             completion: model.completion.as_ref().map(|_| Default::default()),
             values: model
                 .values
@@ -92,6 +96,18 @@ impl Session {
 
     pub fn state(&self) -> StateView {
         StateView {
+            response_entry: self
+                .response_entry
+                .as_ref()
+                .map(|s| super::ResponseEntryStateView {
+                    active: s.active,
+                    boundary_seen: s.boundary.map(|anchor| anchor.at_seen),
+                    steps: s.steps,
+                    last_action: s.last_action,
+                    storage_bytes: std::mem::size_of::<
+                        super::response_entry_types::ResponseEntryState,
+                    >(),
+                }),
             completion: self
                 .completion
                 .as_ref()
@@ -149,6 +165,10 @@ impl Session {
         self.completion.as_ref().and_then(|s| s.pending)
     }
 
+    pub fn response_entry_decision(&self) -> Option<super::ResponseEntryDecision> {
+        self.response_entry.as_ref().and_then(|state| state.pending)
+    }
+
     fn check_model(&self, model: &Model) -> Result<()> {
         if self.artifact_cid != model.artifact_cid {
             return Err(Error(
@@ -166,6 +186,9 @@ impl Session {
         if let Some(state) = &mut self.values {
             state.begin(&mut self.work.values);
         }
+        if let (Some(entry), Some(values)) = (&mut self.response_entry, &self.values) {
+            entry.begin(values, self.control, &mut self.work.response_entry);
+        }
         if self.control != Control::MemoryDisabled && self.control != Control::ResponseStateDisabled
         {
             if let (Some(state), Some(memory)) = (&mut self.memory, &model.memory_read) {
@@ -177,6 +200,9 @@ impl Session {
 
     pub fn end_response(&mut self, model: &Model) -> Result<()> {
         self.check_model(model)?;
+        if let Some(entry) = &mut self.response_entry {
+            entry.reset();
+        }
         if let Some(state) = &mut self.completion {
             state.reset();
         }
@@ -266,6 +292,15 @@ impl Session {
                 .as_ref()
                 .map(super::completion_types::CompletionSeed::from);
             state.observe(model, token, &mut self.work.values);
+            if let Some(entry) = &mut self.response_entry {
+                entry.observe(
+                    model,
+                    state,
+                    token,
+                    self.control,
+                    &mut self.work.response_entry,
+                );
+            }
             if let Some(completion) = &mut self.completion {
                 completion.observe(
                     model,
@@ -478,13 +513,26 @@ impl Session {
                 }
             }
         }
-        if let Some(baseline) = self.candidates.first().copied() {
-            let offer = self
-                .values
-                .as_mut()
-                .and_then(|s| s.offer(model, baseline, self.control, &mut self.work.values));
-            if let Some(candidate) = offer {
-                self.offer_memory(model, candidate);
+        // An active entry proves that the enabled typed gate offered no value
+        // before the selected Enter token was observed. Its sources, query
+        // tokens/words and model/control stay frozen throughout that response;
+        // the changing pose/history and baseline score do not decide NoWrite.
+        // Enter observation clears typed pending state, and restored active
+        // entries independently recheck this gate. Boundaries/EOS/cap clear
+        // entry activity, so their next prediction uses the ordinary gate.
+        if !self
+            .response_entry
+            .as_ref()
+            .is_some_and(|entry| entry.active)
+        {
+            if let Some(baseline) = self.candidates.first().copied() {
+                let offer = self
+                    .values
+                    .as_mut()
+                    .and_then(|s| s.offer(model, baseline, self.control, &mut self.work.values));
+                if let Some(candidate) = offer {
+                    self.offer_memory(model, candidate);
+                }
             }
         }
         if let (Some(baseline), Some(state), Some(values)) = (
@@ -503,6 +551,21 @@ impl Session {
                 self.offer_memory(model, candidate);
             }
         }
+        if let (Some(baseline), Some(entry), Some(values)) = (
+            self.candidates.first().copied(),
+            &mut self.response_entry,
+            &self.values,
+        ) {
+            if let Some(candidate) = entry.offer(
+                model,
+                values,
+                baseline,
+                self.control,
+                &mut self.work.response_entry,
+            ) {
+                self.offer_memory(model, candidate);
+            }
+        }
         let best = *self
             .candidates
             .first()
@@ -514,6 +577,9 @@ impl Session {
             state.selected(best);
         }
         if let Some(state) = &mut self.completion {
+            state.selected(best);
+        }
+        if let Some(state) = &mut self.response_entry {
             state.selected(best);
         }
         Ok(Prediction {

--- a/crates/uor-r4-core/src/native_geometric/snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/snapshot.rs
@@ -2,6 +2,7 @@
 
 use super::completion_types::CompletionState;
 use super::memory_types::{MemoryEntry, MemoryReference, ResponseAction, RESPONSE_MEMORY_SCHEMA};
+use super::response_entry_types::ResponseEntryState;
 use super::value_types::ValueState;
 use super::*;
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,7 @@ const LEGACY_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/1";
 const RESPONSE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/2";
 const VALUE_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/3";
 const COMPLETION_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/4";
+const ENTRY_SESSION_SCHEMA: &str = "uor-r4.native-geometric-session/5";
 const LEGACY_CHECKPOINT_LIMIT: usize = 1024 * 1024;
 const RESPONSE_CHECKPOINT_LIMIT: usize = 8 * 1024 * 1024;
 // Bound allocation before collecting the sparse index. A tuple has two
@@ -69,6 +71,8 @@ struct Checkpoint {
     values: Option<ValueState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     completion: Option<CompletionState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    response_entry: Option<ResponseEntryState>,
 }
 
 impl Session {
@@ -85,7 +89,9 @@ impl Session {
             self.ring[..self.length].to_vec()
         };
         let response_memory = self.response_memory_snapshot()?;
-        let schema = if self.completion.is_some() {
+        let schema = if self.response_entry.is_some() {
+            ENTRY_SESSION_SCHEMA
+        } else if self.completion.is_some() {
             COMPLETION_SESSION_SCHEMA
         } else if self.values.is_some() {
             VALUE_SESSION_SCHEMA
@@ -107,6 +113,7 @@ impl Session {
             response_memory,
             values: self.values.clone(),
             completion: self.completion,
+            response_entry: self.response_entry,
         })
         .map_err(|error| Error(error.to_string()))?;
         let limit = if schema != LEGACY_SESSION_SCHEMA {
@@ -135,7 +142,9 @@ impl Session {
             .memory_read
             .as_ref()
             .is_some_and(|memory| memory.schema == RESPONSE_MEMORY_SCHEMA);
-        let expected_schema = if model.completion.is_some() {
+        let expected_schema = if model.response_entry.is_some() {
+            ENTRY_SESSION_SCHEMA
+        } else if model.completion.is_some() {
             COMPLETION_SESSION_SCHEMA
         } else if model.values.is_some() {
             VALUE_SESSION_SCHEMA
@@ -148,6 +157,7 @@ impl Session {
             serde_json::from_slice(bytes).map_err(|error| Error(error.to_string()))?;
         value_snapshot::validate_lexeme_field_presence(model, &object)?;
         completion_snapshot::validate_field_presence(model, &object)?;
+        response_entry_snapshot::validate_field_presence(model, &object)?;
         // The additive /2 field must remain an unknown field for historical
         // /1 inputs, including an explicit JSON null. Keep their old loader
         // law as well as their byte serialization unchanged.
@@ -158,7 +168,7 @@ impl Session {
         }
         if !matches!(
             checkpoint.schema.as_str(),
-            VALUE_SESSION_SCHEMA | COMPLETION_SESSION_SCHEMA
+            VALUE_SESSION_SCHEMA | COMPLETION_SESSION_SCHEMA | ENTRY_SESSION_SCHEMA
         ) && object.get("values").is_some()
         {
             return Err(Error(
@@ -178,6 +188,9 @@ impl Session {
             || checkpoint.response_memory.is_some() != response_model
             || checkpoint.values.is_some() != model.values.is_some()
             || checkpoint.completion.is_some() != model.completion.is_some()
+            || checkpoint.response_entry.is_some() != model.response_entry.is_some()
+            || (model.response_entry.is_some()
+                && checkpoint.work.response_entry.observations != checkpoint.work.observed_tokens)
             || (model.completion.is_some()
                 && checkpoint.work.completion.observations != checkpoint.work.observed_tokens)
             || (checkpoint.schema == LEGACY_SESSION_SCHEMA && bytes.len() > LEGACY_CHECKPOINT_LIMIT)
@@ -274,6 +287,14 @@ impl Session {
             restored.restore_completion_state(
                 model,
                 completion,
+                &checkpoint.retained_tokens,
+                checkpoint.work.observed_tokens,
+            )?;
+        }
+        if let Some(entry) = checkpoint.response_entry {
+            restored.restore_response_entry_state(
+                model,
+                entry,
                 &checkpoint.retained_tokens,
                 checkpoint.work.observed_tokens,
             )?;
@@ -621,6 +642,9 @@ mod value_snapshot_tests;
 
 #[path = "completion_snapshot.rs"]
 mod completion_snapshot;
+
+#[path = "response_entry_snapshot.rs"]
+mod response_entry_snapshot;
 
 #[cfg(test)]
 #[path = "completion_snapshot_tests.rs"]

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -189,6 +189,7 @@ impl Trainer {
             readout_training: Vec::new(),
             values: None,
             completion: None,
+            response_entry: None,
             memory_read: None,
         };
         template.refresh_identity()?;
@@ -511,6 +512,9 @@ impl Model {
         if let Some(completion) = &self.completion {
             completion.validate(self)?;
         }
+        if let Some(entry) = &self.response_entry {
+            entry.validate(self)?;
+        }
         self.readout.validate(self)?;
         if let Some(memory) = &self.memory_read {
             memory.validate(self)?;
@@ -647,9 +651,15 @@ impl Model {
         let mut response_trace = Vec::new();
         let mut value_trace = Vec::new();
         let mut completion_trace = Vec::new();
+        let mut response_entry_trace = Vec::new();
         let mut stop = "token_budget".to_owned();
         for _ in 0..max_new_tokens {
             let token = session.predict(self)?.token;
+            if let Some(decision) = session.response_entry_decision() {
+                if response_entry_trace.len() < 96 {
+                    response_entry_trace.push(decision);
+                }
+            }
             if let Some(decision) = session.completion_decision() {
                 if completion_trace.len() < 96 {
                     completion_trace.push(decision);
@@ -685,6 +695,7 @@ impl Model {
             response_trace,
             value_trace,
             completion_trace,
+            response_entry_trace,
             stop,
             work: session.work,
             state: session.state(),
@@ -709,6 +720,7 @@ impl Model {
                     .chain(self.memory_read_training())
                     .chain(self.value_training())
                     .chain(self.value_completion_training())
+                    .chain(self.response_entry_training())
                     .any(|known| known.id == candidate.id || known.text_cid == candidate.text_cid)
             {
                 return Err(Error(format!(
@@ -754,6 +766,26 @@ impl Model {
 }
 
 fn add_work(total: &mut Work, work: Work) {
+    total.values.input_bytes += work.values.input_bytes;
+    total.values.literal_writes += work.values.literal_writes;
+    total.values.record_evictions += work.values.record_evictions;
+    total.values.proposals += work.values.proposals;
+    total.values.additions += work.values.additions;
+    total.values.overflow_rejections += work.values.overflow_rejections;
+    total.values.feature_lookups += work.values.feature_lookups;
+    total.values.feature_comparisons += work.values.feature_comparisons;
+    total.values.cue_comparisons += work.values.cue_comparisons;
+    total.values.lexical_comparisons += work.values.lexical_comparisons;
+    total.values.lexical_byte_comparisons += work.values.lexical_byte_comparisons;
+    total.values.lexical_writes += work.values.lexical_writes;
+    total.values.h4_reads += work.values.h4_reads;
+    total.values.phase_updates += work.values.phase_updates;
+    total.values.numeral_steps += work.values.numeral_steps;
+    total.values.derived_writes += work.values.derived_writes;
+    total.values.emission_commits += work.values.emission_commits;
+    total.values.emission_mismatches += work.values.emission_mismatches;
+    add_completion_work(&mut total.completion, work.completion);
+    add_completion_work(&mut total.response_entry, work.response_entry);
     total.response_query_captures += work.response_query_captures;
     total.response_commits += work.response_commits;
     total.response_requeries += work.response_requeries;
@@ -788,4 +820,86 @@ fn add_work(total: &mut Work, work: Work) {
     total.candidate_offers += work.candidate_offers;
     total.candidate_evaluations += work.candidate_evaluations;
     total.score_lookups += work.score_lookups;
+}
+
+fn add_completion_work(total: &mut CompletionWork, work: CompletionWork) {
+    total.observations += work.observations;
+    total.anchors += work.anchors;
+    total.metadata_reads += work.metadata_reads;
+    total.state_copies += work.state_copies;
+    total.feature_queries += work.feature_queries;
+    total.row_comparisons += work.row_comparisons;
+    total.matched_rows += work.matched_rows;
+    total.posting_offers += work.posting_offers;
+    total.candidate_comparisons += work.candidate_comparisons;
+    total.candidate_writes += work.candidate_writes;
+    total.candidate_drops += work.candidate_drops;
+    total.candidate_evaluations += work.candidate_evaluations;
+    total.score_lookups += work.score_lookups;
+    total.score_comparisons += work.score_comparisons;
+    total.h4_reads += work.h4_reads;
+    total.orientation_reads += work.orientation_reads;
+    total.phase_subtractions += work.phase_subtractions;
+    total.commits += work.commits;
+    total.base_steps += work.base_steps;
+    total.mismatches += work.mismatches;
+    total.stops += work.stops;
+    total.step_limits += work.step_limits;
+}
+
+#[cfg(test)]
+mod work_tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn native_evaluation_adds_every_nested_work_counter() {
+        // Seed the individually omitted fields as well as the optional groups
+        // so the independent JSON oracle covers every current counter.
+        let seed = Work {
+            values: ValueWork {
+                lexical_comparisons: 1,
+                lexical_byte_comparisons: 1,
+                lexical_writes: 1,
+                ..ValueWork::default()
+            },
+            completion: CompletionWork {
+                observations: 1,
+                ..CompletionWork::default()
+            },
+            response_entry: CompletionWork {
+                observations: 1,
+                ..CompletionWork::default()
+            },
+            ..Work::default()
+        };
+        fn fill(value: &mut Value, next: &mut u64) {
+            if let Some(fields) = value.as_object_mut() {
+                for field in fields.values_mut() {
+                    fill(field, next);
+                }
+            } else {
+                assert!(value.is_u64());
+                *value = Value::from(*next);
+                *next += 1;
+            }
+        }
+        fn double(value: &mut Value) {
+            if let Some(fields) = value.as_object_mut() {
+                for field in fields.values_mut() {
+                    double(field);
+                }
+            } else {
+                *value = Value::from(value.as_u64().unwrap() * 2);
+            }
+        }
+        let mut expected = serde_json::to_value(seed).unwrap();
+        fill(&mut expected, &mut 1);
+        let work: Work = serde_json::from_value(expected.clone()).unwrap();
+        let mut total = Work::default();
+        add_work(&mut total, work);
+        add_work(&mut total, work);
+        double(&mut expected);
+        assert_eq!(serde_json::to_value(total).unwrap(), expected);
+    }
 }

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -7,8 +7,8 @@ use std::cell::Cell;
 
 use uor_r4_core::native_geometric::{
     Config, Control, Document, MemoryReadFitConfig, MemoryReadSchedule, MemoryReadSupervision,
-    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, Trainer, ValueCompletionFitConfig,
-    ValueExample, ValueFitConfig, BOS, EOS,
+    MemoryReadTokenSpan, MemoryReadTrainer, ReadoutFitConfig, ResponseEntryFitConfig, Trainer,
+    ValueCompletionFitConfig, ValueExample, ValueFitConfig, BOS, EOS,
 };
 
 struct CountingAllocator;
@@ -98,6 +98,7 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         "fn response_decision(",
         "fn value_decision(",
         "fn completion_decision(",
+        "fn response_entry_decision(",
         "fn recent(",
         "fn features(",
         "fn score_candidate(",
@@ -194,6 +195,22 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         );
     }
     let completion_types = include_str!("../src/native_geometric/completion_types.rs");
+    let response_entry = include_str!("../src/native_geometric/response_entry_runtime.rs");
+    for function in [
+        "fn eligible(",
+        "fn reset(",
+        "fn begin(",
+        "fn observe(",
+        "fn features(",
+        "fn offer(",
+        "fn selected(",
+    ] {
+        assert_eq!(
+            response_entry.matches(function).count(),
+            1,
+            "response-entry kernel coverage includes {function}"
+        );
+    }
     let seed = completion_types
         .split_once("impl From<&ValueDecision> for CompletionSeed {")
         .unwrap()
@@ -236,6 +253,7 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         ("native response runtime", response),
         ("native typed-value runtime", value_runtime),
         ("native completion runtime", completion),
+        ("native response-entry runtime", response_entry),
         ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
@@ -424,6 +442,102 @@ fn native_value_completion_commit_mismatch_and_limit_are_allocation_free() {
     assert!(session.work.completion.commits > 0);
     assert!(session.work.completion.mismatches > 0);
     assert_eq!(session.work.completion.step_limits, 4);
+    assert!(session.work.evictions > 0);
+}
+
+#[test]
+fn native_response_entry_commit_mismatch_and_limit_are_allocation_free() {
+    let catalog = [Document {
+        id: "entry-allocation-catalog".into(),
+        text: "left = 13; right = 4; total: 17.\nreply: Unknown.\n Unknown.\n".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 32,
+            candidate_limit: 8,
+            ..Config::default()
+        },
+        &catalog,
+    )
+    .unwrap();
+    trainer.train_documents(&catalog).unwrap();
+    let examples = (0..4)
+        .flat_map(|index| {
+            [
+                ValueExample {
+                    id: format!("entry-allocation-numeric-{index}"),
+                    prompt: format!("left = {}; right = 4; total:", 13 + index),
+                    response: format!("{}.\n", 17 + index),
+                },
+                ValueExample {
+                    id: format!("entry-allocation-no-write-{index}"),
+                    prompt: format!("left = {}; right = 4; reply:", 13 + index),
+                    response: " Unknown.\n".into(),
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+    let (typed, _) = trainer
+        .compile()
+        .unwrap()
+        .fit_values_with_lexeme_cues(
+            &examples,
+            ValueFitConfig {
+                epochs: 64,
+                learning_rate: 0.25,
+                max_features: 4096,
+            },
+        )
+        .unwrap();
+    let (completion, _) = typed
+        .fit_value_completion(&examples, ValueCompletionFitConfig::default())
+        .unwrap();
+    let (model, _) = completion
+        .fit_response_entry(&examples, ResponseEntryFitConfig::default())
+        .unwrap();
+    let prompt = model.encode(&examples[1].prompt).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    let storage = session.state().response_entry.unwrap().storage_bytes;
+    ALLOCATIONS.with(|count| count.set(0));
+    BYTES.with(|count| count.set(0));
+    MEASURING.with(|enabled| enabled.set(true));
+    let result = (|| {
+        session.observe(&model, BOS)?;
+        let mut selected_entry = true;
+        for _ in 0..4 {
+            session.end_response(&model)?;
+            for &token in &prompt {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            let first = session.predict(&model)?.token;
+            selected_entry &= session.response_entry_decision().is_some();
+            // A repeated prediction must preserve the pending first choice.
+            selected_entry &= session.predict(&model)?.token == first;
+            session.observe(&model, first)?;
+            // A mismatching observed byte follows actual history. Repeated
+            // observations then exercise the bounded entry-progress limit.
+            for _ in 0..40 {
+                session.predict(&model)?;
+                session.observe(&model, u32::from(b'x') + 2)?;
+            }
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(selected_entry)
+    })();
+    MEASURING.with(|enabled| enabled.set(false));
+    assert!(
+        result.unwrap(),
+        "fixture must select its learned lexical entry"
+    );
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    assert_eq!(
+        session.state().response_entry.unwrap().storage_bytes,
+        storage
+    );
+    assert!(session.work.response_entry.commits > 0);
+    assert!(session.work.response_entry.mismatches > 0);
+    assert_eq!(session.work.response_entry.step_limits, 4);
+    assert_eq!(session.work.values.derived_writes, 0);
     assert!(session.work.evictions > 0);
 }
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -12,6 +12,33 @@ windows as instructions for new work. A negative binds its exact configuration;
 resource unavailability does not determine model quality. The recovered plan
 allows open development iteration under configurable cumulative machine budgets.
 
+## Native response entry (2026-09-05)
+
+The [response-entry record](native_geometric_response_entry_973.md) adds optional
+learned lexical-token/EOS selection at a captured query boundary after actual
+typed NoWrite. Continuation fitting begins only after a quantized selected Enter
+is observed. The unchanged 192-pair source supplies 32 entry and 224 continuation
+positions; all fit, with 170 rows/250 associations and no drops. The preceding
+numeric artifact is unchanged underneath the additive head.
+
+Full completes 16/16 prose and 16/16 Rust OPEN development responses, preserving
+24 numeric and eight binding outputs. All twenty saved Rust records compile and
+pass their own assertions or separately recorded identity callers. Entry-disabled
+and entry-geometry-disabled return to 12/16 in each family. All thirteen head
+candidates remain available; geometry-disabled preserves correct Enter but loses
+continuation corrections. Full uses ordinary Base for portions of each response
+and all eight NoWrite EOS decisions. These are within-artifact feature effects,
+not a matched geometry-free refit or general geometric advantage.
+
+Four separate OPEN transfer cases fail: city facts are ignored and renamed Rust
+parameters still produce `value`; both new Rust sources fail compilation. The
+learned head lacks those output values in its bounded support and reads no
+content-specific source relation at first entry. Whole-model candidate absence
+was not established. The final runtime reuses the invariant captured NoWrite
+decision only during committed entry; its same-artifact work reduction is recorded
+separately. General conversation, identifier binding, semantic multiscale memory,
+final held-out qualification and alpha remain open.
+
 ## Native typed-value completion (2026-09-05)
 
 The [completion record](native_geometric_value_completion_973.md) adds a learned

--- a/docs/evidence/native_geometric_response_entry_973.json
+++ b/docs/evidence/native_geometric_response_entry_973.json
@@ -1,0 +1,2210 @@
+{
+  "schema": "uor-r4.native-response-entry-evidence/1",
+  "at": "2026-09-05T14:39:03Z",
+  "issue": 973,
+  "status": "RETAIN_BOUNDED_RESPONSE_ENTRY_AND_NOWRITE_REUSE_CONTENT_TRANSFER_NEGATIVE",
+  "base_commit": "4f2dfe3eb91fb24a87f25bc57be48dad0f3cfa84",
+  "branch": "codex/native-response-entry",
+  "scope": "OPEN development with shared response forms. Same-artifact inference ablations, not separately fitted controls. No final held-out, broad conversation, general coding, multiscale abstraction or frontier claim.",
+  "artifact": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+    "bytes": 10107953,
+    "sha256": "9b38704b596c8fc6c30dbb01b155beaf2c7285e61cb81e6e2987ef3cb3663bc6",
+    "cid": "blake3:316837f19043a4a69b481b44c234c06dc3a4c4a688069707eb1ea7137085a574",
+    "baseline_cid": "blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff",
+    "added_bytes": 49374
+  },
+  "fit": {
+    "schema": "uor-r4.native-response-entry/1",
+    "baseline_artifact": "blake3:a1fa0314924fb324f994e449cce6e69793d6c4df6102353a959363cb766009ff",
+    "artifact_cid": "blake3:316837f19043a4a69b481b44c234c06dc3a4c4a688069707eb1ea7137085a574",
+    "examples": 192,
+    "numeric_examples": 160,
+    "matched_numeric": 160,
+    "upstream_failures": 0,
+    "no_write_examples": 32,
+    "unexpected_value_writes": 0,
+    "overlong_responses": 0,
+    "position_limit_skips": 0,
+    "entry_positions": 32,
+    "entry_target_in_candidates": 32,
+    "entry_fit_correct": 32,
+    "entered_rollouts": 32,
+    "entry_rollout_failures": 0,
+    "continuation_positions": 224,
+    "continuation_target_in_candidates": 224,
+    "continuation_fit_correct": 224,
+    "final_entry_correct": 32,
+    "final_exact_responses": 32,
+    "learned_rows": 170,
+    "learned_associations": 250,
+    "dropped_row_events": 0,
+    "dropped_association_events": 0,
+    "entry_fit_loss": 0.025211753664724057,
+    "continuation_fit_loss": 0.03707663207381796,
+    "selected_entry_epoch": 24,
+    "selected_continuation_epoch": 24,
+    "config": {
+      "epochs": 24,
+      "learning_rate": 0.1,
+      "max_positions": 4096
+    },
+    "tokenization_law": "Canonical frozen model.encode(response) plus EOS; an overlong response is skipped whole. Entry action is supervised separately from equal-token Base; continuation frames require actual quantized Enter selection and observation. Final shared-posting entry and free-running response checks are reported."
+  },
+  "generation_ceiling_tokens": 64,
+  "arms": [
+    {
+      "control": "full",
+      "metrics": {
+        "prose": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 16,
+          "generated_tokens": 98,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "prose/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 4,
+          "generated_tokens": 44,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        },
+        "rust": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 16,
+          "generated_tokens": 102,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "rust/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 4,
+          "generated_tokens": 12,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        }
+      },
+      "work_all_primary": {
+        "anchor_table_reads": 2548,
+        "candidate_evaluations": 38002,
+        "candidate_offers": 88456,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 0,
+          "candidate_comparisons": 10120,
+          "candidate_drops": 0,
+          "candidate_evaluations": 648,
+          "candidate_writes": 648,
+          "commits": 108,
+          "feature_queries": 1728,
+          "h4_reads": 216,
+          "matched_rows": 1708,
+          "metadata_reads": 372,
+          "mismatches": 0,
+          "observations": 2316,
+          "orientation_reads": 108,
+          "phase_subtractions": 864,
+          "posting_offers": 3728,
+          "row_comparisons": 15552,
+          "score_comparisons": 18480,
+          "score_lookups": 10248,
+          "state_copies": 7260,
+          "step_limits": 0,
+          "stops": 24
+        },
+        "evictions": 0,
+        "feature_queries": 6032,
+        "h4_table_reads": 2316,
+        "matched_rows": 5472,
+        "memory_candidates": 11946,
+        "memory_composed_candidates": 6155,
+        "memory_composition_comparisons": 1358293,
+        "memory_composition_duplicate_features": 70281,
+        "memory_composition_feature_moves": 502450,
+        "memory_composition_feature_offers": 215028,
+        "memory_cue_reads": 38640,
+        "memory_h4_reads": 85938,
+        "memory_index_reads": 56528,
+        "memory_index_writes": 35776,
+        "memory_phase_updates": 305232,
+        "memory_score_lookups": 144747,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 232,
+        "observed_tokens": 2316,
+        "orientation_table_reads": 232,
+        "phase_additions": 18528,
+        "radial_square_reads": 27792,
+        "response_entry": {
+          "anchors": 32,
+          "base_steps": 32,
+          "candidate_comparisons": 11508,
+          "candidate_drops": 0,
+          "candidate_evaluations": 832,
+          "candidate_writes": 832,
+          "commits": 32,
+          "feature_queries": 1024,
+          "h4_reads": 128,
+          "matched_rows": 1024,
+          "metadata_reads": 224,
+          "mismatches": 0,
+          "observations": 2316,
+          "orientation_reads": 64,
+          "phase_subtractions": 512,
+          "posting_offers": 2752,
+          "row_comparisons": 9216,
+          "score_comparisons": 25844,
+          "score_lookups": 13312,
+          "state_copies": 7300,
+          "step_limits": 0,
+          "stops": 8
+        },
+        "score_lookups": 918979,
+        "values": {
+          "additions": 208,
+          "cue_comparisons": 19456,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 228852,
+          "feature_lookups": 17604,
+          "h4_reads": 3532,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 21160,
+          "lexical_comparisons": 33824,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 23392,
+          "proposals": 304,
+          "record_evictions": 0
+        }
+      },
+      "work_no_write": {
+        "anchor_table_reads": 540,
+        "candidate_evaluations": 15400,
+        "candidate_offers": 24849,
+        "completion": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 476,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 1428,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "evictions": 0,
+        "feature_queries": 1664,
+        "h4_table_reads": 476,
+        "matched_rows": 1626,
+        "memory_candidates": 3184,
+        "memory_composed_candidates": 1316,
+        "memory_composition_comparisons": 358486,
+        "memory_composition_duplicate_features": 19674,
+        "memory_composition_feature_moves": 272254,
+        "memory_composition_feature_offers": 57312,
+        "memory_cue_reads": 10016,
+        "memory_h4_reads": 22764,
+        "memory_index_reads": 13664,
+        "memory_index_writes": 7296,
+        "memory_phase_updates": 80224,
+        "memory_score_lookups": 37638,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 64,
+        "observed_tokens": 476,
+        "orientation_table_reads": 64,
+        "phase_additions": 3808,
+        "radial_square_reads": 5712,
+        "response_entry": {
+          "anchors": 8,
+          "base_steps": 32,
+          "candidate_comparisons": 11508,
+          "candidate_drops": 0,
+          "candidate_evaluations": 832,
+          "candidate_writes": 832,
+          "commits": 32,
+          "feature_queries": 1024,
+          "h4_reads": 128,
+          "matched_rows": 1024,
+          "metadata_reads": 200,
+          "mismatches": 0,
+          "observations": 476,
+          "orientation_reads": 64,
+          "phase_subtractions": 512,
+          "posting_offers": 2752,
+          "row_comparisons": 9216,
+          "score_comparisons": 25844,
+          "score_lookups": 13312,
+          "state_copies": 1516,
+          "step_limits": 0,
+          "stops": 8
+        },
+        "score_lookups": 393857,
+        "values": {
+          "additions": 16,
+          "cue_comparisons": 2048,
+          "derived_writes": 0,
+          "emission_commits": 0,
+          "emission_mismatches": 0,
+          "feature_comparisons": 24336,
+          "feature_lookups": 1872,
+          "h4_reads": 604,
+          "input_bytes": 780,
+          "lexical_byte_comparisons": 1776,
+          "lexical_comparisons": 3712,
+          "lexical_writes": 116,
+          "literal_writes": 16,
+          "numeral_steps": 0,
+          "overflow_rejections": 0,
+          "phase_updates": 4320,
+          "proposals": 32,
+          "record_evictions": 0
+        }
+      }
+    },
+    {
+      "control": "response_entry_disabled",
+      "metrics": {
+        "prose": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 12,
+          "generated_tokens": 237,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "prose/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 0,
+          "generated_tokens": 183,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        },
+        "rust": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 12,
+          "generated_tokens": 148,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "rust/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 0,
+          "generated_tokens": 58,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        }
+      },
+      "work_all_primary": {
+        "anchor_table_reads": 2916,
+        "candidate_evaluations": 78580,
+        "candidate_offers": 157395,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 0,
+          "candidate_comparisons": 10120,
+          "candidate_drops": 0,
+          "candidate_evaluations": 648,
+          "candidate_writes": 648,
+          "commits": 108,
+          "feature_queries": 1728,
+          "h4_reads": 216,
+          "matched_rows": 1708,
+          "metadata_reads": 372,
+          "mismatches": 0,
+          "observations": 2500,
+          "orientation_reads": 108,
+          "phase_subtractions": 864,
+          "posting_offers": 3728,
+          "row_comparisons": 15552,
+          "score_comparisons": 18480,
+          "score_lookups": 10248,
+          "state_copies": 7812,
+          "step_limits": 0,
+          "stops": 24
+        },
+        "evictions": 0,
+        "feature_queries": 10816,
+        "h4_table_reads": 2500,
+        "matched_rows": 9893,
+        "memory_candidates": 31136,
+        "memory_composed_candidates": 9728,
+        "memory_composition_comparisons": 3892606,
+        "memory_composition_duplicate_features": 232217,
+        "memory_composition_feature_moves": 3063600,
+        "memory_composition_feature_offers": 560448,
+        "memory_cue_reads": 62928,
+        "memory_h4_reads": 220452,
+        "memory_index_reads": 82288,
+        "memory_index_writes": 38720,
+        "memory_phase_updates": 767264,
+        "memory_score_lookups": 328231,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 416,
+        "observed_tokens": 2500,
+        "orientation_table_reads": 416,
+        "phase_additions": 20000,
+        "radial_square_reads": 30000,
+        "response_entry": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 2500,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 7500,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "score_lookups": 1902491,
+        "values": {
+          "additions": 688,
+          "cue_comparisons": 80896,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 962156,
+          "feature_lookups": 74012,
+          "h4_reads": 7556,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 80144,
+          "lexical_comparisons": 147168,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 40224,
+          "proposals": 1264,
+          "record_evictions": 0
+        }
+      },
+      "work_no_write": {
+        "anchor_table_reads": 908,
+        "candidate_evaluations": 55978,
+        "candidate_offers": 93788,
+        "completion": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 660,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 1980,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "evictions": 0,
+        "feature_queries": 6448,
+        "h4_table_reads": 660,
+        "matched_rows": 6047,
+        "memory_candidates": 22374,
+        "memory_composed_candidates": 4889,
+        "memory_composition_comparisons": 2892799,
+        "memory_composition_duplicate_features": 181610,
+        "memory_composition_feature_moves": 2833404,
+        "memory_composition_feature_offers": 402732,
+        "memory_cue_reads": 34304,
+        "memory_h4_reads": 157278,
+        "memory_index_reads": 39424,
+        "memory_index_writes": 10240,
+        "memory_phase_updates": 542256,
+        "memory_score_lookups": 221122,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 248,
+        "observed_tokens": 660,
+        "orientation_table_reads": 248,
+        "phase_additions": 5280,
+        "radial_square_reads": 7920,
+        "response_entry": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 660,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 1980,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "score_lookups": 1377369,
+        "values": {
+          "additions": 496,
+          "cue_comparisons": 63488,
+          "derived_writes": 0,
+          "emission_commits": 0,
+          "emission_mismatches": 0,
+          "feature_comparisons": 757640,
+          "feature_lookups": 58280,
+          "h4_reads": 4628,
+          "input_bytes": 780,
+          "lexical_byte_comparisons": 60760,
+          "lexical_comparisons": 117056,
+          "lexical_writes": 116,
+          "literal_writes": 16,
+          "numeral_steps": 0,
+          "overflow_rejections": 0,
+          "phase_updates": 21152,
+          "proposals": 992,
+          "record_evictions": 0
+        }
+      }
+    },
+    {
+      "control": "response_entry_geometry_disabled",
+      "metrics": {
+        "prose": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 12,
+          "generated_tokens": 237,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "prose/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 18,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "prose/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 0,
+          "generated_tokens": 183,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        },
+        "rust": {
+          "cases": 16,
+          "correct_leading_numerals": 12,
+          "exact_responses": 12,
+          "generated_tokens": 296,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 12
+        },
+        "rust/add": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/copy_current": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/dependency_before_update": {
+          "cases": 4,
+          "correct_leading_numerals": 4,
+          "exact_responses": 4,
+          "generated_tokens": 30,
+          "nonnumeric_cases": 0,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 4
+        },
+        "rust/no_write": {
+          "cases": 4,
+          "correct_leading_numerals": 0,
+          "exact_responses": 0,
+          "generated_tokens": 206,
+          "nonnumeric_cases": 4,
+          "nonnumeric_cases_with_leading_numerals": 0,
+          "numeric_cases": 0
+        }
+      },
+      "work_all_primary": {
+        "anchor_table_reads": 3210,
+        "candidate_evaluations": 110747,
+        "candidate_offers": 212546,
+        "completion": {
+          "anchors": 24,
+          "base_steps": 0,
+          "candidate_comparisons": 10120,
+          "candidate_drops": 0,
+          "candidate_evaluations": 648,
+          "candidate_writes": 648,
+          "commits": 108,
+          "feature_queries": 1728,
+          "h4_reads": 216,
+          "matched_rows": 1708,
+          "metadata_reads": 372,
+          "mismatches": 0,
+          "observations": 2647,
+          "orientation_reads": 108,
+          "phase_subtractions": 864,
+          "posting_offers": 3728,
+          "row_comparisons": 15552,
+          "score_comparisons": 18480,
+          "score_lookups": 10248,
+          "state_copies": 8253,
+          "step_limits": 0,
+          "stops": 24
+        },
+        "evictions": 0,
+        "feature_queries": 14638,
+        "h4_table_reads": 2647,
+        "matched_rows": 13452,
+        "memory_candidates": 46393,
+        "memory_composed_candidates": 14476,
+        "memory_composition_comparisons": 5939775,
+        "memory_composition_duplicate_features": 337924,
+        "memory_composition_feature_moves": 4132225,
+        "memory_composition_feature_offers": 835074,
+        "memory_cue_reads": 82332,
+        "memory_h4_reads": 327398,
+        "memory_index_reads": 102868,
+        "memory_index_writes": 41072,
+        "memory_phase_updates": 1134608,
+        "memory_score_lookups": 497150,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 563,
+        "observed_tokens": 2647,
+        "orientation_table_reads": 563,
+        "phase_additions": 21176,
+        "radial_square_reads": 31764,
+        "response_entry": {
+          "anchors": 32,
+          "base_steps": 248,
+          "candidate_comparisons": 26261,
+          "candidate_drops": 0,
+          "candidate_evaluations": 3328,
+          "candidate_writes": 3328,
+          "commits": 8,
+          "feature_queries": 1536,
+          "h4_reads": 0,
+          "matched_rows": 860,
+          "metadata_reads": 544,
+          "mismatches": 0,
+          "observations": 2647,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 5598,
+          "row_comparisons": 13824,
+          "score_comparisons": 34346,
+          "score_lookups": 11180,
+          "state_copies": 8293,
+          "step_limits": 8,
+          "stops": 0
+        },
+        "score_lookups": 2683374,
+        "values": {
+          "additions": 486,
+          "cue_comparisons": 55040,
+          "derived_writes": 24,
+          "emission_commits": 60,
+          "emission_mismatches": 0,
+          "feature_comparisons": 651092,
+          "feature_lookups": 50084,
+          "h4_reads": 6087,
+          "input_bytes": 3772,
+          "lexical_byte_comparisons": 50960,
+          "lexical_comparisons": 97952,
+          "lexical_writes": 560,
+          "literal_writes": 96,
+          "numeral_steps": 9120,
+          "overflow_rejections": 0,
+          "phase_updates": 34936,
+          "proposals": 860,
+          "record_evictions": 0
+        }
+      },
+      "work_no_write": {
+        "anchor_table_reads": 1202,
+        "candidate_evaluations": 88145,
+        "candidate_offers": 148939,
+        "completion": {
+          "anchors": 0,
+          "base_steps": 0,
+          "candidate_comparisons": 0,
+          "candidate_drops": 0,
+          "candidate_evaluations": 0,
+          "candidate_writes": 0,
+          "commits": 0,
+          "feature_queries": 0,
+          "h4_reads": 0,
+          "matched_rows": 0,
+          "metadata_reads": 0,
+          "mismatches": 0,
+          "observations": 807,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 0,
+          "row_comparisons": 0,
+          "score_comparisons": 0,
+          "score_lookups": 0,
+          "state_copies": 2421,
+          "step_limits": 0,
+          "stops": 0
+        },
+        "evictions": 0,
+        "feature_queries": 10270,
+        "h4_table_reads": 807,
+        "matched_rows": 9606,
+        "memory_candidates": 37631,
+        "memory_composed_candidates": 9637,
+        "memory_composition_comparisons": 4939968,
+        "memory_composition_duplicate_features": 287317,
+        "memory_composition_feature_moves": 3902029,
+        "memory_composition_feature_offers": 677358,
+        "memory_cue_reads": 53708,
+        "memory_h4_reads": 264224,
+        "memory_index_reads": 60004,
+        "memory_index_writes": 12592,
+        "memory_phase_updates": 909600,
+        "memory_score_lookups": 390041,
+        "memory_stale_rejections": 0,
+        "mixture_gate_reads": 395,
+        "observed_tokens": 807,
+        "orientation_table_reads": 395,
+        "phase_additions": 6456,
+        "radial_square_reads": 9684,
+        "response_entry": {
+          "anchors": 8,
+          "base_steps": 248,
+          "candidate_comparisons": 26261,
+          "candidate_drops": 0,
+          "candidate_evaluations": 3328,
+          "candidate_writes": 3328,
+          "commits": 8,
+          "feature_queries": 1536,
+          "h4_reads": 0,
+          "matched_rows": 860,
+          "metadata_reads": 520,
+          "mismatches": 0,
+          "observations": 807,
+          "orientation_reads": 0,
+          "phase_subtractions": 0,
+          "posting_offers": 5598,
+          "row_comparisons": 13824,
+          "score_comparisons": 34346,
+          "score_lookups": 11180,
+          "state_copies": 2509,
+          "step_limits": 8,
+          "stops": 0
+        },
+        "score_lookups": 2158252,
+        "values": {
+          "additions": 294,
+          "cue_comparisons": 37632,
+          "derived_writes": 0,
+          "emission_commits": 0,
+          "emission_mismatches": 0,
+          "feature_comparisons": 446576,
+          "feature_lookups": 34352,
+          "h4_reads": 3159,
+          "input_bytes": 780,
+          "lexical_byte_comparisons": 31576,
+          "lexical_comparisons": 67840,
+          "lexical_writes": 116,
+          "literal_writes": 16,
+          "numeral_steps": 0,
+          "overflow_rejections": 0,
+          "phase_updates": 15864,
+          "proposals": 588,
+          "record_evictions": 0
+        }
+      }
+    }
+  ],
+  "preservation": {
+    "old_baseline": {
+      "comparisons": 40,
+      "entire_generation_exact": 40
+    },
+    "prior_numeric_and_binding_generation_exact_except_added_entry_telemetry": 32,
+    "same_artifact_replay": {
+      "comparisons": 104,
+      "entire_generation_exact": 88,
+      "entire_generation_except_only_work_values_equal": 104,
+      "all_typed_counters_nonincreasing": true,
+      "changed_generation_keys": [
+        [
+          "full",
+          "typed-value/development/prose/no_write/100000"
+        ],
+        [
+          "full",
+          "typed-value/development/rust/no_write/100000"
+        ],
+        [
+          "full",
+          "typed-value/development/prose/no_write/100001"
+        ],
+        [
+          "full",
+          "typed-value/development/rust/no_write/100001"
+        ],
+        [
+          "full",
+          "typed-value/development/prose/no_write/100002"
+        ],
+        [
+          "full",
+          "typed-value/development/rust/no_write/100002"
+        ],
+        [
+          "full",
+          "typed-value/development/prose/no_write/100003"
+        ],
+        [
+          "full",
+          "typed-value/development/rust/no_write/100003"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/prose/no_write/100000"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/rust/no_write/100000"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/prose/no_write/100001"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/rust/no_write/100001"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/prose/no_write/100002"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/rust/no_write/100002"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/prose/no_write/100003"
+        ],
+        [
+          "response_entry_geometry_disabled",
+          "typed-value/development/rust/no_write/100003"
+        ]
+      ],
+      "equivalence_report_hashes_metrics_and_counter_totals_verified": true
+    },
+    "frozen_sources": [
+      {
+        "file": "source.json",
+        "bytes": 90946,
+        "sha256": "10b69bfbbd89161032d80905306247b8a2e72ee098ab8f487932827f45d90352",
+        "byte_identical": true
+      },
+      {
+        "file": "binding-controls-source.json",
+        "bytes": 4684,
+        "sha256": "1a858a3cde98c19ecab16be42a4315e8f15f9d85b24e36ebf5da8c9a527cef22",
+        "byte_identical": true
+      }
+    ],
+    "model_bytes_unchanged_by_reuse": true
+  },
+  "no_write_reuse": {
+    "law": {
+      "key": "response_entry.active; no additional cache table or learned parameter.",
+      "establishment": "runtime.rs:516-538 skips typed offer only when entry.active. Initial prediction still invokes typed offer; response_entry_runtime.rs:218-247 blocks entry when typed pending exists. Only matching selected Enter observation activates it. value_runtime.rs:375-398 consumes or clears pending before entry observation.",
+      "fixed_inputs": "value_runtime.rs:138-164 snapshots sources and query entries; value_lexemes.rs:141-149 snapshots word queries. value_runtime.rs:65-99 updates actual geometry/history but returns before scanning/lexeme feed while active. Without typed pending there is no derived write or source/ID change.",
+      "selection": "value_runtime.rs:190-288 uses captured source records, ranks, query/word cues and source/query geometry with fixed model/control; changing current pose/phases and response history are not selection inputs. At325-351 proposal score must exceed zero before baseline.score is used. Initial typed NoWrite therefore remains valid for the active response.",
+      "restore_reset": "response_entry_snapshot.rs:104-198 validates boundary/history and replays the initial typed gate plus selected Enter. Boundary/end, EOS, invalid eligibility and32-step cap reset activity; later prediction resumes the typed gate.",
+      "limits": "Adding response-dependent proposal features or changing captured sources/query/model/control requires revised cache validity. Counter savings measure avoided logical work, not wall-clock speedup."
+    },
+    "counted_reductions": [
+      {
+        "control": "full",
+        "metrics_unchanged": true,
+        "primary_cases": 32,
+        "nonnumeric_cases": 8,
+        "all_primary_reductions": {
+          "additions": {
+            "before": 320,
+            "after": 208,
+            "saved": 112
+          },
+          "cue_comparisons": {
+            "before": 33792,
+            "after": 19456,
+            "saved": 14336
+          },
+          "feature_comparisons": {
+            "before": 400036,
+            "after": 228852,
+            "saved": 171184
+          },
+          "feature_lookups": {
+            "before": 30772,
+            "after": 17604,
+            "saved": 13168
+          },
+          "h4_reads": {
+            "before": 4428,
+            "after": 3532,
+            "saved": 896
+          },
+          "lexical_byte_comparisons": {
+            "before": 35064,
+            "after": 21160,
+            "saved": 13904
+          },
+          "lexical_comparisons": {
+            "before": 60320,
+            "after": 33824,
+            "saved": 26496
+          },
+          "phase_updates": {
+            "before": 26976,
+            "after": 23392,
+            "saved": 3584
+          },
+          "proposals": {
+            "before": 528,
+            "after": 304,
+            "saved": 224
+          }
+        },
+        "nonnumeric_reductions": {
+          "additions": {
+            "before": 128,
+            "after": 16,
+            "saved": 112
+          },
+          "cue_comparisons": {
+            "before": 16384,
+            "after": 2048,
+            "saved": 14336
+          },
+          "feature_comparisons": {
+            "before": 195520,
+            "after": 24336,
+            "saved": 171184
+          },
+          "feature_lookups": {
+            "before": 15040,
+            "after": 1872,
+            "saved": 13168
+          },
+          "h4_reads": {
+            "before": 1500,
+            "after": 604,
+            "saved": 896
+          },
+          "lexical_byte_comparisons": {
+            "before": 15680,
+            "after": 1776,
+            "saved": 13904
+          },
+          "lexical_comparisons": {
+            "before": 30208,
+            "after": 3712,
+            "saved": 26496
+          },
+          "phase_updates": {
+            "before": 7904,
+            "after": 4320,
+            "saved": 3584
+          },
+          "proposals": {
+            "before": 256,
+            "after": 32,
+            "saved": 224
+          }
+        }
+      },
+      {
+        "control": "response_entry_disabled",
+        "metrics_unchanged": true,
+        "primary_cases": 32,
+        "nonnumeric_cases": 8,
+        "all_primary_reductions": {
+        },
+        "nonnumeric_reductions": {
+        }
+      },
+      {
+        "control": "response_entry_geometry_disabled",
+        "metrics_unchanged": true,
+        "primary_cases": 32,
+        "nonnumeric_cases": 8,
+        "all_primary_reductions": {
+          "additions": {
+            "before": 982,
+            "after": 486,
+            "saved": 496
+          },
+          "cue_comparisons": {
+            "before": 118528,
+            "after": 55040,
+            "saved": 63488
+          },
+          "feature_comparisons": {
+            "before": 1405508,
+            "after": 651092,
+            "saved": 754416
+          },
+          "feature_lookups": {
+            "before": 108116,
+            "after": 50084,
+            "saved": 58032
+          },
+          "h4_reads": {
+            "before": 10055,
+            "after": 6087,
+            "saved": 3968
+          },
+          "lexical_byte_comparisons": {
+            "before": 106016,
+            "after": 50960,
+            "saved": 55056
+          },
+          "lexical_comparisons": {
+            "before": 213024,
+            "after": 97952,
+            "saved": 115072
+          },
+          "phase_updates": {
+            "before": 50808,
+            "after": 34936,
+            "saved": 15872
+          },
+          "proposals": {
+            "before": 1852,
+            "after": 860,
+            "saved": 992
+          }
+        },
+        "nonnumeric_reductions": {
+          "additions": {
+            "before": 790,
+            "after": 294,
+            "saved": 496
+          },
+          "cue_comparisons": {
+            "before": 101120,
+            "after": 37632,
+            "saved": 63488
+          },
+          "feature_comparisons": {
+            "before": 1200992,
+            "after": 446576,
+            "saved": 754416
+          },
+          "feature_lookups": {
+            "before": 92384,
+            "after": 34352,
+            "saved": 58032
+          },
+          "h4_reads": {
+            "before": 7127,
+            "after": 3159,
+            "saved": 3968
+          },
+          "lexical_byte_comparisons": {
+            "before": 86632,
+            "after": 31576,
+            "saved": 55056
+          },
+          "lexical_comparisons": {
+            "before": 182912,
+            "after": 67840,
+            "saved": 115072
+          },
+          "phase_updates": {
+            "before": 31736,
+            "after": 15864,
+            "saved": 15872
+          },
+          "proposals": {
+            "before": 1580,
+            "after": 588,
+            "saved": 992
+          }
+        }
+      }
+    ],
+    "no_write_proposal_and_addition_reduction_percent": 87.5,
+    "all_primary_checked_addition_reduction_percent": 35,
+    "latency_speedup": "NOT_MEASURED"
+  },
+  "geometry_control": {
+    "head_global_tokens": 13,
+    "complete_equal_candidate_support": true,
+    "dropped_tokens": 0,
+    "full_eligible_head_requests": 64,
+    "geometry_disabled_eligible_head_requests": 256,
+    "correct_first_entries_both": 8,
+    "full_head_selected_eos": 0,
+    "full_prose_actions": "Enter 0; Emit 1,2,3,9,10; Base 4-8 and EOS 11",
+    "full_rust_actions": "Enter 0; Emit 1; Base newline 2 and EOS 3",
+    "first_entry_geometry_score_offset": 740,
+    "scope": "Combined fitted geometry score dependence for continuation. First-entry factual conditioning, separate-term attribution and geometry-free refit unmeasured."
+  },
+  "cost": {
+    "per_eligible_prediction": {
+      "feature_queries": 16,
+      "posting_offers": 80,
+      "duplicate_comparisons": 1280,
+      "retained_candidates": 16,
+      "score_lookups": 256,
+      "max_row_search_comparisons": 13,
+      "max_token_search_comparisons": 16,
+      "current_vocabulary_conservative_token_search_comparisons": 11,
+      "current_vocabulary_max_score_token_comparisons": 2816,
+      "h4_reads": 2,
+      "orientation_reads": 1,
+      "phase_subtractions": 8,
+      "metadata_reads": 3
+    },
+    "fixed_local_array_logical_bytes": 448,
+    "persistent_entry_state_bytes_current_host": 96,
+    "initial_typed_full_occupancy": {
+      "slot_visits": 272,
+      "valid_proposals": 256,
+      "checked_additions": 240
+    },
+    "other_work": "Ordinary decoding and memory still run. Boundary/observation/reset, token codec, loading, fitting and snapshot validation remain separate work. Host restore allocates and rechecks initial NoWrite."
+  },
+  "generated_rust": {
+    "total": 20,
+    "compiled": 20,
+    "executed": 20,
+    "passed": 20,
+    "unique_complete_source_hashes": 18,
+    "identity_caller_assertions": 28,
+    "all_compiler_products_retained": true,
+    "final_replay_source_hash_matches": 20
+  },
+  "content_transfer": {
+    "total": 4,
+    "exact": 0,
+    "city_fact_responses": " Unknown. The conversation does not give a city.\n",
+    "renamed_parameter_responses": "value\n}\n",
+    "rust_compilation_failures": 2,
+    "rust_executions": 0,
+    "unchanged_final_replay": 4,
+    "compiler_receipt_caveat": "Initial compilation NOT_RUN metadata was copied from source manifest; later compiled:false and compile_code:1 record both actual compiler failures. Final replay source hashes match these failed sources.",
+    "cause_scope": "Selected head lacks query/source-content selection; its thirteen-token support cannot spell the required outputs. Whole-model candidate absence not measured."
+  },
+  "local_verification": {
+    "core_native_final": 96,
+    "allocation_source": 5,
+    "context": 3,
+    "probe": 4,
+    "cli_service_initial": {
+      "passed": 17,
+      "failed": 1,
+      "reason": "New test incorrectly required head-selected Stop although Base EOS is valid."
+    },
+    "cli_service_corrected_focused": 1,
+    "release_cli_and_probe_builds": 2,
+    "final_guard_exercised_in_core_and_real_artifact_replay": true,
+    "broad_legacy_checks": "NOT_RUN",
+    "engineering_commands": [
+      {
+        "label": "response-entry-core-1",
+        "started": "2026-09-05T13:58:57.194Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric",
+          "--offline"
+        ],
+        "elapsed_ms": 100450,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4150640640
+      },
+      {
+        "label": "response-entry-core-2",
+        "started": "2026-09-05T14:02:59.611Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric",
+          "--offline"
+        ],
+        "elapsed_ms": 110693,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4150882304
+      },
+      {
+        "label": "response-entry-interface-tests",
+        "started": "2026-09-05T14:04:56.825Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "-p",
+          "uor-r4-core",
+          "--test",
+          "native_geometric_allocations",
+          "--test",
+          "windowed_geometric_context",
+          "--example",
+          "native_geometric_value_probe",
+          "--offline"
+        ],
+        "elapsed_ms": 150115,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4140875776
+      },
+      {
+        "label": "response-entry-cli-service",
+        "started": "2026-09-05T14:07:30.892Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--bin",
+          "r4",
+          "native_geometric_",
+          "--offline"
+        ],
+        "elapsed_ms": 290722,
+        "code": 101,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4168470528
+      },
+      {
+        "label": "response-entry-cli-service-2",
+        "started": "2026-09-05T14:13:26.713Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "--bin",
+          "r4",
+          "native_geometric_response_entry_http_resumes_observed_lexical_tokens",
+          "--offline"
+        ],
+        "elapsed_ms": 24817,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4144357376
+      },
+      {
+        "label": "response-entry-release",
+        "started": "2026-09-05T14:13:58.087Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "build",
+          "--release",
+          "--offline",
+          "-p",
+          "uor-r4-wasm-router",
+          "--bin",
+          "r4",
+          "-p",
+          "uor-r4-core",
+          "--example",
+          "native_geometric_value_probe"
+        ],
+        "elapsed_ms": 314117,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4171325440
+      },
+      {
+        "label": "response-entry-cache-core",
+        "started": "2026-09-05T14:24:46.427Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "test",
+          "-p",
+          "uor-r4-core",
+          "--lib",
+          "native_geometric",
+          "--offline"
+        ],
+        "elapsed_ms": 116580,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "run_growth_limit_bytes": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4183080960
+      },
+      {
+        "label": "response-entry-cache-release",
+        "started": "2026-09-05T14:26:49.571Z",
+        "command": "/Users/casey.allard/.cargo/bin/cargo",
+        "args": [
+          "build",
+          "--release",
+          "--offline",
+          "-p",
+          "uor-r4-wasm-router",
+          "--bin",
+          "r4",
+          "-p",
+          "uor-r4-core",
+          "--example",
+          "native_geometric_value_probe"
+        ],
+        "elapsed_ms": 311126,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "run_growth_limit_bytes": null,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 4194951168
+      }
+    ]
+  },
+  "resources": {
+    "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+    "at": "2026-09-05T14:33:17.376Z",
+    "inherited_precleanup_bytes": 2747199488,
+    "obsolete_target_growth_credit": 671379456,
+    "current_target_bytes": 1834057728,
+    "predecessor_artifact_root_bytes": 145760256,
+    "current_artifact_root_bytes": 94552064,
+    "predecessor_worktree_bytes": 9875456,
+    "current_worktree_bytes": 8937472,
+    "source_metadata_reserve_bytes": 5242880,
+    "current_sampled_known_storage_bytes": 4174245888,
+    "storage_limit_bytes": 4336910336,
+    "remaining_storage_bytes": 162664448,
+    "stop_margin_bytes": 134217728,
+    "available_growth_before_stop_bytes": 28262400,
+    "model_ledger": {
+      "cumulative_ms": 925824,
+      "limit_ms": 1800000
+    },
+    "model_remaining_ms": 874176,
+    "model_process_limit": 1,
+    "model_process_rss_target_bytes": 4294967296,
+    "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees.",
+    "cycle_model_ms": 22298,
+    "cycle_engineering_ms": 1418620,
+    "sampled_cycle_peak_known_storage_bytes": 4194951168,
+    "release_sampled_growth_bytes": [
+      30887936,
+      27111424
+    ],
+    "further_checked_cycle": "NOT_ADMITTED_REMAINING_STORAGE",
+    "rss_scope": "Child process samples; absent samples unavailable; generated-code wrapper excludes rustc descendants; no whole-machine peak guarantee."
+  },
+  "model_commands": [
+    {
+      "label": "response-entry-fit-1",
+      "started": "2026-09-05T14:19:18.568Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "entry",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/source.json",
+        "--lexeme-cues",
+        "true",
+        "--generated-tokens",
+        "64",
+        "--epochs",
+        "24",
+        "--learning-rate",
+        "0.1",
+        "--entry-max-positions",
+        "4096",
+        "--max-seconds",
+        "120",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1"
+      ],
+      "elapsed_ms": 4622,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 362987520,
+      "process_rss_samples": 4,
+      "peak_sampled_known_bytes": 4158509056
+    },
+    {
+      "label": "response-entry-preserve-completion",
+      "started": "2026-09-05T14:19:45.690Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/source.json",
+        "--lexeme-cues",
+        "true",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "32",
+        "--max-seconds",
+        "120",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-preserve-completion"
+      ],
+      "elapsed_ms": 849,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": 0,
+      "peak_sampled_known_bytes": 4160626688
+    },
+    {
+      "label": "response-entry-transfer-0",
+      "started": "2026-09-05T14:20:09.142Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "User: suri has 73 coins. tavi has 301 coins.\nUser: orin lives in Oslo.\nUser: What city does orin live in?\nAssistant:",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1491,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 112705536,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4160643072
+    },
+    {
+      "label": "response-entry-transfer-1",
+      "started": "2026-09-05T14:20:10.763Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "User: suri has 73 coins. tavi has 301 coins.\nUser: orin lives in Lima.\nUser: What city does orin live in?\nAssistant:",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1073,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 170524672,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4160655360
+    },
+    {
+      "label": "response-entry-transfer-2",
+      "started": "2026-09-05T14:20:11.964Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "// suri has 73 coins; tavi has 301.\n// Return the input unchanged.\nfn identity(input: i32) -> i32 {\n    ",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1150,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 154992640,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4160667648
+    },
+    {
+      "label": "response-entry-transfer-3",
+      "started": "2026-09-05T14:20:13.236Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "// suri has 73 coins; tavi has 301.\n// Return the input unchanged.\nfn identity(count: i32) -> i32 {\n    ",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1077,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 170459136,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4160684032
+    },
+    {
+      "label": "response-entry-generated-check",
+      "started": "2026-09-05T14:20:29.080Z",
+      "command": "node",
+      "args": [
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-compile-execute.mjs",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-generated-source-manifest.json",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-generated-check"
+      ],
+      "elapsed_ms": 4453,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 57180160,
+      "process_rss_samples": 4,
+      "peak_sampled_known_bytes": 4167753728
+    },
+    {
+      "label": "response-entry-transfer-compile",
+      "started": "2026-09-05T14:20:56.841Z",
+      "command": "node",
+      "args": [
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-compile-execute.mjs",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-transfer-source-manifest.json",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-transfer-check"
+      ],
+      "elapsed_ms": 520,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": 0,
+      "peak_sampled_known_bytes": 4167778304
+    },
+    {
+      "label": "response-entry-cache-replay",
+      "started": "2026-09-05T14:32:13.953Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/source.json",
+        "--lexeme-cues",
+        "true",
+        "--controls",
+        "all",
+        "--generated-tokens",
+        "64",
+        "--max-seconds",
+        "120",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-cache-replay"
+      ],
+      "elapsed_ms": 1482,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 5767168,
+      "peak_process_rss_sample_bytes": 141459456,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4172111872
+    },
+    {
+      "label": "response-entry-cache-preserve-completion",
+      "started": "2026-09-05T14:32:41.740Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/model.json",
+        "--source",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/source.json",
+        "--lexeme-cues",
+        "true",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "32",
+        "--max-seconds",
+        "120",
+        "--output-dir",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-cache-preserve-completion"
+      ],
+      "elapsed_ms": 826,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 2621440,
+      "peak_process_rss_sample_bytes": null,
+      "process_rss_samples": 0,
+      "peak_sampled_known_bytes": 4174131200
+    },
+    {
+      "label": "response-entry-cache-transfer-0",
+      "started": "2026-09-05T14:32:52.124Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "User: suri has 73 coins. tavi has 301 coins.\nUser: orin lives in Oslo.\nUser: What city does orin live in?\nAssistant:",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1475,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 2621440,
+      "peak_process_rss_sample_bytes": 114622464,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4174209024
+    },
+    {
+      "label": "response-entry-cache-transfer-1",
+      "started": "2026-09-05T14:32:53.725Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "User: suri has 73 coins. tavi has 301 coins.\nUser: orin lives in Lima.\nUser: What city does orin live in?\nAssistant:",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1092,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 2621440,
+      "peak_process_rss_sample_bytes": 169590784,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4174217216
+    },
+    {
+      "label": "response-entry-cache-transfer-2",
+      "started": "2026-09-05T14:32:54.944Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "// suri has 73 coins; tavi has 301.\n// Return the input unchanged.\nfn identity(input: i32) -> i32 {\n    ",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1096,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 2621440,
+      "peak_process_rss_sample_bytes": 168673280,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4174225408
+    },
+    {
+      "label": "response-entry-cache-transfer-3",
+      "started": "2026-09-05T14:32:56.170Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+        "--prompt",
+        "// suri has 73 coins; tavi has 301.\n// Return the input unchanged.\nfn identity(count: i32) -> i32 {\n    ",
+        "--max-tokens",
+        "64",
+        "--json"
+      ],
+      "elapsed_ms": 1092,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "run_growth_limit_bytes": 2621440,
+      "peak_process_rss_sample_bytes": 171868160,
+      "process_rss_samples": 1,
+      "peak_sampled_known_bytes": 4174237696
+    }
+  ],
+  "preservation_policy": {
+    "worktrees": 33,
+    "new_worktrees": 0,
+    "deleted_material": false,
+    "main_material": "Two preexisting NPZ deletions, modified prompt_conditioning_v4.py, untracked .serena and recorded-corpus material retained.",
+    "python_working_blob": "e09e0c8eb6a4c97a4404d428825c87bc2dd45ce4"
+  },
+  "next_mechanism": "Bounded retained occurrence/span admission and learned query/source selection at response entry, followed by actual-content continuation. Requires new storage admission before another checked implementation cycle.",
+  "receipts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json",
+      "bytes": 10107953,
+      "sha256": "9b38704b596c8fc6c30dbb01b155beaf2c7285e61cb81e6e2987ef3cb3663bc6"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/source.json",
+      "bytes": 90946,
+      "sha256": "10b69bfbbd89161032d80905306247b8a2e72ee098ab8f487932827f45d90352"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/binding-controls-source.json",
+      "bytes": 4684,
+      "sha256": "1a858a3cde98c19ecab16be42a4315e8f15f9d85b24e36ebf5da8c9a527cef22"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/fit-report.json",
+      "bytes": 1458,
+      "sha256": "32ce3eb1535f759912fd8bf45abe8664307d229e7fd8a1c063da0fd74840bc85"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-fit-1/report.json",
+      "bytes": 3712552,
+      "sha256": "3113de1e713b3a1c206089b9f271cce400acf2dc4b80acccaf86bacdc17596b0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-cache-replay/report.json",
+      "bytes": 3710988,
+      "sha256": "16cec47f476415e280ed64c4aaeac944ff98d153e07cc5f884769853afef3ee6"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-cache-preserve-completion/report.json",
+      "bytes": 1436964,
+      "sha256": "eb90ab67cd13f0a5d6010f7942a853cf1aa7e7f01434a1e26aa3463242913a2a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/completion-fit-1/report.json",
+      "bytes": 3991857,
+      "sha256": "9b3871ff2c3ab0a315de7a3c65c128f3fb15d145e64e99c7df78cb35e783cce1"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-cache-equivalence.json",
+      "bytes": 46910,
+      "sha256": "4d864b3fecf1ba10c5415673b24bb19b03239f79fc95e8c7287950a396226001"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-fit-analysis.json",
+      "bytes": 143777,
+      "sha256": "50a377a4bceb9cf7ce8ca55309df383acca5ce532b0e6999bea8d8923779cae7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-independent-audit.json",
+      "bytes": 15632,
+      "sha256": "810788fdaf971fa9c505d26ba27617785cf004d7c027e538b8b79b8208309607"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-final-audit.json",
+      "bytes": 17961,
+      "sha256": "7c225c0b9e5c91598384d3b29c317830cb98a164e308f010bda977c71803669f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-implementation-source.json",
+      "bytes": 8155,
+      "sha256": "bf10252db4c05b28842688c1ee7e96a4609ef36033601af7d0cfa3abcac8d0da"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-final-source.json",
+      "bytes": 7610,
+      "sha256": "9a3e07a6848db0b73785ed492217e9920f839699db720beac71a0b380c56e7ed"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-before-cache-binaries.json",
+      "bytes": 772,
+      "sha256": "864ad1b38491bedd3c345e5e7cdd7fc474e0fa3efaada42da14132bb332eb694"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-final-binaries.json",
+      "bytes": 813,
+      "sha256": "198574037954a6a02ff20052dbf3f5b675be2921ceedbea60d84189af615a13d"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-storage-authorization.json",
+      "bytes": 779,
+      "sha256": "7d253ce3f8884ce89cc4a39f1b98cb8c6dd533a7077ae0fa795eaa9647389f15"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-admission.json",
+      "bytes": 795,
+      "sha256": "68943e9768be142f949ae7c68d9a3549da2739accff9a9f309c4016c7b691a85"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-nowrite-cache-admission.json",
+      "bytes": 2571,
+      "sha256": "2edd5e67870d19f2f19e8968e1dd4c3034d09a02cebbe1ae968b63db6c10942c"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-pre-delivery-storage.json",
+      "bytes": 1424,
+      "sha256": "e5a50218919d594fd4768942d52fdb4a33d9bd5e24a7018edc5569b10f7d9cc0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-generated-source-manifest.json",
+      "bytes": 6862,
+      "sha256": "0c4ecd3f12ef46dae003e114047cd40f52e76bceda2bd40b4782c07e7efbc296"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-generated-check/report.json",
+      "bytes": 28903,
+      "sha256": "8e3f3a7effd40ea7c748f58acaba4874480fd677b6a2df05349f4af46d98a6e8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-transfer-source.json",
+      "bytes": 3835,
+      "sha256": "b9933b09270006ce6b8a393bfc4f7a2741b890330e48dd411bbc61b43e4a1a21"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-transfer-report.json",
+      "bytes": 3858,
+      "sha256": "fb49736ec5f2dd88eb30eecca6108271862fd1a44ae9ab3077929acc97ebc4fd"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/response-entry-cache-transfer-report.json",
+      "bytes": 3894,
+      "sha256": "e36aeef8b87451f4b7ad24c555c447eb04dd12b500b37f59e36795e3a6134048"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/entry-transfer-check/report.json",
+      "bytes": 2596,
+      "sha256": "59ac71f73d0f42109678d353838c2ea3ed65b0598bec1c4a6b5bb3e295381243"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/commands.jsonl",
+      "bytes": 87806,
+      "sha256": "b13bdb6615f9223fe23b1e0f754195bf47802ae068b9d1d9a4d92d7bf5d2d6c6"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/engineering-commands.jsonl",
+      "bytes": 113684,
+      "sha256": "47d63ccaf27c90daf55a4e31a51f78e44564af95d25a1c405f00106ab90dae0d"
+    }
+  ],
+  "final_source": [
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+      "sha256": "716909b1ecde51ee8426847deaa00310d14e2e76fd559bc9c721bc22f155b117",
+      "bytes": 50024
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/anchors.rs",
+      "sha256": "eb653f80cb3160ad083cc16d10952218454bbaefeb9bdd02b38e92c34a32ba8a",
+      "bytes": 11853
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_runtime.rs",
+      "sha256": "2616a289e2580eb20de8500927ac083ac6d96d21d240f32fac2016ae8d9a41d7",
+      "bytes": 11652
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_runtime_tests.rs",
+      "sha256": "00a6678f7c4f9db1cdd78598e4e63e2219ef3ccb86dcd07b716b07b2df4f3a68",
+      "bytes": 11404
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_snapshot.rs",
+      "sha256": "0701775ec18cc2c2efe4d9c916cba51cbc49100f6bf07f4921812278d0729edf",
+      "bytes": 10558
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_snapshot_tests.rs",
+      "sha256": "b11acf8d489c9c9fa15f428f1b3fd0d56b91180e624142e6ba6d77459695090c",
+      "bytes": 11711
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_training.rs",
+      "sha256": "11400a35e9b68b5ba0d7f0f9b459d1a5659ced71d70b0e39d41e049c449997d0",
+      "bytes": 24935
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/completion_types.rs",
+      "sha256": "f27c88bf1d8f359ff1e40a56fd241144f7b032a55e379fc5f2e1bb06694446ca",
+      "bytes": 3886
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/memory_runtime.rs",
+      "sha256": "ba649539cf17774041cec34b4fa5b77a495293004766d36cb9ffccf1956ceb68",
+      "bytes": 21575
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/memory_runtime_tests.rs",
+      "sha256": "ccb1293f2e66ef78e7d0f047b4f512d132d0e4edbb307b9907b8b7421268e6a8",
+      "bytes": 11826
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/memory_training.rs",
+      "sha256": "304d76de48a42c3d8ee0b4c626210cd95131a600c01f82c1c4ed34609484eb7d",
+      "bytes": 52527
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/memory_types.rs",
+      "sha256": "64b235ebb196b95a7e7125f8083893a0ea7b86b78dc3a97ebc831b6fd433a998",
+      "bytes": 13972
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/mixture.rs",
+      "sha256": "cf89e5a634ea48fc027f4e08fadea2af42e2be396d6501f4f34ac4fba704a581",
+      "bytes": 16955
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+      "sha256": "674ede798beecac55b5c01b22c5bbe98b4710e3d4a89e5712ced440a344d3114",
+      "bytes": 14917
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/numeral.rs",
+      "sha256": "2c0012a595d87e653051b067d586d98e93fe1394f9651d75725144cf0ef330fb",
+      "bytes": 13768
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs",
+      "sha256": "68a7f14187567a4ad59f5b2e69fde686ea34e064ce46fb0c5a20a74d460e6539",
+      "bytes": 10186
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs",
+      "sha256": "e46322d6e6547b972aae1dabedfc6d1f99925d26eb4c9a7de34c421a5d979885",
+      "bytes": 18128
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs",
+      "sha256": "626f24a5b41c49fd542b3aec0c0b9f09ecf6f44d92b3094956fc073c576d6d3a",
+      "bytes": 9255
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_training.rs",
+      "sha256": "2714e3229438bd77545350587eefca60839d003c0ba67313f1e194454ad061fd",
+      "bytes": 19158
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_training_tests.rs",
+      "sha256": "ab388e1e8ce45b34989cfd9f0182ef3e3a5faf0c7cbdee07d68cd9946e5ccc2a",
+      "bytes": 8638
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_entry_types.rs",
+      "sha256": "56755d2c860505273ed1083cf22ecf20834f932f0a4b2c8a1c4e58df4f053e6e",
+      "bytes": 2664
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_runtime.rs",
+      "sha256": "79548be47acc125a6025ae946bb07a5a12ef06ac805766a0233711f8360dabd9",
+      "bytes": 11653
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_runtime_tests.rs",
+      "sha256": "b9b26a58ac3026e6307ecfa49de92027b23fc48d380f53f76c1f79ddcda3bea6",
+      "bytes": 9321
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/response_snapshot_tests.rs",
+      "sha256": "b0035296cb47ed804afa2be292b8fed3d540268c8062b8a38673e37a6a36631d",
+      "bytes": 11838
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/runtime.rs",
+      "sha256": "ec3d0cea6bb40ea13f27c11d863452756cd8b7e792c8c69592630c277023b1ce",
+      "bytes": 25530
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/snapshot.rs",
+      "sha256": "ffec2068a7041582aa4f77dd1d358d4abab0e9cc7d5a98673934375bd7a18b98",
+      "bytes": 27315
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/tests.rs",
+      "sha256": "11da699221ff0982b5ea0302b4ede6b890d0e73546333fc05602f6f903c91c49",
+      "bytes": 24139
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+      "sha256": "8d7a2b3519eb966deadcfbb47a5b1db9e88aab5461ca85b896e638ae1650eb2a",
+      "bytes": 36444
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_lexemes.rs",
+      "sha256": "dc79fa8e1c4f0fadb14af0d8153155b4e874a3178f8d33042b3515460467f5e9",
+      "bytes": 12896
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_runtime.rs",
+      "sha256": "0fab61b637c828bce9e11313e53419c404c427c4b7373c04c50ff822a6b122f1",
+      "bytes": 17854
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs",
+      "sha256": "5334bd20f90595932ac38fb18d8aad1d08c75c03af1ac14ae838c795b64c9ce9",
+      "bytes": 13144
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_snapshot.rs",
+      "sha256": "1d1c0e6a849cd82f8c79943915de7c28fcabefb8c6ba43f81efd9cc1e2a4ca7d",
+      "bytes": 26189
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_snapshot_tests.rs",
+      "sha256": "49a0cdd1ea033e32209594e4eaf2973c8e7c4a094ead42444b34a6dd7753babe",
+      "bytes": 19506
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_training.rs",
+      "sha256": "0b056cc7bc210e1201f84f09eae925752954db291aa0d4a095f64a595589602d",
+      "bytes": 16601
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/value_types.rs",
+      "sha256": "27854d550c5d3a5ab9c66af51ac664da76d93cd69ba18f8ed5b0728fc0b2919b",
+      "bytes": 5749
+    },
+    {
+      "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "sha256": "e50a90b174fb77ef1d907240422ba2cb28ee2fc1e1efafa4deb7c94afe3de19e",
+      "bytes": 33647
+    },
+    {
+      "path": "src/native_geometric_cli.rs",
+      "sha256": "3650a33b69cf3db54d681b476cd315d004e28ef5f00e2fa855371cfe45269a88",
+      "bytes": 63040
+    },
+    {
+      "path": "src/native_geometric_service.rs",
+      "sha256": "027138a106d9510004d8c35afb4fa6b524b3fa817cd92ba5fe0f316af320a691",
+      "bytes": 73692
+    }
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,7 +7,68 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
-## Typed values with geometric completion — 2026-09-05
+## Response entry with preserved typed completion — 2026-09-05
+
+The current artifact adds `uor-r4.native-response-entry/1` to the unchanged
+stronger occurrence reader `/4`, typed `/2` and numeric-completion `/1` model.
+It learns canonical lexical entry after the typed selector chooses NoWrite,
+commits only after matching observation, and corrects subsequent tokens from
+bounded actual history and relative H4/zeta state. Numeric selection retains
+precedence; no artificial numeric write or response template is inserted.
+
+| Same 32 OPEN development cases | Correct numeric targets | Exact prose | Exact Rust |
+| --- | ---: | ---: | ---: |
+| Full | 24/24 | 16/16 | 16/16 |
+| Entry disabled | 24/24 | 12/16 | 12/16 |
+| Entry geometry disabled | 24/24 | 12/16 | 12/16 |
+
+The eight previously incorrect NoWrite forms now complete. All eight binding
+outputs remain exact. All twenty saved Rust records compile and pass execution
+checks: sixteen numeric assertion programs and four identity functions tested
+through separate seven-input callers, with eighteen distinct complete sources.
+The first entry stays correct when geometry features are disabled, but subsequent
+corrections disappear despite equal thirteen-token support. Ordinary decoding
+supplies parts of every successful nonnumeric response and all its EOS choices.
+This is combined score dependence within one fitted artifact, not a matched
+refit, learned stopping or general geometric superiority.
+
+The separate four-case transfer check is **0/4**: Oslo/Lima facts still receive
+Unknown, and changing the Rust parameter to `input`/`count` still yields `value`;
+both unchanged new Rust files fail compilation. Content-dependent response
+selection is the observed remaining limitation. The head's thirteen-token support
+cannot spell these outputs; ordinary model candidate absence was not measured.
+The next content intervention should connect bounded retained occurrence/span
+selection to response entry and observation, using actual query/source relation
+features, rather than expanding fixed response-form priors.
+
+The final runtime also reuses captured NoWrite while entry is active, avoiding
+repeat failed operand searches under a verified frozen-input invariant. The
+[response-entry record](../native_geometric_response_entry_973.md) and
+[compact evidence](../evidence/native_geometric_response_entry_973.json) bind the
+behavior, controls, costs, persistence, source and compiler receipts. Artifact:
+`.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json`, CID
+`blake3:316837f19043a4a69b481b44c234c06dc3a4c4a688069707eb1ea7137085a574`.
+
+The same-artifact runtime optimization preserves all 104 compared generations
+apart from decreased typed work. Across eight successful NoWrite responses,
+proposals fall 256→32 and checked additions 128→16 (87.5% reductions); across
+all 32 Full cases, additions fall 320→208. Ordinary scoring remains. This is
+counted work, not a measured whole-model latency advantage.
+
+The owner's approved storage cap is now 4,336,910,336 bytes (+40 MiB), with the
+same 128 MiB stop margin. Cumulative model work is 925.824/1,800 seconds;
+874.176 seconds remain. The 14:33:17 UTC accounting snapshot is 4,174,245,888
+bytes, leaving 28,262,400 bytes under the checked-cycle ceiling. The largest
+recent release-build growth was 30,887,936 bytes, before subsequent retained
+outputs. Another checked implementation cycle is not admitted. All material,
+including new generated compiler products and both historical negatives, is
+preserved; metadata and protected delivery continue within their reserve.
+
+Earlier checkpoints and their then-current next actions follow. Preserve their
+evidence; use this pointer and live GitHub for active work. Final held-out
+qualification and both alpha capability groups remain unqualified.
+
+## Preceding typed values with geometric completion — 2026-09-05
 
 The current development artifact adds optional `uor-r4.native-value-completion/1`
 to the stronger occurrence-memory `/4` reader and typed-value `/2` component.

--- a/docs/native_geometric_mechanism_map_973.md
+++ b/docs/native_geometric_mechanism_map_973.md
@@ -195,6 +195,157 @@ additional work; counters name operations, not every machine instruction.
 There are no runtime floats, matrix products or steady-state allocations in
 this component. Fitting, serialization and initialization are separate host work.
 
+## Learned response entry — 2026-09-05
+
+The optional `uor-r4.native-response-entry/1` component in
+[`response_entry_types.rs`](../crates/uor-r4-core/src/native_geometric/response_entry_types.rs),
+[`response_entry_runtime.rs`](../crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs)
+and [`response_entry_training.rs`](../crates/uor-r4-core/src/native_geometric/response_entry_training.rs)
+addresses a different entry condition from the committed-numeral head. The
+preceding numeric artifact has eight incorrect NoWrite development responses,
+where no derived write exists and numeric completion cannot anchor. This
+implementation's [record](native_geometric_response_entry_973.md) reports all
+eight repaired responses, preserved numeric behavior and four content-transfer
+failures. Exact development response forms do not establish grounded abstention
+or arbitrary identifier binding.
+
+At an explicit response boundary, the state captures the absolute observation
+count, cumulative typed H4 pose, eight fixed-zeta phases and final query-cue
+prime. It retains the last two actual token IDs, actual observation count,
+progress count, active flag and latest action. This origin is a response
+boundary, not a numeric derivation or an invented value record. Eligibility
+requires active typed state, at least one captured numeric source and a
+nonempty query. The typed operator runs first; a positive typed proposal or
+committed numeral emission prevents response entry from offering a token.
+Consequently the new component does not yet serve arbitrary prompts without
+retained numeric sources, or decide when to insert a numeral after prose.
+
+The first selected non-EOS entry token commits `Enter` only when that exact
+prediction is observed at the captured boundary. Repeated prediction cannot
+activate or advance the response. An initial Base or mismatching observation
+closes entry until the next explicit response boundary. After entry, actual
+observations advance the retained history and progress, including mismatches;
+these do not create target-selected provenance. Later learned actions are
+`Emit` and `Stop`, with zero-score Base retained. EOS closes the state.
+Thirty-two actual response observations deactivate the component without
+forcing EOS. Empty continuation preserves an active response; new input
+establishes a new boundary through the existing session callers.
+
+Sixteen feature addresses contain bias, last-token prime, ordered last-two
+primes, captured query-end prime, query/last-prime pair and progress, plus
+`inverse(boundary.pose) * current_typed_pose`, separate signed orientation
+and eight upper-four-bit wrapped phase differences. Entry kinds 0–15 and
+continuation kinds 16–31 occupy disjoint rows. The exact token identities and
+bounded endpoint state survive; arbitrary source text, syntax/dependency
+structure, a full response transcript and individual earlier phase terms do
+not. Finite H4 state and quantized phase features compress history without
+establishing semantic abstraction. Prime and content identities remain
+addresses/integrity, never numeric semantic distances. Existing exact
+`Z[phi]`, radial and paired-H4/icosian state retains its previous roles.
+
+The new head learns **canonical lexical-token/EOS** associations. It can
+therefore preserve learned lexical pieces as single decisions, with ordinary
+byte fallback for other text. The earlier committed-value head learns
+**byte/EOS** associations after a causally emitted numeral, whose exact digits
+are fixed byte tokens. These laws share the model codec and ordinary decoding
+but have distinct boundaries and artifacts. In particular, the 49-byte NoWrite
+prose target exceeds the existing 32-byte completion horizon; response entry
+uses its canonical token length explicitly. Fitting skips a whole example
+when its token sequence plus EOS exceeds 32 or would exceed the remaining
+position budget. It neither truncates the target nor appends a template.
+
+Training reuses the sparse optimizer extracted from
+[`completion_training.rs`](../crates/uor-r4-core/src/native_geometric/completion_training.rs).
+First it collects actual eligible boundary frames and learns entry scores,
+with Base excluded as a correct state-creating action even when Base already
+predicts the target token. It exports quantized first-step rows, executes those
+rows through ordinary selection/observation, and collects continuation frames
+only after a matching selected Enter actually commits. Subsequent authored
+tokens supply declared teacher forcing through actual observation. Continuation
+rows learn separately while the entry rows remain fixed. The final merged
+global postings are followed by actual first-entry and complete free-running
+checks. Reports distinguish numeric upstream verification, NoWrite examples,
+whole-example skips, candidate coverage, entry failures, phase-specific fitting
+and final responses. The five configuration words bind epoch budget, exact
+learning-rate bits, position cap and both selected epochs. The component's
+baseline identity binds the unchanged numeric completion model and all its
+preceding typed/memory/readout state.
+
+Both heads share bounded candidate gathering and integer score reduction in
+[`completion_runtime.rs`](../crates/uor-r4-core/src/native_geometric/completion_runtime.rs).
+Per eligible prediction, response entry performs at most sixteen row queries,
+80 posting offers, 1,280 duplicate-token comparisons, sixteen retained candidate
+writes/evaluations and 256 score lookups. At 4,096 rows, row lookup uses at most
+13 comparisons; the 32,768-association artifact cap bounds each token lookup
+by sixteen comparisons, hence at most 4,096 score-token comparisons. Features
+add two H4 reads, one orientation read, eight wrapped phase subtractions and
+three token/row-base metadata reads. These are conservative source bounds,
+not latency measurements. The fixed feature/token/row-index arrays occupy
+448 logical bytes on a 64-bit host; StateView separately reports the actual
+persistent state layout. Boundary capture copies three scalar fields and eight
+phases; every observation updates the three history scalars. Pending decisions,
+control branches, resets, shortlist insertion and all model tables remain
+additional cost beyond those array sizes and named counters.
+
+The work record uses the shared `CompletionWork` shape. Its entry `anchors`
+counter measures eligible boundary captures, which can precede numeric
+preemption; actual learned entry is identified by the committed `Enter`
+action. All ordinary decoder, `/4` occurrence routing, typed ingestion,
+operand/action scoring, checked additions and numeric-completion work still
+execute at their existing scopes. The final runtime reuses captured NoWrite
+after Enter commits while the response stays active. Sources, query tokens/words
+and model/control remain fixed; current pose/history and ordinary score cannot
+turn that absent proposal positive. EOS, cap and new boundaries restore the
+search; restoration rechecks its origin. The record measures this same-artifact
+avoidance of repeated failed operand searches separately. It is not a sparse
+first-pass arithmetic router, whole-model latency advantage or transformer
+comparison. Loading, canonical tokenization, rendering, training and snapshot
+validation are allocating host work and belong in complete cost accounting.
+
+[`response_entry_snapshot.rs`](../crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs)
+validates the response-boundary origin, retained actual history, progress and
+geometry in session schema `/5`. It rechecks the original typed NoWrite and
+learned first-entry selection using captured state, and rejects a fabricated
+entry or transient pending prediction in persisted data. The active span fits
+the existing 32-entry typed metadata ring before the cap clears its origin.
+Older source truth after eviction remains unauthenticated. Absence of this
+component preserves the prior model and session serialization laws.
+
+## Historical multiscale source inspection for response entry
+
+The historical pieces below remain unchanged evidence. Source inspection found
+reusable update/admission arrangements, with different payload and serving
+contracts from the active response-entry problem:
+
+- [`fixed_recurrent_kv_binding.py::_merge_local_summaries`](../tools/r4-softmax-trainer/src/r4_softmax_trainer/fixed_recurrent_kv_binding.py)
+  transports older K/V into the newer H4 frame and takes a count-weighted mean.
+  `_fold_evicted` uses four binary-carry summary banks beside eight exact live
+  records; its final bank absorbs overflow. Means, counts, latest frames and
+  latest positions survive, while individual evicted K/V values/identities and
+  detailed within-bank order cannot be reconstructed. This fixed compression
+  does not learn semantic consolidation. Original dense Q/K/V/O, softmax and
+  continuous state remain part of the computation.
+- [`sparse_geometric_kv_binding.py::_rank_candidates`](../tools/r4-softmax-trainer/src/r4_softmax_trainer/sparse_geometric_kv_binding.py)
+  examines the twelve-slot metadata directory, orders exact signed-S3 shells,
+  applies greedy maximin separation and age/slot ties, and admits at most eight
+  persistent slots. Only afterward does `_selected_r4_attention` gather K/V
+  and execute unchanged learned Q/K softmax. The gate itself is unfitted. This
+  supplies an admission-before-expensive-gather pattern, but no learned query
+  semantics, numeric result path or response-entry/termination operator.
+- [`quaternion_cube_nonlinear.py::_post_attention_nonlinear`](../tools/r4-softmax-trainer/src/r4_softmax_trainer/quaternion_cube_nonlinear.py)
+  applies a framed quaternion-cube residual to twelve R4 cells. It retains
+  floating-point frame products, reciprocal and RMS normalization. Its
+  mechanical dense-MLP replacement and preserved block norms did not preserve
+  useful generated text; its attempted fit stopped on resources before a new
+  quality result. It does not solve missing learned response entry.
+
+These sources informed integration choices, rather than being copied into the
+new Rust serving path. Reusing the existing integer candidate scorer, actual
+query boundary and causal observation interfaces directly addresses the
+observed NoWrite entry/continuation gap. A future multiscale retention change
+still needs a stated payload, loss/retention law, learned query selector,
+operator and complete cost; no new multiscale capability is asserted here.
+
 ## Historical pieces and what they can contribute
 
 | Preserved piece | Reusable function | Established limit |

--- a/docs/native_geometric_response_entry_973.md
+++ b/docs/native_geometric_response_entry_973.md
@@ -1,0 +1,267 @@
+# Native response entry after NoWrite — #973
+
+Date: 2026-09-05. Status: retained bounded response correction and reduced
+repeated typed work; content-transfer negative preserved. The
+[native project plan](integration/project-track.md) owns the objective.
+
+## Recovered cause and preserved baseline
+
+Protected PR #1131 delivered the preceding numeric completion model at
+`4f2dfe3eb91fb24a87f25bc57be48dad0f3cfa84`. Live source, GitHub, artifact hashes,
+prior output receipts, resource accounting and all 33 worktrees were reconciled
+before this change. The preceding [completion record](native_geometric_value_completion_973.md)
+remains evidence at its original scope. Full generated all 24 numeric targets
+and completed 12/16 prose and 12/16 Rust responses on the 32 reused development
+cases. Eight NoWrite cases remained incorrect: no numeric write existed, so
+completion could not anchor. The stronger occurrence reader `/4`, typed `/2`,
+completion `/1` and both historical reader `/5` negatives were preserved.
+
+This observed entry failure selected the current change. A matched geometry-free
+numeric-completion refit remains useful for attribution, but would not open a
+response path when no numeral is written. NoWrite training has only two response
+forms: the 49-byte unsupported-city sentence and an identity-function body using
+the fixed parameter `value`. The frozen codec represents them in eleven and three
+lexical tokens respectively, plus EOS. Both fit the existing 32-position state
+horizon. No vocabulary, token-ring or arithmetic-capacity increase is needed.
+
+## Representation, selection and execution
+
+The optional `uor-r4.native-response-entry/1` head retains a distinct response
+boundary: absolute observation count, cumulative typed H4 pose, eight fixed-zeta
+phases and query-end cue prime. Last-two actual tokens, observation count,
+progress, active state and latest action complete the bounded state. It does not
+invent a numeric record or reuse a derived-write identity.
+
+At the response boundary the typed selector executes first. Only an eligible
+active, unconsumed query with retained numeric sources and no selected typed
+proposal may offer response entry. The candidate with the largest positive head
+increment competes after that increment is added to the ordinary baseline score.
+Only observing that exact selected token commits
+Enter. Repeated predictions do not advance state, and an initial mismatching or
+unselected observation closes entry. Committed continuations follow the actual
+observed tokens, including later mismatches. EOS ends the state whether selected
+by this head or by the ordinary Base path. The 32-observation cap clears entry
+without fabricating EOS.
+
+Sixteen features use bias, last prime, ordered last-two primes, query-end prime,
+query/last-prime pair, step, relative H4, signed orientation and eight quantized
+phase differences. Entry and continuation occupy disjoint kind ranges 0–15 and
+16–31. Learned sparse rows score canonical lexical tokens and EOS; the numeric
+completion head continues to score byte tokens after an observed numeral. Both
+reuse the same bounded candidate/scoring implementation and normal output codec.
+
+Prime identity supplies addresses, not a semantic distance. Relative H4 and
+upper-four-bit phase differences compress the observed path; they do not retain
+arbitrary source text, syntax, entity roles or dependencies. Retention and
+eviction remain fixed. This head learns entry/next-token scores and postings,
+not semantic memory consolidation. Existing exact `Z[phi]`, radial,
+paired-H4/icosian and UOR identity roles are unchanged. The
+[mechanism map](native_geometric_mechanism_map_973.md#learned-response-entry--2026-09-05)
+names each representation and the inspected historical multiscale mechanisms.
+
+## Fitting and evaluation boundary
+
+The same 192 raw source pairs supervise this additive head. Numeric rows are
+checked through the frozen complete model and do not train entry. Whole NoWrite
+responses are encoded canonically plus EOS; overlong or overbudget examples are
+skipped whole. First-entry fitting treats equal-token Base as insufficient to
+create entry. Quantized entry rows must actually select Enter, which is then
+observed, before continuation frames are collected. Later authored tokens supply
+explicit offline teacher forcing. Continuation rows learn separately; merged
+global postings are followed by actual entry and full free-running checks.
+
+Configuration is 24 epochs, learning rate 0.1 and at most 4,096 positions, with
+4,096 rows, 32,768 associations and sixteen candidate tokens. Rust training uses
+floating-point sparse optimization; serving uses integer/table scores and state
+updates. The exported artifact binds the unchanged completion baseline,
+configuration and ordered source receipts, then is serialized/reloaded before
+evaluation. Removing entry reproduces the preceding baseline identity.
+
+The primary comparison uses the same 32 OPEN development cases plus eight
+separate binding outputs. Full, ResponseEntryDisabled and
+ResponseEntryGeometryDisabled use the same 64-token generation ceiling. Controls
+disable only the new head or its H4/orientation/phase score features; they are
+not separately fitted baselines. Prior preservation uses the original 32-token
+ceiling. A separate four-case OPEN transfer diagnostic adds explicit city facts
+and renames identity parameters. Its expected outputs remain evaluator-only.
+These revealed, small shared-form populations are not final held-out evaluation.
+
+## Complete cost and persistence
+
+Per eligible prediction the new head bounds work to sixteen row queries,
+80 posting offers, 1,280 duplicate comparisons, sixteen retained candidates and
+256 score lookups. Row search takes at most thirteen comparisons at 4,096 rows;
+token search takes at most sixteen under the association cap. At the current
+611-token vocabulary a conservative eleven comparisons per score lookup gives
+2,816. Features add two H4 reads, one orientation read, eight phase subtractions
+and three token/row-base metadata reads. Fixed feature/token/row-index arrays
+occupy 448 logical bytes on the current 64-bit host, separately from persistent
+state, stack locals, model tables and host RSS.
+
+Boundary capture copies three scalar fields and eight phases. Every observation
+updates three history scalars; pending decisions, resets and shortlist insertion
+remain additional work. The shared work shape's `anchors` field counts boundary
+captures, including those later preempted by numeric selection. Enter actions
+and observed commits establish actual entry. Public evaluation now aggregates
+all typed, completion and entry counters; earlier evaluation omitted the nested
+components even when they executed. Generation already retained their counters.
+
+Ordinary decoding and `/4` memory still execute before this head. Initial
+NoWrite selection at full occupancy visits 272 slots, scores up to
+256 proposals and executes 240 checked additions before ranking, with cue/path
+and whole-word comparisons. Once Enter commits, the final runtime reuses that
+NoWrite result while entry remains active. Typed proposals depend only on frozen
+sources, captured query tokens/words, immutable model parameters and fixed
+control; the changing response pose and baseline score cannot change an absent
+proposal. Restoration independently rechecks the original gate. EOS, cap and
+new response boundaries restore the search. This avoids repeated failed operand
+searches without a sparse first-pass operator router or bypassing ordinary
+scoring. No transformer comparison,
+whole-model speedup or learned multiscale abstraction follows from these bounds.
+Encode/decode, loading, fitting, snapshots and generated-code checks remain host
+work and are charged at their declared scopes.
+
+Session schema `/5` validates entry only after typed/completion restoration.
+It checks query origin, actual recent tokens, progress, H4/phase evolution and
+transient-field absence, then replays the original typed gate and first entry
+selection from captured state. It checks consistency with retained evidence,
+not authenticity of evicted source truth. The actual active span fits the existing
+32-entry typed metadata ring. Older artifacts retain their prior serialization
+and behavior. CLI, core and HTTP use the same predict/observe law; empty HTTP
+continuation preserves the active response.
+
+## Executed result
+
+The artifact is
+`blake3:316837f19043a4a69b481b44c234c06dc3a4c4a688069707eb1ea7137085a574`,
+at `.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json`.
+It adds 170 rows and 250 associations. All 160 numeric training responses verify;
+32/32 first entries actually commit, 224/224 continuation targets fit, and
+32/32 NoWrite training responses complete. No upstream failure, position skip,
+row/association drop or unexpected typed write occurs.
+
+| Same 32 OPEN development cases | Correct numeric targets | Exact prose | Exact Rust |
+| --- | ---: | ---: | ---: |
+| Full | 24/24 | 16/16 | 16/16 |
+| Entry disabled | 24/24 | 12/16 | 12/16 |
+| Entry geometry disabled | 24/24 | 12/16 | 12/16 |
+
+All eight primary NoWrite cases improve from incorrect to exact. All 24 numeric
+and eight binding outputs retain their entire preceding Generation objects after
+removing only the added entry telemetry. A separate saved-baseline replay under
+the new implementation reproduces all forty original Generation objects exactly.
+Raw reports, integer-safe comparisons and the independent audit are bound by
+[compact evidence](evidence/native_geometric_response_entry_973.json).
+
+Full combines selected head corrections with ordinary decoding. Prose uses Enter
+at step 0 and Emit at steps 1, 2, 3, 9 and 10; steps 4–8 and EOS 11 come from
+Base. Rust uses Enter 0 and Emit 1; newline 2 and EOS 3 come from Base. None of
+these eight responses contains a head-selected Stop. Actual observed EOS closes
+the entry. This is coordinated entry/continuation correction, not sole-head
+generation or learned stopping evidence.
+
+Every head row posting and score token belongs to the same thirteen global
+tokens. Full and geometry-disabled have complete equal head support below the
+sixteen-token cap, with zero drops. Both choose the correct first Enter on all
+eight cases. Geometry-disabled then selects no Emit, follows 31 Base steps and
+hits the 32-step component cap. It makes 256 eligible head requests versus Full's
+64, so total work differs. Combined H4/orientation/phase score dependence is
+established for this fitted continuation correction; separate-term attribution,
+a geometry-free refit and general geometric superiority remain unmeasured.
+First-entry relative geometry is identity/zero-phase and adds a common 740 to
+the chosen score; that contribution does not establish factual conditioning.
+
+All twenty unchanged saved Rust records compile and pass execution: sixteen
+numeric assertion programs plus four identity libraries with separate callers
+testing seven i32 values each, including both extrema. They contain eighteen
+distinct complete source hashes. Caller code and all compiler products are
+retained; the model did not generate or execute those callers itself.
+
+The separate four-case content-transfer diagnostic scores **0/4**. Even with
+`orin lives in Oslo` or `orin lives in Lima` explicitly supplied, the model emits
+` Unknown. The conversation does not give a city.\n`. Renaming the identity
+parameter to `input` or `count` still produces `value\n}\n`; both unchanged Rust
+files fail compilation because `value` is undefined. These failures establish
+neither a grounded abstention policy nor general identifier binding. The head's
+thirteen-token support cannot spell those required outputs, while its first-step
+features omit source-content selection. Whole-model candidate absence was not
+measured: ordinary retained-token decoding remains available.
+
+The final NoWrite reuse optimization was evaluated with the **same artifact**,
+source, controls and generation ceiling, without fitting. All 96 primary/control
+and eight binding Generation objects retain exact bytes, tokens, stops, scores,
+traces, state and non-typed work. Numeric and entry-disabled objects remain
+entirely identical. Only typed search counters fall:
+
+| Counted typed work | Eight Full NoWrite before | After reuse | All 32 Full before | After reuse |
+| --- | ---: | ---: | ---: | ---: |
+| Valid proposals | 256 | 32 | 528 | 304 |
+| Checked additions | 128 | 16 | 320 | 208 |
+| Feature lookups | 15,040 | 1,872 | 30,772 | 17,604 |
+
+The eight successful NoWrite responses avoid 87.5% of their repeated proposals
+and additions. The full primary population avoids 35% of checked additions.
+This is a counted serving-work reduction from reusing an invariant decision;
+first-pass sparse arithmetic routing, latent geometric superiority and total
+latency improvement are not established. The four transfer outputs and all
+twenty generated Rust source hashes also remain unchanged under the final
+binary, preserving their existing compiler/execution results without rerunning
+identical generated programs.
+
+## Verification, resources and delivery
+
+Local verification used pinned rustup Cargo 1.97.1, offline dependencies,
+`CARGO_TARGET_DIR=/tmp/r4-native-geometric-target`, one Cargo job, disabled
+incremental compilation and zero dev/test debug info. Commands and full logs
+are retained under the artifact root:
+
+- `cargo test -p uor-r4-core --lib native_geometric --offline`: final 96/96,
+  including entry fitting, causal state, caps, malformed snapshots, layered
+  artifact identity, work aggregation and NoWrite reuse. Earlier runs passed
+  89/89 and 95/95 before the final guard/test.
+- `cargo test -p uor-r4-core --test native_geometric_allocations --test windowed_geometric_context --example native_geometric_value_probe --offline`:
+  5 allocation/source checks, 3 context checks and 4 probe checks pass.
+- `cargo test --bin r4 native_geometric_ --offline`: 17 pass; the new service
+  test initially asserted head-selected Stop although ordinary EOS is permitted.
+  Its correction checks actual stopped state and retains exact/split/import
+  continuity assertions; the focused rerun passes. It changed only the test.
+- Combined release CLI/probe build passes twice, including the final NoWrite
+  guard. All selected-artifact replay and final CLI transfer runs use that final
+  build. The later guard introduces no allocation and changes no public schema;
+  final protected CI also exercises the configured allocation/context/service
+  boundary. Queue compatibility acknowledgements are not substitutes for tests.
+- Formatting, native architecture-policy and claim-wording checks pass. Broad
+  legacy fuzz, WASM, Gate C, teacher parity and final held-out qualification
+  remain NOT_RUN in this development cycle.
+
+The owner explicitly approved a 40 MiB storage-cap increase, from 4,294,967,296
+to **4,336,910,336 bytes**, retaining the 128 MiB stop margin, 4 GiB model-process
+RSS target and one-model-process limit. No deletion, new clone or paid compute
+was authorized or performed. The existing full worktree was reused on
+`codex/native-response-entry`; all 33 worktrees and intentional main-checkout
+research/untracked material remain preserved.
+
+Cumulative model work is **925.824/1,800 seconds**, leaving **874.176 seconds**.
+This cycle charges 22.298 seconds across fitting, all controls, preservation,
+both transfer passes and generated-code compilation/execution. Engineering
+builds/tests are separately logged at 1,418.620 seconds, including the failed
+test assertion and correction. Direct fit-process peak RSS sampled at one-second
+intervals is 362,987,520 bytes; subsecond runs have unavailable RSS, not zero.
+Compiler-check wrapper samples exclude descendant rustc RSS; engineering compiler
+peak RSS is unavailable. These are sampled process measurements, not exact
+whole-machine peaks.
+
+At 14:33:17 UTC, conservative cumulative storage is **4,174,245,888 bytes**.
+Usable growth under the checked-cycle ceiling is 28,262,400 bytes. The largest
+sampled total in this cycle was 4,194,951,168 bytes; the two release builds added
+sampled peaks of 30,887,936 and 27,111,424 bytes. A further checked implementation
+cycle is not admitted by the remaining growth once compiler retention and replay
+are included. Preserve this checkpoint rather than silently increasing the cap.
+Source hashes, raw reports, both binary revisions and resource receipts are bound
+by the compact evidence. Later metadata/delivery snapshots remain local receipts.
+
+The next content change is bounded retained occurrence/span admission and learned
+query/source selection at response entry, followed by causal continuation from
+the observed selected content. The existing ordinary memory path is the integration
+point; adding more fixed response forms would not address the demonstrated city
+and parameter failures. A new implementation needs its own storage admission.

--- a/docs/native_geometric_workflow.md
+++ b/docs/native_geometric_workflow.md
@@ -9,6 +9,8 @@ ordinary token memory-write law. The optional typed-value component separately
 learns operand/action selection and whether to write its result.
 An optional completion component learns byte/EOS transitions after a committed
 typed numeral, while preserving that upstream model.
+An optional response-entry component learns canonical lexical transitions after
+an eligible typed NoWrite decision, with observation-only entry commitment.
 An optional learned memory reader retrieves actual retained token values through
 prime-addressed postings, query/source offsets and relative H4/zeta features.
 It is versioned separately in the artifact; the original fixed/readout-only
@@ -135,6 +137,47 @@ bounded routing mechanisms alone.
 The [completion record](native_geometric_value_completion_973.md) and
 [compact evidence](evidence/native_geometric_value_completion_973.json) bind
 the artifact, direct outputs, controls and separate compiler/execution results.
+
+### Response entry after NoWrite
+
+`Model::fit_response_entry` and the same Rust example add the optional
+`uor-r4.native-response-entry/1` head over a frozen completion model:
+
+```sh
+target/release/examples/native_geometric_value_probe entry \
+  --model /absolute/path/to/completion-fit-1/model.json \
+  --source /absolute/path/to/completion-fit-1/source.json \
+  --lexeme-cues true --output-dir /absolute/path/to/new-entry-run \
+  --epochs 24 --learning-rate 0.1 --entry-max-positions 4096 \
+  --generated-tokens 64 --max-seconds 120
+```
+
+Apply the inherited cumulative resource monitor and admit the full checked
+cycle before running. Entry mode bounds saved output to 20 MiB. Its source is
+the same raw 192-pair population; numeric examples verify the unchanged upstream
+path. Whole NoWrite targets use canonical lexical tokens plus EOS, capped at
+32 positions each. First-entry rows must select Enter and observe it before
+continuation fitting; target labels cannot create a hidden serving boundary.
+
+The example reloads the exported model and records Full, ResponseEntryDisabled
+and ResponseEntryGeometryDisabled. The corresponding CLI controls are
+`response-entry-disabled` and `response-entry-geometry-disabled`. They retain
+ordinary, typed and numeral-completion components. Generation exposes optional
+`response_entry_trace`; persistent state uses session schema `/5`. Pending
+predictions remain transient, repeated prediction is idempotent, mismatching
+observations follow actual history, and empty HTTP continuation preserves an
+active response. Once Enter commits, the runtime skips repeated typed NoWrite
+search until EOS, cap or a new boundary. Captured source/query inputs justify
+that reuse; it does not alter fitted model bytes or skip the first typed search.
+
+The [response-entry record](native_geometric_response_entry_973.md) reports
+16/16 exact responses in each family on reused development, twenty generated
+Rust execution passes, preserved numeric behavior and four content-transfer
+failures. The latter prevent a grounded abstention or general coding claim.
+The successful nonnumeric responses use ordinary Base for several tokens and
+every EOS; selected head Stop is a supported mechanism, not a measured action
+in these eight outputs. Work reduction, equal head candidate support and total
+execution cost are reported separately from model quality.
 
 ### General corpus preparation
 

--- a/src/native_geometric_cli.rs
+++ b/src/native_geometric_cli.rs
@@ -260,6 +260,8 @@ enum ControlArg {
     ValueLexemesDisabled,
     ValueCompletionDisabled,
     ValueCompletionGeometryDisabled,
+    ResponseEntryDisabled,
+    ResponseEntryGeometryDisabled,
 }
 impl From<ControlArg> for Control {
     fn from(value: ControlArg) -> Self {
@@ -278,6 +280,8 @@ impl From<ControlArg> for Control {
             ControlArg::ValueLexemesDisabled => Self::ValueLexemesDisabled,
             ControlArg::ValueCompletionDisabled => Self::ValueCompletionDisabled,
             ControlArg::ValueCompletionGeometryDisabled => Self::ValueCompletionGeometryDisabled,
+            ControlArg::ResponseEntryDisabled => Self::ResponseEntryDisabled,
+            ControlArg::ResponseEntryGeometryDisabled => Self::ResponseEntryGeometryDisabled,
         }
     }
 }

--- a/src/native_geometric_service.rs
+++ b/src/native_geometric_service.rs
@@ -412,6 +412,7 @@ impl Service {
         let mut response_trace = Vec::new();
         let mut value_trace = Vec::new();
         let mut completion_trace = Vec::new();
+        let mut response_entry_trace = Vec::new();
         let mut output_bytes = 0;
         let mut stop = "token_limit";
         for _ in 0..request.max_tokens {
@@ -433,6 +434,11 @@ impl Service {
             if let Some(decision) = session.completion_decision() {
                 if completion_trace.len() < 96 {
                     completion_trace.push(decision);
+                }
+            }
+            if let Some(decision) = session.response_entry_decision() {
+                if response_entry_trace.len() < 96 {
+                    response_entry_trace.push(decision);
                 }
             }
             if let Some(decision) = session.response_decision() {
@@ -471,6 +477,9 @@ impl Service {
             "persisted":self.session_directory.is_some() && persist_error.is_none(),"persistence_error":persist_error});
         if self.model.value_completion_version().is_some() {
             response["completion_trace"] = json!(completion_trace);
+        }
+        if self.model.response_entry_version().is_some() {
+            response["response_entry_trace"] = json!(response_entry_trace);
         }
         Ok(response)
     }
@@ -1203,6 +1212,8 @@ mod tests {
         );
         assert_eq!(complete["text"], "17.\n");
         assert_eq!(complete["stop"], "end_of_sequence");
+        assert!(complete.get("response_entry_trace").is_none());
+        assert!(complete["state"].get("response_entry").is_none());
         let first = post(
             Arc::clone(&service),
             "/api/generate",
@@ -1250,6 +1261,137 @@ mod tests {
             assert_eq!(second["session_work"], complete["session_work"]);
             assert_eq!(second["session_work"]["values"]["derived_writes"], 1);
         }
+    }
+
+    #[test]
+    fn native_geometric_response_entry_http_resumes_observed_lexical_tokens() {
+        use uor_r4_core::native_geometric::{
+            ResponseEntryFitConfig, ValueCompletionFitConfig, ValueExample, ValueFitConfig,
+        };
+        let catalog = [Document {
+            id: "entry-service-catalog".into(),
+            text: "left = 13; right = 4; total: 17.\nreply: Unknown.\n Unknown.\n".into(),
+        }];
+        let mut trainer = Trainer::new(
+            Config {
+                context_tokens: 32,
+                candidate_limit: 8,
+                ..Config::default()
+            },
+            &catalog,
+        )
+        .unwrap();
+        trainer.train_documents(&catalog).unwrap();
+        let examples = (0..4)
+            .flat_map(|index| {
+                [
+                    ValueExample {
+                        id: format!("entry-service-numeric-{index}"),
+                        prompt: format!("left = {}; right = 4; total:", 13 + index),
+                        response: format!("{}.\n", 17 + index),
+                    },
+                    ValueExample {
+                        id: format!("entry-service-no-write-{index}"),
+                        prompt: format!("left = {}; right = 4; reply:", 13 + index),
+                        response: " Unknown.\n".into(),
+                    },
+                ]
+            })
+            .collect::<Vec<_>>();
+        let (typed, _) = trainer
+            .compile()
+            .unwrap()
+            .fit_values_with_lexeme_cues(
+                &examples,
+                ValueFitConfig {
+                    epochs: 64,
+                    learning_rate: 0.25,
+                    max_features: 4096,
+                },
+            )
+            .unwrap();
+        let (completion, _) = typed
+            .fit_value_completion(&examples, ValueCompletionFitConfig::default())
+            .unwrap();
+        let (fitted, _) = completion
+            .fit_response_entry(&examples, ResponseEntryFitConfig::default())
+            .unwrap();
+        let model = Model::from_bytes(&fitted.to_bytes().unwrap()).unwrap();
+        let encoded_response = model.encode(&examples[1].response).unwrap();
+        assert_eq!(encoded_response.len(), 3);
+        let service = Arc::new(Service::new(model, None).unwrap());
+        let complete_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let split_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let complete = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":complete_id,"prompt":examples[1].prompt,"max_tokens":16}),
+        );
+        assert_eq!(complete["text"], examples[1].response);
+        assert_eq!(complete["tokens"], json!(encoded_response));
+        assert_eq!(complete["stop"], "end_of_sequence");
+        assert_eq!(complete["session_work"]["values"]["derived_writes"], 0);
+        assert_eq!(complete["response_entry_trace"][0]["action"], "enter");
+        // The ordinary Base action may supply EOS. Its actual observation
+        // must still close the active entry and record the stop.
+        assert_eq!(complete["state"]["response_entry"]["active"], false);
+        assert_eq!(complete["state"]["response_entry"]["last_action"], "stop");
+        assert_eq!(complete["session_work"]["response_entry"]["stops"], 1);
+        let first = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":split_id,"prompt":examples[1].prompt,"max_tokens":1}),
+        );
+        assert_eq!(first["text"], " Unknown");
+        assert_eq!(first["state"]["response_entry"]["active"], true);
+        assert_eq!(first["session_work"]["values"]["derived_writes"], 0);
+        let exported = post(
+            Arc::clone(&service),
+            "/api/export",
+            json!({"session_id":split_id}),
+        );
+        assert_eq!(
+            exported["checkpoint"]["schema"],
+            "uor-r4.native-geometric-session/5"
+        );
+        let imported_id = id(&post(
+            Arc::clone(&service),
+            "/api/import",
+            json!({"checkpoint":exported["checkpoint"]}),
+        ));
+        for session_id in [split_id, imported_id] {
+            let second = post(
+                Arc::clone(&service),
+                "/api/generate",
+                json!({"session_id":session_id,"prompt":"","max_tokens":16}),
+            );
+            assert_eq!(second["observed_prompt_tokens"], 0);
+            assert_eq!(second["text"], ".\n");
+            assert_eq!(second["stop"], "end_of_sequence");
+            let mut tokens = first["tokens"].as_array().unwrap().clone();
+            tokens.extend(second["tokens"].as_array().unwrap().iter().cloned());
+            let mut trace = first["response_entry_trace"].as_array().unwrap().clone();
+            trace.extend(
+                second["response_entry_trace"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .cloned(),
+            );
+            assert_eq!(json!(tokens), complete["tokens"]);
+            assert_eq!(json!(trace), complete["response_entry_trace"]);
+            assert_eq!(second["state"], complete["state"]);
+            assert_eq!(second["session_work"], complete["session_work"]);
+        }
+        let numeric_id = id(&post(Arc::clone(&service), "/api/session", json!({})));
+        let numeric = post(
+            Arc::clone(&service),
+            "/api/generate",
+            json!({"session_id":numeric_id,"prompt":examples[0].prompt,"max_tokens":16}),
+        );
+        assert_eq!(numeric["text"], "17.\n");
+        assert_eq!(numeric["response_entry_trace"], json!([]));
+        assert_eq!(numeric["session_work"]["values"]["derived_writes"], 1);
     }
 
     #[test]


### PR DESCRIPTION
The numeric completion path could not anchor a response after the typed selector returned NoWrite. This adds optional learned lexical response entry and continuation, then reuses the established NoWrite decision while that response remains active. The same 32 open development cases improve from 12/16 to 16/16 exact prose and from 12/16 to 16/16 exact Rust, preserving all 24 numeric targets and eight binding outputs.

Entry captures the response-boundary H4/zeta/query state and commits only after its selected token is actually observed. Sparse integer/table inference, the existing codec, typed precedence, actual-history continuation, bounded state and validated session restoration remain shared across core, CLI and HTTP. The additive artifact has 170 rows / 250 associations and adds 49,374 serialized bytes. Nested typed/completion/entry work is now fully aggregated in evaluation.

The second change avoids repeated typed operand searches after observed Enter has established NoWrite. The same artifact produces 104/104 identical Generation objects except for reduced typed counters; 88 objects remain entirely identical. Across the eight Full NoWrite cases, proposals fall 256→32 and checked additions 128→16 (87.5%). Across all 32 Full cases, checked additions fall 320→208 (35%). This measures avoided logical work, not latency speedup. The prior completion baseline reproduces all 40 saved Generation objects exactly under the final binary.

The limitations are decision-bearing and retained in the record:

- Entry-disabled and entry-geometry-disabled each remain 12/16 prose and 12/16 Rust. Head candidate support is equal and complete; generated work differs. Combined fitted geometry dependence concerns continuation, not general geometric superiority or a separately fitted geometry-free comparison.
- Ordinary Base supplies parts of the successful responses and every observed EOS. This is not evidence of learned stopping.
- A separate four-case open content-transfer diagnostic scores 0/4: explicit Oslo/Lima facts still receive the stock Unknown response; renamed `input`/`count` parameters still generate `value` and both unchanged Rust files fail compilation. Whole-model candidate absence was not measured.
- The next content mechanism is bounded retained occurrence/span admission and query/source selection, requiring new storage admission before another checked implementation cycle. More fixed response forms would not solve this failure.

Validation completed locally:

- Final native core tests: 96 passed.
- Allocation/source checks: 5 passed; context: 3 passed; probe: 4 passed.
- CLI/service: 17 passed initially; one new test incorrectly required head-selected Stop. Its focused corrected rerun passed while retaining exact/split/import continuity assertions.
- Release CLI and probe built twice, including the final reuse guard; final artifact/control, baseline-preservation and transfer replays use that binary.
- Twenty unchanged generated Rust records (18 unique source hashes) compile and pass execution. Four identity libraries additionally pass 28 assertions through separate recorded callers. Final replay preserves all source hashes.
- Formatting, native architecture-policy and claim-wording checks passed. Both protected PR and merge-group CI passed: 96 native core, 3 context, 5 allocation/source and 18 CLI/service tests, plus formatting and architecture policy. The four other required queue statuses are compatibility acknowledgements; broad legacy audit/fuzz/WASM/Gate C and final held-out qualification were not run.

Cumulative model work is 925.824/1,800 seconds, including 22.298 seconds this cycle. Engineering builds/tests are separately logged at 1,418.620 seconds. The owner approved a 40 MiB cumulative storage-cap increase to 4,336,910,336 bytes, retaining the 128 MiB stop margin, 4 GiB model-process RSS target and one-model-process limit. The 14:33 UTC storage checkpoint accounts 4,174,245,888 bytes with 28,262,400 bytes usable under the checked-cycle ceiling; no further checked cycle is admitted. No material was deleted; all 33 worktrees and intentional main-checkout research/untracked state are preserved.

The detailed record, current-state pointer, mechanism map and compact hash-bound evidence are included. The selected local artifact is `.uor-models/native-typed-value-2026-09-05/entry-fit-1/model.json`, CID `blake3:316837f19043a4a69b481b44c234c06dc3a4c4a688069707eb1ea7137085a574`.

Refs #973. The broader native geometric capability objective remains open.
