### PR TITLE
Correct response-entry abstention from repeated unbound scores

### DIFF
--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -74,7 +74,9 @@ impl Options {
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "native_geometric_value_probe [prepare|prepare-copy|prepare-facts|prepare-wording|fit|completion|entry|copy|copy-completed|copy-composed|copy-binding|copy-binding-plain|evaluate] --output-dir NEW_DIRECTORY\n\
+                    "neutralize-zero-binding INPUT_MODEL NEW_OUTPUT_MODEL (no refit; scores only)\n\
+                     prepare-entry-check SOURCE_V3 NEW_OUTPUT_SOURCE (sixteen raw cases)\n\
+                     native_geometric_value_probe [prepare|prepare-copy|prepare-facts|prepare-wording|fit|completion|entry|copy|copy-completed|copy-composed|copy-binding|copy-binding-plain|evaluate] --output-dir NEW_DIRECTORY\n\
                      prepare-copy: --source SOURCE_V2 --lexeme-cues true\n\
                      copy: --model ENTRY_MODEL --source SOURCE_V3 --lexeme-cues true --generated-tokens 64\n\
                      copy-completed: same source/parent, suffix frame starts after the observed copied word\n\
@@ -959,6 +961,23 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("prepare-entry-check") {
+        return wording::prepare_entry_check();
+    }
+    if std::env::args().nth(1).as_deref() == Some("neutralize-zero-binding") {
+        let args: Vec<_> = std::env::args().skip(2).collect();
+        if args.len() != 2 {
+            return Err("neutralize-zero-binding INPUT_MODEL NEW_OUTPUT_MODEL".into());
+        }
+        let parent = Model::from_bytes(&fs::read(&args[0])?)?;
+        let model = parent.neutralize_copy_zero_binding()?;
+        write_new(Path::new(&args[1]), &model.to_bytes()?)?;
+        println!(
+            "{}",
+            json!({"parent":parent.artifact_cid(),"artifact":model.artifact_cid(),"intervention":"zero scores only in prefix feature32/value0; postings unchanged; no fit"})
+        );
+        return Ok(());
+    }
     if std::env::args().nth(1).as_deref() == Some("prepare-wording") {
         return wording::prepare();
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/wording.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/wording.rs
@@ -1,6 +1,76 @@
 //! Authored raw-text interventions. This module never enters inference.
 use super::*;
 
+/// Fresh complete-answer check authored after selecting the single-row ablation.
+/// No fitting consumes these cases. A later reuse must label them development.
+pub(super) fn prepare_entry_check() -> ProbeResult<()> {
+    let args: Vec<_> = std::env::args().skip(2).collect();
+    if args.len() != 2 {
+        return Err("prepare-entry-check SOURCE_V3 NEW_OUTPUT_SOURCE".into());
+    }
+    let mut source: Source = serde_json::from_slice(&fs::read(&args[0])?)?;
+    validate_source(&source)?;
+    if source.schema != WORD_COPY_SOURCE_SCHEMA {
+        return Err("entry check requires word-copy source".into());
+    }
+    source.development.clear();
+    for task in 0..4 {
+        for style in 0..4 {
+            let names = ["elva", "brin", "sena", "kael"];
+            let cities = ["Metz", "Cork", "Graz", "Pune"];
+            let a = names[style];
+            let b = names[(style + 1) % 4];
+            let x = cities[style];
+            let y = cities[(style + 2) % 4];
+            let (facts, answer) = match task {
+                0 => (format!("{a} lives in {x}."), x),
+                1 if style % 2 == 0 => (format!("{a} in {x}. {b} in {y}."), x),
+                1 => (format!("{b} in {y}. {a} in {x}."), x),
+                2 => (format!("{a} in {x}. {a} now in {y}."), y),
+                _ => (format!("{b} lives in {x}."), "Unknown"),
+            };
+            let query = match style {
+                1 => format!("What city does {a} live in?"),
+                3 => format!("Which city is {a} in?"),
+                _ => format!("Where is {a}?"),
+            };
+            let prompt = if style == 2 {
+                format!("User: {facts}\nUser: {query}\nAssistant:")
+            } else {
+                format!("{facts} {query} Answer:")
+            };
+            let words = prompt
+                .split(|c: char| !c.is_ascii_alphanumeric())
+                .filter(|w| !w.is_empty())
+                .count();
+            if words > 16 {
+                return Err("entry check exceeds retained-word capacity".into());
+            }
+            source.development.push(Case {
+                id: format!("source-entry/final/{task}/{style}"),
+                // Evaluator bookkeeping only: these vary wording and names,
+                // so pair metrics are not a matched counterfactual claim.
+                pair_id: format!("source-entry/final/{task}/{}", style / 2),
+                family: "prose".into(),
+                task: format!("fact_{task}_style_{style}"),
+                world: 900000 + style,
+                variant: style % 2,
+                prompt,
+                response: format!(" {answer}.\n"),
+            });
+        }
+    }
+    source.scope = "Final16 after fixed zero-binding ablation selection: four each simple/distractor/update/unsupported, new entity/value combinations, four question/wrapper forms; all source words retained. Pune occurred in earlier material; this is not fully unseen vocabulary. Construction copied for evaluator compatibility only; no refit. First use follows saved preparation and design selection; later reuse is open development.".into();
+    validate_source(&source)?;
+    let bytes = serde_json::to_vec_pretty(&source)?;
+    write_new(Path::new(&args[1]), &bytes)?;
+    println!(
+        "{}",
+        json!({"source":args[1],"blake3":blake3::hash(&bytes).to_hex().to_string(),"evaluation":16})
+    );
+    Ok(())
+}
+
 fn case(split: &str, world: usize, task: usize, style: usize, variant: usize) -> Case {
     let (names, cities) = match split {
         "fit" => (

--- a/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_tests.rs
@@ -9,6 +9,52 @@ mod fixture {
     include!("../../tests/support/native_word_copy_fixture.rs");
 }
 
+#[test]
+fn native_word_copy_zero_binding_ablation_preserves_admission_and_other_parameters() {
+    let parent = fixture::fitted_shared_binding();
+    let changed = parent.neutralize_copy_zero_binding().unwrap();
+    let mut expected = parent.clone();
+    let row = expected
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap()
+        .prefix_rows
+        .iter_mut()
+        .find(|r| r.feature == Feature { kind: 32, value: 0 })
+        .unwrap();
+    assert!(row.default_score != 0 || row.scores.iter().any(|s| s.score != 0));
+    row.default_score = 0;
+    for score in &mut row.scores {
+        score.score = 0;
+    }
+    expected.refresh_identity().unwrap();
+    assert_eq!(changed, expected);
+    assert_ne!(changed.artifact_cid(), parent.artifact_cid());
+    assert_eq!(
+        Model::from_bytes(&changed.to_bytes().unwrap()).unwrap(),
+        changed
+    );
+    assert_eq!(changed.neutralize_copy_zero_binding().unwrap(), changed);
+    assert!(fixture::fitted_composed()
+        .neutralize_copy_zero_binding()
+        .is_err());
+    let mut absent = parent.clone();
+    absent
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap()
+        .prefix_rows
+        .retain(|r| r.feature != Feature { kind: 32, value: 0 });
+    absent.refresh_identity().unwrap();
+    assert!(absent.neutralize_copy_zero_binding().is_err());
+}
+
 fn prefix(model: &Model, prompt: &str, control: Control) -> Session {
     let mut session = model.session(control).unwrap();
     session.observe(model, BOS).unwrap();

--- a/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
@@ -328,6 +328,31 @@ impl WordCopyModel {
 }
 
 impl Model {
+    /// Offline causal intervention: remove only the shared zero-match row's
+    /// score contribution. Keep candidate admission and all other parameters.
+    /// This is an ablation of a fitted artifact, not a training result.
+    pub fn neutralize_copy_zero_binding(&self) -> Result<Model> {
+        let mut model = self.clone();
+        let head = copy_mut(&mut model)?;
+        if !head.shared_binding {
+            return Err(Error(
+                "zero-binding intervention requires shared binding".into(),
+            ));
+        }
+        let row = head
+            .prefix_rows
+            .iter_mut()
+            .find(|row| row.feature == Feature { kind: 32, value: 0 })
+            .ok_or_else(|| Error("shared zero-binding row absent".into()))?;
+        row.default_score = 0;
+        for score in &mut row.scores {
+            score.score = 0;
+        }
+        model.refresh_identity()?;
+        model.validate()?;
+        Ok(model)
+    }
+
     pub fn word_copy_version(&self) -> Option<&str> {
         self.response_entry
             .as_ref()

--- a/docs/evidence/native_geometric_word_copy_973.json
+++ b/docs/evidence/native_geometric_word_copy_973.json
@@ -1475,5 +1475,90 @@
     },
     "scope": "Reserved32authored before fitting and executed once per frozen artifact after design selection. Legacy evaluator names the partition development/OPEN; provenance here distinguishes its first use. No reserved outcome selected or retuned these models. Geometry comparison removes features during fitting and Full/dispatch-controlled serving of the copy extension only; baseline, memory and typed paths remain. Exact equality is 8/32 in both fits, all unsupported; outputs need not match on failures. No geometric advantage or alpha. Complete generation timing includes session construction, encoding, ingest, prediction/observation and decode; artifact load and preparation/fits/serialization/CLI are charged in cumulative parent wall. Work counters are instrumented operations, not every CPU instruction.",
     "next_hypothesis": "Nonmatching occurrences also contribute to prefix scoring. Unknown dictionary predecessors share feature32/value0, whose space score is -242 and Unknown score is -196. Repeated contributions can favor abstention, but a matched removal/refit has NOT_RUN; this is a candidate explanation, not established sole cause."
+  },
+  "zero_binding_correction_2026_09_05": {
+    "decision": "RETAIN_DEVELOPMENT_CORRECTION_MILESTONE_UNMET",
+    "artifact": "blake3:5f590f1c9798c311ddd28b7d47ab1d444331fe08bdf92839a04b2c0fa0af1919",
+    "parent": "blake3:f933b199c342fd715c44d938b86281493730f2b41d6d33287e7369f852c24232",
+    "path": ".uor-models/native-typed-value-2026-09-05/source-entry-neutral-model.json",
+    "change": "Only thirteen token scores in prefix feature32/value0 become zero; default was already zero. All postings, other parameters, serving operations and state unchanged. No refit.",
+    "diagnostic": {
+      "parent": 12,
+      "corrected": 16,
+      "total": 16
+    },
+    "open_transfer": {
+      "parent": 8,
+      "corrected": 16,
+      "total": 32,
+      "supported_parent": 0,
+      "supported_corrected": 8,
+      "supported_total": 24,
+      "unsupported_corrected": 8,
+      "unsupported_total": 8
+    },
+    "preservation": {
+      "original": 32,
+      "identifiers": 12,
+      "facts": 16,
+      "older_cities": 2,
+      "binding": 8,
+      "all_exact": true
+    },
+    "first_use_check": {
+      "prior_selected": 3,
+      "parent": 11,
+      "corrected": 13,
+      "total": 16,
+      "unsupported": 4,
+      "unsupported_total": 4,
+      "failures": "All three supported Which city is ... in? cases",
+      "provenance": "Design selection and source preparation preceded evaluation; no later tuning. Pune previously exposed. Supplemental vocabulary novelty assertion failed; shell continued into evaluation. Additional provenance receipt written afterward. Not fully sealed or vocabulary-disjoint qualification."
+    },
+    "whole_path": {
+      "cases": 62,
+      "dispatch_output_and_causal_state_equal": 62,
+      "full_us": 47210,
+      "dispatch_disabled_us": 63598,
+      "forced_bytes": 120,
+      "ordinary_score_lookups": [
+        1503295,
+        1772626
+      ],
+      "memory_score_lookups": [
+        291498,
+        427481
+      ],
+      "copy_score_lookups": [
+        77151,
+        77151
+      ],
+      "scope": "One generation pass including setup, encoding, ingest, prediction, observation, decode. Existing dispatch optimization retained; no new geometric advantage claim."
+    },
+    "generated_rust": {
+      "same_previously_executed_source_hashes": 32,
+      "new_compilation": "NOT_RUN_REUSED_IDENTICAL_SOURCES"
+    },
+    "cli_generation_equals_evaluator": true,
+    "validation": [
+      "release example build",
+      "focused fitted-artifact ablation and validation test",
+      "formatting",
+      "architecture policy"
+    ],
+    "resources": {
+      "model_cycle_ms": 22785,
+      "engineering_before_final_claim_check_ms": 288800,
+      "cumulative_model_ms": 1081641,
+      "cumulative_limit_ms": 1800000,
+      "remaining_model_ms": 718359,
+      "peak_sampled_model_rss_bytes": 423395328,
+      "storage_increase_bytes": 268435456,
+      "cumulative_storage_limit_bytes": 5922357248,
+      "stop_margin_bytes": 134217728,
+      "scope": "6.8s focused fixture execution conservatively charged to model ledger as well as engineering command wall. Categories overlap for that test. No deletions or paid external compute."
+    },
+    "local_checkpoint": ".uor-models/native-typed-value-2026-09-05/source-entry-checkpoint.json",
+    "next": "Learn a shared occurrence/NoCopy choice and carry occurrence identity through observed commitment; successor not implemented or qualified."
   }
 }

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -7,6 +7,47 @@ remains owned by [#973](https://github.com/UOR-Foundation/uor-r4/issues/973).
 Refresh live GitHub before choosing a follow-up; dated snapshots and lower
 historical “next” paragraphs do not select work.
 
+## Zero-match entry correction — 2026-09-05, latest checkpoint
+
+**Retain a useful development correction; the broader grounding milestone remains
+unmet.** PR #1135 merged as `647fd532`. Its rejected shared-binding artifact
+`f933b199` supplies the unchanged parameters for a single-row intervention:
+zero the default/token scores of prefix feature32/value0, preserving that row,
+its candidate postings, every other parameter and the integer/table serving path.
+No fitting, new state, larger context or new geometric feature is introduced.
+
+The corrected artifact is `5f590f1c9798c311ddd28b7d47ab1d444331fe08bdf92839a04b2c0fa0af1919`,
+at `.uor-models/native-typed-value-2026-09-05/source-entry-neutral-model.json`.
+The matched wording diagnostic improves 12/16 → 16/16; the now-open transfer set
+improves 8/32 → 16/32, including supported answers 0/24 → 8/24 while preserving
+8/8 unsupported answers. It gets all 62 preservation responses and 8/8 binding
+outputs correct, restoring four fact regressions and both older city answers.
+An actual native CLI run changes ` Unknown.\nKyoto.\n` to ` Kyoto.\n`.
+
+After selecting this exact correction, sixteen first-use prompts yield 13/16,
+against 11/16 for its unmodified shared-binding parent and 3/16 for the previously
+selected `d095a1ab` artifact. The three failures all ask “Which city is … in?”;
+all four unsupported answers remain correct. `Pune` occurred in prior material.
+A vocabulary-novelty assertion failed before a shell continued into evaluation;
+the later provenance receipt records this explicitly. Source preparation and
+model selection preceded evaluation, with no subsequent tuning, but this is
+not a fully sealed or vocabulary-disjoint qualification. The 16/16 milestone
+has not passed; `d095a1ab` remains the prior selected baseline.
+
+All 62 outputs and causal states agree with committed-copy dispatch disabled.
+Complete generation totals 47.210/63.598 ms in one pass; this retains the existing
+dispatch optimization and establishes no new geometric efficiency advantage.
+The 32 generated Rust sources match previously executed sources by hash.
+Local `source-entry-checkpoint.json` contains full work counts, artifact/source
+identities, preservation, first-use provenance and cumulative resource accounting.
+One focused fitted-artifact test, release example build, policy and formatting
+checks pass. No broader release checks or refit ran.
+
+The next implementation remains a learned occurrence/NoCopy choice shared with
+response entry and preserved through an observed commit. This correction shows
+that repeated unbound scores caused some failures, not that zero lexical matches
+are universally irrelevant. Do not broaden zeroing or force copying from a match.
+
 ## Wording transfer and shared binding — 2026-09-05, later checkpoint
 
 **Decision: reject the shared-binding candidate for promotion.** Keep the

--- a/docs/native_geometric_word_copy_973.md
+++ b/docs/native_geometric_word_copy_973.md
@@ -324,3 +324,73 @@ For missing dictionary addresses its shared zero-match row penalizes a prefix
 space more than Unknown. Making such evidence neutral is a concrete hypothesis,
 not a completed repair. Full costs, preserved artifacts, comparison source and
 checks are appended to the existing evidence JSON and current-state pointer.
+
+## Single-row response-entry correction — 2026-09-05
+
+The no-refit intervention preserves every parameter of shared-binding parent
+`blake3:f933b199c342fd715c44d938b86281493730f2b41d6d33287e7369f852c24232`
+except the scores of prefix feature32/value0. Its thirteen token coefficients
+become zero; its already-zero default, four candidate postings, global postings
+and row membership remain. `Model::neutralize_copy_zero_binding` refreshes both
+artifact identities and validates the result. It refuses absent/nonshared rows.
+The native probe exposes `neutralize-zero-binding INPUT_MODEL NEW_OUTPUT_MODEL`.
+The artifact is an intervention, not a newly trained model.
+
+The feature represents no local equality binding and an unknown/missing preceding
+word address. Its repeated contribution preferred Unknown over prefix space by
+46 per occurrence. The correction tests that specific contribution; it does not
+assert semantic irrelevance for all zero lexical matches. No persistent state,
+serving operator, candidate support or context bound changes. Existing prime
+addresses, relative H4/zeta features, exact retained payloads, learned occurrence
+selection and observed copy/completion remain. Pooled entry still loses occurrence
+identity, and source selection still competes separately with lexical output.
+
+| Complete-response population | Shared parent | Corrected |
+|---|---:|---:|
+| Matched wording diagnostic | 12/16 | 16/16 |
+| Previously opened transfer | 8/32 | 16/32 |
+| Supported subset of transfer | 0/24 | 8/24 |
+| Unsupported subset of transfer | 8/8 | 8/8 |
+| Original responses | 32/32 | 32/32 |
+| Identifier transfer | 12/12 | 12/12 |
+| Prior facts | 12/16 | 16/16 |
+| Older city prompts | 0/2 | 2/2 |
+| Binding outputs | 8/8 | 8/8 |
+| Sixteen first-use prompts after selection | 11/16 | 13/16 |
+
+The prior selected d095 artifact gets 3/16 on the last row. Improvement from that
+baseline also includes the earlier shared-binding/coverage work; only 11→13 on
+this population is the isolated row effect. All three corrected failures use
+“Which city is … in?” All four unsupported final answers succeed. Names and
+entity/value combinations are new, but Pune had earlier exposure. A supplemental
+all-vocabulary-new assertion failed and the shell still executed evaluation.
+The saved model selection and Rust source-preparation receipt precede evaluation;
+the provenance receipt was written afterward and says so. There was no fitting
+or parameter tuning after source preparation. Do not call this fully sealed or
+vocabulary-disjoint evidence. Later reuse is open development. The preparer's
+scope text was subsequently corrected; the original evaluated source is retained.
+
+The native CLI generates ` Kyoto.\n` for the previously broken zora/Kyoto prompt,
+with all Generation fields identical to the evaluator. The corrected artifact
+is `blake3:5f590f1c9798c311ddd28b7d47ab1d444331fe08bdf92839a04b2c0fa0af1919`.
+All 62 preservation responses and causal states agree with copy dispatch disabled.
+Full/disabled complete generation costs 47.210/63.598 ms, ordinary score lookups
+1,503,295/1,772,626, memory score lookups 291,498/427,481 and copy score lookups
+77,151/77,151. Full dispatch executes 120 forced bytes; both arms also perform
+8,351 equality-byte and 45,256 dictionary-byte comparisons. The complete work
+vectors include routing, geometry, typed operators and causal observation.
+This retains the existing conditional-execution saving, not a new optimization.
+After-fit geometry removal is sensitivity only; no matched geometric advantage
+is established. All 32 generated Rust sources match prior compiler/execution
+receipts by SHA256; no new generated-code compilation is claimed.
+
+The focused fitted-artifact test verifies only intended scores change, postings
+and all other parameters remain, reload/identity validation succeeds, repetition
+is idempotent, and unsupported/missing-row requests fail. Release example,
+formatting and architecture policy checks pass; broader release checks remain
+NOT_RUN. The single-row correction is retained as development progress, with the
+16/16 milestone unmet and d095 retained as the prior selected baseline. The next
+architectural work is shared occurrence/NoCopy selection carried through actual
+observation, not further pooled prefix patches. Full local receipts and cumulative
+resource accounting are in
+`.uor-models/native-typed-value-2026-09-05/source-entry-checkpoint.json`.


### PR DESCRIPTION
Repeated unbound response-entry features can make the model emit ` Unknown.\nKyoto.\n` even though the requested value is retained. Add a Rust offline intervention that zeros only the thirteen token scores in prefix feature 32/value 0, preserves candidate postings and all other parameters, and refreshes/validates artifact identities. The existing native serving path then emits ` Kyoto.\n`; no candidate refit, new serving operation, persistent state or context expansion is introduced.

The corrected artifact improves the wording diagnostic from 12/16 to 16/16 and the previously opened transfer set from 8/32 to 16/32 (supported answers 0/24 → 8/24, unsupported 8/8 preserved). It restores all 62 preservation responses and 8/8 binding outputs. Sixteen first-use prompts after fixed design selection reach 13/16 versus 11/16 for the shared-binding parent and 3/16 for the prior selected artifact. All three failures use “Which city is … in?” The broader 16/16 milestone remains unmet; this is retained development progress.

Provenance limitation: Pune had prior exposure. A supplemental vocabulary-novelty assertion failed, and the shell continued into evaluation. Model selection and Rust source preparation preceded evaluation, with no later fitting/tuning; the supplemental provenance receipt was written afterward. The record explicitly avoids fully sealed or vocabulary-disjoint qualification. The prior source and all results are preserved.

Validation: release example build, one focused fitted-artifact test covering only-intended-score changes/admission/reload/identity/errors/idempotence, formatting, architecture policy and claim wording pass. Actual native CLI Generation matches the evaluator exactly. All 62 outputs and causal states match with copy dispatch disabled; full/disabled complete generation takes 47.210/63.598 ms in one pass, retaining the existing dispatch optimization. All 32 generated Rust sources match previously compiled/executed source hashes. Broader release checks remain NOT_RUN; no geometric advantage is claimed.

Resource use:22.785 s model work,289.008 s engineering. The 6.8 s rounded fixture-test execution is conservatively included in both categories. Cumulative model work 1,081.641/1,800 s;718.359 s remains. Storage cap increased 256 MiB under standing owner approval;128 MiB margin preserved, no deletions or paid external compute. Local full results: `.uor-models/native-typed-value-2026-09-05/source-entry-checkpoint.json`.

Continues #973. Does not close the broader native-model objective.
