### PR TITLE
Make exact relation writes transfer across participant names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ work and its one-pass timing limits are recorded alongside the behavior.
 The [immediate build plan](docs/integration/project-track.md#immediate-build-sequence)
 is role-aware shared source selection, exact relational memory, selective
 geometric routing and typed operator composition, before broader programme
-expansion. The optional [#1138 exact relation implementation](docs/native_geometric_relation_memory_1138.md)
-now learns writes/revisions and retains exact values after raw-window eviction.
-It preserves prior behavior and reaches 56/56 OPEN answers, but the reserved
-check gives 26/28 answers and only 21/28 exact write sequences. Its handoff
-remains unmet: #1138's writer transfer is still the immediate step; selective
-routing and typed composition remain unimplemented and unqualified. General conversation,
-coding/reasoning, semantic multiscale memory and alpha remain unestablished.
+expansion. The [#1138 role-path correction](docs/native_geometric_relation_role_path_1138.md)
+now learns exact relations beyond raw-window eviction: **84/84 OPEN and 28/28
+reserved answers and exact write sequences**, preserving earlier behavior and
+five restored/isolated session reads. Participant-masked role features and ordered
+interior H4/zeta transport repair the preceding writer transfer failures. These
+known grammar cases establish the bounded memory handoff; general conversation,
+coding/reasoning and alpha remain unestablished. After protected delivery, #1139
+selective admission/routing at complete cost is next, then typed composition.
+No independent geometric efficiency advantage is claimed.
 
 ## Preserved project entry points
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -977,6 +977,8 @@ fn main() -> ProbeResult<()> {
             m.as_str(),
             "prepare-relations"
                 | "repair-relations-source"
+                | "role-relations-source"
+                | "fit-role-relations"
                 | "broaden-relations-source"
                 | "fit-relations"
                 | "evaluate-relations"

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/relation_memory.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/relation_memory.rs
@@ -12,7 +12,12 @@ struct RelationSource {
     acceptance: String,
 }
 fn example(split: &str, world: usize, task: usize, long: bool) -> RelationExample {
-    let (names, places) = if split == "fit-transfer" {
+    let (names, places) = if split == "first-use-role-path" {
+        (
+            ["marvik", "nelren", "orveth", "pyrlen"],
+            ["Selvik", "Turven", "Uldor", "Vexran"],
+        )
+    } else if split == "fit-transfer" {
         (
             ["avren", "belvik", "cendra", "dovran"],
             ["Faren", "Belor", "Cevik", "Dulen"],
@@ -114,6 +119,53 @@ fn example(split: &str, world: usize, task: usize, long: bool) -> RelationExampl
 
 pub(super) fn run(mode: &str) -> ProbeResult<()> {
     let args: Vec<_> = std::env::args().skip(2).collect();
+    if mode == "role-relations-source" {
+        if args.len() != 3 {
+            return Err("role-relations-source PARENT_MODEL SOURCE NEW_SOURCE".into());
+        }
+        let parent: Value = serde_json::from_slice(&fs::read(&args[0])?)?;
+        let mut source: RelationSource = serde_json::from_slice(&fs::read(&args[1])?)?;
+        if source.fit.len() != 112 || source.development.len() != 56 || source.first_use.len() != 28
+        {
+            return Err("expected preserved relation coverage source".into());
+        }
+        let prior = serde_json::to_string(&source)?;
+        let dictionary = parent["response_entry"]["copy"]["role_read"]["dictionary"]
+            .as_array()
+            .ok_or("no parent dictionary")?;
+        for novel in [
+            "marvik", "nelren", "orveth", "pyrlen", "Selvik", "Turven", "Uldor", "Vexran",
+        ] {
+            if prior.contains(novel)
+                || dictionary.iter().any(|row| {
+                    row["bytes"].as_array().is_some_and(|bytes| {
+                        bytes
+                            .iter()
+                            .take(row["len"].as_u64().unwrap_or(0) as usize)
+                            .filter_map(Value::as_u64)
+                            .map(|b| b as u8)
+                            .collect::<Vec<_>>()
+                            == novel.as_bytes()
+                    })
+                })
+            {
+                return Err(
+                    format!("reserved word overlaps previous source/dictionary: {novel}").into(),
+                );
+            }
+        }
+        source.development.append(&mut source.first_use);
+        source.first_use = (0..4)
+            .flat_map(|w| (0..7).map(move |t| example("first-use-role-path", w, t, true)))
+            .collect();
+        source.acceptance = "84/84 OPEN answers and exact write sequences;62+24prior+8binding preservation and5restored session reads; then28/28 reserved answers AND writes after design selection. Construction112 unchanged. New reserved vocabulary absent from supplied prior relation source and parent dictionary. Known grammar families, not final programme qualification.".into();
+        write_json(Path::new(&args[2]), &source)?;
+        println!(
+            "{}",
+            json!({"fit":112,"fit_unchanged":true,"open":84,"reserved":28,"novelty":"PASS","acceptance":source.acceptance})
+        );
+        return Ok(());
+    }
     if mode == "broaden-relations-source" {
         if args.len() != 3 {
             return Err("broaden-relations-source PARENT_MODEL SOURCE NEW_SOURCE".into());
@@ -269,8 +321,12 @@ pub(super) fn run(mode: &str) -> ProbeResult<()> {
     if source.schema != "uor-r4.relation-source/1" {
         return Err("unknown relation source".into());
     }
-    if mode == "fit-relations" {
-        let (next, report) = model.fit_relations(&source.fit, 64)?;
+    if matches!(mode, "fit-relations" | "fit-role-relations") {
+        let (next, report) = if mode == "fit-role-relations" {
+            model.fit_relations_with_role_paths(&source.fit, 64)?
+        } else {
+            model.fit_relations(&source.fit, 64)?
+        };
         write_new(Path::new(&args[2]), &next.to_bytes()?)?;
         write_json(Path::new(&args[3]), &report)?;
         println!("{report}");

--- a/crates/uor-r4-core/src/native_geometric/relation.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation.rs
@@ -13,6 +13,10 @@ pub(super) const RELATION_ROWS: usize = 16384;
 #[serde(deny_unknown_fields)]
 pub(super) struct RelationModel {
     pub schema: String,
+    /// Version 2 word-local transport, compiled from the parent tokenizer and
+    /// fixed geometry. Dictionary primes are exact keys, not semantic distances.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub role_context: Vec<TokenGeometry>,
     pub parent: String,
     pub writer: Vec<ValueRow>,
     pub reader: Vec<ValueRow>,
@@ -74,6 +78,17 @@ pub struct RelationWork {
     pub feature_writes: u64,
     pub source_presence_checks: u64,
     pub phase_subtractions: u64,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub role_path_probes: u64,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub role_path_comparisons: u64,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub role_path_steps: u64,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub role_phase_additions: u64,
+}
+fn relation_count_zero(value: &u64) -> bool {
+    *value == 0
 }
 impl RelationWork {
     pub fn is_empty(&self) -> bool {
@@ -146,6 +161,21 @@ pub(super) fn write_features(
     value: usize,
     work: &mut ValueWork,
 ) -> ([ValueFeature; RELATION_FEATURES], usize) {
+    let context = head(model)
+        .filter(|h| h.schema == "uor-r4.exact-relation/2")
+        .map(|h| h.role_context.as_slice());
+    write_features_with_context(model, words, addr, owner, value, context, work)
+}
+
+pub(super) fn write_features_with_context(
+    model: &Model,
+    words: &[WordAtom],
+    addr: &[u32; 16],
+    owner: usize,
+    value: usize,
+    context: Option<&[TokenGeometry]>,
+    work: &mut ValueWork,
+) -> ([ValueFeature; RELATION_FEATURES], usize) {
     let mut out = [ValueFeature::default(); RELATION_FEATURES];
     let mut n = 0;
     let mut add = |kind, a, b| {
@@ -153,7 +183,11 @@ pub(super) fn write_features(
         n += 1;
     };
     let at = |i: usize| {
-        if i < words.len() {
+        if context.is_some() && i == owner {
+            u64::MAX
+        } else if context.is_some() && i == value {
+            u64::MAX - 1
+        } else if i < words.len() {
             u64::from(addr[i])
         } else {
             0
@@ -168,28 +202,72 @@ pub(super) fn write_features(
     add(6, (owner + 8 - value) as u64, 0);
     add(7, at(value + 2), at(value + 1));
     add(8, at(owner + 2), at(owner + 1));
-    let a = &words[owner];
-    let b = &words[value];
-    let inv = model.geometry.inverses[usize::from(a.pose)];
-    let rel =
-        model.geometry.products[model.geometry.row_bases[usize::from(inv)] + usize::from(b.pose)];
-    work.h4_reads = work.h4_reads.saturating_add(3);
+    let (rel, phases) = if let Some(context) = context {
+        // Recent words are newest first. Compose only the ordered interior,
+        // excluding both payloads and all global prefix state. Unknown interior
+        // words contribute identity/zero; their distinctions are not retained.
+        let mut pose = model.geometry.identity;
+        let mut phases = [0_u16; PHASE_CHANNELS];
+        for i in (owner.min(value) + 1..owner.max(value)).rev() {
+            work.relations.role_path_probes = work.relations.role_path_probes.saturating_add(1);
+            if let Ok(j) = context.binary_search_by(|g| {
+                work.relations.role_path_comparisons =
+                    work.relations.role_path_comparisons.saturating_add(1);
+                g.prime.cmp(&addr[i])
+            }) {
+                let g = &context[j];
+                pose = model.geometry.products
+                    [model.geometry.row_bases[usize::from(pose)] + usize::from(g.leaf)];
+                work.h4_reads = work.h4_reads.saturating_add(2);
+                for (p, d) in phases.iter_mut().zip(g.phases) {
+                    *p = p.wrapping_add(d);
+                }
+                work.relations.role_path_steps = work.relations.role_path_steps.saturating_add(1);
+                work.relations.role_phase_additions = work
+                    .relations
+                    .role_phase_additions
+                    .saturating_add(PHASE_CHANNELS as u64);
+            }
+        }
+        if owner < value {
+            pose = model.geometry.inverses[usize::from(pose)];
+            work.h4_reads = work.h4_reads.saturating_add(1);
+            for p in &mut phases {
+                *p = 0_u16.wrapping_sub(*p);
+            }
+            work.relations.phase_subtractions = work
+                .relations
+                .phase_subtractions
+                .saturating_add(PHASE_CHANNELS as u64);
+        }
+        (pose, phases)
+    } else {
+        let a = &words[owner];
+        let b = &words[value];
+        let inv = model.geometry.inverses[usize::from(a.pose)];
+        let rel = model.geometry.products
+            [model.geometry.row_bases[usize::from(inv)] + usize::from(b.pose)];
+        work.h4_reads = work.h4_reads.saturating_add(3);
+        work.relations.phase_subtractions = work
+            .relations
+            .phase_subtractions
+            .saturating_add(PHASE_CHANNELS as u64);
+        (
+            rel,
+            std::array::from_fn(|c| b.phases[c].wrapping_sub(a.phases[c])),
+        )
+    };
     add(10, u64::from(rel), 0);
     add(
         11,
         u64::from(model.geometry.orientation[usize::from(rel)]),
         0,
     );
-    work.relations.phase_subtractions = work
-        .relations
-        .phase_subtractions
-        .saturating_add(PHASE_CHANNELS as u64);
-    for channel in 0..PHASE_CHANNELS {
-        add(
-            12,
-            channel as u64,
-            u64::from(b.phases[channel].wrapping_sub(a.phases[channel]) >> 12),
-        );
+    if context.is_some() {
+        work.h4_reads = work.h4_reads.saturating_add(1);
+    }
+    for (channel, phase) in phases.into_iter().enumerate() {
+        add(12, channel as u64, u64::from(phase >> 12));
     }
     work.relations.feature_writes = work.relations.feature_writes.saturating_add(n as u64);
     (out, n)

--- a/crates/uor-r4-core/src/native_geometric/relation_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_tests.rs
@@ -87,3 +87,134 @@ fn native_relation_snapshot_rejects_dangling_or_rewritten_current_versions() {
     bad.records[1].conflict = true;
     assert!(bad.validate(&values, &model).is_err());
 }
+
+#[test]
+fn native_relation_role_features_ignore_payload_renaming_and_global_pose() {
+    let docs = vec![Document {
+        id: "role-transport".into(),
+        text: "in now not holds".into(),
+    }];
+    let mut trainer = Trainer::new(Config::default(), &docs).unwrap();
+    trainer.train_documents(&docs).unwrap();
+    let model = trainer.compile().unwrap();
+    let mut context = vec![
+        model.geometry.tokens[7].clone(),
+        model.geometry.tokens[11].clone(),
+    ];
+    context[0].prime = 13;
+    context[1].prime = 17;
+    let words = [
+        atom("oldvalue", 32),
+        atom("in", 24),
+        atom("now", 16),
+        atom("owner", 8),
+    ];
+    let addr = [3, 13, 17, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    // Every offered pair is invariant to its own participant payloads, including
+    // pairs where the neighbor feature addresses the other participant.
+    for o in 0..4 {
+        for v in 0..4 {
+            if o == v || (o != 0 && v != 0) {
+                continue;
+            }
+            let mut renamed = words;
+            let mut changed_addr = addr;
+            for (i, name) in [(o, "differentowner"), (v, "differentvalue")] {
+                renamed[i] = atom(name, 80);
+                renamed[i].pose = 37;
+                renamed[i].phases = [62000; PHASE_CHANNELS];
+                changed_addr[i] = 0;
+            }
+            let a = write_features_with_context(
+                &model,
+                &words,
+                &addr,
+                o,
+                v,
+                Some(&context),
+                &mut ValueWork::default(),
+            );
+            let b = write_features_with_context(
+                &model,
+                &renamed,
+                &changed_addr,
+                o,
+                v,
+                Some(&context),
+                &mut ValueWork::default(),
+            );
+            assert_eq!(a, b);
+        }
+    }
+}
+
+#[test]
+fn native_relation_role_path_keeps_context_order_and_direction() {
+    let docs = vec![Document {
+        id: "role-path-order".into(),
+        text: "context".into(),
+    }];
+    let mut trainer = Trainer::new(Config::default(), &docs).unwrap();
+    trainer.train_documents(&docs).unwrap();
+    let model = trainer.compile().unwrap();
+    let g = &model.geometry;
+    let (a, b) = (0..g.inverses.len())
+        .flat_map(|a| (0..g.inverses.len()).map(move |b| (a, b)))
+        .find(|&(a, b)| g.products[g.row_bases[a] + b] != g.products[g.row_bases[b] + a])
+        .unwrap();
+    let context = [
+        TokenGeometry {
+            prime: 13,
+            leaf: a as u16,
+            phases: [8192; PHASE_CHANNELS],
+        },
+        TokenGeometry {
+            prime: 17,
+            leaf: b as u16,
+            phases: [4096; PHASE_CHANNELS],
+        },
+    ];
+    let words = [
+        atom("value", 32),
+        atom("contexta", 24),
+        atom("contextb", 16),
+        atom("owner", 8),
+    ];
+    let mut addr = [0; 16];
+    addr[1] = 13;
+    addr[2] = 17;
+    let (f, n) = write_features_with_context(
+        &model,
+        &words,
+        &addr,
+        3,
+        0,
+        Some(&context),
+        &mut ValueWork::default(),
+    );
+    let mut reversed = addr;
+    reversed.swap(1, 2);
+    let (r, m) = write_features_with_context(
+        &model,
+        &words,
+        &reversed,
+        3,
+        0,
+        Some(&context),
+        &mut ValueWork::default(),
+    );
+    let root = |features: &[super::value_types::ValueFeature]| {
+        features.iter().find(|f| f.kind == 10).unwrap().a as usize
+    };
+    assert_ne!(root(&f[..n]), root(&r[..m]));
+    let (back, k) = write_features_with_context(
+        &model,
+        &words,
+        &addr,
+        0,
+        3,
+        Some(&context),
+        &mut ValueWork::default(),
+    );
+    assert_eq!(root(&back[..k]), usize::from(g.inverses[root(&f[..n])]));
+}

--- a/crates/uor-r4-core/src/native_geometric/relation_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_training.rs
@@ -111,6 +111,7 @@ fn writer_frame(
     model: &Model,
     words: &super::value_lexemes::LexemeState,
     label: Option<&RelationLabel>,
+    context: Option<&[TokenGeometry]>,
 ) -> Result<Frame> {
     let words = &words.recent[..words.recent_len.min(8)];
     let mut work = ValueWork::default();
@@ -124,7 +125,7 @@ fn writer_frame(
             if o == v || (o != 0 && v != 0) {
                 continue;
             }
-            let (f, n) = write_features(model, words, &addr, o, v, &mut work);
+            let (f, n) = write_features_with_context(model, words, &addr, o, v, context, &mut work);
             for a in 1..=3 {
                 alternatives.push(Alternative {
                     keys: f[..n].iter().map(|f| key(*f, a)).collect(),
@@ -157,8 +158,10 @@ impl RelationModel {
                         && (1..=3).contains(&(r.feature.kind >> 5))
                 })
         };
-        if self.schema != "uor-r4.exact-relation/1"
-            || !valid(&self.writer)
+        if !matches!(
+            self.schema.as_str(),
+            "uor-r4.exact-relation/1" | "uor-r4.exact-relation/2"
+        ) || !valid(&self.writer)
             || !valid(&self.reader)
             || !(1..=64).contains(&self.epochs)
             || self.training.is_empty()
@@ -173,6 +176,14 @@ impl RelationModel {
                 != self.training.len()
         {
             return Err(Error("invalid learned relation model".into()));
+        }
+        if (self.schema == "uor-r4.exact-relation/1" && !self.role_context.is_empty())
+            || (self.schema == "uor-r4.exact-relation/2"
+                && self.role_context != compile_role_context(model)?)
+        {
+            return Err(Error(
+                "relation role transport differs from parent tokenizer/geometry".into(),
+            ));
         }
         let mut parent = model.clone();
         let role = parent
@@ -195,6 +206,32 @@ impl RelationModel {
     }
 }
 
+fn compile_role_context(model: &Model) -> Result<Vec<TokenGeometry>> {
+    let role = super::role_read::head(model)
+        .ok_or_else(|| Error("relation role parent missing".into()))?;
+    let mut rows = Vec::with_capacity(role.dictionary.len());
+    for word in &role.dictionary {
+        let text = std::str::from_utf8(&word.bytes[..usize::from(word.len)])
+            .map_err(|e| Error(e.to_string()))?;
+        let mut row = TokenGeometry {
+            prime: word.prime,
+            leaf: model.geometry.identity,
+            phases: [0; PHASE_CHANNELS],
+        };
+        for token in model.encode(text)? {
+            let g = &model.geometry.tokens[token as usize];
+            row.leaf = model.geometry.products
+                [model.geometry.row_bases[usize::from(row.leaf)] + usize::from(g.leaf)];
+            for (p, d) in row.phases.iter_mut().zip(g.phases) {
+                *p = p.wrapping_add(d);
+            }
+        }
+        rows.push(row);
+    }
+    rows.sort_by_key(|r| r.prime);
+    Ok(rows)
+}
+
 impl Model {
     pub fn relation_training(&self) -> &[DocumentReceipt] {
         head(self).map_or(&[], |h| h.training.as_slice())
@@ -203,6 +240,24 @@ impl Model {
         &self,
         documents: &[RelationExample],
         epochs: usize,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.fit_relations_mode(documents, epochs, false)
+    }
+
+    /// Learn participant-independent role context while preserving exact values.
+    pub fn fit_relations_with_role_paths(
+        &self,
+        documents: &[RelationExample],
+        epochs: usize,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.fit_relations_mode(documents, epochs, true)
+    }
+
+    fn fit_relations_mode(
+        &self,
+        documents: &[RelationExample],
+        epochs: usize,
+        role_paths: bool,
     ) -> Result<(Model, serde_json::Value)> {
         self.validate()?;
         if head(self).is_some()
@@ -218,6 +273,12 @@ impl Model {
         {
             return Err(Error("invalid relation fitting source/config".into()));
         }
+        let role_context = if role_paths {
+            compile_role_context(self)?
+        } else {
+            Vec::new()
+        };
+        let context = role_paths.then_some(role_context.as_slice());
         let mut frames = BTreeSet::new();
         let mut receipts = Vec::new();
         let mut ids = BTreeSet::new();
@@ -292,7 +353,7 @@ impl Model {
                         return Err(Error("multiple labels at one relation boundary".into()));
                     }
                     let label = labels.first().map(|(_, l)| *l);
-                    frames.insert(writer_frame(self, &words, label)?);
+                    frames.insert(writer_frame(self, &words, label, context)?);
                     if let Some((i, l)) = labels.first() {
                         consumed.insert(*i);
                         let o = words
@@ -395,7 +456,13 @@ impl Model {
             .and_then(|c| c.role_read.as_mut())
             .ok_or_else(|| Error("role parent absent".into()))?
             .relations = Some(RelationModel {
-            schema: "uor-r4.exact-relation/1".into(),
+            schema: if role_paths {
+                "uor-r4.exact-relation/2"
+            } else {
+                "uor-r4.exact-relation/1"
+            }
+            .into(),
+            role_context,
             parent: self.artifact_cid.clone(),
             writer,
             reader,
@@ -406,6 +473,9 @@ impl Model {
         model.validate()?;
         let h = head(&model).ok_or_else(|| Error("relation fit absent".into()))?;
         let report = serde_json::json!({"schema":"uor-r4.relation-fit/1","parent":self.artifact_cid(),"artifact":model.artifact_cid(),"documents":documents.len(),"writer_frames":frames.len(),"writer_correct":write_correct,"reader_frames":reads.len(),"reader_correct":read_correct,"writer_rows":h.writer.len(),"reader_rows":h.reader.len(),"epochs":epochs,"scope":"Construction-supervised margin updates export sparse integer tables. Writer labels are exact source byte endpoints and typed actions offline only. Read fitting uses labeled construction writes; generated evaluation must test the assembled learned writer/reader. One association family; no general semantic memory claim."});
+        let mut report = report;
+        report["operator_schema"] = serde_json::json!(h.schema);
+        report["role_context_rows"] = serde_json::json!(h.role_context.len());
         Ok((model, report))
     }
 }

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -2,6 +2,20 @@
 
 ## Latest native result — 2026-09-05
 
+[#1138 participant-independent role paths](native_geometric_relation_role_path_1138.md)
+pass the bounded relation handoff with unchanged 112-document construction:
+84/84 OPEN answers/write sequences, then 28/28 reserved answers/writes against
+24/28 answers and 14/28 writes for the preceding relation artifact. All 62+24
+prior responses, eight binding outputs and five restored/isolated session reads
+pass. Only the writer representation and its refitted scores change; exact
+storage, reader and copying remain. The combined role-mask/ordered H4/zeta path
+is the intervention, without independent geometric attribution or a speed claim.
+After protected delivery, #1139 targets complete admission/routing work; repeated
+writer NoWrite scoring dominates the new cost. General memory and alpha remain
+unqualified. All earlier negatives below retain their artifact scope.
+
+## Prior exact-relation transfer negative — 2026-09-05
+
 [#1138 exact relation memory](native_geometric_relation_memory_1138.md) is a
 working development extension with an unmet transfer handoff. The final fit
 reaches 56/56 OPEN answers and exact write sequences, preserves 62+24 prior

--- a/docs/evidence/native_geometric_relation_role_path_1138.json
+++ b/docs/evidence/native_geometric_relation_role_path_1138.json
@@ -1,0 +1,122 @@
+{
+  "schema": "uor-r4.relation-role-checkpoint/1",
+  "at": "2026-09-06T00:45:22.776372+00:00",
+  "verdict": "ACCEPT_BOUNDED_EXACT_RELATION_HANDOFF",
+  "issue": 1138,
+  "artifact": "blake3:793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad",
+  "previous_relation_artifact": "blake3:16f4c10f6b79807868c7774872ba58776acd68a08c0c22054f49aca5206ecbeb",
+  "upstream_parent": "blake3:61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184",
+  "summaries": {
+    "relation-role-fit-report.json": {
+      "artifact": "blake3:793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad",
+      "documents": 112,
+      "epochs": 64,
+      "operator_schema": "uor-r4.exact-relation/2",
+      "parent": "blake3:61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184",
+      "reader_correct": 112,
+      "reader_frames": 112,
+      "reader_rows": 51,
+      "role_context_rows": 82,
+      "schema": "uor-r4.relation-fit/1",
+      "scope": "Construction-supervised margin updates export sparse integer tables. Writer labels are exact source byte endpoints and typed actions offline only. Read fitting uses labeled construction writes; generated evaluation must test the assembled learned writer/reader. One association family; no general semantic memory claim.",
+      "writer_correct": 224,
+      "writer_frames": 224,
+      "writer_rows": 2406
+    },
+    "relation-role-open-report.json": {
+      "artifact": "blake3:793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad",
+      "elapsed_ms": 1401,
+      "exact": 84,
+      "schema": "uor-r4.relation-evaluation/1",
+      "scope": "Actual assembled learned write/read and ordinary native generation. A second source ingestion/checkpoint restore supplies eviction and state evidence; its cost is in total elapsed/parent monitor, outside generation subtotals. No semantic labels enter serving.",
+      "split": "development",
+      "total": 84,
+      "writes_exact": 84
+    },
+    "relation-role-parent-open-report.json": {
+      "artifact": "blake3:16f4c10f6b79807868c7774872ba58776acd68a08c0c22054f49aca5206ecbeb",
+      "elapsed_ms": 1438,
+      "exact": 82,
+      "schema": "uor-r4.relation-evaluation/1",
+      "scope": "Actual assembled learned write/read and ordinary native generation. A second source ingestion/checkpoint restore supplies eviction and state evidence; its cost is in total elapsed/parent monitor, outside generation subtotals. No semantic labels enter serving.",
+      "split": "development",
+      "total": 84,
+      "writes_exact": 77
+    },
+    "relation-role-reserved-report.json": {
+      "artifact": "blake3:793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad",
+      "elapsed_ms": 442,
+      "exact": 28,
+      "schema": "uor-r4.relation-evaluation/1",
+      "scope": "Actual assembled learned write/read and ordinary native generation. A second source ingestion/checkpoint restore supplies eviction and state evidence; its cost is in total elapsed/parent monitor, outside generation subtotals. No semantic labels enter serving.",
+      "split": "first_use",
+      "total": 28,
+      "writes_exact": 28
+    },
+    "relation-role-parent-reserved-report.json": {
+      "artifact": "blake3:16f4c10f6b79807868c7774872ba58776acd68a08c0c22054f49aca5206ecbeb",
+      "elapsed_ms": 476,
+      "exact": 24,
+      "schema": "uor-r4.relation-evaluation/1",
+      "scope": "Actual assembled learned write/read and ordinary native generation. A second source ingestion/checkpoint restore supplies eviction and state evidence; its cost is in total elapsed/parent monitor, outside generation subtotals. No semantic labels enter serving.",
+      "split": "first_use",
+      "total": 28,
+      "writes_exact": 14
+    }
+  },
+  "resources": {
+    "projection": "relation-role-projection.json",
+    "cycle_model_ms": 38821,
+    "cycle_model_limit_ms": 120000,
+    "cycle_engineering_ms": 412722,
+    "cycle_engineering_limit_ms": 1200000,
+    "storage": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-06T00:44:20.640Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2402148352,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 594051072,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 5702713344,
+      "storage_limit_bytes": 6459228160,
+      "remaining_storage_bytes": 756514816,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 401108992,
+      "model_ledger": {
+        "cumulative_ms": 1267771,
+        "limit_ms": 1800000
+      },
+      "model_remaining_ms": 532229,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "peak_sampled_direct_model_rss_bytes": 777273344
+  },
+  "verification": {
+    "release_cli_and_example": "PASS",
+    "relation_tests": 4,
+    "role_commit_tests": 2,
+    "format": "PASS",
+    "native_policy": "PASS",
+    "claim_wording": "PASS",
+    "full_release": "NOT_RUN",
+    "separate_geometric_attribution": "NOT_RUN"
+  },
+  "source_sha256": {
+    "crates/uor-r4-core/examples/native_geometric_value_probe.rs": "22bb7ff426a7f463493e8568419242fb8ea43d2bf10366b5a19aaee5f5185fbc",
+    "crates/uor-r4-core/examples/native_geometric_value_probe/relation_memory.rs": "76f69d15907eeaf25966f6997f462abacce52a3d1a62026ff08873017c543be5",
+    "crates/uor-r4-core/src/native_geometric/relation.rs": "75b73177334daf23d588f2ace26f58f3aa32eef2e31e56f609174d4fbc33bba8",
+    "crates/uor-r4-core/src/native_geometric/relation_tests.rs": "03e5882c0615240e183f0b2f4b29524aabd65a86e29f6f62b5fd4ba724a9b953",
+    "crates/uor-r4-core/src/native_geometric/relation_training.rs": "48e553c9ea98e022aef64faf27449729239b12f2e0f5c598b7cf6b0db122ce3f"
+  },
+  "next": "#1139 after protected delivery: learned geometric metadata admission/routing against matched plain sparse alternative; start with dominant repeated NoWrite writer scoring; preserve exact write sequences and answers, count maintenance/fallback and full model work. Not implemented here.",
+  "scope": "Known grammar families and four reserved name worlds; participant-local writer representation repair, not general memory or alpha. Source/reader/store laws unchanged; no further fitting or serving-law changes after reserved opening.",
+  "local_artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "selection_sha256": "9126c016440fcfbdfb1beefe371411c39e26ca60f6f00ca343ca8495f860c53e"
+}

--- a/docs/integration/CONTINUE.md
+++ b/docs/integration/CONTINUE.md
@@ -21,12 +21,14 @@ learned geometric operators through bounded routing/state/integer-table lookup,
 not a dense transformer concealed behind lookup. Preserve existing Python/dense
 references as evidence, with no new Python model dependency.
 
-Follow the immediate build sequence in project-track.md. The #1137 bounded role-aware
-selection/commit handoff passed and PR #1142 merged. #1138 exact relation storage,
-updates and reads now execute, but writer transfer remains unmet (26/28 reserved
-answers, 21/28 exact write sequences). Continue #1138 with participant-independent
-local role/context representation; preserve the working store and reader.
-Do not repeat completed storage work or proceed to blocked #1139/#1140. A closed negative is
+Follow the immediate build sequence in project-track.md. #1137 passed and PR
+#1142 merged; relation storage PR #1143 also merged. #1138's version-2 role-path
+correction now passes 84/84 OPEN and 28/28 reserved answers AND exact write sequences,
+with prior response/session preservation. After its protected delivery, #1139
+is next: learned geometric admission/routing against a plain sparse comparator
+at matched quality and complete cost. Start from the dominant writer scoring;
+keep exact values and count fallback/index maintenance. #1140 remains dependent
+on an accepted #1139 handoff. A closed negative is
 not an accepted handoff. Do not restart superseded #1083/#1084/#1087/#1089/#1090/
 #1091/#940 as parallel queues; use the plan's responsibility map. Maintain one
 task and one agent under the current owner cadence; necessary storage increases

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,35 @@
 # Current native geometric AI work
 
-## Exact learned relation memory — 2026-09-05, latest checkpoint
+
+## Exact relation writer transfer — 2026-09-05, latest checkpoint
+
+**#1138's bounded behavioral handoff now passes.** Selected artifact
+`793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad`, at
+`.uor-models/native-typed-value-2026-09-05/relation-role-model.json`, uses version-2
+participant-masked role features and ordered interior H4/zeta transport.
+The same 112 construction documents yield 84/84 OPEN answers and exact write
+sequences, then 28/28 newly reserved answers and writes versus 24/28 answers and
+14/28 writes for unchanged relation parent `16f4c10f`. The reader, exact store,
+update laws and copy/completion path remain unchanged.
+
+Preservation passes all 62 earlier responses, 24 prior role-reader responses and
+eight binding outputs. Five actual restored/isolated session reads pass. All 84
+version-1 Generation objects and relation states reproduce exactly on the new
+executable. The [role-path record](../native_geometric_relation_role_path_1138.md)
+binds source selection, tests, costs and limitations. Known grammar/name worlds
+are the scope; no general memory, alpha or standalone geometric advantage claim.
+
+The preceding storage PR #1143 merged at `50caf04de078b2eb5f225936bbc08c1d8291e4c0`.
+After protected delivery of this correction, #1139 is immediate: geometric
+metadata admission/routing at preserved write/answer quality and complete measured
+cost, beginning with the dominant repeated NoWrite scoring. #1140 follows its
+accepted handoff. Refresh `relation-role-checkpoint.json` and shared model/storage
+ledgers before the next complete build/evaluation projection. Cumulative model
+work is 1,267.771/1,800 seconds, leaving 532.229; this cycle used 38.821 seconds
+model and 412.722 seconds engineering, with no cap increase or deletion. Older checkpoints
+below retain their original verdicts and then-next proposals.
+
+## Exact learned relation memory — 2026-09-05, prior checkpoint
 
 **#1138 is implemented at development scope; its transfer handoff remains unmet.**
 The optional `16f4c10f6b79807868c7774872ba58776acd68a08c0c22054f49aca5206ecbeb`

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -85,16 +85,16 @@ skip it, import a dense serving model, or treat issue closure as model quality.
 Necessary fixes to an existing interface, invariant or resource bottleneck may
 accompany a step; they do not start a competing product/research programme.
 
-**Current handoff:** #1137 passed and was delivered through PR #1142.
-[#1138's optional exact relation mechanism](../native_geometric_relation_memory_1138.md)
-now executes, preserving prior behavior and five session reads. Its final
-first-use result is 26/28 answers but only 21/28 exact write sequences, so its
-handoff remains unmet. #1138 is immediate; #1139 and #1140 remain blocked.
-The next build changes the writer's participant-dependent local role/context
-representation, preserving the exact store, read/copy path and update laws.
-The record names the bounded R4/zeta role-path hypothesis and complete next-cycle
-projection; it is not already implemented or qualified. All three fitted
-artifacts and their negatives remain evidence.
+**Current handoff:** #1137 was delivered through PR #1142; the exact storage
+implementation through PR #1143. [#1138's role-path correction](../native_geometric_relation_role_path_1138.md)
+now passes its bounded handoff: 84/84 OPEN and 28/28 reserved answers AND exact
+write sequences, preserving 62+24 previous responses, eight binding outputs and
+five restored/isolated session reads. After protected delivery, #1139 is next.
+Begin its complete-cost admission/routing work with the measured dominant writer
+scoring; include a plain sparse comparator and all fallback/index maintenance.
+#1140 remains dependent on an accepted #1139 handoff. The earlier relation fits
+and their negative transfer results remain preserved, with known grammar and
+geometric-attribution limits explicit.
 
 ### Step 1: role-aware source choice shared with generation
 

--- a/docs/native_geometric_mechanism_map_973.md
+++ b/docs/native_geometric_mechanism_map_973.md
@@ -1,5 +1,13 @@
 # Native geometric mechanism map — #973
 
+**Role-path update (2026-09-05):** optional relation schema `/2` masks candidate
+payload identities and composes ordered interior word-local H4/zeta transports.
+Its 82-row exact prime-keyed context table is compiled from the existing tokenizer
+and fixed geometry, then reconstructed at load. Stored payload witnesses and
+reader weights remain unchanged. The [bounded handoff now passes](native_geometric_relation_role_path_1138.md);
+writer scoring still dominates new cost and selective geometric admission/routing
+remains the unimplemented next step. Version-1 negatives below stay preserved.
+
 **Relation-memory implementation update (2026-09-05):**
 [`relation.rs`](../crates/uor-r4-core/src/native_geometric/relation.rs) and
 [`relation_training.rs`](../crates/uor-r4-core/src/native_geometric/relation_training.rs)

--- a/docs/native_geometric_relation_memory_1138.md
+++ b/docs/native_geometric_relation_memory_1138.md
@@ -1,5 +1,9 @@
 # Exact learned relation memory — #1138
 
+**Subsequent result:** the [version-2 role-path correction](native_geometric_relation_role_path_1138.md)
+now passes the bounded handoff. This record preserves the version-1 implementation,
+its negative transfer verdicts and the resulting then-next proposal.
+
 ## Implementation and scope
 
 The native role-reader parent is `61a24cfa4ce262fd974bc8e84f082a0489db3b58cfafb46c4c42a86e49c13184`,

--- a/docs/native_geometric_relation_role_path_1138.md
+++ b/docs/native_geometric_relation_role_path_1138.md
@@ -1,0 +1,165 @@
+# Participant-independent relation role paths — #1138
+
+## Change and preserved source
+
+The preceding [exact relation implementation](native_geometric_relation_memory_1138.md)
+retained sixteen exact versions and current references, but its final artifact
+`16f4c10f6b79807868c7774872ba58776acd68a08c0c22054f49aca5206ecbeb` omitted an initial
+association in one new-name world. It reached 26/28 answers and 21/28 exact write
+sequences. Those cases are now OPEN; the artifact and its original selection
+remain unchanged.
+
+This successor versions the relation operator as `uor-r4.exact-relation/2`.
+Version 1 keeps its existing feature law and omits the new context table when
+serialized. The version-2 writer masks each proposed owner/value's lexical
+identity using two fixed role markers, then composes the ordered interior words'
+H4 transports and fixed-zeta phase increments. Dictionary primes are exact keys
+into a table compiled from the unchanged parent tokenizer/geometry. They are not
+numeric semantic distances. The table is reconstructed and checked at artifact
+load; it contains no learned dense weights or hidden source model.
+
+The new path excludes participant payloads and global prefix state. For a
+reverse-directed pair, the path uses its H4 inverse and negated phase increments.
+Its score features retain full H4 root identity, signed orientation and the
+existing four-bit phase bins. Absolute endpoint geometry remains in the exact
+stored atoms and does not supply the new role-path feature. Ordered nearby prime
+features and the relative position remain; other neighboring words can still
+influence the role score. This is candidate-payload invariance, not invariance to
+all context changes or a general semantic role representation.
+
+Unknown interior words contribute identity/zero and therefore lose their lexical
+and geometric distinctions in this path. Exact payload bytes are still retained,
+so unknown names can be copied and distinguished by equality after a learned
+write. Finite H4/phase classes can still collide. H4 is noncommutative; phase addition alone is order-insensitive. The two
+mechanisms must not be identified with each other. The inherited exact Z[phi],
+orientation, paired-H4/icosian and UOR artifact boundaries remain unchanged.
+
+At most fourteen ordered pairs from eight recent words are scored. A path has at
+most six interior words; each offers one bounded context-table search, then two
+H4 table reads and eight phase additions on a hit. Reverse direction adds one
+inverse lookup and eight phase subtractions. The signed orientation read is
+counted. New counters expose context probes/comparisons, successful path steps
+and phase additions alongside dictionary, feature, score, directory, copy and
+ordinary generation work. No end-to-end efficiency advantage is presumed.
+
+The exact version store, FIFO retention, typed assert/revise/contradict laws,
+persistent reader, observed commit and copy/completion path are unchanged.
+Construction supervision and fitting are Rust-only. The source keeps the same
+112 construction documents, opens the previous 28 reserved cases (84 total
+OPEN), and prepares 28 new reserved cases before fitting. No additional
+construction name cohort is introduced. Known grammar families remain a limit.
+
+## Resource admission
+
+`relation-role-projection.json` under
+`.uor-models/native-typed-value-2026-09-05` projects 650 seconds engineering,
+90 seconds model execution and 384 MiB new storage, under the unchanged
+1,200/120-second cycle ceilings. The inherited model ledger starts at
+1,228.950/1,800 seconds with 571.050 remaining; existing storage cap is
+6,459,228,160 bytes and the 128 MiB stop margin remains. Initial available
+growth before the monitor's tighter ceiling is 428,851,200 bytes. Necessary
+storage increases remain preauthorized but none is needed for this admission.
+All commands, failures and retries are charged through the existing monitor.
+
+The release CLI and example are built together to preserve Cargo feature
+unification. The complete plan includes a focused test build, direct generated
+answers/write sequences, prior-response preservation, the existing five-turn
+restored session, reserved evaluation only after selection, and protected PR
+delivery. Results follow after execution; implementation alone is not acceptance.
+
+
+## Selected result — 2026-09-05
+
+**ACCEPT_BOUNDED_EXACT_RELATION_HANDOFF.** The selected artifact is
+`blake3:793cb9adad8bc812a85a46cf867495faae80b16570dc01b3244bf7887846caad`,
+at `.uor-models/native-typed-value-2026-09-05/relation-role-model.json`.
+Its accepted upstream role-reader parent remains `61a24cfa`. The preceding
+relation implementation was delivered through PR #1143 at
+`50caf04de078b2eb5f225936bbc08c1d8291e4c0`; its unqualified `16f4c10f` artifact
+and all earlier negatives remain preserved.
+
+| Complete generated evaluation | Previous relation artifact `/1` | Selected role-path artifact `/2` |
+|---|---|---|
+| 84 OPEN answers | 82/84 | 84/84 |
+| 84 OPEN exact write sequences | 77/84 | 84/84 |
+| 28 newly reserved answers | 24/28 | 28/28 |
+| 28 newly reserved exact write sequences | 14/28 | 28/28 |
+
+The construction source remains byte-equivalent at its 112-document fit field.
+The new representation has 224 distinct construction write frames rather than
+773; all 224 classify correctly. It exports 2,406 writer rows rather than 2,172,
+so the smaller frame population is not a serving table-size reduction. All
+112 read frames classify correctly. The 51 reader rows, their weights, training
+receipts and upstream parent are identical between the compared artifacts.
+One fit produced the selected successor; no additional construction cohort or
+post-reserved fitting was used.
+
+The source prepares 28 reserved cases with new participant/value strings absent
+from the supplied previous relation source and inherited dictionary. Its SHA-256
+is `6579d45f1b1e2b240fdc613d2a8b336d0acac32cc81d02f1c9f8dce4caaf306b`. `relation-role-selection.json` binds the exact artifact/source
+and OPEN, preservation, session and relation-test receipts before opening the
+reserved cases. Four known grammar/name worlds are represented; the 28 rows are
+not 28 unrelated natural-language domains. This is a bounded handoff, not general
+memory, unrestricted language, alpha or final programme-wide qualification.
+
+All 62 older responses, 24 prior role-reader responses and eight binding outputs
+remain correct. Thirty-two generated Rust case sources are byte-identical to
+previously compiled/executed sources; no new generated-code capability or repeat
+rustc execution is claimed. The native CLI reproduces every saved Generation
+field for a reserved initial-fact case. Five successive real-session reads pass
+with revision, unrelated-fact preservation, contradiction abstention, isolated
+state and committed-version restore. Restore still excludes only the separately
+reported historical stale-index rejection counter from full checkpoint equality.
+
+The rebuilt executable exactly reproduces all 84 previous version-1 Generation
+objects and relation states. Four relation tests pass: the two retained storage/
+validation checks and two new checks for candidate-payload invariance and ordered,
+directed context transport. Two role/observed-commit tests also pass. The combined
+release CLI/example build and focused test build complete; native architecture
+policy and formatting pass. Claim wording is checked for protected delivery.
+Broader release and standalone matched geometric attribution are NOT_RUN.
+The combined mask/path representation is the measured intervention; this does
+not identify an independent H4 or zeta advantage over matched lexical learning.
+
+## Complete exposed cost and next build
+
+The new model JSON is 10,706,728 bytes, +24,437 over the preceding relation model.
+The immutable context table has 82 rows; record capacity, exact payload storage
+and the current directory are unchanged. The representative first OPEN case
+still observes 202 completed words, chooses 200 NoWrites, writes two relations,
+offers 8,316 action candidates and performs 2,054,052 writer score-row comparisons.
+Its new role paths add 8,260 context probes and 66,080 comparisons, execute 204
+known-word steps and 1,632 phase additions, and use 11,088 reverse phase
+subtractions rather than the old 22,176 endpoint subtractions. Unknown context
+words explain most failed probes. The persistent reader still uses sixteen
+directory probes and 168 score-row comparisons. Full generation retains all
+base-model, dictionary, geometric, exact-copy and directory counters in reports.
+The representative one-pass generation times are 6,564 microseconds new and
+6,763 old; this is diagnostic, not a latency-distribution or speedup claim.
+
+After protected delivery, **#1139 is the next immediate build**. Start with
+learned geometric metadata admission before exhaustive write-candidate scoring,
+using the now-demonstrated relation workload and exact write/answer preservation.
+Compare against a plain sparse admission/index alternative at matched quality,
+capacity and complete work, including maintenance and fallback. The writer's
+repeated NoWrite scoring is the measured dominant new cost; optimizing only the
+sixteen-entry read directory would miss it. Keep retained values recoverable
+and measure geometric selection separately from the correctness of exact storage.
+This selective routing/admission successor is not implemented by the present PR.
+
+
+## Charged checkpoint
+
+The [compact evidence](evidence/native_geometric_relation_role_path_1138.json)
+binds the sources and measurements; `relation-role-checkpoint.json` retains
+all command receipts and selection details locally. Actual cycle work is
+**38.821/120 seconds model execution** and **412.722/1,200 seconds engineering**,
+against the 90/650-second complete projection. Cumulative model work is
+**1,267.771/1,800 seconds**, leaving **532.229 seconds**. The sampled direct
+model RSS maximum is 777,273,344 bytes, below the 4 GiB target; sampling is not
+an exact-peak guarantee. Known storage at the final sample is 5,702,713,344 bytes
+under the unchanged 6,459,228,160-byte cap, with 401,108,992 bytes available before
+the monitor's tighter growth ceiling. The 128 MiB margin remains; subsequent
+source/report metadata is charged on refresh. No deletion, cap increase or paid
+compute occurred. Source preparation, fitting, both artifacts' evaluation,
+CLI execution, tests and the extra prior-executable replay are all charged.

--- a/docs/native_geometric_workflow.md
+++ b/docs/native_geometric_workflow.md
@@ -14,7 +14,11 @@ The optional [#1138 relation extension](native_geometric_relation_memory_1138.md
 adds Rust `prepare-relations`, `fit-relations`, `evaluate-relations` and
 `verify-relations` example modes and `Model::fit_relations`. Its versioned exact
 store/read path executes through ordinary generation and snapshots, but its
-writer-transfer handoff remains unmet. Do not rerun the frozen fits by default.
+version-1 writer-transfer negative remains preserved. The
+[version-2 role-path correction](native_geometric_relation_role_path_1138.md) uses
+`role-relations-source`, `fit-role-relations` and
+`Model::fit_relations_with_role_paths`; its bounded handoff passes. Version 1
+artifacts retain their behavior. Do not rerun frozen fits by default.
 
 The native path is `r4 geometric`. Data preparation, fitting, artifacts,
 evaluation, sessions and generation use Rust. Its initial learner estimates


### PR DESCRIPTION
The relation writer could omit an initial fact for a new participant name, then treat a later conflicting assertion as an initial fact. Version 2 masks the proposed owner/value identities in local role features and composes ordered interior H4/zeta word transports independently of payload/global-prefix state. Exact stored values, reader weights, update laws and copy/completion remain unchanged; version-1 artifacts keep their original behavior.

Closes #1138 at its declared bounded handoff scope.

- With the same 112 construction documents, OPEN answers/write sequences improve from 82/84 and 77/84 to 84/84 for both.
- After selection freezes, newly reserved names give 28/28 answers and 28/28 exact write sequences, versus 24/28 and 14/28 for the unchanged relation parent. No subsequent fitting or selection-law change.
- All 62 older responses, 24 prior role-reader responses and eight binding outputs remain correct. Thirty-two generated Rust case sources match their previously checked bytes. Five actual restored/isolated session reads pass; the inherited stale-index work-counter exception remains explicitly reported.
- The rebuilt executable reproduces all 84 previous version-1 Generation objects and relation states exactly. Actual native CLI Generation fields match a reserved case.

The immutable 82-row context table is compiled from the existing tokenizer/fixed geometry and reconstructed at load. Candidate-payload masking and the ordered path are one combined intervention; independent geometric attribution, general memory, alpha and speedup are not claimed. The representative writer still performs 2,054,052 score-row comparisons and now adds 66,080 context-table comparisons. Next is #1139: complete-cost geometric admission/routing with a matched plain sparse comparator, starting with dominant repeated NoWrite scoring.

Validation: combined release CLI/example build; focused test build; four relation tests (including payload-renaming and order/direction checks), two role/commit tests; formatting, native policy, claim wording and diff checks. Broader release qualification was not run. Historical compatibility statuses are not audit/fuzz/WASM/Gate C execution.

Actual cycle: 38.821/120 seconds model, 412.722/1,200 seconds engineering; cumulative model 1,267.771/1,800 seconds, leaving 532.229. Existing storage cap sufficed, with no deletion or paid compute. `docs/native_geometric_relation_role_path_1138.md` and its compact evidence bind artifacts, source splits, costs and limitations. Current-state, plan, research and continuation pointers now name the accepted result and conditional #1139 handoff.
