### PR TITLE
Learn shared role-aware source selection and causal response entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,28 +46,26 @@ results, remaining learned-operator work and capability limitations.
 
 The [native mechanism map](docs/native_geometric_mechanism_map_973.md) traces
 the implemented prime/zeta/R4 mechanisms from source to generated responses.
-The delivered path includes /4 occurrence memory, typed value operators, lexical
-response entry, retained-word copying, learned completion and committed-copy
-dispatch. The [current checkpoint](docs/integration/current-state.md) records
-PR #1136's zero-match entry correction: 16/16 wording diagnostic, 16/32 open
-transfer (8/24 supported), all 62 preservation responses and eight binding
-outputs. Sixteen first-use prompts yield 13/16, with the three remaining failures
-using “Which city is ... in?”; their provenance does not support a fully sealed
-or vocabulary-disjoint claim. The older city answers are repaired. The prior
-selected `d095a1ab` baseline and development correction `5f590f1c` remain distinct.
+The latest [role-aware source/entry result](docs/native_geometric_role_read_1137.md)
+learns one retained-occurrence/NoRead decision shared with entry and copying.
+Observed entry commits its exact source for later bytes. The selected artifact
+preserves **62/62 responses and eight binding outputs**, reaches **24/24 first-use
+answers** against 13/24 for its parent, and repairs the earlier sixteen-case
+wording set. Four fresh generated Rust functions compile and pass 28 semantic
+assertions. The [current checkpoint](docs/integration/current-state.md) carries
+exact artifacts, source scope and remaining failures.
 
-Committed interior copying already bypasses unnecessary ordinary scoring while
-preserving causal updates. Its complete 62-response comparison measured
-47.210/63.598 ms in one pass with equal outputs/state; this retains a generic
-conditional-execution benefit, not new geometric superiority. The
-[retained-word record](docs/native_geometric_word_copy_973.md) preserves the
-identifier, fact-composition, wording and dispatch experiments at their scopes.
+The first-use grammar families are known and the word capture remains bounded
+at sixteen. Two older transfer cases still abstain incorrectly. These results
+establish a bounded #1137 handoff, with no general-language, alpha or matched
+geometric-superiority claim. Committed-copy dispatch remains useful; complete
+work and its one-pass timing limits are recorded alongside the behavior.
 
 The [immediate build plan](docs/integration/project-track.md#immediate-build-sequence)
 is role-aware shared source selection, exact relational memory, selective
 geometric routing and typed operator composition, before broader programme
-expansion. Only its first unmet step is immediate work; these successors are
-not implemented or qualified by this planning update. General conversation,
+expansion. After #1137 protected delivery, #1138 exact relation memory is the next
+unmet step. Later successors remain unimplemented and unqualified. General conversation,
 coding/reasoning, semantic multiscale memory and alpha remain unestablished.
 
 ## Preserved project entry points

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -19,6 +19,8 @@ use uor_r4_core::native_geometric::{
 };
 
 type ProbeResult<T> = Result<T, Box<dyn Error>>;
+#[path = "native_geometric_value_probe/role_read.rs"]
+mod role_read;
 #[path = "native_geometric_value_probe/wording.rs"]
 mod wording;
 const SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/1";
@@ -74,7 +76,9 @@ impl Options {
         while let Some(flag) = arguments.next() {
             if flag == "--help" || flag == "-h" {
                 println!(
-                    "neutralize-zero-binding INPUT_MODEL NEW_OUTPUT_MODEL (no refit; scores only)\n\
+                    "prepare-role-read SOURCE_V3 NEW_DIRECTORY (construction and reserved24, checks before writing)\n\
+                     fit-role-read MODEL SOURCE NEW_MODEL NEW_REPORT (joint source/entry selection)\n\
+                     neutralize-zero-binding INPUT_MODEL NEW_OUTPUT_MODEL (no refit; scores only)\n\
                      prepare-entry-check SOURCE_V3 NEW_OUTPUT_SOURCE (sixteen raw cases)\n\
                      native_geometric_value_probe [prepare|prepare-copy|prepare-facts|prepare-wording|fit|completion|entry|copy|copy-completed|copy-composed|copy-binding|copy-binding-plain|evaluate] --output-dir NEW_DIRECTORY\n\
                      prepare-copy: --source SOURCE_V2 --lexeme-cues true\n\
@@ -732,6 +736,7 @@ fn reject_training_overlap(model: &Model, cases: &[Case]) -> ProbeResult<()> {
             .chain(model.value_completion_training())
             .chain(model.response_entry_training())
             .chain(model.word_copy_training())
+            .chain(model.role_read_training())
             .any(|known| {
                 known.id == case.id || known.text_cid == pair_cid || known.text_cid == whole_cid
             })
@@ -961,6 +966,33 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("prepare-role-read") {
+        return role_read::prepare();
+    }
+    if std::env::args().nth(1).as_deref() == Some("fit-role-read") {
+        let args: Vec<_> = std::env::args().skip(2).collect();
+        if args.len() != 4 {
+            return Err("fit-role-read MODEL SOURCE NEW_MODEL NEW_REPORT".into());
+        }
+        let parent = Model::from_bytes(&fs::read(&args[0])?)?;
+        let source: Source = serde_json::from_slice(&fs::read(&args[1])?)?;
+        validate_source(&source)?;
+        let documents: Vec<_> = source
+            .fit
+            .iter()
+            .map(|c| ValueExample {
+                id: c.id.clone(),
+                prompt: c.prompt.clone(),
+                response: c.response.clone(),
+            })
+            .collect();
+        let (model, report) =
+            parent.fit_role_read(&documents, ResponseEntryFitConfig::default())?;
+        write_new(Path::new(&args[2]), &model.to_bytes()?)?;
+        write_json(Path::new(&args[3]), &report)?;
+        println!("{report}");
+        return Ok(());
+    }
     if std::env::args().nth(1).as_deref() == Some("prepare-entry-check") {
         return wording::prepare_entry_check();
     }
@@ -1171,6 +1203,10 @@ fn main() -> ProbeResult<()> {
     }
     if options.controls != "all" {
         report["controls_selection"] = json!(options.controls);
+    }
+    if !model.role_read_training().is_empty() {
+        report["response_entry_scope"] = json!("Joint role-aware occurrence/NoRead and entry action. The selected occurrence/version commits only on the observed entry token and is reused for byte copying; historical pooled prefix/copy choice is bypassed at entry. Relative local lexical/equality and signed H4/zeta features learn sparse quantized scores; no supplied semantic roles or answer buffer enter serving. The inherited suffix, numeric operators and /4 memory remain fixed. Geometry-disabled is a same-artifact sensitivity control, not a matched-refit advantage.");
+        report["role_read_training_documents"] = json!(model.role_read_training().len());
     }
     if options.mode == "copy-composed" {
         report["response_entry_scope"] = json!("Composed /2 extension: first response word after at most one learned lexical prefix token; exact source/query equality plus relative H4/phase features select a retained occurrence. No numeric-source requirement. NoCopy lexical continuation learns after an actually selected first transition. Forced interior copy bytes dispatch before ordinary scoring with score1 marker; observation/memory updates remain.64new construction and16fresh cases augment the unchanged source; no template or target buffer enters inference.");

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/role_read.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/role_read.rs
@@ -1,0 +1,141 @@
+//! Construction and first-use cases. This module never enters serving.
+use super::*;
+
+fn case(split: &str, world: usize, task: usize, style: usize) -> Case {
+    let (names, places) = if split == "fit" {
+        (
+            ["ada", "cyra", "ivy", "mina"],
+            ["Rome", "Cairo", "Perth", "Dover"],
+        )
+    } else {
+        (
+            ["velra", "tovin", "neril", "sovek"],
+            ["Lodov", "Merok", "Vesul", "Talven"],
+        )
+    };
+    let a = names[world % 4];
+    let b = names[(world + 1) % 4];
+    let x = places[(world + style) % 4];
+    let y = places[(world + style + 1) % 4];
+    if task == 5 {
+        let mut c = word_copy_case(split, style, world * 4 + style, names[(world + style) % 4]);
+        c.id = format!("role-read/{split}/{world}/{task}/{style}");
+        c.pair_id = format!("role-read/{split}/{world}/{task}/{}", style / 2);
+        c.world = if split == "fit" {
+            1_000_000 + world
+        } else {
+            2_000_000 + world
+        };
+        c.variant = style % 2;
+        return c;
+    }
+    let (fact, answer) = match task {
+        0 => (format!("{a} in {x}."), x),
+        1 => (format!("{x} holds {a}."), x),
+        2 if style % 2 == 0 => (format!("{a} in {x}. {b} in {y}."), x),
+        2 => (format!("{b} in {y}. {a} in {x}."), x),
+        3 => (format!("{a} in {x}. {a} now in {y}."), y),
+        _ => (format!("{b} in {x}."), "Unknown"),
+    };
+    let query = match style {
+        1 => format!("Which city is {a} in?"),
+        2 => format!("What city does {a} live in?"),
+        _ => format!("Where is {a}?"),
+    };
+    Case {
+        id: format!("role-read/{split}/{world}/{task}/{style}"),
+        pair_id: format!("role-read/{split}/{world}/{task}/{}", style / 2),
+        family: "prose".into(),
+        task: format!("role_{task}_style_{style}"),
+        world: if split == "fit" {
+            1_000_000 + world
+        } else {
+            2_000_000 + world
+        },
+        variant: style % 2,
+        prompt: format!("Record: {fact} {query} Answer:"),
+        response: format!(" {answer}.\n"),
+    }
+}
+
+pub(super) fn prepare() -> ProbeResult<()> {
+    let args: Vec<_> = std::env::args().skip(2).collect();
+    if args.len() != 2 {
+        return Err("prepare-role-read SOURCE_V3 NEW_DIRECTORY".into());
+    }
+    let mut source: Source = serde_json::from_slice(&fs::read(&args[0])?)?;
+    validate_source(&source)?;
+    let prior = source.clone();
+    for world in 0..4 {
+        for task in 0..6 {
+            for style in 0..4 {
+                source.fit.push(case("fit", world, task, style));
+            }
+        }
+    }
+    // The source copies prior development only for preservation evaluation;
+    // fitting reads only `fit`. First-use cases are a separate saved source.
+    validate_source(&source)?;
+    let mut first = source.clone();
+    first.development.clear();
+    for task in 0..6 {
+        for style in 0..4 {
+            first.development.push(case("first-use", 0, task, style));
+        }
+    }
+    validate_source(&first)?;
+    let words = |text: &str| {
+        text.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .filter(|w| !w.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    };
+    let old_words: BTreeSet<_> = prior
+        .fit
+        .iter()
+        .chain(&prior.development)
+        .chain(&source.fit)
+        .flat_map(|c| words(&c.prompt).into_iter().chain(words(&c.response)))
+        .collect();
+    for novel in [
+        "velra", "tovin", "neril", "sovek", "Lodov", "Merok", "Vesul", "Talven",
+    ] {
+        if old_words.contains(novel) {
+            return Err(format!("first-use word already in supplied material: {novel}").into());
+        }
+    }
+    for c in source
+        .fit
+        .iter()
+        .filter(|c| c.id.starts_with("role-read/"))
+        .chain(&first.development)
+    {
+        // Prose examples deliberately fit the whole capture. Rust tests the
+        // actual last16 words, preserving the required declared argument.
+        let retained = words(&c.prompt);
+        if c.family == "prose" && retained.len() > 16 {
+            return Err(format!("retention exceeds16: {}", c.id).into());
+        }
+        if c.family == "rust" {
+            let target = c.response.lines().next().ok_or("empty Rust response")?;
+            if !retained.iter().rev().take(16).any(|w| w == target) {
+                return Err("Rust argument not retained".into());
+            }
+        }
+    }
+    let root = Path::new(&args[1]);
+    fs::create_dir(root)?;
+    source.scope="OPEN role-read construction plus unchanged prior preservation. Position-shared source/query local contexts, role reversal, source order, updates, absence and Rust names. No semantic labels enter serving.".into();
+    first.scope="24 first-use cases prepared before fitting/design selection:20 prose (4 unsupported) and4 Rust; new entity/value words relative to the supplied construction and prior development. Known grammar families, no unrestricted-language or final sealed capability claim. Acceptance:24/24 complete responses, all62 preservation responses and8binding outputs, causal/snapshot and generated-Rust semantic checks. A negative retains #1137 open.".into();
+    write_json(&root.join("development.json"), &source)?;
+    write_json(&root.join("first-use.json"), &first)?;
+    write_json(
+        &root.join("acceptance.json"),
+        &json!({"fit_cases":source.fit.len(),"first_use":24,"required_exact":24,"preservation":62,"binding":8,"selection":"construction quantized objective only; open development may diagnose, but no changes after first-use evaluation","retention_and_split_assertions":"PASS before any evaluation","model_execution":"NOT_RUN"}),
+    )?;
+    println!(
+        "{}",
+        json!({"fit":source.fit.len(),"preservation":source.development.len(),"first_use":24,"assertions":"PASS"})
+    );
+    Ok(())
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -20,6 +20,8 @@ mod response_entry_runtime;
 mod response_entry_training;
 mod response_entry_types;
 mod response_runtime;
+mod role_read;
+mod role_read_training;
 mod runtime;
 mod snapshot;
 mod training;
@@ -480,5 +482,7 @@ mod completion_runtime_tests;
 mod response_entry_runtime_tests;
 #[cfg(test)]
 mod response_entry_training_tests;
+#[cfg(test)]
+mod role_read_tests;
 #[cfg(test)]
 mod word_copy_tests;

--- a/crates/uor-r4-core/src/native_geometric/role_read.rs
+++ b/crates/uor-r4-core/src/native_geometric/role_read.rs
@@ -1,0 +1,306 @@
+//! Candidate-relative, position-shared source/entry selection. No grammar
+//! parser or response text enters this bounded integer/table operation.
+use super::response_entry_types::*;
+use super::value_types::{ValueFeature, ValueRow, ValueState};
+use super::word_copy_types::*;
+use super::*;
+
+pub(super) const READ_FEATURES: usize = 512;
+pub(super) const READ_ROWS: usize = 16384;
+pub(super) const READ_ACTIONS: usize = 8;
+pub(super) const NO_SOURCE: u8 = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ReadAction {
+    pub copy: bool,
+    /// None means start the selected word directly. Otherwise emit this learned
+    /// lexical token and commit the same source for the following byte.
+    pub prefix: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RoleReadModel {
+    pub schema: String,
+    pub baseline_artifact: String,
+    pub dictionary: Vec<WordCopyAddress>,
+    pub actions: Vec<ReadAction>,
+    pub rows: Vec<ValueRow>,
+    pub training: Vec<DocumentReceipt>,
+    pub epochs: usize,
+    pub learning_rate_bits: u64,
+    /// Remove pooled query identities; keep candidate-relative role context.
+    #[serde(default, skip_serializing_if = "roles_include_query_identity")]
+    pub local_roles_only: bool,
+}
+
+fn roles_include_query_identity(value: &bool) -> bool {
+    !*value
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ReadCommit {
+    pub source: Option<u8>,
+    pub source_end: u64,
+    pub source_byte_end: u64,
+    pub at_seen: u64,
+    pub token: u32,
+    pub prepare: bool,
+}
+
+pub(super) fn head(model: &Model) -> Option<&RoleReadModel> {
+    model
+        .response_entry
+        .as_ref()?
+        .copy
+        .as_ref()?
+        .role_read
+        .as_ref()
+}
+
+pub(super) fn context(
+    model: &Model,
+    values: &ValueState,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> WordCopyContext {
+    let mut ctx = super::word_copy_runtime::context(model, values, control, work);
+    if let (Some(read), Some(words)) = (head(model), &values.lexemes) {
+        for (i, word) in words.queries[..words.query_len].iter().enumerate() {
+            work.dictionary_lookups = work.dictionary_lookups.saturating_add(1);
+            work.word_record_reads = work.word_record_reads.saturating_add(1);
+            let found = read.dictionary.binary_search_by(|item| {
+                work.dictionary_comparisons = work.dictionary_comparisons.saturating_add(1);
+                for j in 0..usize::from(item.len.min(word.len)) {
+                    work.dictionary_byte_comparisons =
+                        work.dictionary_byte_comparisons.saturating_add(1);
+                    let order = item.bytes[j].cmp(&word.bytes[j]);
+                    if !order.is_eq() {
+                        return order;
+                    }
+                }
+                item.len.cmp(&word.len)
+            });
+            ctx.addresses[i] = found.map_or(0, |j| read.dictionary[j].prime);
+            work.selector.state_copies = work.selector.state_copies.saturating_add(1);
+        }
+    }
+    ctx
+}
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+pub(super) fn features(
+    model: &Model,
+    values: &ValueState,
+    ctx: &WordCopyContext,
+    index: usize,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> ([ValueFeature; READ_FEATURES], usize) {
+    let mut out = [ValueFeature::default(); READ_FEATURES];
+    let Some(words) = &values.lexemes else {
+        return (out, 0);
+    };
+    let mut len = 0;
+    let mut add = |kind, a, b| {
+        // Fewer than 384 features under the 16-word cap, including all matches.
+        out[len] = ValueFeature { kind, a, b };
+        len += 1;
+    };
+    add(0, u64::from(index < words.query_len), 0);
+    // Query context has shared positions: identities and ordered adjacent pairs.
+    for q in 0..if head(model).is_some_and(|h| h.local_roles_only) {
+        0
+    } else {
+        words.query_len.min(8)
+    } {
+        add(7, u64::from(ctx.addresses[q]), 0);
+        if q + 1 < words.query_len.min(8) {
+            add(
+                8,
+                u64::from(ctx.addresses[q + 1]),
+                u64::from(ctx.addresses[q]),
+            );
+        }
+    }
+    if index < words.query_len {
+        let at = |i: usize| {
+            if i < words.query_len {
+                u64::from(ctx.addresses[i])
+            } else {
+                0
+            }
+        };
+        let before = at(index + 1);
+        let after = index.checked_sub(1).map_or(0, at);
+        add(1, before, 0);
+        add(2, after, 0);
+        add(3, before, after);
+        add(4, at(index + 2), before);
+        // Relative recency remains explicit for revisions; no absolute query position.
+        add(6, index as u64, 0);
+        for q in 0..index {
+            for offset in [-3_i32, -2, -1, 1, 2, 3, 4] {
+                let source = index as i32 + offset;
+                if source <= q as i32 || source < 0 || source as usize >= words.query_len {
+                    continue;
+                }
+                let a = &words.queries[q];
+                let b = &words.queries[source as usize];
+                work.word_record_reads = work.word_record_reads.saturating_add(2);
+                if a.len == 0 || a.len != b.len {
+                    continue;
+                }
+                let mut equal = true;
+                for j in 0..usize::from(a.len) {
+                    work.equality_byte_comparisons =
+                        work.equality_byte_comparisons.saturating_add(1);
+                    if a.bytes[j] != b.bytes[j] {
+                        equal = false;
+                        break;
+                    }
+                }
+                if equal {
+                    let role = (offset + 4) as u64;
+                    add(9, role, at(q + 1));
+                    add(10, role, q.checked_sub(1).map_or(0, at));
+                    add(11, (role << 32) | before, at(q + 1));
+                }
+            }
+        }
+        // Retain the existing signed relative H4 and wrapped zeta channels;
+        // discard old absolute-query masks and pooled source votes.
+        let (geometric, n) =
+            super::word_copy_runtime::features(model, values, ctx, index, control, work);
+        for feature in &geometric[..n] {
+            if (10..20).contains(&feature.kind) {
+                add(feature.kind + 10, feature.a, feature.b);
+            }
+        }
+    }
+    work.selector.state_copies = work.selector.state_copies.saturating_add(len as u64);
+    work.selector.metadata_reads = work.selector.metadata_reads.saturating_add(len as u64);
+    (out, len)
+}
+
+pub(super) fn key(mut feature: ValueFeature, action: usize) -> ValueFeature {
+    feature.kind |= (action as u8) << 5;
+    feature
+}
+
+pub(super) fn choose(
+    model: &Model,
+    values: &ValueState,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> Option<(u8, usize, i64)> {
+    let read = head(model)?;
+    let words = values.lexemes.as_ref()?;
+    let ctx = context(model, values, control, work);
+    let mut best = None;
+    for index in 0..=words.query_len {
+        let source = if index == words.query_len {
+            NO_SOURCE
+        } else {
+            index as u8
+        };
+        let (features, len) = features(model, values, &ctx, index, control, work);
+        work.word_candidates = work
+            .word_candidates
+            .saturating_add(u64::from(source != NO_SOURCE));
+        for (action_index, action) in read.actions.iter().enumerate() {
+            if action.copy != (source != NO_SOURCE) {
+                continue;
+            }
+            if action.copy
+                && usize::from(words.queries[index].len) + 1 + usize::from(action.prefix.is_some())
+                    > usize::from(RESPONSE_ENTRY_STEPS)
+            {
+                work.bound_rejections = work.bound_rejections.saturating_add(1);
+                continue;
+            }
+            let mut score = 0_i64;
+            for feature in &features[..len] {
+                let k = key(*feature, action_index);
+                work.selector.feature_queries = work.selector.feature_queries.saturating_add(1);
+                let found = read.rows.binary_search_by(|row| {
+                    work.selector.row_comparisons = work.selector.row_comparisons.saturating_add(1);
+                    row.feature.cmp(&k)
+                });
+                if let Ok(i) = found {
+                    score += i64::from(read.rows[i].weight);
+                    work.selector.matched_rows = work.selector.matched_rows.saturating_add(1);
+                    work.selector.score_lookups = work.selector.score_lookups.saturating_add(1);
+                }
+            }
+            work.selector.candidate_evaluations =
+                work.selector.candidate_evaluations.saturating_add(1);
+            work.selector.candidate_comparisons =
+                work.selector.candidate_comparisons.saturating_add(1);
+            // Strict comparison retains the newest equal-scoring occurrence.
+            if best.is_none_or(|(_, _, prior)| score > prior) {
+                best = Some((source, action_index, score));
+                work.selector.candidate_writes = work.selector.candidate_writes.saturating_add(1);
+            }
+        }
+    }
+    best
+}
+
+pub(super) fn offer(
+    copy: &mut WordCopyState,
+    model: &Model,
+    entry: &mut ResponseEntryState,
+    values: &ValueState,
+    baseline: Candidate,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> Option<Candidate> {
+    let (source, action_index, _) = choose(model, values, control, work)?;
+    let action = &head(model)?.actions[action_index];
+    let word = values.lexemes.as_ref()?.queries.get(usize::from(source));
+    let token = if let Some(prefix) = action.prefix {
+        prefix
+    } else {
+        work.byte_reads = work.byte_reads.saturating_add(1);
+        u32::from(word?.bytes[0]) + 2
+    };
+    // Internal read scores compare joint actions. The winning operator uses a
+    // dispatch marker relative to Base, not a fabricated calibrated LM score.
+    let score = baseline.score + 1;
+    let action = if !action.copy {
+        WordCopyAction::NoRead
+    } else if action.prefix.is_some() {
+        WordCopyAction::Prepare
+    } else {
+        WordCopyAction::Read
+    };
+    copy.pending = Some(WordCopyDecision {
+        token,
+        score,
+        word_index: source,
+        cursor: 0,
+        source_end: word.map_or(0, |w| w.end),
+        source_byte_end: word.map_or(0, |w| w.byte_end),
+        at_seen: values.seen,
+        step: entry.steps,
+        action,
+    });
+    entry.pending = Some(ResponseEntryDecision {
+        token,
+        score,
+        boundary_seen: entry.boundary?.at_seen,
+        step: entry.steps,
+        at_seen: values.seen,
+        action: if token == EOS {
+            ResponseEntryAction::Stop
+        } else {
+            ResponseEntryAction::Enter
+        },
+    });
+    work.selector.state_copies = work.selector.state_copies.saturating_add(16);
+    Some(Candidate { token, score })
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END

--- a/crates/uor-r4-core/src/native_geometric/role_read_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/role_read_tests.rs
@@ -1,0 +1,167 @@
+//! Real-fit state/serialization checks; these are construction laws, not transfer.
+use super::*;
+#[allow(dead_code)]
+mod fixture {
+    use crate::native_geometric as native;
+    include!("../../tests/support/native_word_copy_fixture.rs");
+}
+
+fn fitted() -> &'static Model {
+    static MODEL: std::sync::OnceLock<Model> = std::sync::OnceLock::new();
+    MODEL.get_or_init(|| {
+        let mut docs = Vec::new();
+        for (i, name) in ["alpha", "bravo", "cedar", "delta"].iter().enumerate() {
+            for (j, prompt, response) in [
+                (
+                    0,
+                    format!("left = 13; right = 4; fn identity({name}: i32) -> i32 {{\n    "),
+                    format!("{name}\n}}\n"),
+                ),
+                (
+                    1,
+                    format!("holder in {name}. Where is holder? Answer:"),
+                    format!(" {name}.\n"),
+                ),
+                (
+                    2,
+                    format!("{name} in city. Where is missing? Answer:"),
+                    " Unknown.\n".into(),
+                ),
+            ] {
+                docs.push(ValueExample {
+                    id: format!("role-state-{i}-{j}"),
+                    prompt,
+                    response,
+                });
+            }
+        }
+        let (model, report) = fixture::fitted_composed()
+            .fit_role_read(
+                &docs,
+                ResponseEntryFitConfig {
+                    epochs: 64,
+                    ..ResponseEntryFitConfig::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(report["fit_correct"], report["frames"]);
+        Model::from_bytes(&model.to_bytes().unwrap()).unwrap()
+    })
+}
+
+fn begin(model: &Model, prompt: &str) -> Session {
+    let mut s = model.session(Control::Full).unwrap();
+    s.observe(model, BOS).unwrap();
+    for t in model.encode(prompt).unwrap() {
+        s.observe(model, t).unwrap();
+    }
+    s.begin_response(model).unwrap();
+    s
+}
+
+#[test]
+fn native_role_read_commits_only_observed_entry_and_restores_before_byte_zero() {
+    let model = fitted();
+    for (prompt, action) in [
+        (fixture::COPY_PROMPT, WordCopyAction::Read),
+        (
+            "holder in alpha. Where is holder? Answer:",
+            WordCopyAction::Prepare,
+        ),
+        (
+            "alpha in city. Where is missing? Answer:",
+            WordCopyAction::NoRead,
+        ),
+    ] {
+        let mut s = begin(model, prompt);
+        let before = s.checkpoint().unwrap();
+        let first = s.predict(model).unwrap();
+        let decision = s.word_copy_decision().unwrap();
+        assert_eq!(decision.action, action);
+        let before_wire: serde_json::Value = serde_json::from_slice(&before).unwrap();
+        let after_wire: serde_json::Value =
+            serde_json::from_slice(&s.checkpoint().unwrap()).unwrap();
+        assert_eq!(
+            after_wire["word_copy"], before_wire["word_copy"],
+            "selection is transient; work counters still advance"
+        );
+        let mut mismatch = model.restore_session(&before).unwrap();
+        mismatch.predict(model).unwrap();
+        mismatch.observe(model, u32::from(b'?') + 2).unwrap();
+        assert!(mismatch.word_copy.as_ref().unwrap().read_commit.is_none());
+        assert!(mismatch.word_copy.as_ref().unwrap().origin.is_none());
+        s.observe(model, first.token).unwrap();
+        let snapshot = s.checkpoint().unwrap();
+        let mut restored = model.restore_session(&snapshot).unwrap();
+        assert_eq!(restored.word_copy, s.word_copy);
+        let mut bad: serde_json::Value = serde_json::from_slice(&snapshot).unwrap();
+        bad["word_copy"]["read_commit"]["source_end"] = serde_json::json!(u64::MAX);
+        assert!(model
+            .restore_session(&serde_json::to_vec(&bad).unwrap())
+            .is_err());
+        let mut missing: serde_json::Value = serde_json::from_slice(&snapshot).unwrap();
+        missing["word_copy"]
+            .as_object_mut()
+            .unwrap()
+            .remove("read_commit");
+        assert!(model
+            .restore_session(&serde_json::to_vec(&missing).unwrap())
+            .is_err());
+        for _ in 0..3 {
+            let next = s.predict(model).unwrap();
+            assert_eq!(restored.predict(model).unwrap(), next);
+            assert_eq!(restored.word_copy_decision(), s.word_copy_decision());
+            s.observe(model, next.token).unwrap();
+            restored.observe(model, next.token).unwrap();
+            assert_eq!(restored.word_copy, s.word_copy);
+            model.restore_session(&s.checkpoint().unwrap()).unwrap();
+            if next.token == EOS {
+                break;
+            }
+        }
+    }
+}
+
+#[test]
+fn native_role_read_validates_quantized_rows_and_parent_identity() {
+    let model = fitted();
+    for change in 0..3 {
+        let mut bad = model.clone();
+        let head = bad
+            .response_entry
+            .as_mut()
+            .unwrap()
+            .copy
+            .as_mut()
+            .unwrap()
+            .role_read
+            .as_mut()
+            .unwrap();
+        match change {
+            0 => head.rows[0].weight = 1_000_001,
+            1 => head.baseline_artifact = "bad".into(),
+            _ => head.dictionary[0].prime += 1,
+        }
+        bad.refresh_identity().unwrap();
+        assert!(bad.validate().is_err());
+    }
+    let mut changed = model.clone();
+    changed
+        .response_entry
+        .as_mut()
+        .unwrap()
+        .copy
+        .as_mut()
+        .unwrap()
+        .role_read
+        .as_mut()
+        .unwrap()
+        .rows[0]
+        .weight += 1;
+    changed.refresh_identity().unwrap();
+    assert_ne!(changed.artifact_cid(), model.artifact_cid());
+    assert_eq!(
+        Model::from_bytes(&changed.to_bytes().unwrap()).unwrap(),
+        changed
+    );
+}

--- a/crates/uor-r4-core/src/native_geometric/role_read_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/role_read_training.rs
@@ -1,0 +1,401 @@
+//! Offline Rust learning of a shared, quantized source/entry decision.
+use super::role_read::*;
+use super::value_types::{ValueFeature, ValueRow};
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+impl RoleReadModel {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        let valid = self.schema == "uor-r4.role-read/1"
+            && !self.actions.is_empty()
+            && self.actions.len() <= READ_ACTIONS
+            && self.actions.iter().all(|a| {
+                (a.copy || a.prefix.is_some())
+                    && a.prefix
+                        .is_none_or(|t| t != BOS && (t as usize) < model.geometry.tokens.len())
+            })
+            && !self.rows.is_empty()
+            && self.rows.len() <= READ_ROWS
+            && self.rows.windows(2).all(|p| p[0].feature < p[1].feature)
+            && self.rows.iter().all(|r| {
+                (r.feature.kind >> 5) < self.actions.len() as u8
+                    && (r.feature.kind & 31) < 30
+                    && (-1_000_000..=1_000_000).contains(&r.weight)
+            })
+            && !self.training.is_empty()
+            && self.training.len() <= 1024
+            && self.training.iter().all(|r| !r.id.trim().is_empty())
+            && self
+                .training
+                .iter()
+                .map(|r| &r.id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                == self.training.len()
+            && (1..=64).contains(&self.epochs)
+            && (0.0001..=1.0).contains(&f64::from_bits(self.learning_rate_bits))
+            && self.dictionary.len() <= super::word_copy_types::WORD_COPY_DICTIONARY
+            && self.dictionary.iter().all(|w| {
+                w.len > 0
+                    && w.len <= 32
+                    && w.bytes[usize::from(w.len)..].iter().all(|b| *b == 0)
+                    && w.bytes[..usize::from(w.len)]
+                        .iter()
+                        .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
+            })
+            && self
+                .dictionary
+                .windows(2)
+                .all(|p| p[0].bytes[..usize::from(p[0].len)] < p[1].bytes[..usize::from(p[1].len)]);
+        if !valid {
+            return Err(Error("invalid role-read artifact".into()));
+        }
+        let primes = crate::corpus_induced_spin_placement::first_primes(self.dictionary.len())
+            .map_err(|e| Error(e.to_string()))?;
+        if self
+            .dictionary
+            .iter()
+            .zip(primes)
+            .any(|(w, p)| u64::from(w.prime) != p)
+        {
+            return Err(Error("role-read prime dictionary mismatch".into()));
+        }
+        let mut parent = model.clone();
+        let copy = parent
+            .response_entry
+            .as_mut()
+            .and_then(|e| e.copy.as_mut())
+            .ok_or_else(|| Error("role read requires the copy parent".into()))?;
+        if !copy.composed_entry || !copy.completed_word_suffix {
+            return Err(Error("role read requires composed entry/completion".into()));
+        }
+        copy.role_read = None;
+        parent.refresh_identity()?;
+        if parent.artifact_cid != self.baseline_artifact {
+            return Err(Error("role-read parent differs".into()));
+        }
+        Ok(())
+    }
+}
+
+struct Alternative {
+    keys: Vec<ValueFeature>,
+    correct: bool,
+}
+struct Frame {
+    alternatives: Vec<Alternative>,
+}
+
+fn session(model: &Model, prompt: &str) -> Result<Session> {
+    let mut s = model.session(Control::Full)?;
+    s.observe(model, BOS)?;
+    for token in model.encode(prompt)? {
+        s.observe(model, token)?;
+    }
+    s.begin_response(model)?;
+    Ok(s)
+}
+
+impl Model {
+    pub fn role_read_training(&self) -> &[DocumentReceipt] {
+        head(self).map_or(&[], |h| h.training.as_slice())
+    }
+    /// Fit only this source/entry selector. Parent copy/completion, typed
+    /// arithmetic, occurrence memory and lexical continuation stay fixed.
+    pub fn fit_role_read(
+        &self,
+        documents: &[ValueExample],
+        config: ResponseEntryFitConfig,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.validate()?;
+        if head(self).is_some()
+            || documents.is_empty()
+            || documents.len() > 1024
+            || documents
+                .iter()
+                .map(|d| d.prompt.len() + d.response.len())
+                .sum::<usize>()
+                > 4 * 1024 * 1024
+            || !(1..=64).contains(&config.epochs)
+            || !config.learning_rate.is_finite()
+            || !(0.0001..=1.0).contains(&config.learning_rate)
+        {
+            return Err(Error("invalid role-read source/configuration".into()));
+        }
+        let (dictionary, omitted, _) = super::word_copy_training::dictionary(documents)?;
+        let mut actions = Vec::<ReadAction>::new();
+        let mut targets = Vec::new();
+        let mut receipts = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut prompts = BTreeMap::new();
+        let mut skipped_numeric = 0;
+        for doc in documents {
+            if doc.id.trim().is_empty()
+                || !ids.insert(&doc.id)
+                || prompts
+                    .insert(&doc.prompt, &doc.response)
+                    .is_some_and(|r| r != &doc.response)
+            {
+                return Err(Error(
+                    "role-read document identities or targets conflict".into(),
+                ));
+            }
+            receipts.push(super::training::receipt(&Document {
+                id: doc.id.clone(),
+                text: serde_json::to_string(&(&doc.prompt, &doc.response))
+                    .map_err(|e| Error(e.to_string()))?,
+            }));
+            let mut s = session(self, &doc.prompt)?;
+            s.predict(self)?;
+            let values = s
+                .values
+                .as_ref()
+                .ok_or_else(|| Error("role-read typed words missing".into()))?;
+            let entry = s
+                .response_entry
+                .as_ref()
+                .ok_or_else(|| Error("role-read entry missing".into()))?;
+            if !super::word_copy_runtime::eligible(self, entry, values, Control::Full) {
+                if self.generate(&doc.prompt, 64, Control::Full)?.bytes != doc.response.as_bytes() {
+                    return Err(Error(format!("upstream response differs for {}", doc.id)));
+                }
+                skipped_numeric += 1;
+                targets.push(None);
+                continue;
+            }
+            let words = values
+                .lexemes
+                .as_ref()
+                .ok_or_else(|| Error("role-read words missing".into()))?;
+            let offset = doc
+                .response
+                .bytes()
+                .position(|b| b.is_ascii_alphabetic() || b == b'_')
+                .unwrap_or(0);
+            let mut correct = Vec::new();
+            for (i, w) in words.queries[..words.query_len].iter().enumerate() {
+                let len = usize::from(w.len);
+                let tail = &doc.response.as_bytes()[offset..];
+                if len > 0
+                    && tail.starts_with(&w.bytes[..len])
+                    && tail
+                        .get(len)
+                        .is_none_or(|b| !b.is_ascii_alphanumeric() && *b != b'_')
+                    && len + 1 + usize::from(offset > 0)
+                        <= usize::from(super::response_entry_types::RESPONSE_ENTRY_STEPS)
+                {
+                    correct.push(i as u8);
+                }
+            }
+            let copy = !correct.is_empty();
+            let tokens = if copy {
+                self.encode(&doc.response[..offset])?
+            } else {
+                self.encode(&doc.response)?
+            };
+            if (copy && tokens.len() > 1) || (!copy && tokens.is_empty()) {
+                return Err(Error("role-read entry exceeds one lexical prefix".into()));
+            }
+            let action = ReadAction {
+                copy,
+                prefix: tokens.first().copied(),
+            };
+            let ai = if let Some(i) = actions.iter().position(|a| *a == action) {
+                i
+            } else {
+                let i = actions.len();
+                actions.push(action);
+                i
+            };
+            if actions.len() > READ_ACTIONS {
+                return Err(Error("role-read action vocabulary exceeds8".into()));
+            }
+            if !copy {
+                correct.push(NO_SOURCE);
+            }
+            targets.push(Some((ai, correct)));
+        }
+        let mut model = self.clone();
+        model
+            .response_entry
+            .as_mut()
+            .and_then(|e| e.copy.as_mut())
+            .ok_or_else(|| Error("role-read copy parent missing".into()))?
+            .role_read = Some(RoleReadModel {
+            schema: "uor-r4.role-read/1".into(),
+            baseline_artifact: self.artifact_cid.clone(),
+            dictionary,
+            actions,
+            rows: Vec::new(),
+            training: receipts,
+            epochs: config.epochs,
+            learning_rate_bits: config.learning_rate.to_bits(),
+            local_roles_only: true,
+        });
+        model.refresh_identity()?;
+        let mut frames = Vec::new();
+        let mut weights = BTreeMap::<ValueFeature, f64>::new();
+        for (doc, target) in documents.iter().zip(&targets) {
+            let Some((wanted, sources)) = target else {
+                continue;
+            };
+            // Prepare from the frozen parent: prediction is used only for its
+            // actual NoWrite eligibility, never to supply a source label.
+            let mut s = session(self, &doc.prompt)?;
+            s.predict(self)?;
+            let values = s
+                .values
+                .as_ref()
+                .ok_or_else(|| Error("role values absent".into()))?;
+            let words = values
+                .lexemes
+                .as_ref()
+                .ok_or_else(|| Error("role words absent".into()))?;
+            let ctx = context(&model, values, Control::Full, &mut WordCopyWork::default());
+            let read = head(&model).ok_or_else(|| Error("role head absent".into()))?;
+            let mut alternatives = Vec::new();
+            for i in 0..=words.query_len {
+                let source = if i == words.query_len {
+                    NO_SOURCE
+                } else {
+                    i as u8
+                };
+                let (feat, n) = features(
+                    &model,
+                    values,
+                    &ctx,
+                    i,
+                    Control::Full,
+                    &mut WordCopyWork::default(),
+                );
+                for (a, action) in read.actions.iter().enumerate() {
+                    if action.copy != (source != NO_SOURCE) {
+                        continue;
+                    }
+                    let keys: Vec<_> = feat[..n].iter().map(|f| key(*f, a)).collect();
+                    for k in &keys {
+                        weights.entry(*k).or_default();
+                    }
+                    alternatives.push(Alternative {
+                        keys,
+                        correct: a == *wanted && sources.contains(&source),
+                    });
+                }
+            }
+            if !alternatives.iter().any(|a| a.correct) {
+                return Err(Error("role-read target unreachable".into()));
+            }
+            frames.push(Frame { alternatives });
+        }
+        if frames.is_empty() || frames.len() > config.max_positions || weights.len() > READ_ROWS {
+            return Err(Error(format!(
+                "role-read feature/position capacity exceeded: {} rows, {} frames",
+                weights.len(),
+                frames.len()
+            )));
+        }
+        let mut best = weights.clone();
+        let mut best_correct = 0;
+        let mut best_loss = f64::INFINITY;
+        let mut selected_epoch = 0;
+        for epoch in 1..=config.epochs {
+            for frame in &frames {
+                let scores: Vec<f64> = frame
+                    .alternatives
+                    .iter()
+                    .map(|a| a.keys.iter().map(|k| weights[k]).sum())
+                    .collect();
+                let max = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let z: f64 = scores.iter().map(|s| (s - max).exp()).sum();
+                let positive_max = frame
+                    .alternatives
+                    .iter()
+                    .zip(&scores)
+                    .filter(|(a, _)| a.correct)
+                    .map(|(_, s)| *s)
+                    .fold(f64::NEG_INFINITY, f64::max);
+                let pz: f64 = frame
+                    .alternatives
+                    .iter()
+                    .zip(&scores)
+                    .filter(|(a, _)| a.correct)
+                    .map(|(_, s)| (s - positive_max).exp())
+                    .sum();
+                for (a, score) in frame.alternatives.iter().zip(scores) {
+                    let desired = if a.correct {
+                        (score - positive_max).exp() / pz
+                    } else {
+                        0.0
+                    };
+                    let delta = config.learning_rate * (desired - (score - max).exp() / z)
+                        / (a.keys.len() as f64).sqrt();
+                    if !delta.is_finite() {
+                        return Err(Error("nonfinite role-read fit".into()));
+                    }
+                    for k in &a.keys {
+                        if let Some(w) = weights.get_mut(k) {
+                            *w = (*w + delta).clamp(-3900.0, 3900.0);
+                        }
+                    }
+                }
+            }
+            // Select with the actual quantized table and the runtime's strict tie law.
+            let mut correct = 0;
+            let mut loss = 0.0;
+            for frame in &frames {
+                let scores: Vec<i64> = frame
+                    .alternatives
+                    .iter()
+                    .map(|a| {
+                        a.keys
+                            .iter()
+                            .map(|k| (weights[k] * 256.0).round() as i64)
+                            .sum()
+                    })
+                    .collect();
+                let mut winner = 0;
+                for i in 1..scores.len() {
+                    if scores[i] > scores[winner] {
+                        winner = i;
+                    }
+                }
+                correct += usize::from(frame.alternatives[winner].correct);
+                let max = scores[winner] as f64 / 256.0;
+                let z: f64 = scores.iter().map(|s| (*s as f64 / 256.0 - max).exp()).sum();
+                let p: f64 = frame
+                    .alternatives
+                    .iter()
+                    .zip(&scores)
+                    .filter(|(a, _)| a.correct)
+                    .map(|(_, s)| (*s as f64 / 256.0 - max).exp())
+                    .sum();
+                loss += z.ln() - p.ln();
+            }
+            if correct > best_correct || (correct == best_correct && loss < best_loss) {
+                best_correct = correct;
+                best_loss = loss;
+                best = weights.clone();
+                selected_epoch = epoch;
+            }
+        }
+        let read = model
+            .response_entry
+            .as_mut()
+            .and_then(|e| e.copy.as_mut())
+            .and_then(|c| c.role_read.as_mut())
+            .ok_or_else(|| Error("role read missing".into()))?;
+        read.rows = best
+            .into_iter()
+            .map(|(feature, w)| ValueRow {
+                feature,
+                weight: (w * 256.0).round() as i32,
+            })
+            .collect();
+        model.refresh_identity()?;
+        model.validate()?;
+        Ok((
+            model.clone(),
+            serde_json::json!({"schema":"uor-r4.role-read-fit/1","parent":self.artifact_cid(),"artifact":model.artifact_cid(),"frames":frames.len(),"numeric_preserved":skipped_numeric,"rows":weights.len(),"dictionary_omitted":omitted,"fit_correct":best_correct,"fit_loss":best_loss,"selected_epoch":selected_epoch,"epochs":config.epochs,"learning_rate":config.learning_rate,"scope":"Joint occurrence-or-NoRead and entry action. Relative local role features use exact equality and ordered prime context; weights learn their selection contribution. No separate semantic role classifier is claimed. Suffix and upstream parent remain fixed; construction accuracy is not transfer."}),
+        ))
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
@@ -425,13 +425,39 @@ impl WordCopyState {
         let Some(words) = &values.lexemes else {
             return lexical;
         };
+        if head.role_read.is_some()
+            && entry.steps == 0
+            && self.read_commit.is_none()
+            && eligible(model, entry, values, control)
+        {
+            return super::role_read::offer(self, model, entry, values, baseline, control, work);
+        }
+        if let Some(commit) = self.read_commit.filter(|c| c.source.is_some()) {
+            work.word_record_reads = work.word_record_reads.saturating_add(1);
+            work.selector.metadata_reads = work.selector.metadata_reads.saturating_add(3);
+            let valid = commit
+                .source
+                .and_then(|i| words.queries.get(usize::from(i)))
+                .is_some_and(|w| {
+                    w.end == commit.source_end && w.byte_end == commit.source_byte_end
+                });
+            if !valid {
+                self.reset();
+                work.bound_rejections = work.bound_rejections.saturating_add(1);
+                return lexical;
+            }
+        }
         let mut chosen = None;
         let lexical = if self.progress == WordCopyProgress::Idle {
             prefix_offer(model, entry, values, baseline, lexical, control, work)
         } else {
             lexical
         };
-        if eligible(model, entry, values, control) && self.progress == WordCopyProgress::Idle {
+        if eligible(model, entry, values, control)
+            && self.progress == WordCopyProgress::Idle
+            && self.read_commit.is_none()
+            && head.role_read.is_none()
+        {
             let context = context(model, values, control, work);
             let mut threshold = lexical
                 .map_or(0, |candidate| candidate.score - baseline.score)
@@ -617,7 +643,37 @@ impl WordCopyState {
         });
         if let Some(decision) = matched {
             work.selector.commits = work.selector.commits.saturating_add(1);
-            if decision.action == WordCopyAction::Start {
+            if matches!(
+                decision.action,
+                WordCopyAction::Prepare | WordCopyAction::NoRead | WordCopyAction::Read
+            ) {
+                // The committed identity is the actually selected occurrence,
+                // not a later matching spelling or an output-derived pointer.
+                let source = (decision.word_index != super::role_read::NO_SOURCE)
+                    .then_some(decision.word_index);
+                if matches!(
+                    decision.action,
+                    WordCopyAction::Prepare | WordCopyAction::NoRead | WordCopyAction::Read
+                ) {
+                    self.read_commit = Some(super::role_read::ReadCommit {
+                        source,
+                        source_end: decision.source_end,
+                        source_byte_end: decision.source_byte_end,
+                        at_seen: decision.at_seen,
+                        token: decision.token,
+                        prepare: decision.action == WordCopyAction::Prepare,
+                    });
+                }
+                if decision.action == WordCopyAction::Prepare {
+                    self.origin = source;
+                    self.start_step = decision.step + 1;
+                    self.progress = WordCopyProgress::Emitting { cursor: 0 };
+                }
+            }
+            if matches!(
+                decision.action,
+                WordCopyAction::Start | WordCopyAction::Read
+            ) {
                 self.origin = Some(decision.word_index);
                 self.start_step = decision.step;
                 work.word_record_reads = work.word_record_reads.saturating_add(1);

--- a/crates/uor-r4-core/src/native_geometric/word_copy_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_snapshot.rs
@@ -71,6 +71,90 @@ impl Session {
             }
             Ok(item.token)
         };
+        if super::role_read::head(model).is_some()
+            && super::word_copy_runtime::enabled(self.control)
+        {
+            let commit = saved
+                .read_commit
+                .ok_or_else(|| invalid("role-read commit missing"))?;
+            if commit.at_seen != anchor.at_seen || token_at(commit.at_seen)? != commit.token {
+                return Err(invalid("read commitment differs from observed entry"));
+            }
+            let mut boundary = values.clone();
+            boundary.seen = anchor.at_seen;
+            boundary.pose = anchor.pose;
+            boundary.phases = anchor.phases;
+            boundary.pending = None;
+            let mut initial = ResponseEntryState {
+                boundary: Some(anchor),
+                seen: anchor.at_seen,
+                ..ResponseEntryState::default()
+            };
+            let mut choice = WordCopyState::default();
+            super::role_read::offer(
+                &mut choice,
+                model,
+                &mut initial,
+                &boundary,
+                Candidate {
+                    token: BOS,
+                    score: 0,
+                },
+                self.control,
+                &mut WordCopyWork::default(),
+            );
+            let decision = choice
+                .pending
+                .ok_or_else(|| invalid("read selection absent"))?;
+            let source =
+                (decision.word_index != super::role_read::NO_SOURCE).then_some(decision.word_index);
+            if source != commit.source
+                || saved.origin != source
+                || decision.source_end != commit.source_end
+                || decision.source_byte_end != commit.source_byte_end
+                || decision.token != commit.token
+                || (decision.action == WordCopyAction::Prepare) != commit.prepare
+            {
+                return Err(invalid("committed source differs from joint selection"));
+            }
+            if let Some(index) = source {
+                let word = words
+                    .queries
+                    .get(usize::from(index))
+                    .filter(|_| usize::from(index) < words.query_len)
+                    .ok_or_else(|| invalid("read source outside capture"))?;
+                if saved.start_step != u8::from(commit.prepare) {
+                    return Err(invalid("read start differs"));
+                }
+                let observed = entry
+                    .steps
+                    .checked_sub(saved.start_step)
+                    .ok_or_else(|| invalid("read prefix not observed"))?;
+                let prefix = match saved.progress {
+                    WordCopyProgress::Emitting { cursor }
+                        if cursor == observed && cursor < word.len =>
+                    {
+                        usize::from(cursor)
+                    }
+                    WordCopyProgress::Complete if observed >= word.len => usize::from(word.len),
+                    WordCopyProgress::Aborted if observed >= 1 => usize::from(!commit.prepare),
+                    _ => return Err(invalid("read cursor differs from observations")),
+                };
+                for offset in 0..prefix {
+                    if token_at(anchor.at_seen + u64::from(saved.start_step) + offset as u64)?
+                        != u32::from(word.bytes[offset]) + 2
+                    {
+                        return Err(invalid("read bytes differ from committed source"));
+                    }
+                }
+            } else if saved.progress != WordCopyProgress::Idle || saved.start_step != 0 {
+                return Err(invalid("NoRead retains copy progress"));
+            }
+            self.word_copy = Some(saved);
+            return Ok(());
+        } else if saved.read_commit.is_some() {
+            return Err(invalid("read commit is absent from this artifact/control"));
+        }
         // Recreate the actual first combined choice independently of the
         // ordinary total score: every head increment shares that same Base.
         let mut boundary_values = values.clone();

--- a/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_training.rs
@@ -113,7 +113,7 @@ fn response_session(model: &Model, prompt: &str) -> Result<Session> {
 
 /// The exact existing scanner supplies dictionary words, including words that
 /// later leave the sixteen-word ring. Only construction prompts contribute.
-fn dictionary(documents: &[ValueExample]) -> Result<(Vec<WordCopyAddress>, usize, u64)> {
+pub(super) fn dictionary(documents: &[ValueExample]) -> Result<(Vec<WordCopyAddress>, usize, u64)> {
     let mut counts = BTreeMap::<Vec<u8>, u64>::new();
     for document in documents {
         let mut state = LexemeState::default();
@@ -166,6 +166,9 @@ fn dictionary(documents: &[ValueExample]) -> Result<(Vec<WordCopyAddress>, usize
 
 impl WordCopyModel {
     pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        if let Some(read) = &self.role_read {
+            read.validate(model)?;
+        }
         if model
             .values
             .as_ref()
@@ -458,6 +461,7 @@ impl Model {
             .ok_or_else(|| Error("entry parent missing".into()))?;
         entry.schema = RESPONSE_COPY_SCHEMA.into();
         entry.copy = Some(WordCopyModel {
+            role_read: None,
             completed_word_suffix,
             composed_entry,
             shared_binding,

--- a/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_types.rs
@@ -19,6 +19,8 @@ pub(super) struct WordCopyAddress {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct WordCopyModel {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_read: Option<super::role_read::RoleReadModel>,
     pub baseline_artifact: String,
     pub dictionary: Vec<WordCopyAddress>,
     pub rows: Vec<ValueRow>,
@@ -77,6 +79,12 @@ impl WordCopyWork {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WordCopyAction {
+    /// Direct byte-zero entry from the joint source/entry selector.
+    Read,
+    /// Commit a source on an observed learned lexical prefix, before byte zero.
+    Prepare,
+    /// Commit a learned lexical entry without a retained source.
+    NoRead,
     Start,
     Byte,
     Emit,
@@ -112,6 +120,8 @@ pub enum WordCopyProgress {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub(super) struct WordCopyState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_commit: Option<super::role_read::ReadCommit>,
     /// Immutable selected first-entry occurrence until the entry ends.
     pub origin: Option<u8>,
     pub progress: WordCopyProgress,

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,6 +1,17 @@
 # Research: what is measured, what is closed, what is open
 
-## Current direction and latest checkpoint — 2026-09-05
+## Latest native result — 2026-09-05
+
+[#1137 role-aware source/entry selection](native_geometric_role_read_1137.md)
+passes its bounded handoff: 62/62 preserved responses, 8/8 binding, 24/24 first-use
+answers versus 13/24 parent, and four generated Rust functions passing 28 assertions.
+Earlier OPEN sets improve to 16/16 and 30/32; two cases still abstain incorrectly.
+The first 61/62 fit is retained as a negative. Local role features and one causal
+source commitment are useful here; no standalone role codebook, general language
+or matched geometric superiority is qualified. Next is #1138 after protected
+handoff delivery. See [current-state](integration/current-state.md).
+
+## Plan-adoption and prior #1136 checkpoint — 2026-09-05
 
 The owner-adopted [immediate sequence](integration/project-track.md#immediate-build-sequence)
 now governs development. Its [research synthesis](native_geometric_direction_review_973.md)
@@ -14,7 +25,7 @@ implemented. These results do not establish alpha or a new geometric advantage.
 [current-state.md](integration/current-state.md) carries exact artifacts,
 provenance, complete work counts and remaining failures.
 
-The next implementation is #1137's learned role-aware source choice shared with
+At that checkpoint the next implementation was #1137's learned role-aware source choice shared with
 entry and copying. Historical sections below retain their original statements
 about missing prefix-to-copy transitions, byte rescoring and failed city answers;
 those describe their dated artifacts and are superseded as current status by

--- a/docs/integration/CONTINUE.md
+++ b/docs/integration/CONTINUE.md
@@ -21,9 +21,10 @@ learned geometric operators through bounded routing/state/integer-table lookup,
 not a dense transformer concealed behind lookup. Preserve existing Python/dense
 references as evidence, with no new Python model dependency.
 
-Follow the immediate build sequence in project-track.md. The first unmet issue
-is #1137 until its accepted role-aware selection/commit handoff is recorded;
-#1138, #1139 and #1140 follow their native dependencies. A closed negative is
+Follow the immediate build sequence in project-track.md. The #1137 bounded role-aware
+selection/commit handoff now passes as recorded in current-state; after its
+protected delivery, #1138 is the next build. #1139 and #1140 follow their native
+dependencies. A closed negative is
 not an accepted handoff. Do not restart superseded #1083/#1084/#1087/#1089/#1090/
 #1091/#940 as parallel queues; use the plan's responsibility map. Maintain one
 task and one agent under the current owner cadence; necessary storage increases

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,37 @@
 # Current native geometric AI work
 
+## Role-aware source/entry handoff — 2026-09-05, latest checkpoint
+
+**#1137 passes its bounded handoff.** The selected artifact is
+`blake3:61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184`,
+at `.uor-models/native-typed-value-2026-09-05/role-read-local-model.json`.
+A learned joint occurrence/NoRead and entry choice now shares one exact source
+through observed commitment and copying. Local role/context weights replace
+pooled initial source votes; the sixteen-word capture, numeric behavior, /4
+memory and completion remain. No semantic role codebook is claimed.
+
+The artifact preserves 62/62 responses and 8/8 binding outputs, repairs the
+previous sixteen-case wording set to 16/16, and improves the separate OPEN
+transfer set from 16/32 to 30/32. The predeclared first-use set passes 24/24
+versus 13/24 for the unchanged `5f590f1c` parent. Four new generated Rust
+functions pass 28 executed assertions; 32 older sources remain byte-identical
+to their checked versions. Actual native CLI Generation fields agree exactly.
+
+The first role fit preserved only 61/62; removing pooled query identity restored
+preservation and reduced rows from 4,804 to 3,973. Both fits remain preserved.
+The [role-read record](../native_geometric_role_read_1137.md) states source,
+first-use, geometric-control and complete-cost limits. Two older transfer cases
+still abstain incorrectly. This is bounded binding/generation, not alpha or a
+matched geometric superiority result.
+
+The next build is #1138 after protected delivery of this #1137 handoff: learned
+exact associations and updates surviving raw-window eviction. The plan PR #1141
+merged at `0731aa0b6ac444c89b294e146e1dbe1f5742c40b`. Live GitHub owns delivery
+and dependency status. Local cumulative model work is 1,138.842/1,800 seconds,
+leaving 661.158; necessary storage cap is 6,459,228,160 bytes with the 128 MiB
+margin. Refresh the local `role-read-checkpoint.json` and shared monitors before
+projecting #1138. Historical checkpoints below retain their original scope.
+
 ## Immediate plan adopted from the research review — 2026-09-05
 
 The owner has adopted the [four-step immediate build sequence](project-track.md#immediate-build-sequence):
@@ -9,7 +41,7 @@ exact learned relation memory -> [#1139](https://github.com/UOR-Foundation/uor-r
 selective geometric access at complete cost -> [#1140](https://github.com/UOR-Foundation/uor-r4/issues/1140)
 typed operator composition for conversation and Rust reasoning.
 
-**Earliest unmet step: #1137.** This plan adoption implements no new model and
+**At plan adoption, the earliest unmet step was #1137.** This plan adoption implements no new model and
 qualifies none of those handoffs. Reuse current retained words, /4 memory,
 copying and completion; learn relative role features and preserve one selected
 occurrence through entry/commit. Current positional/pooled binding is the

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -85,10 +85,15 @@ skip it, import a dense serving model, or treat issue closure as model quality.
 Necessary fixes to an existing interface, invariant or resource bottleneck may
 accompany a step; they do not start a competing product/research programme.
 
+**Current handoff:** [#1137's bounded result](../native_geometric_role_read_1137.md)
+passes with 24/24 first-use answers and all 62 preservation responses. After its
+protected delivery, #1138 is the next implementation. The remaining two older
+wording failures and geometric-attribution limits remain explicit in that record.
+
 ### Step 1: role-aware source choice shared with generation
 
-Start from the existing /4 memory, typed operators, lexical entry, retained-word
-copy and completion. The current correction fixes unbound prefix scores, but
+The starting point was /4 memory, typed operators, lexical entry, retained-word
+copy and completion. The preceding correction fixed unbound prefix scores, but
 positional query/source features and pooled source votes do not provide a
 general role representation. Required answer values are retained in the
 observed failures; widening the window first does not address that cause.
@@ -103,10 +108,12 @@ sixteen-word bound and the existing numeric and completion behavior.
 Reuse #1073/#1077's association-preserving representations, role supervision
 and owner/value contrasts. Their original dense soft readers and supplied
 clauses are reference evidence, not a qualified hard/table implementation.
-The first native candidate is a sparse additive scorer over ordered local
-n-lets and learned discrete role codes, trained in Rust and exported to
-quantized tables. Construction labels may supervise learning; serving receives
-raw text, not hand-parsed semantic answers or a city-specific template.
+Use sparse additive scoring over ordered local n-lets and role/context features,
+trained in Rust and exported to quantized tables. The bounded #1137 handoff
+learns weights over these features; a separate semantic role codebook remains
+unimplemented and is not required by that handoff. Construction labels may
+supervise learning; serving receives raw text, not hand-parsed semantic answers
+or a city-specific template.
 
 Acceptance requires preservation of the existing 62 responses and eight binding
 outputs, repaired open wording cases without lost abstention, causal

--- a/docs/native_geometric_mechanism_map_973.md
+++ b/docs/native_geometric_mechanism_map_973.md
@@ -9,6 +9,15 @@ unimplemented until their issue supplies evidence. See
 [current-state](integration/current-state.md) for the latest artifact and
 [research synthesis](native_geometric_direction_review_973.md) for reuse decisions.
 
+**Implemented #1137 successor:**
+[`role_read.rs`](../crates/uor-r4-core/src/native_geometric/role_read.rs) learns
+one candidate-relative source/NoRead and lexical-entry choice, with the exact
+source committed on observation and reused by copying. Its
+[implementation record](native_geometric_role_read_1137.md) gives the retained
+information, quantized fitting, complete work and 24/24 bounded first-use result.
+It preserves the sixteen-word capture and does not yet implement persistent
+relation memory or selective geometric access.
+
 This source map connects the native model to reusable mathematical and runtime
 components. Its baseline is the implementation delivered through PR #1127 at
 `3abf9d7e85f70416c95161863b4413cc42a6912c`; the versioned occurrence-selection,

--- a/docs/native_geometric_role_read_1137.md
+++ b/docs/native_geometric_role_read_1137.md
@@ -1,0 +1,149 @@
+# Role-aware source selection and causal entry — #1137
+
+## Bounded handoff, 2026-09-05
+
+**Accept the bounded role-sensitive binding/entry handoff.** The selected native
+artifact is `blake3:61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184`,
+at `.uor-models/native-typed-value-2026-09-05/role-read-local-model.json`.
+It extends the unchanged `5f590f1c` development correction. Preserve that parent,
+the previously selected `d095a1ab`, and the first new fit's negative result.
+The [current plan](integration/project-track.md#immediate-build-sequence) still
+requires exact learned relation memory, selective geometric access and typed
+operator composition before broader capability qualification. This is not alpha.
+
+## Implemented operator and retained information
+
+`role_read.rs` replaces the independent initial prefix/copy decisions with one
+learned joint choice: a retained occurrence and optional lexical prefix, or
+NoRead and a lexical token. The action vocabulary comes from construction
+targets. Serving receives raw text and a model, without supplied semantic roles,
+an answer buffer, a city parser or an expected source index.
+
+The scorer uses relative local word context, exact word equality at relative
+offsets, ordered prime context, source recency and the existing signed H4/zeta
+relations. It learns sparse scalar weights in Rust and exports quantized integer
+tables. These are learned contributions from local role features, not a separate
+semantic role classifier or a learned discrete role codebook. The first fit also
+included pooled query identities; the selected `local_roles_only` revision removes
+those features. Its identity-bound flag preserves the first fit's execution law.
+
+The sixteen-word capture remains unchanged. Exact word bytes, occurrence end,
+source-byte end, pose and phase state remain recoverable. The dictionary's prime
+addresses are equality identities, not a semantic metric; dictionary misses share
+zero while exact byte matching still distinguishes unseen words. Local features
+retain nearby ordering and participant matches, but lose distant syntax and full
+clause structure. Existing geometric phase binning remains lossy. Equal-spelling
+source matches are latent fitting alternatives, so these results do not identify
+the semantic role of every duplicate occurrence.
+
+Prediction is transient. Observing the selected lexical prefix commits the same
+occurrence/version before copied byte zero; direct copying commits on its first
+observed byte. NoRead is also committed, preventing a second source selection.
+Mismatched initial observation clears the selection; an interrupted committed
+copy retains provenance but disables copying as in the existing copy contract.
+Changed source provenance rejects further copying. Checkpoints validate the
+joint choice, observed prefix, exact source and cursor. Existing numeric
+precedence, /4 memory, copy completion and committed-byte dispatch remain.
+
+## Measured behavior
+
+Construction contains 480 raw prompt/response pairs: 160 upstream numeric
+responses are verified unchanged and 320 joint source/entry decisions are fitted.
+Both fits use 24 epochs and learning rate 0.1. Epoch selection uses the quantized
+construction objective; no first-use result selects a parameter or feature.
+
+| Evaluation | `5f590f1c` parent | Selected role reader |
+|---|---:|---:|
+| Existing preservation | 62/62 | 62/62 |
+| Existing binding outputs | 8/8 | 8/8 |
+| Earlier sixteen-case wording set, now OPEN | 13/16 | 16/16 |
+| Earlier 32-case transfer set, now OPEN | 16/32 | 30/32 |
+| New first-use set | 13/24 | 24/24 |
+
+The first role fit (`ed05aea4`) selected 320/320 construction decisions but
+preserved only 61/62 responses, incorrectly abstaining on the older Oslo answer.
+The local-role revision retains 320/320 construction decisions, restores Oslo,
+and reduces learned rows from 4,804 to 3,973. This is the observed result of
+removing pooled query identity; it does not prove that identity leakage caused
+every earlier failure. Both model files and their reports are retained.
+
+The first-use source was prepared before fitting, with split and retention
+assertions passing before any evaluation. The selected artifact and source hashes
+were recorded before opening it. The 24 cases contain 20 prose answers (including
+four unsupported queries) and four Rust arguments, with wording, reversed relation
+wording, source order, updates and absent entities. Names and values are new
+relative to the supplied construction and prior development material; grammar
+families are known. This is a bounded first-use result, not unrestricted language
+or a final programme-wide held-out qualification. No parameter or selection-law
+change followed opening. Two older transfer cases still abstain incorrectly.
+
+All four new Rust functions compile unchanged and pass seven identity inputs
+each, including the i32 endpoints: 28 assertions. All 32 earlier generated Rust
+sources match their previously checked bytes/hashes. An actual `r4 geometric
+generate` run produces ` Merok.\n`; every Generation field equals the evaluator's
+result. The CLI artifact identity matches; its additional UOR address metadata
+is recorded separately.
+
+## Complete work and resources
+
+The operator admits at most sixteen source words, eight learned action forms,
+512 feature slots and 16,384 sparse rows. This artifact has three action forms
+and 3,973 rows. Feature construction still scans bounded word pairs and performs
+dictionary searches; the current implementation also computes the parent copy
+context before its role dictionary lookup. The inherited initial lexical offer
+still executes before the joint choice. Those costs are counted, not claimed
+eliminated. Selected read scores compare joint actions internally; the winning
+operator's `Base + 1` score is a dispatch marker, not calibrated LM confidence.
+
+| Same 62 responses, one pass | Parent Full | Role Full | Role dispatch disabled |
+|---|---:|---:|---:|
+| Complete generation time, including session setup/encoding/ingest/output | 49.267 ms | 46.517 ms | 65.037 ms |
+| Ordinary score lookups | 1,503,295 | 1,470,063 | 1,772,626 |
+| Memory score lookups | 291,498 | 277,122 | 427,481 |
+| Copy/role score lookups | 77,151 | 44,238 | 44,238 |
+| Copy dictionary comparisons | 23,104 | 14,224 | 14,224 |
+| Copy equality byte comparisons | 8,351 | 8,608 | 8,608 |
+
+All 62 outputs, token sequences and final causal states agree with dispatch
+disabled. Artifact loading/validation, report serialization and process startup
+are outside the generation subtotal and included in the recorded full command
+wall times and cumulative budget. The parent/role timing difference is one pass,
+not a robust speedup estimate. Copy-geometry suppression reaches 45/62 and copy
+suppression 32/62; these are within-artifact sensitivity results. No matched-refit
+geometric superiority is established.
+
+The model JSON grows from 10,274,524 to 10,557,795 bytes. Local model work uses
+57.201/120 seconds this cycle, including failed/passing fixture runs and generated
+code. The cumulative ledger is 1,138.842/1,800 seconds, leaving 661.158 seconds.
+Peak sampled direct model RSS is 613,810,176 bytes; engineering compiler and
+unmonitored fixture peaks remain unavailable. Engineering commands have their
+separate cumulative record; final totals and retained storage are in the local
+checkpoint. The necessary 512 MiB preauthorized storage increase raises the cap
+to 6,459,228,160 bytes, retaining the 128 MiB stop margin. No material was deleted
+and no paid external compute was used.
+
+## Reproduction and limits
+
+The existing Rust example now supports:
+
+```text
+prepare-role-read SOURCE_V3 NEW_DIRECTORY
+fit-role-read MODEL SOURCE NEW_MODEL NEW_REPORT
+evaluate --model MODEL --source SOURCE --output-dir NEW_DIRECTORY --controls full
+```
+
+Use the existing cumulative monitor and a complete build/evaluation projection.
+The model API is `Model::fit_role_read`; inference and checkpoint loading use the
+ordinary native CLI/service interfaces. Local evidence is under
+`.uor-models/native-typed-value-2026-09-05/role-read-*`, particularly
+`role-read-source/`, `role-read-selection.json`, the two fit reports, preservation,
+OPEN/first-use/control reports, CLI output, compiler receipts and
+`role-read-checkpoint.json`. Earlier reports used the example's generic old copy
+scope prose; this record supplies the actual joint-operator scope and the example
+metadata is corrected. Their original measurements and outputs are preserved.
+
+Focused checks pass fourteen existing copy tests and two new real-fit tests for
+observed commitment, pre-byte-zero restore, provenance rejection, quantized row
+validation and artifact identity. Broader release qualification is NOT_RUN.
+The next build is #1138: learn exact associations and revisions that remain
+answerable after raw-window eviction, reusing this accepted bounded reader.

--- a/docs/native_geometric_workflow.md
+++ b/docs/native_geometric_workflow.md
@@ -5,7 +5,11 @@ for new work and [current-state](integration/current-state.md) for artifact
 selection. The delivered optional path also includes retained-word copying,
 composed prefix-to-copy entry, completion and committed-copy dispatch. Examples
 below are command/API references, not permission to rerun an earlier fit or a
-claim that role-aware selection and relational memory are already implemented.
+claim that the remaining relational-memory step is already implemented.
+The optional [#1137 role reader](native_geometric_role_read_1137.md) now implements
+one learned source/NoRead and entry choice, reused through observed commitment.
+Its Rust preparation/fitting commands and bounded transfer result are in that
+record; ordinary native generation and checkpoint loading execute the artifact.
 
 The native path is `r4 geometric`. Data preparation, fitting, artifacts,
 evaluation, sessions and generation use Rust. Its initial learner estimates


### PR DESCRIPTION
The native reader previously chose lexical entry and a copied source independently. Retained answer words could therefore produce the wrong entry or source under changed wording. This adds one learned candidate-relative occurrence/NoRead choice, commits its exact source when entry is observed, and reuses that source through copying and checkpoint restore.

Rust fitting exports bounded quantized tables over relative local role/context, exact equality, ordered prime context and existing signed H4/zeta features. The selected revision removes pooled query identities. The sixteen-word capture, numeric precedence, /4 memory, completion and committed-byte dispatch remain. It learns weights over role features; a separate semantic role codebook is not implemented or claimed. Old artifacts omit the optional head and retain their prior behavior.

## Measured result

Selected artifact: `blake3:61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184`.

| Evaluation | Unchanged parent | Selected reader |
|---|---:|---:|
| Preservation | 62/62 | 62/62 |
| Binding outputs | 8/8 | 8/8 |
| Earlier sixteen-case wording set, now OPEN | 13/16 | 16/16 |
| Earlier 32-case transfer set, now OPEN | 16/32 | 30/32 |
| Predeclared first-use set | 13/24 | 24/24 |

The first fit's 61/62 preservation negative is retained. The first-use set was prepared before fitting, and the selected artifact/source hashes were recorded before opening it. Names and values are new relative to supplied construction and prior development; grammar families are known. No parameter or selection-law change followed opening. Two older transfer cases still falsely abstain. This accepts a bounded binding/entry handoff, not broad language or alpha.

All four new generated Rust functions compile unchanged and pass seven identity inputs each (28 assertions). Thirty-two earlier generated sources remain byte-identical to their checked versions. Every Generation field from an actual native CLI run matches evaluation, with matching artifact identity.

## Validation and cost

- Release CLI and example build: PASS using pinned Rust, offline, one build job.
- Fourteen existing copy tests and two new real-fit role/commit tests: PASS. Coverage includes observed commitment, mismatch, pre-byte-zero restore, source provenance, quantized row bounds and parent/artifact identity. An initial assertion wrongly required prediction work counters to stay unchanged; its correction and failed run are retained.
- Formatting, native architecture policy, claim wording and diff checks: PASS. Local documentation links resolve. Broader release qualification: NOT_RUN.
- All 62 outputs, token sequences and final causal states match with committed-copy dispatch disabled. Ordinary score lookups fall from 1,772,626 to 1,470,063. The single-pass generation times are 65.037 and 46.517 ms; startup, artifact loading/validation and report I/O are separately included in full command wall accounting. No robust speedup claim.
- Copy-geometry suppression reaches 45/62; copy suppression 32/62. These are sensitivity controls, not matched-refit geometric superiority.
- Artifact JSON grows by 283,271 bytes. Model work is 57.201/120 seconds; engineering commands 742.865/1,200 seconds. Cumulative model ledger is 1,138.842/1,800 seconds, leaving 661.158. Peak sampled direct model RSS is 613,810,176 bytes; compiler/unmonitored fixture peaks are unavailable.
- The preauthorized necessary 512 MiB storage increase raises the inherited cap to 6,459,228,160 bytes with a 128 MiB stop margin. No material was deleted or paid external compute used.

`docs/native_geometric_role_read_1137.md` records implementation, information loss, artifacts, full work scope and remaining failures. README, roadmap, current-state, research and continuation pointers agree. Local receipts and the cumulative checkpoint are retained under `.uor-models/native-typed-value-2026-09-05/role-read-*`.

After protected delivery, #1138 exact learned relation memory across raw-window eviction is the next step. #1139 selective geometric access and #1140 typed operator composition remain subsequent, unqualified work.

Closes #1137
