### PR TITLE
Compose fact answers with retained-word copying and selective execution

### DIFF
--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -72,7 +72,7 @@ impl Options {
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "native_geometric_value_probe [prepare|prepare-copy|fit|completion|entry|copy|copy-completed|evaluate] --output-dir NEW_DIRECTORY\n\
+                    "native_geometric_value_probe [prepare|prepare-copy|prepare-facts|fit|completion|entry|copy|copy-completed|copy-composed|evaluate] --output-dir NEW_DIRECTORY\n\
                      prepare-copy: --source SOURCE_V2 --lexeme-cues true\n\
                      copy: --model ENTRY_MODEL --source SOURCE_V3 --lexeme-cues true --generated-tokens 64\n\
                      copy-completed: same source/parent, suffix frame starts after the observed copied word\n\
@@ -121,37 +121,50 @@ impl Options {
         if ![
             "prepare",
             "prepare-copy",
+            "prepare-facts",
             "fit",
             "completion",
             "entry",
             "copy",
             "copy-completed",
+            "copy-composed",
             "evaluate",
         ]
         .contains(&result.mode.as_str())
             || result.output_dir.as_os_str().is_empty()
-            || (!["prepare", "prepare-copy"].contains(&result.mode.as_str())
+            || (!["prepare", "prepare-copy", "prepare-facts"].contains(&result.mode.as_str())
                 && result.model.as_os_str().is_empty())
             || ([
                 "prepare-copy",
+                "prepare-facts",
                 "completion",
                 "entry",
                 "copy",
                 "copy-completed",
+                "copy-composed",
                 "evaluate",
             ]
             .contains(&result.mode.as_str())
                 && result.source.is_none())
             || ([
                 "prepare-copy",
+                "prepare-facts",
                 "completion",
                 "entry",
                 "copy",
                 "copy-completed",
+                "copy-composed",
             ]
             .contains(&result.mode.as_str())
                 && !result.lexeme_cues)
-            || (["completion", "entry", "copy", "copy-completed"].contains(&result.mode.as_str())
+            || ([
+                "completion",
+                "entry",
+                "copy",
+                "copy-completed",
+                "copy-composed",
+            ]
+            .contains(&result.mode.as_str())
                 && result.epochs > 64)
             || !(1..=4096).contains(&result.completion_max_positions)
             || !["all", "full"].contains(&result.controls.as_str())
@@ -496,13 +509,16 @@ fn source(options: &Options) -> ProbeResult<Source> {
     if options.mode == "prepare-copy" {
         append_word_copy_cases(&mut result)?;
     }
+    if options.mode == "prepare-facts" {
+        append_fact_cases(&mut result)?;
+    }
     validate_source(&result)?;
     if (result.schema != SOURCE_SCHEMA) != options.lexeme_cues {
         return Err(
             "source schema must match --lexeme-cues; prepare a new /2 source with true".into(),
         );
     }
-    if ["copy", "copy-completed"].contains(&options.mode.as_str())
+    if ["copy", "copy-completed", "copy-composed"].contains(&options.mode.as_str())
         && result.schema != WORD_COPY_SOURCE_SCHEMA
     {
         return Err("copy fitting requires the prepared /3 source".into());
@@ -729,6 +745,7 @@ fn evaluate(
             Control::Full,
             Control::WordCopyDisabled,
             Control::WordCopyGeometryDisabled,
+            Control::WordCopyDispatchDisabled,
         ]
     } else if entry {
         vec![
@@ -763,7 +780,9 @@ fn evaluate(
         let mut pairs: BTreeMap<&str, Vec<(bool, Option<Vec<u8>>)>> = BTreeMap::new();
         for (index, case) in source.development.iter().enumerate() {
             within_limit(start, options)?;
+            let generation_start = Instant::now();
             let generation = model.generate(&case.prompt, options.generated_tokens, control)?;
+            let generation_elapsed_us = generation_start.elapsed().as_micros();
             let expected = leading_numeral(case.response.as_bytes());
             let actual = leading_numeral(&generation.bytes);
             let numeral_correct = expected.map(|value| actual == Some(value));
@@ -809,6 +828,7 @@ fn evaluate(
                 "exact_response":exact,
                 "generated_source":generated_source,
                 "generation":generation,
+                "generation_elapsed_us":generation_elapsed_us,
             }));
         }
         let pair_rows: Vec<_> = pairs.into_iter().map(|(id, values)| json!({
@@ -923,14 +943,21 @@ fn evaluate_binding(
 
 fn main() -> ProbeResult<()> {
     let options = Options::parse()?;
-    let output_limit =
-        if ["completion", "entry", "copy", "copy-completed"].contains(&options.mode.as_str()) {
-            Some(COMPLETION_OUTPUT_BYTES)
-        } else if options.controls == "full" {
-            Some(PRESERVATION_OUTPUT_BYTES)
-        } else {
-            None
-        };
+    let output_limit = if [
+        "completion",
+        "entry",
+        "copy",
+        "copy-completed",
+        "copy-composed",
+    ]
+    .contains(&options.mode.as_str())
+    {
+        Some(COMPLETION_OUTPUT_BYTES)
+    } else if options.controls == "full" {
+        Some(PRESERVATION_OUTPUT_BYTES)
+    } else {
+        None
+    };
     OUTPUT_BYTES_REMAINING.store(output_limit.unwrap_or(usize::MAX), Ordering::Relaxed);
     let start = Instant::now();
     let source = source(&options)?;
@@ -962,7 +989,7 @@ fn main() -> ProbeResult<()> {
         &options.output_dir.join("binding-controls-source.json"),
         &binding_bytes,
     )?;
-    if ["prepare", "prepare-copy"].contains(&options.mode.as_str()) {
+    if ["prepare", "prepare-copy", "prepare-facts"].contains(&options.mode.as_str()) {
         println!(
             "{}",
             json!({"status":"prepared","fit_cases":source.fit.len(),"development_cases":source.development.len(),"source_blake3":blake3::hash(&source_bytes).to_hex().to_string(),"elapsed_ms":start.elapsed().as_millis()})
@@ -972,59 +999,69 @@ fn main() -> ProbeResult<()> {
     within_limit(start, &options)?;
     let baseline = Model::from_bytes(&fs::read(&options.model)?)?;
     let input_artifact = baseline.artifact_cid().to_owned();
-    let (model, fit_report) = if ["fit", "completion", "entry", "copy", "copy-completed"]
-        .contains(&options.mode.as_str())
+    let (model, fit_report) = if [
+        "fit",
+        "completion",
+        "entry",
+        "copy",
+        "copy-completed",
+        "copy-composed",
+    ]
+    .contains(&options.mode.as_str())
     {
         let examples: Vec<_> = source.fit.iter().map(Case::example).collect();
-        let (fitted, report) = if ["copy", "copy-completed"].contains(&options.mode.as_str()) {
-            let config = ResponseEntryFitConfig {
-                epochs: options.epochs,
-                learning_rate: options.learning_rate,
-                max_positions: options.completion_max_positions,
-            };
-            let (fitted, report) = if options.mode == "copy-completed" {
-                baseline.fit_response_entry_copy_completed_word(&examples, config)?
-            } else {
-                baseline.fit_response_entry_copy(&examples, config)?
-            };
-            write_json(&options.output_dir.join("fit-report.json"), &report)?;
-            (fitted, serde_json::to_value(report)?)
-        } else if options.mode == "entry" {
-            let (fitted, report) = baseline.fit_response_entry(
-                &examples,
-                ResponseEntryFitConfig {
+        let (fitted, report) =
+            if ["copy", "copy-completed", "copy-composed"].contains(&options.mode.as_str()) {
+                let config = ResponseEntryFitConfig {
                     epochs: options.epochs,
                     learning_rate: options.learning_rate,
                     max_positions: options.completion_max_positions,
-                },
-            )?;
-            write_json(&options.output_dir.join("fit-report.json"), &report)?;
-            (fitted, serde_json::to_value(report)?)
-        } else if options.mode == "completion" {
-            let (fitted, report) = baseline.fit_value_completion(
-                &examples,
-                ValueCompletionFitConfig {
+                };
+                let (fitted, report) = if options.mode == "copy-composed" {
+                    baseline.fit_response_entry_copy_composed(&examples, config)?
+                } else if options.mode == "copy-completed" {
+                    baseline.fit_response_entry_copy_completed_word(&examples, config)?
+                } else {
+                    baseline.fit_response_entry_copy(&examples, config)?
+                };
+                write_json(&options.output_dir.join("fit-report.json"), &report)?;
+                (fitted, serde_json::to_value(report)?)
+            } else if options.mode == "entry" {
+                let (fitted, report) = baseline.fit_response_entry(
+                    &examples,
+                    ResponseEntryFitConfig {
+                        epochs: options.epochs,
+                        learning_rate: options.learning_rate,
+                        max_positions: options.completion_max_positions,
+                    },
+                )?;
+                write_json(&options.output_dir.join("fit-report.json"), &report)?;
+                (fitted, serde_json::to_value(report)?)
+            } else if options.mode == "completion" {
+                let (fitted, report) = baseline.fit_value_completion(
+                    &examples,
+                    ValueCompletionFitConfig {
+                        epochs: options.epochs,
+                        learning_rate: options.learning_rate,
+                        max_positions: options.completion_max_positions,
+                    },
+                )?;
+                write_json(&options.output_dir.join("fit-report.json"), &report)?;
+                (fitted, serde_json::to_value(report)?)
+            } else {
+                let config = ValueFitConfig {
                     epochs: options.epochs,
                     learning_rate: options.learning_rate,
-                    max_positions: options.completion_max_positions,
-                },
-            )?;
-            write_json(&options.output_dir.join("fit-report.json"), &report)?;
-            (fitted, serde_json::to_value(report)?)
-        } else {
-            let config = ValueFitConfig {
-                epochs: options.epochs,
-                learning_rate: options.learning_rate,
-                max_features: options.max_features,
+                    max_features: options.max_features,
+                };
+                let (fitted, report) = if options.lexeme_cues {
+                    baseline.fit_values_with_lexeme_cues(&examples, config)?
+                } else {
+                    baseline.fit_values(&examples, config)?
+                };
+                write_json(&options.output_dir.join("fit-report.json"), &report)?;
+                (fitted, serde_json::to_value(report)?)
             };
-            let (fitted, report) = if options.lexeme_cues {
-                baseline.fit_values_with_lexeme_cues(&examples, config)?
-            } else {
-                baseline.fit_values(&examples, config)?
-            };
-            write_json(&options.output_dir.join("fit-report.json"), &report)?;
-            (fitted, serde_json::to_value(report)?)
-        };
         write_new(&options.output_dir.join("model.json"), &fitted.to_bytes()?)?;
         // Evaluate the serialized/reloaded artifact, not only the trainer's
         // in-memory object. Parent monitoring charges this loading/serialization.
@@ -1077,6 +1114,9 @@ fn main() -> ProbeResult<()> {
     }
     if options.controls != "all" {
         report["controls_selection"] = json!(options.controls);
+    }
+    if options.mode == "copy-composed" {
+        report["response_entry_scope"] = json!("Composed /2 extension: first response word after at most one learned lexical prefix token; exact source/query equality plus relative H4/phase features select a retained occurrence. No numeric-source requirement. NoCopy lexical continuation learns after an actually selected first transition. Forced interior copy bytes dispatch before ordinary scoring with score1 marker; observation/memory updates remain.64new construction and16fresh cases augment the unchanged source; no template or target buffer enters inference.");
     }
     if let Some(limit) = output_limit {
         report["resources"]["output_bytes_limit"] = json!(limit);
@@ -1246,5 +1286,97 @@ mod tests {
             assert_eq!(pair.original.prompt, original.prompt);
             assert_eq!(pair.original.response, original.response);
         }
+    }
+}
+
+/// Authored before fitting; labels remain probe-only. All prompts fit the
+/// sixteen retained-word bound, including both entities in update cases.
+fn append_fact_cases(source: &mut Source) -> ProbeResult<()> {
+    if source.schema != WORD_COPY_SOURCE_SCHEMA {
+        return Err("prepare-facts requires /3".into());
+    }
+    let names = ["ada", "bea", "cyra", "dara", "elin", "faye", "gita", "hana"];
+    let places = [
+        "Rome", "Paris", "Dover", "York", "Bath", "Perth", "Cairo", "Tokyo",
+    ];
+    for world in 0..8 {
+        for task in 0..4 {
+            for variant in 0..2 {
+                source.fit.push(fact_case(
+                    "fit",
+                    world,
+                    task,
+                    variant,
+                    names[world % 8],
+                    names[(world + 1) % 8],
+                    places[(world + variant) % 8],
+                    places[(world + variant + 2) % 8],
+                ));
+            }
+        }
+    }
+    for task in 0..4 {
+        for world in 0..2 {
+            for variant in 0..2 {
+                let names = [["mira", "theo"], ["nora", "kian"]][world];
+                let cities = [["Oslo", "Lima"], ["Bern", "Pune"]][world];
+                source.development.push(fact_case(
+                    "fresh",
+                    world,
+                    task,
+                    variant,
+                    names[0],
+                    names[1],
+                    cities[variant],
+                    cities[1 - variant],
+                ));
+            }
+        }
+    }
+    source.scope.push_str(" Fact composition:64additional construction cases,16fresh cases fixed before fit (four each simple,distractor,update,unsupported), no numeric decoys. Fresh names and values are absent from added construction. Existing46development remain open. All sixteen fresh results must be reported, without tuning on them.");
+    validate_source(source)
+}
+fn fact_case(
+    split: &str,
+    world: usize,
+    task: usize,
+    variant: usize,
+    a: &str,
+    b: &str,
+    x: &str,
+    y: &str,
+) -> Case {
+    let style = world % 2;
+    let (verb, query) = if style == 0 {
+        ("lives", format!("Where is {a}?"))
+    } else {
+        ("stays", format!("Where does {a} stay?"))
+    };
+    let (facts, answer) = match task {
+        0 => (format!("{a} {verb} in {x}."), x),
+        1 if variant == 0 => (format!("{a} {verb} in {x}. {b} {verb} in {y}."), x),
+        1 => (format!("{b} {verb} in {y}. {a} {verb} in {x}."), x),
+        2 => (format!("{a} in {x}. {b} in Bath. {a} now in {y}."), y),
+        _ => (format!("{b} {verb} in {x}."), "Unknown"),
+    };
+    Case {
+        id: format!("fact/{split}/{world}/{task}/{variant}"),
+        family: "prose".into(),
+        task: [
+            "fact_simple",
+            "fact_distractor",
+            "fact_update",
+            "fact_unsupported",
+        ][task]
+            .into(),
+        world: if split == "fit" {
+            400000 + world
+        } else {
+            500000 + world
+        },
+        pair_id: format!("fact/{split}/{world}/{task}"),
+        variant,
+        prompt: format!("{facts} {query} Answer:"),
+        response: format!(" {answer}.\n"),
     }
 }

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -154,6 +154,7 @@ pub enum Control {
     ResponseEntryGeometryDisabled,
     WordCopyDisabled,
     WordCopyGeometryDisabled,
+    WordCopyDispatchDisabled,
 }
 
 /// Explicit feature addresses, never content digests. Kinds 0/1 are full
@@ -199,7 +200,8 @@ impl Feature {
             | Control::ResponseEntryDisabled
             | Control::ResponseEntryGeometryDisabled
             | Control::WordCopyDisabled
-            | Control::WordCopyGeometryDisabled => true,
+            | Control::WordCopyGeometryDisabled
+            | Control::WordCopyDispatchDisabled => true,
             Control::GeometryDisabled => self.kind < 2,
             Control::ZetaDisabled => !(8..=15).contains(&self.kind) && self.kind != 5,
             Control::H4Disabled => self.kind < 2 || (8..=15).contains(&self.kind),

--- a/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
@@ -7,7 +7,7 @@ use super::response_entry_types::*;
 use super::value_types::ValueState;
 use super::*;
 
-pub(super) fn eligible(values: &ValueState, control: Control) -> bool {
+pub(super) fn eligible(model: &Model, values: &ValueState, control: Control) -> bool {
     !matches!(
         control,
         Control::ResponseEntryDisabled | Control::ValuesDisabled | Control::MemoryDisabled
@@ -15,7 +15,7 @@ pub(super) fn eligible(values: &ValueState, control: Control) -> bool {
         && !values.consumed
         && values.emission.is_none()
         && values.query_len > 0
-        && !values.sources.is_empty()
+        && (!values.sources.is_empty() || super::word_copy_runtime::composed(model))
         && values.next_id != u64::MAX
 }
 
@@ -31,12 +31,13 @@ impl ResponseEntryState {
 
     pub(super) fn begin(
         &mut self,
+        model: &Model,
         values: &ValueState,
         control: Control,
         work: &mut CompletionWork,
     ) {
         self.reset();
-        if !eligible(values, control)
+        if !eligible(model, values, control)
             || values.pending.is_some()
             || values.started_at != values.seen
             || self.seen != values.seen
@@ -56,7 +57,7 @@ impl ResponseEntryState {
 
     pub(super) fn observe(
         &mut self,
-        _model: &Model,
+        model: &Model,
         values: &ValueState,
         token: u32,
         control: Control,
@@ -97,7 +98,7 @@ impl ResponseEntryState {
             self.last_action = ResponseEntryAction::Stop;
             return;
         }
-        if !eligible(values, control) {
+        if !eligible(model, values, control) {
             self.reset();
             return;
         }
@@ -216,7 +217,7 @@ impl ResponseEntryState {
         work: &mut CompletionWork,
     ) -> Option<Candidate> {
         self.pending = None;
-        if !eligible(values, control)
+        if !eligible(model, values, control)
             || values.pending.is_some()
             || self.steps >= RESPONSE_ENTRY_STEPS
             || self.seen != values.seen

--- a/crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs
@@ -102,7 +102,7 @@ impl Session {
             return Err(invalid("last tokens differ from actual observations"));
         }
         if let Some(anchor) = saved.boundary {
-            if !eligible(values, self.control)
+            if !eligible(model, values, self.control)
                 || values.pending.is_some()
                 || anchor.at_seen == 0
                 || anchor.at_seen != values.started_at
@@ -182,12 +182,21 @@ impl Session {
                     seen: anchor.at_seen,
                     ..ResponseEntryState::default()
                 };
-                let selection = origin.offer(
+                let inherited = origin.offer(
                     model,
                     &boundary_values,
                     baseline,
                     self.control,
                     &mut CompletionWork::default(),
+                );
+                let selection = super::word_copy_runtime::prefix_offer(
+                    model,
+                    &mut origin,
+                    &boundary_values,
+                    baseline,
+                    inherited,
+                    self.control,
+                    &mut WordCopyWork::default(),
                 );
                 let copy_origin = self
                     .word_copy

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -3,7 +3,10 @@
 //! external model calls occur in observe/predict. Buffers are allocated once
 //! when a session is created; candidate work is bounded by artifact postings.
 
-use super::{Candidate, Control, Error, Feature, Model, Prediction, Result, Work, PHASE_CHANNELS};
+use super::{
+    Candidate, Control, Error, Feature, Model, Prediction, Result, WordCopyProgress, Work, BOS,
+    PHASE_CHANNELS,
+};
 use serde::{Deserialize, Serialize};
 
 pub(super) const FEATURE_COUNT: usize = 26;
@@ -210,7 +213,7 @@ impl Session {
             state.begin(&mut self.work.values);
         }
         if let (Some(entry), Some(values)) = (&mut self.response_entry, &self.values) {
-            entry.begin(values, self.control, &mut self.work.response_entry);
+            entry.begin(model, values, self.control, &mut self.work.response_entry);
         }
         if self.control != Control::MemoryDisabled && self.control != Control::ResponseStateDisabled
         {
@@ -467,6 +470,60 @@ impl Session {
     /// evaluation. The model never scans the vocabulary or retained prefix.
     pub fn predict(&mut self, model: &Model) -> Result<Prediction> {
         self.check_model(model)?;
+        self.work.word_copy.dispatch_checks = self
+            .work
+            .word_copy
+            .dispatch_checks
+            .saturating_add(u64::from(super::word_copy_runtime::composed(model)));
+        if super::word_copy_runtime::composed(model)
+            && self.control != Control::WordCopyDispatchDisabled
+            && self
+                .word_copy
+                .as_ref()
+                .is_some_and(|c| matches!(c.progress, WordCopyProgress::Emitting { .. }))
+        {
+            if let (Some(copy), Some(entry), Some(values)) =
+                (&mut self.word_copy, &mut self.response_entry, &self.values)
+            {
+                // /4 has no causal response writer. No ordinary collection or
+                // scoring is required for an immutable committed byte. Score1
+                // is a dispatch marker, not a comparable model likelihood.
+                entry.pending = None;
+                if let Some(best) = copy.offer(
+                    model,
+                    entry,
+                    values,
+                    Candidate {
+                        token: BOS,
+                        score: 0,
+                    },
+                    None,
+                    self.control,
+                    &mut self.work.word_copy,
+                ) {
+                    self.candidates.clear();
+                    if let Some(memory) = &mut self.memory {
+                        memory.select_response(model, best, &mut self.work);
+                    }
+                    if let Some(values) = &mut self.values {
+                        values.selected(best);
+                    }
+                    if let Some(completion) = &mut self.completion {
+                        completion.selected(best);
+                    }
+                    entry.selected(best);
+                    copy.selected(best);
+                    self.work.word_copy.forced_dispatches =
+                        self.work.word_copy.forced_dispatches.saturating_add(1);
+                    return Ok(Prediction {
+                        token: best.token,
+                        score: best.score,
+                        candidate_count: 1,
+                        geometric_rows: 0,
+                    });
+                }
+            }
+        }
         let features = self.features(model);
         let gates = match model
             .readout

--- a/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
@@ -12,15 +12,19 @@ pub(super) fn enabled(control: Control) -> bool {
     control != Control::WordCopyDisabled
 }
 
-pub(super) fn eligible(entry: &ResponseEntryState, values: &ValueState, control: Control) -> bool {
+pub(super) fn eligible(
+    model: &Model,
+    entry: &ResponseEntryState,
+    values: &ValueState,
+    control: Control,
+) -> bool {
     enabled(control)
-        && super::response_entry_runtime::eligible(values, control)
+        && super::response_entry_runtime::eligible(model, values, control)
         && values.pending.is_none()
-        && !entry.active
-        && entry.steps == 0
+        && ((!entry.active && entry.steps == 0) || (composed(model) && entry.active))
         && entry.seen == values.seen
         && entry.boundary.is_some_and(|anchor| {
-            anchor.at_seen == values.seen && anchor.at_seen == values.started_at
+            anchor.at_seen == values.started_at && (entry.active || anchor.at_seen == values.seen)
         })
         && values
             .lexemes
@@ -186,6 +190,19 @@ pub(super) fn features(
             .phase_subtractions
             .saturating_add((PHASE_CHANNELS + PHASE_CHANNELS) as u64);
     }
+    if composed(model) {
+        let mask = binding_mask(values, index, work);
+        let steps = values.seen.saturating_sub(values.started_at);
+        let last = if steps == 0 {
+            BOS
+        } else {
+            values.recent[((values.seen - 1) & 31) as usize].token
+        };
+        add(20, mask, 0);
+        add(21, mask, index as u64);
+        add(22, u64::from(last), steps);
+        add(23, mask, u64::from(preceding));
+    }
     (features, len)
 }
 
@@ -283,10 +300,17 @@ impl WordCopyState {
         if anchor.at_seen != values.started_at {
             return absent;
         }
-        let Some(steps) = entry.steps.checked_sub(word.len) else {
+        let Some(steps) = entry
+            .steps
+            .checked_sub(self.start_step)
+            .and_then(|steps| steps.checked_sub(word.len))
+        else {
             return absent;
         };
-        let Some(final_seen) = anchor.at_seen.checked_add(u64::from(word.len)) else {
+        let Some(final_seen) = anchor
+            .at_seen
+            .checked_add(u64::from(self.start_step) + u64::from(word.len))
+        else {
             return absent;
         };
         let Some(sequence) = final_seen.checked_sub(1) else {
@@ -365,7 +389,7 @@ impl WordCopyState {
     ) -> Option<Candidate> {
         self.pending = None;
         if !enabled(control)
-            || !super::response_entry_runtime::eligible(values, control)
+            || !super::response_entry_runtime::eligible(model, values, control)
             || values.pending.is_some()
             || entry.steps >= RESPONSE_ENTRY_STEPS
             || entry.seen != values.seen
@@ -386,7 +410,12 @@ impl WordCopyState {
             return lexical;
         };
         let mut chosen = None;
-        if eligible(entry, values, control) {
+        let lexical = if self.progress == WordCopyProgress::Idle {
+            prefix_offer(model, entry, values, baseline, lexical, control, work)
+        } else {
+            lexical
+        };
+        if eligible(model, entry, values, control) && self.progress == WordCopyProgress::Idle {
             let context = context(model, values, control, work);
             let mut threshold = lexical
                 .map_or(0, |candidate| candidate.score - baseline.score)
@@ -574,6 +603,7 @@ impl WordCopyState {
             work.selector.commits = work.selector.commits.saturating_add(1);
             if decision.action == WordCopyAction::Start {
                 self.origin = Some(decision.word_index);
+                self.start_step = decision.step;
                 work.word_record_reads = work.word_record_reads.saturating_add(1);
                 let len = values.lexemes.as_ref().map_or(0, |words| {
                     words.queries[usize::from(decision.word_index)].len
@@ -601,4 +631,152 @@ impl WordCopyState {
         }
         work.selector.state_copies = work.selector.state_copies.saturating_add(3);
     }
+}
+
+/// This switch is identity-bound and absent in historical artifacts.
+pub(super) fn composed(model: &Model) -> bool {
+    model
+        .response_entry
+        .as_ref()
+        .and_then(|h| h.copy.as_ref())
+        .is_some_and(|h| h.composed_entry)
+}
+
+fn equal_word(a: &WordAtom, b: &WordAtom, work: &mut WordCopyWork) -> bool {
+    if a.len == 0 || a.len != b.len {
+        return false;
+    }
+    for i in 0..usize::from(a.len) {
+        work.equality_byte_comparisons = work.equality_byte_comparisons.saturating_add(1);
+        if a.bytes[i] != b.bytes[i] {
+            return false;
+        }
+    }
+    true
+}
+
+/// Four recent query words by three predecessor offsets. Exact equality is
+/// useful for unseen names; neither bytes nor dictionary hashes become a metric.
+fn binding_mask(values: &ValueState, index: usize, work: &mut WordCopyWork) -> u64 {
+    let Some(words) = &values.lexemes else {
+        return 0;
+    };
+    let mut mask = 0;
+    for q in 0..words.query_len.min(4) {
+        for offset in 1..=3 {
+            let source = index + offset;
+            if q < index && source < words.query_len {
+                work.word_record_reads = work.word_record_reads.saturating_add(2);
+                if equal_word(&words.queries[q], &words.queries[source], work) {
+                    mask |= 1 << (q + q + q + offset - 1);
+                }
+            }
+        }
+    }
+    mask
+}
+
+pub(super) fn prefix_features(
+    model: &Model,
+    entry: &ResponseEntryState,
+    values: &ValueState,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> ([Feature; RESPONSE_ENTRY_FEATURES], usize) {
+    let control = if control == Control::WordCopyGeometryDisabled {
+        Control::ResponseEntryGeometryDisabled
+    } else {
+        control
+    };
+    let (mut features, len) = entry.features(model, values, control, &mut work.selector);
+    for feature in &mut features[..len] {
+        feature.kind &= 15;
+    }
+    let mut repeated = 0;
+    if let Some(words) = &values.lexemes {
+        for q in 0..words.query_len.min(4) {
+            for older in 4..words.query_len {
+                work.word_record_reads = work.word_record_reads.saturating_add(2);
+                if equal_word(&words.queries[q], &words.queries[older], work) {
+                    repeated |= 1 << q;
+                }
+            }
+        }
+    }
+    let query_word = model
+        .response_entry
+        .as_ref()
+        .and_then(|h| h.copy.as_ref())
+        .zip(values.lexemes.as_ref())
+        .map_or(0, |(head, words)| {
+            if words.query_len == 0 {
+                0
+            } else {
+                work.word_record_reads = work.word_record_reads.saturating_add(1);
+                address(head, &words.queries[0], work)
+            }
+        });
+    for feature in &mut features[..len] {
+        if feature.kind == 3 {
+            feature.value = (repeated << 32) | u64::from(query_word);
+        }
+        if feature.kind == 4 {
+            feature.value = (repeated << 32) | u64::from(entry.last);
+        }
+    }
+    (features, len)
+}
+
+pub(super) fn prefix_offer(
+    model: &Model,
+    entry: &mut ResponseEntryState,
+    values: &ValueState,
+    baseline: Candidate,
+    inherited: Option<Candidate>,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> Option<Candidate> {
+    if !composed(model) || !eligible(model, entry, values, control) {
+        return inherited;
+    }
+    let head = model.response_entry.as_ref()?.copy.as_ref()?;
+    let (features, len) = prefix_features(model, entry, values, control, work);
+    let (tokens, count, rows, row_count) = candidate_rows(
+        &head.prefix_rows,
+        &head.prefix_postings,
+        &features[..len],
+        &mut work.selector,
+    );
+    let mut best = inherited;
+    let mut threshold = 0;
+    for &token in &tokens[..count] {
+        let increment = score_rows(
+            &head.prefix_rows,
+            token,
+            &rows[..row_count],
+            &mut work.selector,
+        );
+        if increment > threshold {
+            threshold = increment;
+            best = Some(Candidate {
+                token,
+                score: baseline.score + increment,
+            });
+            entry.pending = Some(ResponseEntryDecision {
+                token,
+                score: baseline.score + increment,
+                boundary_seen: entry.boundary?.at_seen,
+                at_seen: values.seen,
+                step: entry.steps,
+                action: if token == EOS {
+                    ResponseEntryAction::Stop
+                } else if entry.active {
+                    ResponseEntryAction::Emit
+                } else {
+                    ResponseEntryAction::Enter
+                },
+            });
+        }
+    }
+    best
 }

--- a/crates/uor-r4-core/src/native_geometric/word_copy_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_snapshot.rs
@@ -93,30 +93,62 @@ impl Session {
             token: BOS,
             score: 0,
         };
-        let lexical = initial.offer(
-            model,
-            &boundary_values,
-            baseline,
-            self.control,
-            &mut CompletionWork::default(),
-        );
-        let mut choice = WordCopyState::default();
-        let selected = choice.offer(
-            model,
-            &mut initial,
-            &boundary_values,
-            baseline,
-            lexical,
-            self.control,
-            &mut WordCopyWork::default(),
-        );
-        if selected.is_none_or(|candidate| {
-            !token_at(anchor.at_seen).is_ok_and(|token| token == candidate.token)
-        }) || choice.pending.map(|decision| decision.word_index) != saved.origin
+        if (!super::word_copy_runtime::composed(model) && saved.start_step != 0)
+            || saved.start_step >= entry.steps
+            || (saved.origin.is_none() && saved.start_step != 0)
         {
-            return Err(invalid(
-                "origin differs from observed combined first selection",
-            ));
+            return Err(invalid("copy start is outside the observed entry"));
+        }
+        let mut choice = WordCopyState::default();
+        for step in 0..=saved.start_step {
+            let inherited = initial.offer(
+                model,
+                &boundary_values,
+                baseline,
+                self.control,
+                &mut CompletionWork::default(),
+            );
+            let selected = choice.offer(
+                model,
+                &mut initial,
+                &boundary_values,
+                baseline,
+                inherited,
+                self.control,
+                &mut WordCopyWork::default(),
+            );
+            let actual = token_at(anchor.at_seen + u64::from(step))?;
+            if selected.is_none_or(|candidate| candidate.token != actual) {
+                return Err(invalid(
+                    "start differs from actual selected lexical/copy prefix",
+                ));
+            }
+            if step == saved.start_step {
+                if choice.pending.map(|decision| decision.word_index) != saved.origin {
+                    return Err(invalid("origin differs from observed copy selection"));
+                }
+            } else {
+                if choice.pending.is_some() {
+                    return Err(invalid("copy began before saved start"));
+                }
+                boundary_values.seen += 1;
+                let observed = values.recent[((boundary_values.seen - 1) & 31) as usize];
+                boundary_values.pose = observed.pose;
+                boundary_values.phases = observed.phases;
+                initial.observe(
+                    model,
+                    &boundary_values,
+                    actual,
+                    self.control,
+                    &mut CompletionWork::default(),
+                );
+                choice.observe(
+                    &initial,
+                    &boundary_values,
+                    actual,
+                    &mut WordCopyWork::default(),
+                );
+            }
         }
         if let Some(index) = saved.origin {
             if !super::word_copy_runtime::enabled(self.control)
@@ -130,18 +162,30 @@ impl Session {
             }
             let prefix = match saved.progress {
                 WordCopyProgress::Emitting { cursor }
-                    if cursor > 0 && cursor < word.len && cursor == entry.steps =>
+                    if cursor > 0
+                        && cursor < word.len
+                        && Some(cursor) == entry.steps.checked_sub(saved.start_step) =>
                 {
                     usize::from(cursor)
                 }
-                WordCopyProgress::Complete if entry.steps >= word.len => usize::from(word.len),
+                WordCopyProgress::Complete
+                    if entry.steps.saturating_sub(saved.start_step) >= word.len =>
+                {
+                    usize::from(word.len)
+                }
                 // Omission of predict before a byte can abort even if its
                 // value agrees; checkpoint consistency cannot prove a call.
-                WordCopyProgress::Aborted if word.len > 1 && entry.steps >= 2 => 1,
+                WordCopyProgress::Aborted
+                    if word.len > 1 && entry.steps.saturating_sub(saved.start_step) >= 2 =>
+                {
+                    1
+                }
                 _ => return Err(invalid("progress is inconsistent with actual observations")),
             };
             for offset in 0..prefix {
-                if token_at(anchor.at_seen + offset as u64)? != u32::from(word.bytes[offset]) + 2 {
+                if token_at(anchor.at_seen + u64::from(saved.start_step) + offset as u64)?
+                    != u32::from(word.bytes[offset]) + 2
+                {
                     return Err(invalid(
                         "observed byte prefix differs from selected occurrence",
                     ));

--- a/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
@@ -576,3 +576,119 @@ fn native_word_copy_preserves_parent_and_respects_typed_precedence_and_controls(
         assert!(word.len < RESPONSE_ENTRY_STEPS);
     }
 }
+
+#[test]
+fn native_word_copy_composed_prefix_dispatch_and_restore() {
+    use super::value_types::{ValueFeature, ValueRow};
+    let mut model = fixture::fitted_completed_word().clone();
+    let head = model
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap();
+    head.composed_entry = true;
+    model.refresh_identity().unwrap();
+    let prompt = "alpha remains. reply:";
+    let session = prefix(&model, prompt, Control::Full);
+    assert!(session.values.as_ref().unwrap().sources.is_empty());
+    assert!(session.response_entry.as_ref().unwrap().boundary.is_some());
+    let words = session.values.as_ref().unwrap().lexemes.as_ref().unwrap();
+    let index = words.queries[..words.query_len]
+        .iter()
+        .position(|w| &w.bytes[..usize::from(w.len)] == b"alpha")
+        .unwrap();
+    // Explicit weights test the operator contract, not predictive learning.
+    let head = model
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap();
+    head.rows = vec![
+        ValueRow {
+            feature: ValueFeature {
+                kind: 0,
+                a: 0,
+                b: 0,
+            },
+            weight: -100000,
+        },
+        ValueRow {
+            feature: ValueFeature {
+                kind: 3,
+                a: index as u64,
+                b: 0,
+            },
+            weight: 50000,
+        },
+        ValueRow {
+            feature: ValueFeature {
+                kind: 22,
+                a: u64::from(b' ') + 2,
+                b: 1,
+            },
+            weight: 200000,
+        },
+    ];
+    head.prefix_rows = vec![ScoreRow {
+        feature: Feature { kind: 5, value: 0 },
+        default_score: 0,
+        scores: vec![TokenScore {
+            token: u32::from(b' ') + 2,
+            score: 10000,
+        }],
+        postings: vec![u32::from(b' ') + 2],
+    }];
+    head.prefix_postings = vec![u32::from(b' ') + 2];
+    model.refresh_identity().unwrap();
+    let model = Model::from_bytes(&model.to_bytes().unwrap()).unwrap();
+    let mut fast = prefix(&model, prompt, Control::Full);
+    let mut ordinary = prefix(&model, prompt, Control::WordCopyDispatchDisabled);
+    for (step, byte) in b" alpha".iter().enumerate() {
+        let before = fast.work.clone();
+        let next = fast.predict(&model).unwrap();
+        assert_eq!(next.token, u32::from(*byte) + 2);
+        assert_eq!(ordinary.predict(&model).unwrap().token, next.token);
+        if step > 1 {
+            assert_eq!(next.score, 1);
+            assert_eq!(next.candidate_count, 1);
+            assert_eq!(fast.work.feature_queries, before.feature_queries);
+            assert_eq!(fast.work.score_lookups, before.score_lookups);
+            assert_eq!(fast.work.memory_score_lookups, before.memory_score_lookups);
+            assert_eq!(fast.work.memory_index_reads, before.memory_index_reads);
+        }
+        fast.observe(&model, next.token).unwrap();
+        ordinary.observe(&model, next.token).unwrap();
+        let snapshot = fast.checkpoint().unwrap();
+        let mut restored = model.restore_session(&snapshot).unwrap();
+        assert_eq!(restored.state(), fast.state());
+        assert_eq!(
+            restored.predict(&model).unwrap(),
+            fast.predict(&model).unwrap()
+        );
+        let mut a: serde_json::Value = serde_json::from_slice(&snapshot).unwrap();
+        let mut b: serde_json::Value =
+            serde_json::from_slice(&ordinary.checkpoint().unwrap()).unwrap();
+        for key in ["work", "control"] {
+            a.as_object_mut().unwrap().remove(key);
+            b.as_object_mut().unwrap().remove(key);
+        }
+        assert_eq!(a, b, "required causal state at step{step}");
+        if step > 0 {
+            a = serde_json::from_slice(&snapshot).unwrap();
+            a["word_copy"]["start_step"] = json!(0);
+            assert!(model
+                .restore_session(&serde_json::to_vec(&a).unwrap())
+                .is_err());
+        }
+    }
+    assert_eq!(
+        fast.word_copy.as_ref().unwrap().progress,
+        WordCopyProgress::Complete
+    );
+    assert_eq!(fast.word_copy.as_ref().unwrap().start_step, 1);
+    assert!(!suffix_features(&model, &fast).is_empty());
+}

--- a/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
@@ -70,6 +70,7 @@ struct Example {
     baseline_score: f64,
     baseline_correct: bool,
     prefix_len: Option<usize>,
+    prefix_start: usize,
 }
 
 fn identifier_byte(byte: u8) -> bool {
@@ -206,6 +207,33 @@ impl WordCopyModel {
                 row.feature.kind >= WORD_COPY_FEATURES as u8
                     || !(-1_000_000..=1_000_000).contains(&row.weight)
             })
+            || (!self.composed_entry
+                && (!self.prefix_rows.is_empty()
+                    || !self.prefix_postings.is_empty()
+                    || self.rows.iter().any(|r| r.feature.kind >= 20)))
+            || (self.composed_entry
+                && (!self.completed_word_suffix
+                    || model
+                        .memory_read
+                        .as_ref()
+                        .is_some_and(|h| h.schema == super::memory_types::RESPONSE_MEMORY_SCHEMA)))
+            || self.prefix_rows.len() > RESPONSE_ENTRY_ROWS
+            || self
+                .prefix_rows
+                .windows(2)
+                .any(|p| p[0].feature >= p[1].feature)
+            || self.prefix_rows.iter().any(|r| r.feature.kind >= 16)
+            || self
+                .prefix_rows
+                .iter()
+                .map(|r| r.scores.len())
+                .sum::<usize>()
+                > RESPONSE_ENTRY_ASSOCIATIONS
+            || self.prefix_postings.len() > RESPONSE_ENTRY_CANDIDATES
+            || self.prefix_postings.iter().any(|&t| !valid_token(t))
+            || self.prefix_postings.iter().collect::<BTreeSet<_>>().len()
+                != self.prefix_postings.len()
+            || self.continuation_rows.iter().any(|r| r.feature.kind < 16)
             || self.continuation_rows.len() > RESPONSE_ENTRY_ROWS
             || self
                 .continuation_rows
@@ -228,25 +256,29 @@ impl WordCopyModel {
                 .continuation_rows
                 .windows(2)
                 .any(|pair| pair[0].feature >= pair[1].feature)
-            || self.continuation_rows.iter().any(|row| {
-                !(16..32).contains(&row.feature.kind)
-                    || row.default_score != 0
-                    || row.postings.len() > RESPONSE_ENTRY_POSTINGS
-                    || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
-                    || row
-                        .scores
-                        .windows(2)
-                        .any(|pair| pair[0].token >= pair[1].token)
-                    || row.scores.iter().any(|entry| {
-                        !valid_token(entry.token)
-                            || !(-1_000_000..=1_000_000).contains(&entry.score)
-                    })
-                    || row.postings.iter().any(|token| {
-                        row.scores
-                            .binary_search_by_key(token, |entry| entry.token)
-                            .is_err()
-                    })
-            })
+            || self
+                .continuation_rows
+                .iter()
+                .chain(&self.prefix_rows)
+                .any(|row| {
+                    row.feature.kind >= 32
+                        || row.default_score != 0
+                        || row.postings.len() > RESPONSE_ENTRY_POSTINGS
+                        || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
+                        || row
+                            .scores
+                            .windows(2)
+                            .any(|pair| pair[0].token >= pair[1].token)
+                        || row.scores.iter().any(|entry| {
+                            !valid_token(entry.token)
+                                || !(-1_000_000..=1_000_000).contains(&entry.score)
+                        })
+                        || row.postings.iter().any(|token| {
+                            row.scores
+                                .binary_search_by_key(token, |entry| entry.token)
+                                .is_err()
+                        })
+                })
             || self.fit_positions > RESPONSE_ENTRY_POSITIONS
             || self
                 .training
@@ -307,7 +339,7 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
-        self.fit_response_entry_copy_impl(documents, config, false)
+        self.fit_response_entry_copy_impl(documents, config, false, false)
     }
 
     /// Fit suffix transitions relative to the observed end of a copied word.
@@ -318,7 +350,15 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
-        self.fit_response_entry_copy_impl(documents, config, true)
+        self.fit_response_entry_copy_impl(documents, config, true, false)
+    }
+
+    pub fn fit_response_entry_copy_composed(
+        &self,
+        documents: &[ValueExample],
+        config: ResponseEntryFitConfig,
+    ) -> Result<(Model, ResponseEntryCopyFitReport)> {
+        self.fit_response_entry_copy_impl(documents, config, true, true)
     }
 
     fn fit_response_entry_copy_impl(
@@ -326,6 +366,7 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
         completed_word_suffix: bool,
+        composed_entry: bool,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
         let source_bytes = documents.iter().try_fold(0_usize, |sum, document| {
             sum.checked_add(document.prompt.len())?
@@ -351,6 +392,17 @@ impl Model {
                 "invalid retained-word fitting source, configuration or entry parent".into(),
             ));
         }
+        if composed_entry
+            && self
+                .memory_read
+                .as_ref()
+                .is_some_and(|h| h.schema == super::memory_types::RESPONSE_MEMORY_SCHEMA)
+        {
+            return Err(Error(
+                "composed copy excludes response-writing /5; ordinary and occurrence memory remain supported"
+                    .into(),
+            ));
+        }
         let (dictionary, omitted_words, omitted_occurrences) = dictionary(documents)?;
         let dictionary_words = dictionary.len();
         let mut model = self.clone();
@@ -361,6 +413,9 @@ impl Model {
         entry.schema = RESPONSE_COPY_SCHEMA.into();
         entry.copy = Some(WordCopyModel {
             completed_word_suffix,
+            composed_entry,
+            prefix_rows: Vec::new(),
+            prefix_postings: Vec::new(),
             baseline_artifact: self.artifact_cid.clone(),
             dictionary,
             rows: Vec::new(),
@@ -371,13 +426,18 @@ impl Model {
             training: Vec::new(),
         });
         model.refresh_identity()?;
+        let prefix_positions = if composed_entry {
+            fit_prefix(&mut model, documents, &config)?
+        } else {
+            0
+        };
         let mut ids = BTreeSet::new();
         let mut prompts = BTreeMap::new();
         let mut receipts = Vec::new();
         let mut registry = BTreeMap::<ValueFeature, usize>::new();
         let mut weights = Vec::new();
         let mut examples = Vec::new();
-        let mut reserved_positions = 0_usize;
+        let mut reserved_positions = prefix_positions;
         let mut numeric_examples = 0;
         let mut matched_numeric = 0;
         let mut upstream_failures = 0;
@@ -439,10 +499,109 @@ impl Model {
                 }
                 continue;
             }
-            let prefix = target_prefix(&document.response);
+            let prefix_start = if composed_entry {
+                target_start(&model, document)?
+            } else {
+                0
+            };
+            let prefix = target_prefix(&document.response[prefix_start..]);
+            let prefix = if composed_entry && !target_reachable(&model, document, prefix_start)? {
+                None
+            } else {
+                prefix
+            };
             copy_targets += usize::from(prefix.is_some());
             no_copy_targets += usize::from(prefix.is_none());
-            let mut session = response_session(&model, &document.prompt)?;
+            if prefix_start > 0 {
+                if reserved_positions >= config.max_positions {
+                    position_limit_skips += 1;
+                    continue;
+                }
+                let mut initial = response_session(&model, &document.prompt)?;
+                let predicted = initial.predict(&model)?;
+                let values = initial
+                    .values
+                    .as_ref()
+                    .ok_or_else(|| Error("prefix values missing".into()))?;
+                let mut entry = *initial
+                    .response_entry
+                    .as_ref()
+                    .ok_or_else(|| Error("prefix entry missing".into()))?;
+                let inherited = entry.offer(
+                    &model,
+                    values,
+                    Candidate {
+                        token: BOS,
+                        score: 0,
+                    },
+                    Control::Full,
+                    &mut CompletionWork::default(),
+                );
+                let threshold = word_copy_runtime::prefix_offer(
+                    &model,
+                    &mut entry,
+                    values,
+                    Candidate {
+                        token: BOS,
+                        score: 0,
+                    },
+                    inherited,
+                    Control::Full,
+                    &mut WordCopyWork::default(),
+                )
+                .map_or(0, |c| c.score);
+                let context = word_copy_runtime::context(
+                    &model,
+                    values,
+                    Control::Full,
+                    &mut WordCopyWork::default(),
+                );
+                let mut alternatives = Vec::new();
+                let words = values
+                    .lexemes
+                    .as_ref()
+                    .ok_or_else(|| Error("prefix words missing".into()))?;
+                for index in 0..words.query_len {
+                    let (features, len) = word_copy_runtime::features(
+                        &model,
+                        values,
+                        &context,
+                        index,
+                        Control::Full,
+                        &mut WordCopyWork::default(),
+                    );
+                    let mut indices = Vec::new();
+                    for feature in &features[..len] {
+                        let next = registry.len();
+                        if next >= WORD_COPY_ROWS && !registry.contains_key(feature) {
+                            dropped_feature_events += 1;
+                            continue;
+                        }
+                        let index = *registry.entry(*feature).or_insert_with(|| {
+                            weights.push(0.0);
+                            next
+                        });
+                        indices.push(index);
+                    }
+                    alternatives.push(Alternative {
+                        features: indices,
+                        correct: false,
+                    });
+                }
+                if predicted.token != model.encode(&document.response[..prefix_start])?[0] {
+                    return Err(Error("prefix head failed before copy fit".into()));
+                }
+                examples.push(Example {
+                    document: index,
+                    alternatives,
+                    baseline_score: threshold as f64 / 256.0,
+                    baseline_correct: true,
+                    prefix_len: None,
+                    prefix_start: 0,
+                });
+                reserved_positions += 1;
+            }
+            let mut session = prefixed_session(&model, document, prefix_start)?;
             session.predict(&model)?;
             let values = session
                 .values
@@ -452,13 +611,18 @@ impl Model {
                 .response_entry
                 .as_ref()
                 .ok_or_else(|| Error("copy fit entry state missing".into()))?;
-            if !word_copy_runtime::eligible(entry, values, Control::Full) {
+            if !word_copy_runtime::eligible(&model, entry, values, Control::Full) {
                 upstream_failures += 1;
                 continue;
             }
             let positions = if let Some(prefix_len) = prefix {
                 prefix_len
-                    .saturating_add(model.encode(&document.response[prefix_len..])?.len())
+                    .saturating_add(model.encode(&document.response[..prefix_start])?.len())
+                    .saturating_add(
+                        model
+                            .encode(&document.response[prefix_start + prefix_len..])?
+                            .len(),
+                    )
                     .saturating_add(1)
             } else {
                 1
@@ -472,18 +636,29 @@ impl Model {
                 continue;
             }
             let mut lexical = *entry;
-            let threshold = lexical
-                .offer(
-                    &model,
-                    values,
-                    Candidate {
-                        token: BOS,
-                        score: 0,
-                    },
-                    Control::Full,
-                    &mut CompletionWork::default(),
-                )
-                .map_or(0, |candidate| candidate.score);
+            let inherited = lexical.offer(
+                &model,
+                values,
+                Candidate {
+                    token: BOS,
+                    score: 0,
+                },
+                Control::Full,
+                &mut CompletionWork::default(),
+            );
+            let threshold = word_copy_runtime::prefix_offer(
+                &model,
+                &mut lexical,
+                values,
+                Candidate {
+                    token: BOS,
+                    score: 0,
+                },
+                inherited,
+                Control::Full,
+                &mut WordCopyWork::default(),
+            )
+            .map_or(0, |candidate| candidate.score);
             let context = word_copy_runtime::context(
                 &model,
                 values,
@@ -501,7 +676,7 @@ impl Model {
                 if word.len == 0 || usize::from(word.len) + 1 > usize::from(RESPONSE_ENTRY_STEPS) {
                     continue;
                 }
-                let correct = matches_target(&word, &document.response);
+                let correct = matches_target(&word, &document.response[prefix_start..]);
                 reachable |= correct;
                 let (features, len) = word_copy_runtime::features(
                     &model,
@@ -545,6 +720,7 @@ impl Model {
                 baseline_score: threshold as f64 / 256.0,
                 baseline_correct: prefix.is_none(),
                 prefix_len: prefix,
+                prefix_start,
             });
         }
         if examples.is_empty() || !examples.iter().any(|example| !example.baseline_correct) {
@@ -587,7 +763,8 @@ impl Model {
         let mut false_copies = 0;
         for example in &examples {
             let document = &documents[example.document];
-            let mut session = response_session(&model, &document.prompt)?;
+            let prefix_start = example.prefix_start;
+            let mut session = prefixed_session(&model, document, prefix_start)?;
             let first = session.predict(&model)?;
             let Some(prefix_len) = example.prefix_len else {
                 false_copies += usize::from(
@@ -607,17 +784,19 @@ impl Model {
                             usize::from(decision.word_index) < words.query_len
                                 && matches_target(
                                     &words.queries[usize::from(decision.word_index)],
-                                    &document.response,
+                                    &document.response[prefix_start..],
                                 )
                         })
             });
-            if !selected || first.token != u32::from(document.response.as_bytes()[0]) + 2 {
+            if !selected || first.token != u32::from(document.response.as_bytes()[prefix_start]) + 2
+            {
                 copy_rollout_failures += 1;
                 continue;
             }
             selected_copies += 1;
             let mut complete = true;
-            for (byte_index, &byte) in document.response.as_bytes()[..prefix_len]
+            for (byte_index, &byte) in document.response.as_bytes()
+                [prefix_start..prefix_start + prefix_len]
                 .iter()
                 .enumerate()
             {
@@ -642,7 +821,7 @@ impl Model {
                 continue;
             }
             committed_complete_copies += 1;
-            let mut targets = model.encode(&document.response[prefix_len..])?;
+            let mut targets = model.encode(&document.response[prefix_start + prefix_len..])?;
             targets.push(EOS);
             for target in targets {
                 let baseline = session.predict(&model)?.token;
@@ -713,7 +892,7 @@ impl Model {
                 .as_ref()
                 .map_or(0, |fit| fit.selected_epoch as u64),
         ];
-        head.fit_positions = examples.len() + continuation_frames.len();
+        head.fit_positions = prefix_positions + examples.len() + continuation_frames.len();
         head.training = receipts;
         let learned_features = head.rows.len();
         let continuation_rows = head.continuation_rows.len();
@@ -729,7 +908,8 @@ impl Model {
         let mut final_exact_responses = 0;
         for example in &examples {
             let document = &documents[example.document];
-            let mut session = response_session(&model, &document.prompt)?;
+            let prefix_start = example.prefix_start;
+            let mut session = prefixed_session(&model, document, prefix_start)?;
             session.predict(&model)?;
             let selected = session
                 .word_copy_decision()
@@ -746,7 +926,7 @@ impl Model {
                             usize::from(decision.word_index) < words.query_len
                                 && matches_target(
                                     &words.queries[usize::from(decision.word_index)],
-                                    &document.response,
+                                    &document.response[prefix_start..],
                                 )
                         }),
                 );
@@ -764,7 +944,7 @@ impl Model {
             selected_copies, committed_complete_copies, copy_rollout_failures, false_copies, continuation_positions: continuation_frames.len(),
             continuation_target_in_candidates: continuation_fit.as_ref().map_or(0, |fit| fit.target_in_candidates), continuation_fit_correct: continuation_fit.as_ref().map_or(0, |fit| fit.correct), continuation_fit_loss: continuation_fit.as_ref().map(|fit| fit.loss), selected_continuation_epoch: continuation_fit.as_ref().map_or(0, |fit| fit.selected_epoch),
             continuation_rows, continuation_associations, dropped_row_events: continuation_fit.as_ref().map_or(0, |fit| fit.dropped_row_events), dropped_association_events: continuation_fit.as_ref().map_or(0, |fit| fit.dropped_association_events), final_copy_correct, final_no_copy_correct, final_exact_responses, config,
-            target_law: "Offline complete identifier-prefix matching marks all matching retained occurrences positive. Copy must strictly beat the actual inherited lexical/Base score. Only actual quantized first-copy selection and complete matching observations create suffix frames; suffix uses canonical encoding after byte-token copied history plus EOS. Whole trajectories above32observations or positioncap are skipped, not truncated. No target index or answer buffer is serialized.".into(),
+            target_law: if composed_entry { "Offline: one learned lexical prefix token before the first complete response word that equals a retained word; selector labels all equal-spelling retained occurrences, then actual selected copy bytes create suffix frames. Unsupported responses train the first lexical transition. The prefix head is fit at the observed query boundary; no target creates a hidden serving anchor. Numeric trajectories remain inherited. At most512raw examples,4096positions,32response observations.".into() } else { "Offline complete identifier-prefix matching marks all matching retained occurrences positive. Copy must strictly beat the actual inherited lexical/Base score. Only actual quantized first-copy selection and complete matching observations create suffix frames; suffix uses canonical encoding after byte-token copied history plus EOS. Whole trajectories above32observations or positioncap are skipped, not truncated. No target index or answer buffer is serialized.".into() },
             suffix_law: completed_word_suffix.then(|| "Observed-completed-word boundary: H4/phase origin comes from the actual final copied byte in retained history; progress and last-two-token features contain only actual suffix observations, with BOS for unavailable suffix context. Original occurrence provenance and query prime remain. Selector dictionary, feature construction and fitting law are unchanged.".into()),
         };
         Ok((model, report))
@@ -915,6 +1095,7 @@ mod tests {
             baseline_score: 2000.0,
             baseline_correct: false,
             prefix_len: Some(1),
+            prefix_start: 0,
         };
         let (correct, loss) = measure(&[copy_target], &[0.0]).unwrap();
         assert_eq!(correct, 0);
@@ -929,9 +1110,200 @@ mod tests {
             baseline_score: 0.0,
             baseline_correct: true,
             prefix_len: None,
+            prefix_start: 0,
         };
         let (correct, loss) = measure(&[no_copy_target], &[2000.0]).unwrap();
         assert_eq!(correct, 0);
         assert_eq!(loss, 2000.0);
     }
+}
+
+// Labels are used only offline to locate a whole retained word in the response.
+fn target_start(model: &Model, document: &ValueExample) -> Result<usize> {
+    let session = response_session(model, &document.prompt)?;
+    let words = session
+        .values
+        .as_ref()
+        .and_then(|v| v.lexemes.as_ref())
+        .ok_or_else(|| Error("prefix words absent".into()))?;
+    // Copy only the first response word. A later shared grammar word in an
+    // abstention is not its value target.
+    if let Some((offset, _)) = document
+        .response
+        .char_indices()
+        .find(|(_, c)| c.is_ascii_alphabetic() || *c == '_')
+    {
+        if words.queries[..words.query_len]
+            .iter()
+            .any(|w| matches_target(w, &document.response[offset..]))
+            && model.encode(&document.response[..offset])?.len() <= 1
+        {
+            return Ok(offset);
+        }
+    }
+    Ok(0)
+}
+fn target_reachable(model: &Model, document: &ValueExample, offset: usize) -> Result<bool> {
+    let session = response_session(model, &document.prompt)?;
+    Ok(session
+        .values
+        .as_ref()
+        .and_then(|v| v.lexemes.as_ref())
+        .is_some_and(|words| {
+            words.queries[..words.query_len]
+                .iter()
+                .any(|w| matches_target(w, &document.response[offset..]))
+        }))
+}
+fn prefixed_session(model: &Model, document: &ValueExample, offset: usize) -> Result<Session> {
+    let mut session = response_session(model, &document.prompt)?;
+    for token in model.encode(&document.response[..offset])? {
+        let prediction = session.predict(model)?;
+        if prediction.token != token {
+            return Err(Error(format!(
+                "learned prefix rollout failed for {}",
+                document.id
+            )));
+        }
+        session.observe(model, token)?;
+    }
+    Ok(session)
+}
+fn fit_prefix(
+    model: &mut Model,
+    documents: &[ValueExample],
+    config: &ResponseEntryFitConfig,
+) -> Result<usize> {
+    if documents.len() > 512 {
+        return Err(Error("composed copy source exceeds512examples".into()));
+    }
+    let mut frames = Vec::new();
+    for document in documents {
+        if document
+            .response
+            .as_bytes()
+            .first()
+            .is_some_and(|b| b.is_ascii_digit() || matches!(*b, b'+' | b'-'))
+        {
+            continue;
+        }
+        let offset = target_start(model, document)?;
+        let mut session = response_session(model, &document.prompt)?;
+        let baseline = session.predict(model)?.token;
+        let target = if offset == 0 && target_reachable(model, document, 0)? {
+            baseline
+        } else {
+            *model
+                .encode(&document.response)?
+                .first()
+                .ok_or_else(|| Error("empty prefix target".into()))?
+        };
+        // Encode the prefix independently: a lexical token spanning copied bytes
+        // cannot be the prefix action.
+        let target = if offset > 0 {
+            model.encode(&document.response[..offset])?[0]
+        } else {
+            target
+        };
+        let (features, len) = word_copy_runtime::prefix_features(
+            model,
+            session
+                .response_entry
+                .as_ref()
+                .ok_or_else(|| Error("entry missing".into()))?,
+            session
+                .values
+                .as_ref()
+                .ok_or_else(|| Error("values missing".into()))?,
+            Control::Full,
+            &mut WordCopyWork::default(),
+        );
+        if len == 0 {
+            continue;
+        }
+        frames.push(Frame {
+            features,
+            len,
+            target,
+            baseline,
+        });
+    }
+    if frames.len() > config.max_positions {
+        return Err(Error("prefix fit exceeds position cap".into()));
+    }
+    for phase in 0..2 {
+        let fit = fit_sparse_frames(
+            &frames,
+            ValueCompletionFitConfig {
+                epochs: config.epochs,
+                learning_rate: config.learning_rate,
+                max_positions: config.max_positions,
+            },
+            RESPONSE_ENTRY_ROWS,
+            RESPONSE_ENTRY_ASSOCIATIONS,
+            0,
+        )?;
+        let head = copy_mut(model)?;
+        head.prefix_rows = fit.rows;
+        head.prefix_postings = fit.global_postings;
+        model.refresh_identity()?;
+        if phase == 1 {
+            break;
+        }
+        for document in documents {
+            if document
+                .response
+                .as_bytes()
+                .first()
+                .is_some_and(|b| b.is_ascii_digit() || matches!(*b, b'+' | b'-'))
+            {
+                continue;
+            }
+            let offset = target_start(model, document)?;
+            if offset > 0 || target_reachable(model, document, 0)? {
+                continue;
+            }
+            let mut targets = model.encode(&document.response)?;
+            targets.push(EOS);
+            if targets.len() > usize::from(RESPONSE_ENTRY_STEPS)
+                || frames.len() + targets.len() - 1 > config.max_positions
+            {
+                continue;
+            }
+            let mut session = response_session(model, &document.prompt)?;
+            let first = session.predict(model)?;
+            if first.token != targets[0] || session.response_entry_decision().is_none() {
+                continue;
+            }
+            session.observe(model, first.token)?;
+            for &target in &targets[1..] {
+                let baseline = session.predict(model)?.token;
+                let entry = session
+                    .response_entry
+                    .as_ref()
+                    .ok_or_else(|| Error("lexical continuation entry missing".into()))?;
+                if !entry.active {
+                    break;
+                }
+                let (features, len) = word_copy_runtime::prefix_features(
+                    model,
+                    entry,
+                    session
+                        .values
+                        .as_ref()
+                        .ok_or_else(|| Error("lexical continuation values missing".into()))?,
+                    Control::Full,
+                    &mut WordCopyWork::default(),
+                );
+                frames.push(Frame {
+                    features,
+                    len,
+                    target,
+                    baseline,
+                });
+                session.observe(model, target)?;
+            }
+        }
+    }
+    Ok(frames.len())
 }

--- a/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
@@ -3,7 +3,7 @@ use super::value_types::{ValueFeature, ValueRow};
 use super::*;
 
 pub(super) const RESPONSE_COPY_SCHEMA: &str = "uor-r4.native-response-entry/2";
-pub(super) const WORD_COPY_FEATURES: usize = 20;
+pub(super) const WORD_COPY_FEATURES: usize = 24;
 pub(super) const WORD_COPY_ROWS: usize = 4096;
 pub(super) const WORD_COPY_DICTIONARY: usize = 256;
 
@@ -30,6 +30,13 @@ pub(super) struct WordCopyModel {
     /// byte. False preserves the first /2 artifact's entry-boundary frame.
     #[serde(default, skip_serializing_if = "copy_suffix_disabled")]
     pub completed_word_suffix: bool,
+    /// General entry composition and committed-copy dispatch. Omission keeps /2 behavior.
+    #[serde(default, skip_serializing_if = "copy_suffix_disabled")]
+    pub composed_entry: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefix_rows: Vec<ScoreRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefix_postings: Vec<u32>,
 }
 
 fn copy_suffix_disabled(value: &bool) -> bool {
@@ -47,6 +54,12 @@ pub struct WordCopyWork {
     pub word_record_reads: u64,
     pub bound_rejections: u64,
     pub byte_reads: u64,
+    #[serde(default)]
+    pub equality_byte_comparisons: u64,
+    #[serde(default)]
+    pub dispatch_checks: u64,
+    #[serde(default)]
+    pub forced_dispatches: u64,
 }
 impl WordCopyWork {
     pub fn is_empty(&self) -> bool {
@@ -95,6 +108,8 @@ pub(super) struct WordCopyState {
     /// Immutable selected first-entry occurrence until the entry ends.
     pub origin: Option<u8>,
     pub progress: WordCopyProgress,
+    #[serde(default, skip_serializing_if = "copy_start_zero")]
+    pub start_step: u8,
     #[serde(skip)]
     pub pending: Option<WordCopyDecision>,
 }
@@ -113,3 +128,7 @@ pub(super) struct WordCopyContext {
 }
 
 pub(super) type CopyFeatures = ([ValueFeature; WORD_COPY_FEATURES], usize);
+
+fn copy_start_zero(value: &u8) -> bool {
+    *value == 0
+}

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -553,9 +553,11 @@ fn native_response_entry_commit_mismatch_and_limit_are_allocation_free() {
 fn native_word_copy_selection_bytes_mismatch_and_cap_are_allocation_free() {
     let (_, original) = copy_fixture::fitted();
     let completed_word = copy_fixture::fitted_completed_word();
+    let composed = copy_fixture::fitted_composed();
     for (variant, model) in [
         ("actual-byte suffix", original),
         ("completed-word suffix", completed_word),
+        ("composed dispatch", composed),
     ] {
         let prompt = model.encode(copy_fixture::COPY_PROMPT).unwrap();
         let mut session = model.session(Control::Full).unwrap();
@@ -633,6 +635,9 @@ fn native_word_copy_selection_bytes_mismatch_and_cap_are_allocation_free() {
         assert!(session.work.word_copy.word_candidates > 0);
         assert!(session.work.word_copy.dictionary_comparisons > 0);
         assert!(session.work.word_copy.byte_reads > 0);
+        if variant == "composed dispatch" {
+            assert!(session.work.word_copy.forced_dispatches > 0);
+        }
         assert!(session.work.word_copy.selector.mismatches > 0);
         assert!(session.work.response_entry.step_limits > 0);
         assert_eq!(session.work.values.derived_writes, 0);

--- a/crates/uor-r4-core/tests/support/native_word_copy_fixture.rs
+++ b/crates/uor-r4-core/tests/support/native_word_copy_fixture.rs
@@ -111,3 +111,15 @@ pub fn fitted_completed_word() -> &'static Model {
         Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
     })
 }
+
+#[allow(dead_code)]
+pub fn fitted_composed() -> &'static Model {
+    static MODEL: OnceLock<Model> = OnceLock::new();
+    MODEL.get_or_init(|| {
+        let (entry, _) = fitted();
+        let (model, _) = entry.fit_response_entry_copy_composed(
+            CONSTRUCTION.get().unwrap(), ResponseEntryFitConfig::default()
+        ).unwrap();
+        Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
+    })
+}

--- a/docs/evidence/native_geometric_word_copy_973.json
+++ b/docs/evidence/native_geometric_word_copy_973.json
@@ -168,8 +168,7 @@
         "expected": "argument\n}\n",
         "actual": "value\n}\n",
         "stop": "end_of_document",
-        "copy_actions": {
-        }
+        "copy_actions": {}
       }
     },
     {
@@ -1101,5 +1100,108 @@
       "bytes": 1425,
       "sha256": "2f5e867836460e4dabb542fd1db9f42e180ef0f71d6b8d56c90f398bb1eebee4"
     }
-  ]
+  ],
+  "composed_entry_successor_2026_09_05": {
+    "artifact_cid": "blake3:d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586",
+    "artifact_path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fact-copy-fit-3/model.json",
+    "artifact_sha256": "d70413f558e0f1d3ae3fd099b378a9912609e23983d541732ab3b79e47368f3c",
+    "artifact_bytes": 10230192,
+    "source_sha256": "467b99a574e912b39c695a936250fc790611ab54b34fc179da411a42a2e18779",
+    "raw_construction_examples": 288,
+    "added_construction_examples": 64,
+    "original_development": {
+      "exact": 32,
+      "total": 32
+    },
+    "identifier_transfer": {
+      "exact": 12,
+      "total": 12
+    },
+    "binding": {
+      "exact": 8,
+      "total": 8
+    },
+    "fact_development": {
+      "exact": 16,
+      "total": 16,
+      "baseline_exact": 0,
+      "categories": [
+        "simple",
+        "distractor",
+        "update",
+        "unsupported"
+      ],
+      "words_retained_per_case": [
+        8,
+        15
+      ]
+    },
+    "older_city_cases": {
+      "exact": 0,
+      "total": 2
+    },
+    "table_sizes": {
+      "dictionary": 75,
+      "selector_rows": 941,
+      "prefix_rows": 154,
+      "prefix_associations": 253,
+      "suffix_rows": 66,
+      "suffix_associations": 91
+    },
+    "dispatch_equal_output_and_final_state_cases": 62,
+    "forced_interior_bytes": 114,
+    "debug_optimized_equal_generation_objects": 248,
+    "whole_62_case_single_pass_us": {
+      "full": 46864,
+      "dispatch_disabled": 61984
+    },
+    "kernel_score_lookups": {
+      "full": {
+        "ordinary": 1509562,
+        "memory": 287313,
+        "copy": 60764
+      },
+      "dispatch_disabled": {
+        "ordinary": 1764910,
+        "memory": 417983,
+        "copy": 60764
+      }
+    },
+    "copy_geometry_disabled": {
+      "original_exact": 32,
+      "identifier_exact": 10,
+      "fact_exact": 3,
+      "scope": "within-artifact sensitivity only; matched-refit geometric advantage undetermined"
+    },
+    "compiler_execution_receipts_reused_by_exact_sha256": 32,
+    "cli_generation_matches": 3,
+    "runtime_checks": {
+      "native_tests": 108,
+      "allocation_and_source_checks": 6,
+      "preparation_tests": 5,
+      "prefix_checkpoint_and_per_step_causal_state": "PASS",
+      "forced_byte_ordinary_scoring": "zero"
+    },
+    "resource_checkpoint": {
+      "model_cycle_ms": 78172,
+      "model_cumulative_ms": 1025234,
+      "model_limit_ms": 1800000,
+      "engineering_build_test_ms": 1099542,
+      "engineering_cycle_limit_ms": 1200000,
+      "peak_sampled_model_rss_bytes": 767180800,
+      "additional_storage_authorized_and_recorded_mib": 896,
+      "storage_limit_bytes": 5385486336,
+      "stop_margin_bytes": 134217728,
+      "deletions": false,
+      "paid_external_compute": false
+    },
+    "complete_cost_and_preservation_record": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/fact-copy-optimized/checkpoint.json",
+    "scope": "The sixteen cases were frozen before fit. A stopped fit and an implementation-invalid fit were preserved; the label-slice repair was based on48unreachable construction targets, with no data, hyperparameter or feature retuning. The sixteen now constitute repaired OPEN development evidence, not a new final-held-out claim. final_exact_responses and eligible_examples in fit report count selector frames, including48prefix NoCopy guards, not distinct raw examples. The composed selector differs from the old selector; its suffix-law inherited wording applies only to keeping its selected rows fixed while fitting its suffix. Complete timed generation includes session creation, encoding, ingest and decode; counters cover instrumented kernel work, not every tokenizer or CPU instruction. No matched-refit geometric advantage is claimed.",
+    "negative_history": [
+      "fit1 stopped before model creation because a later shared grammar word was wrongly selected as a target; source and binaries retained",
+      "fit2 received no positive fact copies because one offline label comparison omitted the prefix offset: 48 construction targets incorrectly unreachable, 4/16 complete fact answers; model, source, binaries and outputs retained",
+      "fit3 corrects only that label slice: all96copy targets reachable and committed,176/176selector frames and288/288suffix positions fit; no data, features or hyperparameter retuning"
+    ],
+    "next_bottleneck": "The same retained fact does not yet transfer reliably across question wrappers; the two older city prompts still fail. Reuse this generic lexical/copy choice rather than add a task-specific head."
+  }
 }

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,6 +7,56 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
+## Composed fact answers and committed-copy dispatch — 2026-09-05
+
+The optional `composed_entry` extension now learns lexical output → retained-word
+selection → exact byte copying → completion. It also learns NoCopy lexical
+continuation after an actually selected first transition. No numeric fact is
+required. It reuses the existing sixteen-word capture, immutable occurrence,
+relative H4/zeta paths and completed-word frame. Exact query/source equality
+features support unseen names. Older artifacts retain their previous behavior.
+
+Artifact `blake3:d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586`
+is at `.uor-models/native-typed-value-2026-09-05/fact-copy-fit-3/model.json`.
+It answers **16/16** fixed fact cases (four each simple, distractor, update and
+unsupported), against **0/16** for the preceding artifact, while preserving
+**32/32** original responses, **12/12** identifier transfers and **8/8** binding
+outputs. All 32 generated Rust source hashes match prior compiler/execution
+receipts. Three actual CLI runs match evaluator Generation fields exactly;
+248 debug/optimized Generation objects match exactly. The two older city prompts
+still fail: this is bounded grounding, not general conversation or alpha.
+
+The cases were frozen before fitting, then exposed during an implementation-invalid
+attempt. That attempt incorrectly marked 48 construction copy targets unreachable
+because a label comparison omitted the prefix offset. Correcting that single
+slice admits all 96 copy targets; no source, features or hyperparameters were
+retuned. The sixteen cases now provide repaired OPEN development evidence,
+not a fresh final-held-out claim. Both failed attempts and their material remain.
+
+Committed interior bytes dispatch before ordinary candidate scoring, with score
+`1` explicitly marking dispatch rather than a comparable ranking score. Required
+observation/memory updates continue. All 62 outputs and final states match the
+same artifact with dispatch disabled; focused tests also compare per-step
+checkpoint state. On that workload, 114 forced bytes eliminate 255,348 ordinary
+and 130,670 memory score lookups. Complete generation, including session setup,
+encoding, ingest and decode, measured **46.864 ms vs 61.984 ms** in one pass.
+All other instrumented work is retained in the local cost report. This is a
+generic conditional-execution gain. Copy-geometry suppression reaches 3/16 fact
+answers; a matched-refit geometric advantage remains undetermined.
+
+The [existing evidence record](../evidence/native_geometric_word_copy_973.json)
+and local `fact-copy-optimized/checkpoint.json` bind source, artifacts, costs,
+negative history and preservation. Model work is **1,025.234/1,800 seconds**
+(**78.172/120** this cycle); engineering builds/tests at that checkpoint are
+**1,099.542/1,200 seconds**. Necessary storage increases total **+896 MiB** this
+cycle, including the stopped task's extra worktree and a separate fitter cache;
+the cumulative cap is **5,385,486,336 bytes**, retaining the 128 MiB stop margin.
+Peak sampled model RSS is 767,180,800 bytes. No material was deleted.
+
+The next bottleneck is wording transfer for the same retained facts. Test that
+existing lexical/copy choice across question wrappers before adding another
+mechanism. The approved cycle stops after protected delivery of this result.
+
 ## Retained words with observed completion state — 2026-09-05
 
 The current optional response-entry `/2` model selects an exact retained word

--- a/src/native_geometric_cli.rs
+++ b/src/native_geometric_cli.rs
@@ -264,6 +264,7 @@ enum ControlArg {
     ResponseEntryGeometryDisabled,
     WordCopyDisabled,
     WordCopyGeometryDisabled,
+    WordCopyDispatchDisabled,
 }
 impl From<ControlArg> for Control {
     fn from(value: ControlArg) -> Self {
@@ -286,6 +287,7 @@ impl From<ControlArg> for Control {
             ControlArg::ResponseEntryGeometryDisabled => Self::ResponseEntryGeometryDisabled,
             ControlArg::WordCopyDisabled => Self::WordCopyDisabled,
             ControlArg::WordCopyGeometryDisabled => Self::WordCopyGeometryDisabled,
+            ControlArg::WordCopyDispatchDisabled => Self::WordCopyDispatchDisabled,
         }
     }
 }
@@ -1278,6 +1280,11 @@ mod tests {
                 "word-copy-geometry-disabled",
                 Control::WordCopyGeometryDisabled,
                 "word_copy_geometry_disabled",
+            ),
+            (
+                "word-copy-dispatch-disabled",
+                Control::WordCopyDispatchDisabled,
+                "word_copy_dispatch_disabled",
             ),
         ] {
             let control: Control = ControlArg::from_str(argument, false).unwrap().into();


### PR DESCRIPTION
The existing copy path could only begin at the first response token and required a numeric source. The optional, artifact-bound `composed_entry` extension learns lexical output, retained-word selection, causal copying and completion without that numeric dependency. Exact query/source word equality supplements the existing relative H4/zeta paths. Unsupported answers learn lexical continuation after an actually selected first token. Numeric precedence, immutable copy provenance, the sixteen-word capture and the 32-observation bound remain.

Committed interior bytes now execute their copy operator before ordinary candidate scoring. Their score is explicitly a dispatch marker of 1. Required observation and memory updates continue; old artifacts retain their previous behavior. The change remains Rust integer/table serving with floating-point fitting offline.

Validation and measured behavior:

- 16/16 fixed fact cases (simple, distractor, update, unsupported), versus 0/16 for the preceding artifact. All 32 original answers, 12 identifier transfers and eight binding outputs remain correct. All 32 generated Rust source hashes match previously compiled/executed sources.
- 62/62 outputs and final states match with dispatch disabled; the focused test also compares per-step checkpoint state. Across 114 committed interior bytes, ordinary score lookups fall 1,764,910 → 1,509,562 and memory lookups 417,983 → 287,313. Other copy work is unchanged. Complete generation measured 61.984 → 46.864 ms in one pass; this is descriptive timing and a generic conditional-execution gain.
- 108 native tests, six allocation/source checks, five preparation tests, formatting, architecture policy and claim wording pass. Three direct optimized CLI runs match evaluator Generation fields. All 248 Generation objects replay exactly between the development fitter and optimized serving. Only the final offline label-slice correction required the development rebuild; serving code is unchanged.

The sixteen cases were frozen before fitting but exposed during an implementation-invalid attempt, so the repaired result is OPEN development evidence. The stopped attempt and the model that incorrectly marked 48 construction targets unreachable are preserved. No data, features or hyperparameters were retuned for the label-slice repair. Two older city prompts still fail. Copy-geometry suppression reaches 3/16 fact answers; a matched-refit geometric advantage and general conversation remain unestablished.

Model work: 78.172/120 seconds this cycle, 1,025.234/1,800 cumulative. Engineering: 1,099.542/1,200 seconds. Necessary storage increases were preauthorized and recorded (+896 MiB, including the stopped task's worktree and separate fitter cache); the 128 MiB stop margin remains. No user material was deleted.

The current-state pointer and existing evidence JSON identify artifact `blake3:d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586`, complete costs, failures and preservation. Broader release checks were not run; protected CI reports its actual checks separately.

Refs #973.
