### PR TITLE
Evaluate shared binding and preserve the wording-transfer negative

### DIFF
--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -19,6 +19,8 @@ use uor_r4_core::native_geometric::{
 };
 
 type ProbeResult<T> = Result<T, Box<dyn Error>>;
+#[path = "native_geometric_value_probe/wording.rs"]
+mod wording;
 const SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/1";
 const LEXEME_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/2";
 const WORD_COPY_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/3";
@@ -72,7 +74,7 @@ impl Options {
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "native_geometric_value_probe [prepare|prepare-copy|prepare-facts|fit|completion|entry|copy|copy-completed|copy-composed|evaluate] --output-dir NEW_DIRECTORY\n\
+                    "native_geometric_value_probe [prepare|prepare-copy|prepare-facts|prepare-wording|fit|completion|entry|copy|copy-completed|copy-composed|copy-binding|copy-binding-plain|evaluate] --output-dir NEW_DIRECTORY\n\
                      prepare-copy: --source SOURCE_V2 --lexeme-cues true\n\
                      copy: --model ENTRY_MODEL --source SOURCE_V3 --lexeme-cues true --generated-tokens 64\n\
                      copy-completed: same source/parent, suffix frame starts after the observed copied word\n\
@@ -128,6 +130,8 @@ impl Options {
             "copy",
             "copy-completed",
             "copy-composed",
+            "copy-binding",
+            "copy-binding-plain",
             "evaluate",
         ]
         .contains(&result.mode.as_str())
@@ -142,6 +146,8 @@ impl Options {
                 "copy",
                 "copy-completed",
                 "copy-composed",
+                "copy-binding",
+                "copy-binding-plain",
                 "evaluate",
             ]
             .contains(&result.mode.as_str())
@@ -154,6 +160,8 @@ impl Options {
                 "copy",
                 "copy-completed",
                 "copy-composed",
+                "copy-binding",
+                "copy-binding-plain",
             ]
             .contains(&result.mode.as_str())
                 && !result.lexeme_cues)
@@ -163,6 +171,8 @@ impl Options {
                 "copy",
                 "copy-completed",
                 "copy-composed",
+                "copy-binding",
+                "copy-binding-plain",
             ]
             .contains(&result.mode.as_str())
                 && result.epochs > 64)
@@ -210,7 +220,7 @@ impl Case {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Source {
     schema: String,
@@ -518,7 +528,14 @@ fn source(options: &Options) -> ProbeResult<Source> {
             "source schema must match --lexeme-cues; prepare a new /2 source with true".into(),
         );
     }
-    if ["copy", "copy-completed", "copy-composed"].contains(&options.mode.as_str())
+    if [
+        "copy",
+        "copy-completed",
+        "copy-composed",
+        "copy-binding",
+        "copy-binding-plain",
+    ]
+    .contains(&options.mode.as_str())
         && result.schema != WORD_COPY_SOURCE_SCHEMA
     {
         return Err("copy fitting requires the prepared /3 source".into());
@@ -942,6 +959,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("prepare-wording") {
+        return wording::prepare();
+    }
     let options = Options::parse()?;
     let output_limit = if [
         "completion",
@@ -949,6 +969,8 @@ fn main() -> ProbeResult<()> {
         "copy",
         "copy-completed",
         "copy-composed",
+        "copy-binding",
+        "copy-binding-plain",
     ]
     .contains(&options.mode.as_str())
     {
@@ -1006,62 +1028,78 @@ fn main() -> ProbeResult<()> {
         "copy",
         "copy-completed",
         "copy-composed",
+        "copy-binding",
+        "copy-binding-plain",
     ]
     .contains(&options.mode.as_str())
     {
         let examples: Vec<_> = source.fit.iter().map(Case::example).collect();
-        let (fitted, report) =
-            if ["copy", "copy-completed", "copy-composed"].contains(&options.mode.as_str()) {
-                let config = ResponseEntryFitConfig {
-                    epochs: options.epochs,
-                    learning_rate: options.learning_rate,
-                    max_positions: options.completion_max_positions,
-                };
-                let (fitted, report) = if options.mode == "copy-composed" {
+        let (fitted, report) = if [
+            "copy",
+            "copy-completed",
+            "copy-composed",
+            "copy-binding",
+            "copy-binding-plain",
+        ]
+        .contains(&options.mode.as_str())
+        {
+            let config = ResponseEntryFitConfig {
+                epochs: options.epochs,
+                learning_rate: options.learning_rate,
+                max_positions: options.completion_max_positions,
+            };
+            let (fitted, report) =
+                if matches!(options.mode.as_str(), "copy-binding" | "copy-binding-plain") {
+                    baseline.fit_response_entry_copy_binding(
+                        &examples,
+                        config,
+                        options.mode == "copy-binding-plain",
+                    )?
+                } else if options.mode == "copy-composed" {
                     baseline.fit_response_entry_copy_composed(&examples, config)?
                 } else if options.mode == "copy-completed" {
                     baseline.fit_response_entry_copy_completed_word(&examples, config)?
                 } else {
                     baseline.fit_response_entry_copy(&examples, config)?
                 };
-                write_json(&options.output_dir.join("fit-report.json"), &report)?;
-                (fitted, serde_json::to_value(report)?)
-            } else if options.mode == "entry" {
-                let (fitted, report) = baseline.fit_response_entry(
-                    &examples,
-                    ResponseEntryFitConfig {
-                        epochs: options.epochs,
-                        learning_rate: options.learning_rate,
-                        max_positions: options.completion_max_positions,
-                    },
-                )?;
-                write_json(&options.output_dir.join("fit-report.json"), &report)?;
-                (fitted, serde_json::to_value(report)?)
-            } else if options.mode == "completion" {
-                let (fitted, report) = baseline.fit_value_completion(
-                    &examples,
-                    ValueCompletionFitConfig {
-                        epochs: options.epochs,
-                        learning_rate: options.learning_rate,
-                        max_positions: options.completion_max_positions,
-                    },
-                )?;
-                write_json(&options.output_dir.join("fit-report.json"), &report)?;
-                (fitted, serde_json::to_value(report)?)
-            } else {
-                let config = ValueFitConfig {
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
+        } else if options.mode == "entry" {
+            let (fitted, report) = baseline.fit_response_entry(
+                &examples,
+                ResponseEntryFitConfig {
                     epochs: options.epochs,
                     learning_rate: options.learning_rate,
-                    max_features: options.max_features,
-                };
-                let (fitted, report) = if options.lexeme_cues {
-                    baseline.fit_values_with_lexeme_cues(&examples, config)?
-                } else {
-                    baseline.fit_values(&examples, config)?
-                };
-                write_json(&options.output_dir.join("fit-report.json"), &report)?;
-                (fitted, serde_json::to_value(report)?)
+                    max_positions: options.completion_max_positions,
+                },
+            )?;
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
+        } else if options.mode == "completion" {
+            let (fitted, report) = baseline.fit_value_completion(
+                &examples,
+                ValueCompletionFitConfig {
+                    epochs: options.epochs,
+                    learning_rate: options.learning_rate,
+                    max_positions: options.completion_max_positions,
+                },
+            )?;
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
+        } else {
+            let config = ValueFitConfig {
+                epochs: options.epochs,
+                learning_rate: options.learning_rate,
+                max_features: options.max_features,
             };
+            let (fitted, report) = if options.lexeme_cues {
+                baseline.fit_values_with_lexeme_cues(&examples, config)?
+            } else {
+                baseline.fit_values(&examples, config)?
+            };
+            write_json(&options.output_dir.join("fit-report.json"), &report)?;
+            (fitted, serde_json::to_value(report)?)
+        };
         write_new(&options.output_dir.join("model.json"), &fitted.to_bytes()?)?;
         // Evaluate the serialized/reloaded artifact, not only the trainer's
         // in-memory object. Parent monitoring charges this loading/serialization.
@@ -1117,6 +1155,13 @@ fn main() -> ProbeResult<()> {
     }
     if options.mode == "copy-composed" {
         report["response_entry_scope"] = json!("Composed /2 extension: first response word after at most one learned lexical prefix token; exact source/query equality plus relative H4/phase features select a retained occurrence. No numeric-source requirement. NoCopy lexical continuation learns after an actually selected first transition. Forced interior copy bytes dispatch before ordinary scoring with score1 marker; observation/memory updates remain.64new construction and16fresh cases augment the unchanged source; no template or target buffer enters inference.");
+    }
+    if matches!(options.mode.as_str(), "copy-binding" | "copy-binding-plain") {
+        report["response_entry_scope"] = json!({
+            "operator": "Composed copy with the existing candidate binding-mask/preceding-word address supplied to lexical entry as one sparse feature per retained occurrence. At most32entry features,16lexical candidates and16retained words. Source payloads and copy selection remain unchanged. No candidate rank or answer bytes enter the new entry feature; repeated features retain multiplicity.",
+            "copy_geometry_disabled_during_fit_and_serving": options.mode == "copy-binding-plain",
+            "control_scope": "Matched parent, source, dose, caps and nongeometric features. This flag removes H4/orientation/zeta features from the copy extension only; inherited ordinary/memory/typed paths remain. Reserved cases are evaluated separately after design selection."
+        });
     }
     if let Some(limit) = output_limit {
         report["resources"]["output_bytes_limit"] = json!(limit);

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/wording.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/wording.rs
@@ -1,0 +1,164 @@
+//! Authored raw-text interventions. This module never enters inference.
+use super::*;
+
+fn case(split: &str, world: usize, task: usize, style: usize, variant: usize) -> Case {
+    let (names, cities) = match split {
+        "fit" => (
+            ["ivy", "jade", "lyra", "mina"],
+            ["Rome", "Dover", "Cairo", "Perth"],
+        ),
+        _ => (
+            ["zora", "leif", "rhea", "noam"],
+            ["Kyoto", "Turin", "Basel", "Dakar"],
+        ),
+    };
+    let a = names[world % 4];
+    let b = names[(world + 1) % 4];
+    let x = cities[(world + variant) % 4];
+    let y = cities[(world + variant + 2) % 4];
+    let (facts, answer) = match task {
+        0 => (format!("{a} lives in {x}."), x),
+        1 if variant == 0 => (format!("{a} in {x}. {b} in {y}."), x),
+        1 => (format!("{b} in {y}. {a} in {x}."), x),
+        2 => (format!("{a} in {x}. {a} now in {y}."), y),
+        _ => (format!("{b} lives in {x}."), "Unknown"),
+    };
+    let query = match style {
+        1 | 3 => format!("What city does {a} live in?"),
+        4 => format!("Which city is {a} in?"),
+        _ => format!("Where is {a}?"),
+    };
+    let prompt = if matches!(style, 2 | 3) {
+        format!("User: {facts}\nUser: {query}\nAssistant:")
+    } else {
+        format!("{facts} {query} Answer:")
+    };
+    Case {
+        id: format!("wording/{split}/{world}/{task}/{style}/{variant}"),
+        pair_id: format!("wording/{split}/{world}/{task}/{style}"),
+        family: "prose".into(),
+        task: format!("wording_{task}_style_{style}"),
+        world: if split == "fit" {
+            600000 + world
+        } else {
+            700000 + world
+        },
+        variant,
+        prompt,
+        response: format!(" {answer}.\n"),
+    }
+}
+
+pub(super) fn prepare() -> ProbeResult<()> {
+    let args: Vec<_> = std::env::args().skip(2).collect();
+    if args.len() != 2 {
+        return Err("prepare-wording SOURCE_V3 NEW_DIRECTORY".into());
+    }
+    let mut source: Source = serde_json::from_slice(&fs::read(&args[0])?)?;
+    validate_source(&source)?;
+    if source.schema != WORD_COPY_SOURCE_SCHEMA || source.fit.len() != 288 {
+        return Err("wording preparation requires the unchanged 288-case fact source".into());
+    }
+    let root = Path::new(&args[1]);
+    fs::create_dir(root)?;
+    // Diagnostic factorial: same entity/value and query meaning; question,
+    // source distractor and speaker wrapper each vary independently.
+    let mut diagnostic = source.clone();
+    diagnostic.development.clear();
+    for distractor in 0..2 {
+        for long in 0..2 {
+            for wrapper in 0..2 {
+                for variant in 0..2 {
+                    let city = ["Oslo", "Lima"][variant];
+                    let facts = format!(
+                        "{}orin lives in {city}.",
+                        if distractor == 1 {
+                            "suri has 73 coins. tavi has 301 coins. "
+                        } else {
+                            ""
+                        }
+                    );
+                    let query = if long == 1 {
+                        "What city does orin live in?"
+                    } else {
+                        "Where is orin?"
+                    };
+                    let prompt = if wrapper == 1 {
+                        format!("User: {facts}\nUser: {query}\nAssistant:")
+                    } else {
+                        format!("{facts} {query} Answer:")
+                    };
+                    let pair = format!("wording/diagnostic/{distractor}/{long}/{wrapper}");
+                    diagnostic.development.push(Case {
+                        id: format!("{pair}/{variant}"),
+                        pair_id: pair,
+                        family: "prose".into(),
+                        task: format!("diagnostic_d{distractor}_q{long}_w{wrapper}"),
+                        world: 800000,
+                        variant,
+                        prompt,
+                        response: format!(" {city}.\n"),
+                    });
+                }
+            }
+        }
+    }
+    for world in 0..4 {
+        for task in 0..4 {
+            for style in 0..3 {
+                for variant in 0..2 {
+                    source.fit.push(case("fit", world, task, style, variant));
+                }
+            }
+        }
+    }
+    let mut reserved = source.clone();
+    reserved.development.clear();
+    for world in [0, 2] {
+        for task in 0..4 {
+            for style in [3, 4] {
+                for variant in 0..2 {
+                    reserved
+                        .development
+                        .push(case("reserved", world, task, style, variant));
+                }
+            }
+        }
+    }
+    source.scope.push_str(" Wording successor:96new construction cases cross short/long questions and short-question speaker wrappers. Existing62development remain open; separately saved32reserved cases cross long-question speaker wrappers and a new question form with new names/value combinations. No reserved response is passed to fitting.");
+    for (name, data) in [
+        ("source", &source),
+        ("diagnostic", &diagnostic),
+        ("reserved", &reserved),
+    ] {
+        validate_source(data)?;
+        let bytes = serde_json::to_vec_pretty(data)?;
+        write_new(&root.join(format!("{name}.json")), &bytes)?;
+        println!(
+            "{}",
+            json!({"source":name,"fit":data.fit.len(),"evaluation":data.development.len(),"blake3":blake3::hash(&bytes).to_hex().to_string()})
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn native_wording_sources_retain_all_fact_words() {
+        for split in ["fit", "reserved"] {
+            for task in 0..4 {
+                for style in 0..5 {
+                    let c = case(split, 0, task, style, 0);
+                    let words = c
+                        .prompt
+                        .split(|c: char| !c.is_ascii_alphanumeric())
+                        .filter(|s| !s.is_empty())
+                        .count();
+                    assert!(words <= 16, "{}: {words}", c.prompt);
+                }
+            }
+        }
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_runtime.rs
@@ -260,9 +260,20 @@ pub(super) fn candidate_rows(
     [usize; COMPLETION_FEATURES],
     usize,
 ) {
+    candidate_rows_bounded::<COMPLETION_FEATURES>(score_rows, global_postings, features, work)
+}
+
+/// Fixed scratch selected by the caller's feature bound. Existing completion
+/// callers retain their sixteen-row scratch; composed binding uses thirty-two.
+pub(super) fn candidate_rows_bounded<const N: usize>(
+    score_rows: &[ScoreRow],
+    global_postings: &[u32],
+    features: &[Feature],
+    work: &mut CompletionWork,
+) -> ([u32; COMPLETION_CANDIDATES], usize, [usize; N], usize) {
     let mut tokens = [0; COMPLETION_CANDIDATES];
     let mut count = 0;
-    let mut rows = [0; COMPLETION_FEATURES];
+    let mut rows = [0; N];
     let mut row_count = 0;
     for feature in features {
         work.feature_queries = work.feature_queries.saturating_add(1);

--- a/crates/uor-r4-core/src/native_geometric/completion_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/completion_training.rs
@@ -47,8 +47,8 @@ pub struct ValueCompletionFitReport {
     pub config: ValueCompletionFitConfig,
 }
 
-pub(super) struct Frame {
-    pub(super) features: [Feature; COMPLETION_FEATURES],
+pub(super) struct Frame<const N: usize = COMPLETION_FEATURES> {
+    pub(super) features: [Feature; N],
     pub(super) len: usize,
     pub(super) target: u32,
     pub(super) baseline: u32,
@@ -423,8 +423,8 @@ pub(super) struct SparseFit {
     pub(super) selected_epoch: usize,
 }
 
-pub(super) fn fit_sparse_frames(
-    frames: &[Frame],
+pub(super) fn fit_sparse_frames<const N: usize>(
+    frames: &[Frame<N>],
     config: ValueCompletionFitConfig,
     max_rows: usize,
     max_associations: usize,
@@ -484,7 +484,7 @@ pub(super) fn fit_sparse_frames(
     let mut examples = Vec::new();
     let mut target_in_candidates = 0;
     for frame in frames {
-        let (tokens, len, _, _) = completion_runtime::candidate_rows(
+        let (tokens, len, _, _) = completion_runtime::candidate_rows_bounded::<N>(
             &rows,
             &global_postings,
             &frame.features[..frame.len],

--- a/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
@@ -1,7 +1,7 @@
 //! Learned occurrence admission followed by one bounded, causal byte cursor.
 //! Dictionary primes are equality addresses. Exact payload bytes never become
 //! selector labels, and output observations never select a source occurrence.
-use super::completion_runtime::{candidate_rows, score_rows};
+use super::completion_runtime::{candidate_rows, candidate_rows_bounded, score_rows};
 use super::response_entry_types::*;
 use super::value_lexemes::{WordAtom, WORD_QUERY};
 use super::value_types::{ValueFeature, ValueState};
@@ -10,6 +10,20 @@ use super::*;
 
 pub(super) fn enabled(control: Control) -> bool {
     control != Control::WordCopyDisabled
+}
+
+fn geometry_control(model: &Model, control: Control) -> Control {
+    if matches!(control, Control::Full | Control::WordCopyDispatchDisabled)
+        && model
+            .response_entry
+            .as_ref()
+            .and_then(|h| h.copy.as_ref())
+            .is_some_and(|h| h.binding_geometry_disabled)
+    {
+        Control::WordCopyGeometryDisabled
+    } else {
+        control
+    }
 }
 
 pub(super) fn eligible(
@@ -54,6 +68,7 @@ pub(super) fn context(
     control: Control,
     work: &mut WordCopyWork,
 ) -> WordCopyContext {
+    let control = geometry_control(model, control);
     let mut context = WordCopyContext {
         addresses: [0; WORD_QUERY],
         query_path: None,
@@ -257,6 +272,7 @@ impl WordCopyState {
         control: Control,
         work: &mut WordCopyWork,
     ) -> ([Feature; RESPONSE_ENTRY_FEATURES], usize) {
+        let control = geometry_control(model, control);
         let suffix_control = if control == Control::WordCopyGeometryDisabled {
             Control::ResponseEntryGeometryDisabled
         } else {
@@ -682,13 +698,16 @@ pub(super) fn prefix_features(
     values: &ValueState,
     control: Control,
     work: &mut WordCopyWork,
-) -> ([Feature; RESPONSE_ENTRY_FEATURES], usize) {
+) -> ([Feature; WORD_COPY_PREFIX_FEATURES], usize) {
+    let control = geometry_control(model, control);
     let control = if control == Control::WordCopyGeometryDisabled {
         Control::ResponseEntryGeometryDisabled
     } else {
         control
     };
-    let (mut features, len) = entry.features(model, values, control, &mut work.selector);
+    let (base, mut len) = entry.features(model, values, control, &mut work.selector);
+    let mut features = [Feature { kind: 0, value: 0 }; WORD_COPY_PREFIX_FEATURES];
+    features[..len].copy_from_slice(&base[..len]);
     for feature in &mut features[..len] {
         feature.kind &= 15;
     }
@@ -724,6 +743,36 @@ pub(super) fn prefix_features(
             feature.value = (repeated << 32) | u64::from(entry.last);
         }
     }
+    if let Some(head) = model
+        .response_entry
+        .as_ref()
+        .and_then(|h| h.copy.as_ref())
+        .filter(|h| h.shared_binding)
+    {
+        if let Some(words) = &values.lexemes {
+            // Same relation as selector feature23, without candidate rank or
+            // payload identity. Keep every occurrence, including zero matches;
+            // sparse learned token coefficients decide its influence. Equal
+            // features retain multiplicity in both fitting and integer scoring.
+            for index in 0..words.query_len {
+                let mask = binding_mask(values, index, work);
+                let preceding = words
+                    .queries
+                    .get(index + 1)
+                    .filter(|_| index + 1 < words.query_len)
+                    .map_or(0, |word| {
+                        work.word_record_reads = work.word_record_reads.saturating_add(1);
+                        address(head, word, work)
+                    });
+                features[len] = Feature {
+                    kind: 32,
+                    value: (mask << 32) | u64::from(preceding),
+                };
+                len += 1;
+                work.selector.state_copies = work.selector.state_copies.saturating_add(1);
+            }
+        }
+    }
     (features, len)
 }
 
@@ -741,7 +790,7 @@ pub(super) fn prefix_offer(
     }
     let head = model.response_entry.as_ref()?.copy.as_ref()?;
     let (features, len) = prefix_features(model, entry, values, control, work);
-    let (tokens, count, rows, row_count) = candidate_rows(
+    let (tokens, count, rows, row_count) = candidate_rows_bounded::<WORD_COPY_PREFIX_FEATURES>(
         &head.prefix_rows,
         &head.prefix_postings,
         &features[..len],

--- a/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
@@ -578,6 +578,94 @@ fn native_word_copy_preserves_parent_and_respects_typed_precedence_and_controls(
 }
 
 #[test]
+fn native_word_copy_shared_binding_matches_selector_and_preserves_old_identity() {
+    let old = fixture::fitted_completed_word();
+    let bytes = old.to_bytes().unwrap();
+    assert!(!String::from_utf8_lossy(&bytes).contains("shared_binding"));
+    assert_eq!(
+        Model::from_bytes(&bytes).unwrap().artifact_cid(),
+        old.artifact_cid()
+    );
+    let mut model = old.clone();
+    let head = model
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap();
+    head.composed_entry = true;
+    head.shared_binding = true;
+    model.refresh_identity().unwrap();
+    for prompt in [
+        "orin lives in Oslo. What city does orin live in? Answer:",
+        "User: orin lives in Oslo. User: What city does orin live in? Assistant:",
+        "User: orin in Oslo. orin now in Lima. User: What city does orin live in? Assistant:",
+    ] {
+        let session = prefix(&model, prompt, Control::Full);
+        let values = session.values.as_ref().unwrap();
+        let entry = session.response_entry.as_ref().unwrap();
+        let mut work = WordCopyWork::default();
+        let (shared, len) =
+            word_copy_runtime::prefix_features(&model, entry, values, Control::Full, &mut work);
+        let words = values.lexemes.as_ref().unwrap();
+        assert_eq!(len, 16 + words.query_len);
+        assert!(len <= word_copy_types::WORD_COPY_PREFIX_FEATURES);
+        let context = word_copy_runtime::context(&model, values, Control::Full, &mut work);
+        for index in 0..words.query_len {
+            let (features, n) = word_copy_runtime::features(
+                &model,
+                values,
+                &context,
+                index,
+                Control::Full,
+                &mut work,
+            );
+            let binding = features[..n].iter().find(|f| f.kind == 23).unwrap();
+            assert_eq!(
+                shared[16 + index],
+                Feature {
+                    kind: 32,
+                    value: (binding.a << 32) | binding.b
+                }
+            );
+        }
+        assert!(work.equality_byte_comparisons > 0);
+        let mut controlled = model.clone();
+        controlled
+            .response_entry
+            .as_mut()
+            .unwrap()
+            .copy
+            .as_mut()
+            .unwrap()
+            .binding_geometry_disabled = true;
+        controlled.refresh_identity().unwrap();
+        let (plain, n) = word_copy_runtime::prefix_features(
+            &controlled,
+            entry,
+            values,
+            Control::Full,
+            &mut work,
+        );
+        assert!(plain[..n].iter().all(|f| f.kind < 6 || f.kind == 32));
+        let context = word_copy_runtime::context(&controlled, values, Control::Full, &mut work);
+        assert!(context.query_path.is_none() && context.query_phases.is_none());
+    }
+    let head = model
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap();
+    head.shared_binding = false;
+    head.binding_geometry_disabled = true;
+    model.refresh_identity().unwrap();
+    assert!(Model::from_bytes(&model.to_bytes().unwrap()).is_err());
+}
+
+#[test]
 fn native_word_copy_composed_prefix_dispatch_and_restore() {
     use super::value_types::{ValueFeature, ValueRow};
     let mut model = fixture::fitted_completed_word().clone();

--- a/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
@@ -222,7 +222,12 @@ impl WordCopyModel {
                 .prefix_rows
                 .windows(2)
                 .any(|p| p[0].feature >= p[1].feature)
-            || self.prefix_rows.iter().any(|r| r.feature.kind >= 16)
+            || (self.shared_binding && !self.composed_entry)
+            || (self.binding_geometry_disabled && !self.shared_binding)
+            || self
+                .prefix_rows
+                .iter()
+                .any(|r| r.feature.kind >= 16 && !(self.shared_binding && r.feature.kind == 32))
             || self
                 .prefix_rows
                 .iter()
@@ -233,7 +238,10 @@ impl WordCopyModel {
             || self.prefix_postings.iter().any(|&t| !valid_token(t))
             || self.prefix_postings.iter().collect::<BTreeSet<_>>().len()
                 != self.prefix_postings.len()
-            || self.continuation_rows.iter().any(|r| r.feature.kind < 16)
+            || self
+                .continuation_rows
+                .iter()
+                .any(|r| !(16..32).contains(&r.feature.kind))
             || self.continuation_rows.len() > RESPONSE_ENTRY_ROWS
             || self
                 .continuation_rows
@@ -261,7 +269,7 @@ impl WordCopyModel {
                 .iter()
                 .chain(&self.prefix_rows)
                 .any(|row| {
-                    row.feature.kind >= 32
+                    (row.feature.kind >= 32 && !(self.shared_binding && row.feature.kind == 32))
                         || row.default_score != 0
                         || row.postings.len() > RESPONSE_ENTRY_POSTINGS
                         || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
@@ -339,7 +347,7 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
-        self.fit_response_entry_copy_impl(documents, config, false, false)
+        self.fit_response_entry_copy_impl(documents, config, false, false, false, false)
     }
 
     /// Fit suffix transitions relative to the observed end of a copied word.
@@ -350,7 +358,7 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
-        self.fit_response_entry_copy_impl(documents, config, true, false)
+        self.fit_response_entry_copy_impl(documents, config, true, false, false, false)
     }
 
     pub fn fit_response_entry_copy_composed(
@@ -358,7 +366,18 @@ impl Model {
         documents: &[ValueExample],
         config: ResponseEntryFitConfig,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
-        self.fit_response_entry_copy_impl(documents, config, true, true)
+        self.fit_response_entry_copy_impl(documents, config, true, true, false, false)
+    }
+
+    /// Fit entry with candidate-relative binding evidence. The optional matched
+    /// control removes copy-extension geometry throughout fitting and serving.
+    pub fn fit_response_entry_copy_binding(
+        &self,
+        documents: &[ValueExample],
+        config: ResponseEntryFitConfig,
+        geometry_disabled: bool,
+    ) -> Result<(Model, ResponseEntryCopyFitReport)> {
+        self.fit_response_entry_copy_impl(documents, config, true, true, true, geometry_disabled)
     }
 
     fn fit_response_entry_copy_impl(
@@ -367,6 +386,8 @@ impl Model {
         config: ResponseEntryFitConfig,
         completed_word_suffix: bool,
         composed_entry: bool,
+        shared_binding: bool,
+        binding_geometry_disabled: bool,
     ) -> Result<(Model, ResponseEntryCopyFitReport)> {
         let source_bytes = documents.iter().try_fold(0_usize, |sum, document| {
             sum.checked_add(document.prompt.len())?
@@ -414,6 +435,8 @@ impl Model {
         entry.copy = Some(WordCopyModel {
             completed_word_suffix,
             composed_entry,
+            shared_binding,
+            binding_geometry_disabled,
             prefix_rows: Vec::new(),
             prefix_postings: Vec::new(),
             baseline_artifact: self.artifact_cid.clone(),

--- a/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
@@ -4,6 +4,7 @@ use super::*;
 
 pub(super) const RESPONSE_COPY_SCHEMA: &str = "uor-r4.native-response-entry/2";
 pub(super) const WORD_COPY_FEATURES: usize = 24;
+pub(super) const WORD_COPY_PREFIX_FEATURES: usize = 32;
 pub(super) const WORD_COPY_ROWS: usize = 4096;
 pub(super) const WORD_COPY_DICTIONARY: usize = 256;
 
@@ -33,6 +34,12 @@ pub(super) struct WordCopyModel {
     /// General entry composition and committed-copy dispatch. Omission keeps /2 behavior.
     #[serde(default, skip_serializing_if = "copy_suffix_disabled")]
     pub composed_entry: bool,
+    /// Add each candidate's existing mask/preceding-address evidence at entry.
+    #[serde(default, skip_serializing_if = "copy_suffix_disabled")]
+    pub shared_binding: bool,
+    /// Matched offline fit and serving control, scoped to this copy extension.
+    #[serde(default, skip_serializing_if = "copy_suffix_disabled")]
+    pub binding_geometry_disabled: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub prefix_rows: Vec<ScoreRow>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -554,10 +554,12 @@ fn native_word_copy_selection_bytes_mismatch_and_cap_are_allocation_free() {
     let (_, original) = copy_fixture::fitted();
     let completed_word = copy_fixture::fitted_completed_word();
     let composed = copy_fixture::fitted_composed();
+    let binding = copy_fixture::fitted_shared_binding();
     for (variant, model) in [
         ("actual-byte suffix", original),
         ("completed-word suffix", completed_word),
         ("composed dispatch", composed),
+        ("shared binding entry", binding),
     ] {
         let prompt = model.encode(copy_fixture::COPY_PROMPT).unwrap();
         let mut session = model.session(Control::Full).unwrap();

--- a/crates/uor-r4-core/tests/support/native_word_copy_fixture.rs
+++ b/crates/uor-r4-core/tests/support/native_word_copy_fixture.rs
@@ -123,3 +123,15 @@ pub fn fitted_composed() -> &'static Model {
         Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
     })
 }
+
+#[allow(dead_code)]
+pub fn fitted_shared_binding() -> &'static Model {
+    static MODEL: OnceLock<Model> = OnceLock::new();
+    MODEL.get_or_init(|| {
+        let (entry, _) = fitted();
+        let (model, _) = entry.fit_response_entry_copy_binding(
+            CONSTRUCTION.get().unwrap(), ResponseEntryFitConfig::default(), false
+        ).unwrap();
+        Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
+    })
+}

--- a/docs/evidence/native_geometric_word_copy_973.json
+++ b/docs/evidence/native_geometric_word_copy_973.json
@@ -1203,5 +1203,277 @@
       "fit3 corrects only that label slice: all96copy targets reachable and committed,176/176selector frames and288/288suffix positions fit; no data, features or hyperparameter retuning"
     ],
     "next_bottleneck": "The same retained fact does not yet transfer reliably across question wrappers; the two older city prompts still fail. Reuse this generic lexical/copy choice rather than add a task-specific head."
+  },
+  "wording_binding_successor_2026_09_05": {
+    "decision": "REJECT_SHARED_BINDING_PROMOTION_RETAIN_D095",
+    "selected_artifact": "blake3:d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586",
+    "source_freeze": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/wording-source/freeze.json",
+    "checkpoint": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/wording-checkpoint.json",
+    "analysis": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/wording-analysis.json",
+    "artifacts": [
+      {
+        "path": "fact-copy-fit-3/model.json",
+        "sha256": "d70413f558e0f1d3ae3fd099b378a9912609e23983d541732ab3b79e47368f3c",
+        "artifact": "blake3:d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586"
+      },
+      {
+        "path": "wording-coverage-fit/model.json",
+        "sha256": "9a3f0b16ce06273d87ddd54cb51175e340f3790a23257486d6e31362ac4ab9d0",
+        "artifact": "blake3:00b96b972706b8f514d09ce95ddc24801d3c12b78d07bb018af4d5af4232312f"
+      },
+      {
+        "path": "wording-binding-fit/model.json",
+        "sha256": "30a7a3ba270e17e751033858b31ddd1f433a9b3457cde7ea4c39e665a13253ef",
+        "artifact": "blake3:f933b199c342fd715c44d938b86281493730f2b41d6d33287e7369f852c24232"
+      },
+      {
+        "path": "wording-plain-fit/model.json",
+        "sha256": "ba69c33416d8dfc5f89d4ae41cae10b91ea44ee9c71caab40ecbc186d1ae93a7",
+        "artifact": "blake3:a42264fc7599f9f1b0053a9c52880925b72deed00ef5c3595353861f7ec52c64"
+      }
+    ],
+    "comparison": {
+      "diagnostic": {
+        "parent": 4,
+        "extra_coverage": 12,
+        "shared_binding": 12,
+        "total": 16
+      },
+      "reserved": {
+        "parent": 3,
+        "extra_coverage": 0,
+        "shared_binding": 8,
+        "matched_no_copy_geometry": 8,
+        "total": 32,
+        "supported_shared_binding": 0,
+        "supported_total": 24
+      },
+      "shared_binding_preservation": {
+        "original": 32,
+        "original_total": 32,
+        "identifiers": 12,
+        "identifier_total": 12,
+        "binding": 8,
+        "binding_total": 8,
+        "facts": 12,
+        "fact_total": 16,
+        "old_cities": 0,
+        "old_city_total": 2
+      }
+    },
+    "mechanism": "Up to16candidate-relative mask/preceding-word sparse features augment existing16entry features. Exact payload/provenance stays at the occurrence; entry sums features with multiplicity and loses absolute occurrence rank. No extra persistent state or dense inference. Existing copy/observation/completion operators execute.",
+    "cost": {
+      "same_62_full_us": 50597,
+      "same_62_no_dispatch_us": 65275,
+      "full_ordinary_score_lookups": 1619990,
+      "no_dispatch_ordinary_score_lookups": 1867776,
+      "full_memory_score_lookups": 294190,
+      "no_dispatch_memory_score_lookups": 418735,
+      "copy_score_lookups_each": 90651,
+      "full_equality_byte_comparisons": 10764,
+      "full_dictionary_byte_comparisons": 54336,
+      "forced_bytes": 111,
+      "equal_responses_and_causal_states": 62,
+      "scope": "Single-pass complete generation, including failed answers; compare mode field separately from causal state. Full operation vectors and parent wall in local report."
+    },
+    "checks": {
+      "first_native_units": 109,
+      "first_other_allocation_checks": 5,
+      "initial_new_allocation_fixture": "FAILED: second legacy serialized-row validator rejected kind32; corrected without data/dose change",
+      "corrected_copy_tests": 12,
+      "corrected_allocation_fixture": 1,
+      "preparation_word_bound": 1,
+      "architecture_policy": "PASS; existing checker source unchanged",
+      "broader_release": "NOT_RUN",
+      "preparation_tests": 6,
+      "format": "PASS",
+      "claim_wording": "PASS"
+    },
+    "compiler_and_cli": {
+      "primary_rust_sources": [
+        {
+          "id": "typed-value/development/rust/copy_current/100000",
+          "sha256": "e61f90d2aa38709da5359f151c07be4736902caa26cfd0aaa67251ed59076ceb",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/add/100000",
+          "sha256": "c292364e9eb6266145bf036b1f8e83beb1be7ee5db1d717eff965838c02871cc",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100000",
+          "sha256": "e7f616298e08196303ef15b2fb07a3680b16f3a7b8c671ac8210c36283156e6c",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100000",
+          "sha256": "299881eec91f60a179921730b9682ace4f7d279adbfd27550271f7d6f01734f7",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100001",
+          "sha256": "c557d2df58880d276e54535478ec62a1813a1b4e8c8b2e5e4bf2fb0a6f0d7946",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/add/100001",
+          "sha256": "23ab8e2699972be781259a26196a02b279bde80fffed667a4e0b23d4bf6bc0a8",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100001",
+          "sha256": "e9598a4a22328f4eaaaabd43efbccccdfc104f2856ed92ad82aee6db81ed9a28",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100001",
+          "sha256": "25a17208dea97ff149e909e44f7a426f8bc5ea4f6487619aff7434946795a464",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100002",
+          "sha256": "85d7b8b3ed676b2fa0edffd6a6567551cc137d18b0cac3ca509f825b2b68ae46",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/add/100002",
+          "sha256": "396cae8077457f9de9017a28e29f43eaeac1ea7d7f8cad0f01f1a171fcf78f3d",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100002",
+          "sha256": "602073f96b9821543ade567a4a83f1e35a4dbd7d486d775d67e6ca1d1518c1e6",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100002",
+          "sha256": "39af86739650c691fd5021eda5970e0aee413991ec3f0ff6339b7d93d8cce797",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/copy_current/100003",
+          "sha256": "778d32ee744aa9bb9706f37cfd8ffb661c583c48ec0a20f145e939471faf7afb",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/add/100003",
+          "sha256": "c312ab219b6d8da0d26073e3df724f2be1dbcadea432beab315a81140494bd7e",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/dependency_before_update/100003",
+          "sha256": "331b8a5ee693357c72531a7b7a26e7e315ee784e6be8095082fe10eb44c11e39",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/development/rust/no_write/100003",
+          "sha256": "ed0f77f68dfa017837f1b56e8c5dc190fcde4870e915d69d8ffbdeb482551010",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-0/name-0",
+          "sha256": "e8e7095aafc543051954356830a4ab73a15a7cf61bb96af5c10aeebc6de6a3d4",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-0/name-1",
+          "sha256": "d8d84907bf18113866c86166da38873855204252afc4a620db3e8584a53b4d5e",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-0/name-2",
+          "sha256": "ccb9ee1f0dbdca9b3a554e6ed8d29ef6bb8b99047fc9a464b57355136223acd8",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-0/name-3",
+          "sha256": "64bf5e18bd9623ffab1c44da14953de2868313355b8c757e293f6a05f658104a",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-1/name-4",
+          "sha256": "d827d783d23a02ff8b63cbe7ada558d436d95d111efc60f2759acc56499e12f0",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-1/name-5",
+          "sha256": "2a08631ec0229e15a718cac835dbd454991cbe4efeaee4b8a5c86c963abbcf4f",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-2/name-6",
+          "sha256": "d217ee39f7eb66fbd91da62114993ec905e543ca659473395872c95a821098f0",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-2/name-7",
+          "sha256": "44df0d1754a3efa57821a1eb476e79dbb92a1f33ae810dbad30083d105eeab5b",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-3/name-8",
+          "sha256": "6a6d515a98fa92789b16aa77d407c5f0129525db0837f8a4e408546dac9a9e11",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-3/name-9",
+          "sha256": "77206067e6b631af966880176c2cb67d01d39d24b152a2156dbf395a4c9d6d4c",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-1/name-10",
+          "sha256": "16fb5e596e223c3618affb6b5af9a707533dba5f69ac4cbe76ddd6251d9f59b9",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "word-copy/development/context-1/name-11",
+          "sha256": "2853d71c7b5ad960f9480189d5f3525ebe9ce882c6b915af5b1a1a7190689765",
+          "same_previously_executed_source": true
+        }
+      ],
+      "prior_receipt": "fact-copy-optimized/cli-and-compiler-reuse.json and prior exact compiler receipts",
+      "scope": "Reuse previously compiled and executed generated sources only when exact full-source SHA256 agrees. No new compiler execution is claimed.",
+      "binding_exact": 8,
+      "binding_rust_sources": [
+        {
+          "id": "typed-value/binding/rust/copy_current/original",
+          "sha256": "e61f90d2aa38709da5359f151c07be4736902caa26cfd0aaa67251ed59076ceb",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/binding/rust/copy_current/source_names_swapped",
+          "sha256": "b783ed24990162c4f5bb69a34a54c794691bc435cd0f52e711cd3b23585b00a9",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/binding/rust/add/original",
+          "sha256": "c292364e9eb6266145bf036b1f8e83beb1be7ee5db1d717eff965838c02871cc",
+          "same_previously_executed_source": true
+        },
+        {
+          "id": "typed-value/binding/rust/add/source_names_swapped",
+          "sha256": "90c50d166f18ffaa54b009d2a509f303fee617648be94f3ece6c88afde895e2a",
+          "same_previously_executed_source": true
+        }
+      ],
+      "actual_cli": {
+        "text": " Unknown.\nKyoto.\n",
+        "generation_fields_equal": true,
+        "artifact": "blake3:f933b199c342fd715c44d938b86281493730f2b41d6d33287e7369f852c24232"
+      }
+    },
+    "resources": {
+      "model_ms": 33622,
+      "engineering_checkpoint_ms": 1101175,
+      "cumulative_model_ms": 1058856,
+      "cumulative_limit_ms": 1800000,
+      "peak_sampled_model_rss_bytes": 761085952,
+      "storage_increase_bytes": 268435456,
+      "storage_limit_bytes": 5653921792,
+      "engineering_final_ms": 1104632
+    },
+    "scope": "Reserved32authored before fitting and executed once per frozen artifact after design selection. Legacy evaluator names the partition development/OPEN; provenance here distinguishes its first use. No reserved outcome selected or retuned these models. Geometry comparison removes features during fitting and Full/dispatch-controlled serving of the copy extension only; baseline, memory and typed paths remain. Exact equality is 8/32 in both fits, all unsupported; outputs need not match on failures. No geometric advantage or alpha. Complete generation timing includes session construction, encoding, ingest, prediction/observation and decode; artifact load and preparation/fits/serialization/CLI are charged in cumulative parent wall. Work counters are instrumented operations, not every CPU instruction.",
+    "next_hypothesis": "Nonmatching occurrences also contribute to prefix scoring. Unknown dictionary predecessors share feature32/value0, whose space score is -242 and Unknown score is -196. Repeated contributions can favor abstention, but a matched removal/refit has NOT_RUN; this is a candidate explanation, not established sole cause."
   }
 }

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,6 +7,62 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
+## Wording transfer and shared binding — 2026-09-05, later checkpoint
+
+**Decision: reject the shared-binding candidate for promotion.** Keep the
+composed fact artifact `d095a1abccefd68678a9d7da61e4d8fd094d9f7ca71e10c5e0383518889ed586`
+selected. Its delivery, PR #1134, merged as `19f25ddb`. Useful geometric-only
+conversation/coding remains the goal; broader transfer is not established.
+
+A sixteen-case matched check separates question wording, speaker formatting and
+numeric distractors. Distractors do not change outcomes. The selected artifact
+gets 4/16 exact. Adding 96 construction cases to the existing 288, with unchanged
+operators and fitting dose, reaches 12/16 but regresses four original abstentions.
+
+The optional `shared_binding` implementation adds each retained occurrence's
+existing query/source equality mask and preceding-word prime address to lexical
+entry. It keeps the sixteen-word capture, /4 memory, typed operators, copy cursor,
+completion frame and integer/table serving. Entry has at most 32 features; no new
+persistent state or answer buffer is added. These features preserve local
+matches and their multiplicity, while pooled scoring loses occurrence rank and
+full clause/query meaning. All matching, dictionary lookup and scoring work is
+included in the existing counters.
+
+The shared-binding fit preserves 32/32 original,12/12 identifier and 8/8 binding
+responses, but gets 12/16 prior fact cases and 0/2 old cities. It also reaches 12/16
+on the matched diagnostic. A matched fit without copy-extension geometry has
+the same preservation counts. The 32 reserved cases were authored before fitting
+and opened once per frozen artifact after design selection, with no subsequent
+tuning: selected parent 3/32, extra-coverage fit 0/32, shared binding 8/32 and matched
+geometry-disabled fit 8/32. Both shared fits get only the eight unsupported cases
+right: **0/24supported complete answers**. This is a transfer negative, with no
+geometric advantage established. Existing benchmark/report OPEN labels do not
+replace the first-use provenance in the local checkpoint.
+
+The new fit's 62 responses and causal final states match with committed-copy
+dispatch enabled/disabled. Complete generation totals 50.597/65.275 ms in one pass;
+ordinary score lookups 1,619,990/1,867,776, memory 294,190/418,735, and copy 90,651
+in both. Shared entry adds work; this is not an efficiency improvement over the
+selected artifact. Failed outputs also contribute to those timings.
+
+Local evidence lives under
+`.uor-models/native-typed-value-2026-09-05/wording-checkpoint.json`, with frozen
+sources, three fitted artifacts, all outputs/cost vectors, CLI equality and 32
+unchanged generated-Rust compiler receipts. Checks passed 109 native units; after
+repairing a serialized-row validation omission, 12 affected copy tests, the new
+allocation fixture and the source word-bound test passed. Model work used
+33.622/120 seconds; cumulative 1,058.856/1,800 seconds. Engineering used 1,104.632/1,200 seconds, including final
+formatting, claim wording and all six preparation tests. Necessary storage increased 256 MiB
+to a cumulative 5,653,921,792-byte cap, preserving the 128 MiB margin. No deletions
+or external compute.
+
+A concrete remaining hypothesis is that nonmatching occurrences should not cast
+lexical votes: feature32/value0 currently penalizes the prefix space by 242 per
+occurrence and Unknown by 196. This can favor abstention for unseen dictionary
+words. Neutralizing that contribution and testing source-supported entry is
+**not implemented or evaluated**. Do not widen context or promote these fits on
+the strength of construction accuracy.
+
 ## Composed fact answers and committed-copy dispatch — 2026-09-05
 
 The optional `composed_entry` extension now learns lexical output → retained-word

--- a/docs/native_geometric_word_copy_973.md
+++ b/docs/native_geometric_word_copy_973.md
@@ -302,3 +302,25 @@ bound and charge prefix scoring, selection, copying, suffix and ordinary work.
 This successor is not implemented or qualified by this record. Removing numeric
 distractors exposes a separate earlier eligibility restriction; selecting one
 entity's city among multiple facts is also unproven.
+
+## Later wording-transfer result — 2026-09-05
+
+The composed-entry successor above has since been implemented and delivered in
+PR #1134; its selected artifact answers 16/16 fixed fact cases. The subsequent
+wording experiment is a negative. A same-fact factorial separates distractors
+from wording and speaker wrappers: numeric distractors do not change outcomes;
+wording/format changes do. Wider construction alone gets 12/16 diagnostic cases,
+but does not transfer to the 32 reserved cases and regresses four original answers.
+
+The optional shared-binding fit adds existing candidate mask/preceding-word
+features to lexical entry, preserving bounded integer/table inference. It gets
+12/16 diagnostic and 8/32 reserved exact answers; all eight reserved successes are
+unsupported questions. A matched fit with copy-extension geometry removed also
+gets 8/32. Both regress four prior fact cases. Keep the prior composed artifact
+selected; neither new fit establishes transfer or geometric advantage.
+
+Entry pools occurrence features, including zero-match features, with multiplicity.
+For missing dictionary addresses its shared zero-match row penalizes a prefix
+space more than Unknown. Making such evidence neutral is a concrete hypothesis,
+not a completed repair. Full costs, preserved artifacts, comparison source and
+checks are appended to the existing evidence JSON and current-state pointer.


### PR DESCRIPTION
Conversational formatting and question wording can make the native model answer “Unknown” even when the requested value remains available for copying. Add an optional experiment that supplies the existing occurrence binding-mask/preceding-word feature to response entry, plus a matched fit without copy-extension geometry. **The experiment fails promotion; the previous d095a1ab artifact remains selected.**

Entry uses at most 32 sparse features and 16 lexical candidates, with no new persistent state or dense inference. The existing integer/table selector, immutable byte cursor, completion frame and typed precedence remain. Older artifacts omit the new flags. The shared sparse fitter and row scratch accept a compile-time bound so other completion callers retain their existing bounds.

The Rust preparation path adds 96 construction examples and saves a 16-case matched diagnostic and 32 reserved transfer cases. All required fact words in the reserved cases fit the existing sixteen-word capture. Labels never enter inference. Sources, artifact identities, outputs and complete cost vectors are recorded in the existing evidence record and local `wording-checkpoint.json`.

| Variant | Matched diagnostic | Original responses | Prior facts | Reserved transfer |
|---|---:|---:|---:|---:|
| Selected parent | 4/16 | 32/32 | 16/16 | 3/32 |
| More coverage, same mechanism | 12/16 | 28/32 | 16/16 | 0/32 |
| Shared binding | 12/16 | 32/32 | 12/16 | 8/32 |
| Matched fit without copy geometry | Not run | 32/32 | 12/16 | 8/32 |

Both shared fits get only the eight unsupported reserved questions correct: 0/24 supported complete answers. Both preserve 12/12 identifier and 8/8 binding responses and still fail the two older city cases. Reserved results were opened after design selection and did not tune the implementation. No geometric advantage is established. Zero-match contributions from unknown dictionary addresses are a concrete remaining hypothesis, not a completed correction.

Validation: 109 native unit tests passed. The new allocation fixture caught a second legacy validator rejecting the new serialized feature kind; after correction, 12 affected copy tests, the allocation fixture and all six preparation tests pass. Formatting, architecture policy and claim wording pass. One actual CLI run matches evaluator fields exactly. All 32 generated Rust source hashes match prior compilation/execution receipts. Broader release checks were not run.

On the shared fit's same 62 cases, dispatch preserves all response bytes and causal final states: complete generation 50.597 vs 65.275 ms in one pass; ordinary score lookups 1,619,990 vs 1,867,776; memory 294,190 vs 418,735; copy 90,651 in both. Failures are included. This retains conditional-execution savings, not a new model-quality or geometry-specific efficiency gain.

Cycle resources: 33.622/120 seconds model work; 1,104.632/1,200 seconds engineering, including the failed check. Cumulative model work 1,058.856/1,800 seconds. Peak sampled model RSS 761,085,952 bytes. The preauthorized 256 MiB storage increment carries the cumulative ceiling to 5,653,921,792 bytes with the existing stop margin. No deletion or external compute.

Refs #973.
