### PR TITLE
feat(native): learn bounded H4 routing and selected transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ generation, persistent sessions and a local workbench. The initial model fits
 finite score tables over prime context and exact geometric state. Its useful
 language and coding behavior is under development.
 
+An experimental [learned H4 routing block](docs/native_geometric_learned_routing_1139.md)
+now learns token placement, source selection and table-based transport on this
+path. Its small token-prediction gain does not yet yield useful generation or
+preserve all prior responses, so the accepted artifact remains unchanged.
+
 ```sh
 cargo build --release --bin r4
 target/release/r4 geometric --help

--- a/crates/uor-r4-core/examples/native_geometric_routing_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_routing_probe.rs
@@ -1,0 +1,235 @@
+//! One bounded learned-routing comparison. Inputs are deliberately small,
+//! authored prose/Rust development fixtures, not broad language qualification.
+//! Usage: native_geometric_routing_probe PARENT_MODEL NEW_OUTPUT_DIRECTORY
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::{error::Error, fs, path::Path, time::Instant};
+use uor_r4_core::native_geometric::{Control, Document, Model, RoutingFitConfig, RoutingMode, BOS};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+fn write(path: &Path, value: &impl Serialize) -> Result<()> {
+    use std::io::Write;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.write_all(&serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn documents(prefix: &str, texts: &[&str]) -> Vec<Document> {
+    texts
+        .iter()
+        .enumerate()
+        .map(|(i, text)| Document {
+            id: format!("routing-v1/{prefix}/{i}"),
+            text: (*text).into(),
+        })
+        .collect()
+}
+
+fn source() -> (Vec<Document>, Vec<Document>, Vec<Document>) {
+    let mut fit=documents("fit/prose", &[
+        "A map records the paths between towns. A traveler follows a path to reach another town. The shortest path may change when a bridge closes.",
+        "Alice put the red book beside the blue cup. Bob moved the cup to the shelf. The book stayed on the table while the cup changed places.",
+        "Memory retains information from earlier events. A useful answer selects the relevant information and combines it with the current question.",
+        "The first box contains three stones. The second box contains five stones. Moving two stones from the first box to the second leaves one and seven.",
+        "A function accepts an input and returns an output. Calling the function twice can produce a different result when the function changes stored state.",
+        "Learning adjusts a model using examples. Evaluation uses separate examples to measure whether the learned rule applies beyond the training data.",
+        "The river flows from the mountain through the village. After heavy rain the water rises. The villagers close the bridge until the river falls.",
+        "A sequence preserves order. Reversing two instructions can change the result. First add four to three, then double the sum to obtain fourteen.",
+        "The green key opens the small door. The blue key opens the large door. To enter the small room, select the green key and turn it in the lock.",
+        "A local model reads text and predicts the next token. Its prediction depends on retained context, learned parameters and the available computation.",
+        "A tree has a root and branches. Each branch can contain smaller branches. Searching one relevant branch avoids visiting every leaf.",
+        "The program stores a value under a name. A later instruction reads that value, adds a number and writes the result under a different name.",
+    ]);
+    fit.extend(documents("fit/rust", &[
+        "fn add(left: i32, right: i32) -> i32 { left + right }\nfn main() { assert_eq!(add(3, 4), 7); }",
+        "fn twice(value: i32) -> i32 { value + value }\nfn main() { let sum = 3 + 4; assert_eq!(twice(sum), 14); }",
+        "fn first(values: &[i32]) -> Option<i32> { values.first().copied() }\nfn main() { assert_eq!(first(&[2, 5]), Some(2)); }",
+        "fn count(values: &[i32]) -> usize { values.len() }\nfn main() { assert_eq!(count(&[1, 2, 3]), 3); }",
+        "fn largest(left: i32, right: i32) -> i32 { if left > right { left } else { right } }",
+        "fn total(values: &[i32]) -> i32 { let mut sum = 0; for value in values { sum += value; } sum }",
+        "fn next(value: Option<i32>) -> Option<i32> { value.map(|number| number + 1) }",
+        "fn main() { let mut left = 3; let mut right = 5; left -= 2; right += 2; assert_eq!((left, right), (1, 7)); }",
+        "fn contains(values: &[i32], target: i32) -> bool { values.iter().any(|value| *value == target) }",
+        "fn main() { let name = String::from(\"alice\"); let copy = name.clone(); assert_eq!(name, copy); }",
+        "fn positive(value: i32) -> bool { value > 0 }\nfn main() { assert!(positive(4)); }",
+        "fn combine(left: &str, right: &str) -> String { format!(\"{} {}\", left, right) }",
+    ]));
+    let prose=documents("development/prose", &[
+        "A traveler reads a map before crossing the river. When the bridge is closed, the traveler must find another path to the village.",
+        "Alice moved the blue book from the shelf to the table. Bob left the red cup on the shelf. The two objects are now in different places.",
+        "The first instruction adds two to five. The second instruction doubles the result. Applying the instructions in order gives fourteen.",
+        "A program can keep a value in memory and read it later. To answer a question, the model must select the relevant value and use it correctly.",
+    ]);
+    let rust=documents("development/rust", &[
+        "fn sum(a: i32, b: i32) -> i32 { a + b }\nfn main() { assert_eq!(sum(5, 2), 7); }",
+        "fn double(x: i32) -> i32 { x + x }\nfn main() { let result = double(5 + 2); assert_eq!(result, 14); }",
+        "fn last(items: &[i32]) -> Option<i32> { items.last().copied() }\nfn main() { assert_eq!(last(&[5, 2]), Some(2)); }",
+        "fn main() { let mut count = 2; count += 5; let result = count + count; assert_eq!(result, 14); }",
+    ]);
+    (fit, prose, rust)
+}
+
+const PROMPTS: [(&str,&str,&str); 8] = [
+    ("prose-continuation", "A useful answer selects the relevant information and", " combines"),
+    ("rust-continuation", "fn sum(a: i32, b: i32) -> i32 {", " a + b }"),
+    ("prose-two-operations", "Start with five. Add two, then double the result. Answer:", "14"),
+    ("rust-two-operations", "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,", "14); }"),
+    ("prose-binding", "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:", "Rome"),
+    ("rust-binding", "let first = 5; let second = first + 2; let third = second + 3; // third =", "10"),
+    ("known-copy-shape", "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:", "blue"),
+    ("known-number-shape", "left = 13; right = 4; total:", "17"),
+];
+
+fn evaluate(
+    model: &Model,
+    control: Control,
+    prose: &[Document],
+    rust: &[Document],
+) -> Result<Value> {
+    let start = Instant::now();
+    let prose_score = model.evaluate(prose, control)?;
+    let rust_score = model.evaluate(rust, control)?;
+    let next_token_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let generation_start = Instant::now();
+    let mut generated = Vec::new();
+    for (id, prompt, expected) in PROMPTS {
+        let output = model.generate(prompt, 24, control)?;
+        generated.push(json!({"id":id,"prompt":prompt,"expected":expected,
+            "exact":output.text.trim()==expected.trim(),"expected_prefix":output.text.trim_start().starts_with(expected.trim_start()),"generation":output}));
+    }
+    let mut route_samples = Vec::new();
+    for document in [&prose[0], &rust[0]] {
+        let mut session = model.session(control)?;
+        session.observe(model, BOS)?;
+        for token in model.encode(&document.text)?.into_iter().take(16) {
+            let prediction = session.predict(model)?;
+            route_samples.push(json!({"id":document.id,"prediction":prediction,
+                "route":session.routing_decision(),"actual_next_token":token}));
+            session.observe(model, token)?;
+        }
+    }
+    Ok(
+        json!({"control":control,"artifact_cid":model.artifact_cid(),"prose":prose_score,"rust":rust_score,
+        "next_token_ms":next_token_ms,"generation_and_trace_ms":generation_start.elapsed().as_secs_f64()*1000.0,
+        "generation":generated,"route_samples":route_samples}),
+    )
+}
+
+fn token_exposure(model: &Model, documents: &[Document]) -> Result<Value> {
+    let mut byte_tokens = 0;
+    let mut lexical_tokens = 0;
+    for document in documents {
+        for token in model.encode(&document.text)? {
+            if (2..258).contains(&token) {
+                byte_tokens += 1;
+            } else {
+                lexical_tokens += 1;
+            }
+        }
+    }
+    Ok(
+        json!({"byte_fallback_tokens":byte_tokens,"lexical_tokens":lexical_tokens,"document_end_targets":documents.len()}),
+    )
+}
+
+fn main() -> Result<()> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        return Err(
+            "usage: native_geometric_routing_probe PARENT_MODEL NEW_OUTPUT_DIRECTORY".into(),
+        );
+    }
+    let output = Path::new(&args[1]);
+    fs::create_dir(output)?;
+    let start = Instant::now();
+    let parent = Model::from_bytes(&fs::read(&args[0])?)?;
+    let parent_read_and_validate_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let (fit, prose, rust) = source();
+    let source = json!({"schema":"uor-r4.routing-development-source/1","scope":"Authored synthetic raw-text development; labels are next tokens. New text is separated from this fit. This is not sealed or broad natural-language qualification.",
+        "fit":fit,"development_prose":prose,"development_rust":rust,"prompts":PROMPTS});
+    write(&output.join("source.json"), &source)?;
+    write(
+        &output.join("token-exposure.json"),
+        &json!({"vocabulary":parent.vocabulary_size(),
+        "fit":token_exposure(&parent,&fit)?,"prose":token_exposure(&parent,&prose)?,"rust":token_exposure(&parent,&rust)?}),
+    )?;
+    let source_cid = blake3::hash(&serde_json::to_vec(&source)?)
+        .to_hex()
+        .to_string();
+    let parent_result = evaluate(&parent, Control::Full, &prose, &rust)?;
+    write(&output.join("parent.json"), &parent_result)?;
+    let mut arms = Vec::new();
+    for (name, mode, learn_placement) in [
+        ("angular", RoutingMode::Angular, true),
+        ("equality", RoutingMode::Equality, true),
+        ("fixed-placement", RoutingMode::Angular, false),
+    ] {
+        let config = RoutingFitConfig {
+            mode,
+            learn_placement,
+            ..RoutingFitConfig::default()
+        };
+        let (model, fit_report) = parent.fit_routing_block(&fit, config)?;
+        let bytes = model.to_bytes()?;
+        use std::io::Write;
+        let mut artifact = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(output.join(format!("{name}-model.json")))?;
+        artifact.write_all(&bytes)?;
+        write(&output.join(format!("{name}-fit.json")), &fit_report)?;
+        let load_start = Instant::now();
+        let loaded = Model::from_bytes(&bytes)?;
+        let deserialize_and_validate_ms = load_start.elapsed().as_secs_f64() * 1000.0;
+        let full = evaluate(&loaded, Control::Full, &prose, &rust)?;
+        write(&output.join(format!("{name}-full.json")), &full)?;
+        let mut controls = Vec::new();
+        if name == "angular" {
+            for (label, control) in [
+                ("disabled", Control::LearnedRoutingDisabled),
+                (
+                    "selection-disabled",
+                    Control::LearnedRoutingSelectionDisabled,
+                ),
+                (
+                    "transform-disabled",
+                    Control::LearnedRoutingTransformDisabled,
+                ),
+            ] {
+                let result = evaluate(&model, control, &prose, &rust)?;
+                write(&output.join(format!("angular-{label}.json")), &result)?;
+                controls.push(result);
+            }
+            let prompt = PROMPTS[1].1;
+            let replay = model.generate(prompt, 24, Control::Full)?
+                == loaded.generate(prompt, 24, Control::Full)?;
+            if !replay {
+                return Err("artifact replay mismatch".into());
+            }
+            write(
+                &output.join("reload.json"),
+                &json!({"exact_generation_work_state":replay}),
+            )?;
+        }
+        arms.push(
+            json!({"name":name,"artifact_cid":model.artifact_cid(),"artifact_bytes":bytes.len(),"deserialize_and_validate_ms":deserialize_and_validate_ms,
+            "fit":fit_report,"full":full,"controls":controls}),
+        );
+        println!(
+            "{}",
+            json!({"completed":name,"elapsed_ms":start.elapsed().as_millis()})
+        );
+    }
+    write(
+        &output.join("result.json"),
+        &json!({"schema":"uor-r4.routing-development-result/1",
+        "source_cid":source_cid,"parent_cid":parent.artifact_cid(),"parent_read_and_validate_ms":parent_read_and_validate_ms,"parent":parent_result,"arms":arms,
+        "elapsed_ms":start.elapsed().as_millis(),"rust_compile_and_execute":"NOT_RUN; exact generated text is reported",
+        "decision":"DEVELOPMENT_ONLY; inspect quality, controls and whole-path cost before adoption"}),
+    )?;
+    Ok(())
+}

--- a/crates/uor-r4-core/src/native_geometric/learned_routing.rs
+++ b/crates/uor-r4-core/src/native_geometric/learned_routing.rs
@@ -1,0 +1,237 @@
+//! Bounded learned placement, source selection and transported payload readout.
+//! This residual block augments the existing predictor. It is not a dense
+//! projection or a whole-context lookup. All products below read the existing
+//! exact H4 group table; fitting and scalar angular-order construction are host work.
+
+use super::{Control, Model};
+use serde::{Deserialize, Serialize};
+
+pub(super) const WINDOW: usize = 8;
+pub(super) const ROOTS: usize = 120;
+pub(super) const HEADS: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingMode {
+    Angular,
+    /// Matched exact-code selector; H4 composition/readout remain the same.
+    Equality,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RoutingWork {
+    pub predictions: u64,
+    pub context_tokens_read: u64,
+    pub code_reads: u64,
+    pub table_reads: u64,
+    pub sources_examined: u64,
+    pub comparisons: u64,
+    pub payload_gathers: u64,
+    pub operator_executions: u64,
+    pub emission_queries: u64,
+    /// Logical operands read, not a physical cache/DRAM traffic measurement.
+    pub logical_bytes_read: u64,
+}
+impl RoutingWork {
+    pub(super) fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+    pub(super) fn add(&mut self, other: Self) {
+        self.predictions = self.predictions.saturating_add(other.predictions);
+        self.context_tokens_read = self
+            .context_tokens_read
+            .saturating_add(other.context_tokens_read);
+        self.code_reads = self.code_reads.saturating_add(other.code_reads);
+        self.table_reads = self.table_reads.saturating_add(other.table_reads);
+        self.sources_examined = self.sources_examined.saturating_add(other.sources_examined);
+        self.comparisons = self.comparisons.saturating_add(other.comparisons);
+        self.payload_gathers = self.payload_gathers.saturating_add(other.payload_gathers);
+        self.operator_executions = self
+            .operator_executions
+            .saturating_add(other.operator_executions);
+        self.emission_queries = self.emission_queries.saturating_add(other.emission_queries);
+        self.logical_bytes_read = self
+            .logical_bytes_read
+            .saturating_add(other.logical_bytes_read);
+    }
+    fn codes(&mut self, count: u64) {
+        self.code_reads = self.code_reads.saturating_add(count);
+        self.logical_bytes_read = self.logical_bytes_read.saturating_add(count << 1);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RoutingHeadDecision {
+    pub query: u16,
+    pub source_offset: usize,
+    pub source_token: u32,
+    pub selected_key: u16,
+    pub selected_value: u16,
+    pub operator: u16,
+    pub output: u16,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RoutingDecision {
+    pub heads: [RoutingHeadDecision; HEADS],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Emission {
+    pub default_score: i32,
+    pub scores: Vec<super::TokenScore>,
+    pub postings: Vec<u32>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Head {
+    pub queries: Vec<u16>,
+    pub keys: Vec<u16>,
+    pub values: Vec<u16>,
+    pub operators: Vec<u16>,
+    pub emissions: Vec<Emission>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RoutingBlock {
+    pub schema: String,
+    pub parent_artifact: String,
+    pub mode: RoutingMode,
+    pub heads: Vec<Head>,
+    pub angular_rank: Vec<u16>,
+    pub training: Vec<super::DocumentReceipt>,
+    pub fit_config: super::RoutingFitConfig,
+}
+
+fn product(model: &Model, a: u16, b: u16, work: &mut RoutingWork) -> u16 {
+    work.table_reads = work.table_reads.saturating_add(2);
+    work.logical_bytes_read = work
+        .logical_bytes_read
+        .saturating_add(std::mem::size_of::<usize>() as u64 + 2);
+    model.geometry.products[model.geometry.row_bases[usize::from(a)] + usize::from(b)]
+}
+
+impl Head {
+    pub(super) fn route(
+        &self,
+        model: &Model,
+        ranks: &[u16],
+        mode: RoutingMode,
+        context: &[u32],
+        control: Control,
+        work: &mut RoutingWork,
+    ) -> RoutingHeadDecision {
+        let last = context.first().copied().unwrap_or(super::BOS);
+        let previous = context.get(1).copied().unwrap_or(super::BOS);
+        work.codes(2);
+        let query = product(
+            model,
+            self.queries[previous as usize],
+            self.queries[last as usize],
+            work,
+        );
+        let mut selected = last;
+        let mut selected_key = self.keys[last as usize];
+        work.codes(1);
+        let mut selected_offset = 0;
+        let mut best_rank = 0;
+        for (offset, &token) in context.iter().enumerate() {
+            let key = self.keys[token as usize];
+            work.codes(1);
+            work.sources_examined = work.sources_examined.saturating_add(1);
+            let rank = match mode {
+                RoutingMode::Angular => {
+                    let inverse = model.geometry.inverses[usize::from(key)];
+                    let relative = product(model, query, inverse, work);
+                    work.table_reads = work.table_reads.saturating_add(2);
+                    work.logical_bytes_read = work.logical_bytes_read.saturating_add(4);
+                    ranks[usize::from(relative)]
+                }
+                RoutingMode::Equality => u16::from(query == key),
+            };
+            work.comparisons = work.comparisons.saturating_add(1);
+            if offset == 0
+                || (rank > best_rank && control != Control::LearnedRoutingSelectionDisabled)
+            {
+                best_rank = rank;
+                selected = token;
+                selected_key = key;
+                selected_offset = offset;
+            }
+        }
+        // Only the selected source's value code is gathered and transported.
+        let value = self.values[selected as usize];
+        let operator = if control == Control::LearnedRoutingTransformDisabled {
+            model.geometry.identity
+        } else {
+            self.operators[usize::from(query)]
+        };
+        work.codes(2);
+        work.payload_gathers = work.payload_gathers.saturating_add(1);
+        let payload = product(model, query, value, work);
+        let output = product(model, operator, payload, work);
+        work.operator_executions = work.operator_executions.saturating_add(1);
+        RoutingHeadDecision {
+            query,
+            source_offset: selected_offset,
+            source_token: selected,
+            selected_key,
+            selected_value: value,
+            operator,
+            output,
+        }
+    }
+}
+
+impl RoutingBlock {
+    pub(super) fn route(
+        &self,
+        model: &Model,
+        context: &[u32],
+        control: Control,
+        work: &mut RoutingWork,
+    ) -> RoutingDecision {
+        work.predictions = work.predictions.saturating_add(1);
+        work.context_tokens_read = work
+            .context_tokens_read
+            .saturating_add(context.len() as u64);
+        work.logical_bytes_read = work
+            .logical_bytes_read
+            .saturating_add((context.len() as u64) << 2);
+        let mut result = RoutingDecision::default();
+        for (slot, head) in result.heads.iter_mut().zip(&self.heads) {
+            *slot = head.route(model, &self.angular_rank, self.mode, context, control, work);
+        }
+        result
+    }
+
+    pub(super) fn score(
+        &self,
+        model: &Model,
+        decision: RoutingDecision,
+        token: u32,
+        work: &mut RoutingWork,
+    ) -> i64 {
+        let mut score = 0;
+        for (head, selected) in self.heads.iter().zip(decision.heads) {
+            let row = &head.emissions[usize::from(selected.output)];
+            work.emission_queries = work.emission_queries.saturating_add(1);
+            if row.scores.is_empty() {
+                continue;
+            }
+            let found = row.scores.binary_search_by(|entry| {
+                work.comparisons = work.comparisons.saturating_add(1);
+                work.logical_bytes_read = work.logical_bytes_read.saturating_add(4);
+                entry.token.cmp(&token)
+            });
+            let conditional = found
+                .map(|index| row.scores[index].score)
+                .unwrap_or(row.default_score);
+            work.table_reads = work.table_reads.saturating_add(2);
+            work.logical_bytes_read = work.logical_bytes_read.saturating_add(8);
+            // Bounded residual in the parent's quantized log-score units.
+            score += (i64::from(conditional) - i64::from(model.prior_scores[token as usize])) >> 1;
+        }
+        score
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/learned_routing_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/learned_routing_tests.rs
@@ -1,0 +1,244 @@
+use super::*;
+
+fn fixture() -> (Model, Vec<Document>) {
+    let docs:Vec<_>=(0..8).map(|i| Document{id:format!("routing-fit-{i}"),text:format!(
+        "Alice saved {} gems. Bob saved {} gems. Alice gave Bob one gem. Bob has {} gems.\nfn add(a:i32,b:i32)->i32{{a+b}}\n",
+        i+2,i+3,i+4)}).collect();
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 16,
+            ..Config::default()
+        },
+        &docs,
+    )
+    .unwrap();
+    trainer.train_documents(&docs).unwrap();
+    (trainer.compile().unwrap(), docs)
+}
+
+#[test]
+fn learned_routing_hard_fit_reload_and_disabled_parent_preservation() {
+    let (parent, mut docs) = fixture();
+    for document in &mut docs {
+        document.id.push_str("-routing");
+        document.text.push('\n');
+    }
+    let original = parent.to_bytes().unwrap();
+    let (model, report) = parent
+        .fit_routing_block(
+            &docs,
+            RoutingFitConfig {
+                max_positions: 128,
+                learned_tokens: 4,
+                passes: 1,
+                ..RoutingFitConfig::default()
+            },
+        )
+        .unwrap();
+    assert!(!report.stopped_at_time_limit);
+    assert!(report.proposals > 0);
+    assert!(report
+        .initial_conditional_nll
+        .iter()
+        .zip(&report.final_conditional_nll)
+        .all(|(a, b)| b <= a));
+    let loaded = Model::from_bytes(&model.to_bytes().unwrap()).unwrap();
+    assert!(parent.evaluate(&docs[..1], Control::Full).is_ok());
+    assert!(model.evaluate(&docs[..1], Control::Full).is_err());
+    let score = model
+        .evaluate(
+            &[Document {
+                id: "routing-development".into(),
+                text: "Alice saved 9 gems.".into(),
+            }],
+            Control::Full,
+        )
+        .unwrap();
+    assert_eq!(score.work.learned_routing.predictions, score.positions);
+    let prompt = "Alice saved 4 gems. Bob saved 5 gems. Bob has";
+    assert_eq!(
+        model.generate(prompt, 8, Control::Full).unwrap(),
+        loaded.generate(prompt, 8, Control::Full).unwrap()
+    );
+    let before = parent.generate(prompt, 8, Control::Full).unwrap();
+    let disabled = model
+        .generate(prompt, 8, Control::LearnedRoutingDisabled)
+        .unwrap();
+    assert_eq!(before.bytes, disabled.bytes);
+    assert_eq!(before.work, disabled.work);
+    assert_eq!(original, parent.to_bytes().unwrap());
+    let mut malformed = model.clone();
+    malformed.learned_routing.as_mut().unwrap().heads[0].keys[0] = 120;
+    malformed.refresh_identity().unwrap();
+    assert!(Model::from_bytes(&malformed.to_bytes().unwrap()).is_err());
+}
+
+#[test]
+fn learned_routing_selects_exact_source_then_executes_query_conditioned_transport() {
+    let (model, _) = fixture();
+    let identity = model.geometry.identity;
+    let opposite = (0..120)
+        .find(|&i| model.geometry.anchors.rows[i].root_scaled_zphi[0] == [-2, 0])
+        .unwrap() as u16;
+    let rank: Vec<_> = model
+        .geometry
+        .anchors
+        .rows
+        .iter()
+        .map(|r| u16::from(r.root_index == identity))
+        .collect();
+    let vocab = model.vocabulary_size();
+    let mut head = learned_routing::Head {
+        queries: vec![identity; vocab],
+        keys: vec![opposite; vocab],
+        values: vec![identity; vocab],
+        operators: vec![opposite; 120],
+        emissions: vec![],
+    };
+    head.keys[3] = identity;
+    let mut work = RoutingWork::default();
+    let chosen = head.route(
+        &model,
+        &rank,
+        RoutingMode::Angular,
+        &[2, 3, 4],
+        Control::Full,
+        &mut work,
+    );
+    assert_eq!(chosen.source_token, 3);
+    assert_eq!(chosen.source_offset, 1);
+    assert_eq!(chosen.output, opposite);
+    let recent = head.route(
+        &model,
+        &rank,
+        RoutingMode::Angular,
+        &[2, 3, 4],
+        Control::LearnedRoutingSelectionDisabled,
+        &mut RoutingWork::default(),
+    );
+    assert_eq!(recent.source_token, 2);
+    let unchanged = head.route(
+        &model,
+        &rank,
+        RoutingMode::Angular,
+        &[2, 3, 4],
+        Control::LearnedRoutingTransformDisabled,
+        &mut RoutingWork::default(),
+    );
+    assert_eq!(unchanged.output, identity);
+    assert_eq!(
+        (
+            work.sources_examined,
+            work.payload_gathers,
+            work.operator_executions
+        ),
+        (3, 1, 1)
+    );
+    let mut saturated = RoutingWork {
+        comparisons: u64::MAX,
+        table_reads: u64::MAX,
+        logical_bytes_read: u64::MAX,
+        ..RoutingWork::default()
+    };
+    assert_eq!(
+        chosen,
+        head.route(
+            &model,
+            &rank,
+            RoutingMode::Angular,
+            &[2, 3, 4],
+            Control::Full,
+            &mut saturated
+        )
+    );
+    assert_eq!(saturated.table_reads, u64::MAX);
+}
+
+#[test]
+fn learned_routing_preserves_frozen_nested_parent_validation() {
+    let (mut parent, docs) = fixture();
+    parent.values = Some(value_types::ValueModel {
+        schema: value_types::LEXEME_VALUE_SCHEMA.into(),
+        codec: numeral::NUMERAL_CODEC.into(),
+        capacity: value_types::VALUES,
+        rows: Vec::new(),
+        continuation_score: 0,
+        fit_config: [0; 4],
+        training: Vec::new(),
+    });
+    parent.refresh_identity().unwrap();
+    parent.completion = Some(completion_types::CompletionModel {
+        schema: completion_types::COMPLETION_SCHEMA.into(),
+        baseline_artifact: parent.artifact_cid.clone(),
+        rows: Vec::new(),
+        global_postings: Vec::new(),
+        fit_config: [0; 4],
+        fit_positions: 0,
+        training: Vec::new(),
+    });
+    parent.refresh_identity().unwrap();
+    let (model, _) = parent
+        .fit_routing_block(
+            &docs,
+            RoutingFitConfig {
+                max_positions: 32,
+                learned_tokens: 1,
+                passes: 1,
+                ..RoutingFitConfig::default()
+            },
+        )
+        .unwrap();
+    let loaded = Model::from_bytes(&model.to_bytes().unwrap()).unwrap();
+    assert_eq!(loaded.completion, parent.completion);
+    let mut malformed = model.clone();
+    malformed.completion.as_mut().unwrap().baseline_artifact = "wrong".into();
+    let mut changed_parent = malformed.clone();
+    changed_parent.learned_routing = None;
+    changed_parent.refresh_identity().unwrap();
+    malformed.learned_routing.as_mut().unwrap().parent_artifact = changed_parent.artifact_cid;
+    malformed.refresh_identity().unwrap();
+    assert!(Model::from_bytes(&malformed.to_bytes().unwrap()).is_err());
+}
+
+#[test]
+fn learned_routing_uses_ordered_retained_context_and_snapshot_replay() {
+    let (parent, docs) = fixture();
+    let (model, _) = parent
+        .fit_routing_block(
+            &docs,
+            RoutingFitConfig {
+                max_positions: 64,
+                learned_tokens: 2,
+                passes: 1,
+                ..RoutingFitConfig::default()
+            },
+        )
+        .unwrap();
+    let tokens = model.encode(&docs[0].text).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    for &t in &tokens {
+        session.observe(&model, t).unwrap();
+    }
+    let expected = session.predict(&model).unwrap();
+    let decision = session.routing_decision().unwrap();
+    let mut restored = model
+        .restore_session(&session.checkpoint().unwrap())
+        .unwrap();
+    assert_eq!(expected, restored.predict(&model).unwrap());
+    assert_eq!(decision, restored.routing_decision().unwrap());
+    for head in decision.heads {
+        assert_eq!(
+            head.source_token,
+            tokens[tokens.len() - 1 - head.source_offset]
+        );
+        assert!(head.source_offset < 8);
+    }
+    let mut tail = model.session(Control::Full).unwrap();
+    for &t in &tokens[tokens.len() - 16..] {
+        tail.observe(&model, t).unwrap();
+    }
+    // The parent's previous-window feature can differ after eviction. The
+    // new routing block itself must depend only on the retained recent tail.
+    tail.predict(&model).unwrap();
+    assert_eq!(decision, tail.routing_decision().unwrap());
+}

--- a/crates/uor-r4-core/src/native_geometric/learned_routing_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/learned_routing_training.rs
@@ -1,0 +1,432 @@
+//! Host-only hard-coordinate learning. Each proposal runs the serving selector
+//! and transport, then refits sparse emission counts. No soft routing is used.
+use super::learned_routing::{Emission, Head, RoutingBlock, HEADS, ROOTS, WINDOW};
+use super::{
+    Control, Document, DocumentReceipt, Error, Model, Result, RoutingMode, RoutingWork, TokenScore,
+    BOS, EOS, SCORE_SCALE,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::time::Instant;
+
+const SCHEMA: &str = "uor-r4.learned-h4-routing/1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutingFitConfig {
+    pub max_positions: usize,
+    pub learned_tokens: usize,
+    pub passes: usize,
+    pub max_seconds: u64,
+    pub mode: RoutingMode,
+    pub learn_placement: bool,
+    pub seed: u64,
+}
+impl Default for RoutingFitConfig {
+    fn default() -> Self {
+        Self {
+            max_positions: 2048,
+            learned_tokens: 24,
+            passes: 2,
+            max_seconds: 15,
+            mode: RoutingMode::Angular,
+            learn_placement: true,
+            seed: 1139,
+        }
+    }
+}
+impl RoutingFitConfig {
+    fn validate(&self) -> Result<()> {
+        if !(1..=8192).contains(&self.max_positions)
+            || !(1..=64).contains(&self.learned_tokens)
+            || !(1..=4).contains(&self.passes)
+            || !(1..=120).contains(&self.max_seconds)
+        {
+            return Err(Error("learned routing fit exceeds supported bounds".into()));
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingFitReport {
+    pub schema: String,
+    pub positions: usize,
+    pub documents: usize,
+    pub proposals: u64,
+    pub accepted_query_moves: u64,
+    pub accepted_key_moves: u64,
+    pub accepted_value_moves: u64,
+    pub accepted_operator_moves: u64,
+    pub initial_conditional_nll: Vec<f64>,
+    pub final_conditional_nll: Vec<f64>,
+    pub elapsed_ms: u128,
+    pub stopped_at_time_limit: bool,
+    pub block_bytes: usize,
+    pub config: RoutingFitConfig,
+}
+struct Example {
+    context: [u32; WINDOW],
+    length: usize,
+    target: u32,
+}
+
+fn ranks(model: &Model) -> Vec<u16> {
+    let mut cosines: Vec<_> = model
+        .geometry
+        .anchors
+        .rows
+        .iter()
+        .map(|row| row.root_scaled_zphi[0])
+        .collect();
+    cosines.sort_by(|a, b| super::training::exact_sign([a[0] - b[0], a[1] - b[1]]).cmp(&0));
+    cosines.dedup();
+    model
+        .geometry
+        .anchors
+        .rows
+        .iter()
+        .map(|row| {
+            cosines
+                .iter()
+                .position(|v| *v == row.root_scaled_zphi[0])
+                .unwrap_or(0) as u16
+        })
+        .collect()
+}
+
+impl RoutingBlock {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        self.fit_config.validate()?;
+        if self.schema != SCHEMA
+            || self.mode != self.fit_config.mode
+            || self.heads.len() != HEADS
+            || self.angular_rank != ranks(model)
+            || self.training.is_empty()
+        {
+            return Err(Error(
+                "learned routing schema, geometry or provenance invalid".into(),
+            ));
+        }
+        let mut ids = BTreeSet::new();
+        for receipt in &self.training {
+            if receipt.id.is_empty()
+                || receipt.bytes == 0
+                || !ids.insert(&receipt.id)
+                || !receipt.text_cid.starts_with("blake3:")
+            {
+                return Err(Error("learned routing receipt invalid".into()));
+            }
+        }
+        let vocab = model.prior_scores.len();
+        for head in &self.heads {
+            for codes in [&head.queries, &head.keys, &head.values] {
+                if codes.len() != vocab || codes.iter().any(|&v| usize::from(v) >= ROOTS) {
+                    return Err(Error("learned routing token code out of range".into()));
+                }
+            }
+            if head.operators.len() != ROOTS
+                || head.operators.iter().any(|&v| usize::from(v) >= ROOTS)
+                || head.emissions.len() != ROOTS
+            {
+                return Err(Error("learned routing operator shape invalid".into()));
+            }
+            for row in &head.emissions {
+                if row.scores.len() > vocab
+                    || row.scores.windows(2).any(|p| p[0].token >= p[1].token)
+                    || row
+                        .scores
+                        .iter()
+                        .any(|p| p.token == BOS || p.token as usize >= vocab || p.score > 0)
+                    || row.default_score > 0
+                    || row.postings.len() > 8
+                    || row
+                        .postings
+                        .iter()
+                        .any(|token| row.scores.binary_search_by_key(token, |p| p.token).is_err())
+                {
+                    return Err(Error("learned routing emission shape invalid".into()));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct Counts {
+    counts: Vec<u32>,
+    totals: Vec<u32>,
+    touched: Vec<usize>,
+    logs: Vec<f64>,
+    vocab: usize,
+}
+impl Counts {
+    fn new(vocab: usize, positions: usize) -> Self {
+        Self {
+            counts: vec![0; ROOTS * vocab],
+            totals: vec![0; ROOTS],
+            touched: Vec::with_capacity(positions),
+            logs: (0..=positions).map(|n| (n as f64 + 0.5).ln()).collect(),
+            vocab,
+        }
+    }
+    fn fit(
+        &mut self,
+        head: &Head,
+        model: &Model,
+        ranks: &[u16],
+        mode: RoutingMode,
+        examples: &[Example],
+    ) -> f64 {
+        for &index in &self.touched {
+            self.counts[index] = 0;
+        }
+        self.touched.clear();
+        self.totals.fill(0);
+        for example in examples {
+            let route = head.route(
+                model,
+                ranks,
+                mode,
+                &example.context[..example.length],
+                Control::Full,
+                &mut RoutingWork::default(),
+            );
+            let root = usize::from(route.output);
+            let index = root * self.vocab + example.target as usize;
+            if self.counts[index] == 0 {
+                self.touched.push(index);
+            }
+            self.counts[index] += 1;
+            self.totals[root] += 1;
+        }
+        let normalizers: f64 = self
+            .totals
+            .iter()
+            .filter(|&&n| n > 0)
+            .map(|&n| n as f64 * (n as f64 + 0.5 * self.vocab as f64).ln())
+            .sum();
+        let observed: f64 = self
+            .touched
+            .iter()
+            .map(|&i| {
+                let n = self.counts[i] as usize;
+                n as f64 * self.logs[n]
+            })
+            .sum();
+        (normalizers - observed) / examples.len() as f64
+    }
+    fn emissions(&self) -> Vec<Emission> {
+        (0..ROOTS)
+            .map(|root| {
+                let denominator = self.totals[root] as f64 + 0.5 * self.vocab as f64;
+                let quantize =
+                    |n| (SCORE_SCALE * ((n as f64 + 0.5) / denominator).ln()).round() as i32;
+                let scores: Vec<_> = (1..self.vocab)
+                    .filter_map(|token| {
+                        let count = self.counts[root * self.vocab + token];
+                        (count > 0).then(|| TokenScore {
+                            token: token as u32,
+                            score: quantize(count),
+                        })
+                    })
+                    .collect();
+                let mut ranked = scores.clone();
+                ranked.sort_by(|a, b| b.score.cmp(&a.score).then(a.token.cmp(&b.token)));
+                Emission {
+                    default_score: quantize(0),
+                    scores,
+                    postings: ranked.iter().take(8).map(|p| p.token).collect(),
+                }
+            })
+            .collect()
+    }
+}
+
+fn next_random(seed: &mut u64) -> u64 {
+    *seed ^= *seed << 13;
+    *seed ^= *seed >> 7;
+    *seed ^= *seed << 17;
+    *seed
+}
+fn field(head: &mut Head, kind: usize) -> &mut Vec<u16> {
+    match kind {
+        0 => &mut head.queries,
+        1 => &mut head.keys,
+        2 => &mut head.values,
+        _ => &mut head.operators,
+    }
+}
+
+impl Model {
+    pub fn fit_routing_block(
+        &self,
+        documents: &[Document],
+        config: RoutingFitConfig,
+    ) -> Result<(Self, RoutingFitReport)> {
+        config.validate()?;
+        if documents.is_empty()
+            || documents.len() > 256
+            || self.prior_scores.len() > 8192
+            || self.learned_routing.is_some()
+        {
+            return Err(Error(
+                "learned routing corpus/vocabulary bound exceeded".into(),
+            ));
+        }
+        let started = Instant::now();
+        let vocab = self.prior_scores.len();
+        let mut examples = Vec::new();
+        let mut receipts = Vec::new();
+        let mut ids = BTreeSet::new();
+        let mut frequencies = vec![0_u32; vocab];
+        for (document_index, document) in documents.iter().enumerate() {
+            if document.id.is_empty()
+                || document.text.is_empty()
+                || document.text.len() > 65536
+                || !ids.insert(document.id.clone())
+            {
+                return Err(Error("learned routing document invalid".into()));
+            }
+            receipts.push(DocumentReceipt {
+                id: document.id.clone(),
+                text_cid: format!("blake3:{}", blake3::hash(document.text.as_bytes()).to_hex()),
+                bytes: document.text.len(),
+            });
+            let mut tokens = self.encode(&document.text)?;
+            tokens.push(EOS);
+            let quota = (config.max_positions / documents.len()
+                + usize::from(document_index < config.max_positions % documents.len()))
+            .min(tokens.len());
+            let mut context = [BOS; WINDOW];
+            let mut length = 1;
+            for (position, target) in tokens.iter().copied().enumerate() {
+                // Uniformly cover the whole document instead of silently truncating its end.
+                if quota > 0
+                    && ((position + 1) * quota / tokens.len() > position * quota / tokens.len())
+                {
+                    examples.push(Example {
+                        context,
+                        length,
+                        target,
+                    });
+                    for &token in &context[..length] {
+                        frequencies[token as usize] += 1;
+                    }
+                }
+                context.rotate_right(1);
+                context[0] = target;
+                length = (length + 1).min(WINDOW);
+            }
+        }
+        if examples.is_empty() {
+            return Err(Error("no learned routing positions".into()));
+        }
+        let mut active: Vec<_> = (1..vocab).filter(|&i| frequencies[i] > 0).collect();
+        active.sort_by_key(|&i| (std::cmp::Reverse(frequencies[i]), i));
+        active.truncate(config.learned_tokens);
+        let angular_rank = ranks(self);
+        let mut heads = Vec::new();
+        let mut report = RoutingFitReport {
+            schema: SCHEMA.into(),
+            positions: examples.len(),
+            documents: documents.len(),
+            proposals: 0,
+            accepted_query_moves: 0,
+            accepted_key_moves: 0,
+            accepted_value_moves: 0,
+            accepted_operator_moves: 0,
+            initial_conditional_nll: Vec::new(),
+            final_conditional_nll: Vec::new(),
+            elapsed_ms: 0,
+            stopped_at_time_limit: false,
+            block_bytes: 0,
+            config: config.clone(),
+        };
+        for head_index in 0..HEADS {
+            let mut seed = config.seed.wrapping_add(head_index as u64).max(1);
+            let mut codes = || {
+                (0..vocab)
+                    .map(|_| (next_random(&mut seed) % ROOTS as u64) as u16)
+                    .collect()
+            };
+            let mut head = Head {
+                queries: codes(),
+                keys: codes(),
+                values: codes(),
+                operators: vec![self.geometry.identity; ROOTS],
+                emissions: Vec::new(),
+            };
+            let mut counts = Counts::new(vocab, examples.len());
+            let mut best = counts.fit(&head, self, &angular_rank, config.mode, &examples);
+            report.initial_conditional_nll.push(best);
+            'passes: for _ in 0..config.passes {
+                for kind in 0..4 {
+                    if kind < 3 && !config.learn_placement {
+                        continue;
+                    }
+                    let indices = if kind == 3 {
+                        (0..ROOTS).collect()
+                    } else {
+                        active.clone()
+                    };
+                    for index in indices {
+                        let original = field(&mut head, kind)[index];
+                        let mut winner = original;
+                        for _ in 0..3 {
+                            if started.elapsed().as_secs_f64() >= config.max_seconds as f64 {
+                                field(&mut head, kind)[index] = winner;
+                                report.stopped_at_time_limit = true;
+                                break 'passes;
+                            }
+                            let proposal = (next_random(&mut seed) % ROOTS as u64) as u16;
+                            field(&mut head, kind)[index] = proposal;
+                            let loss =
+                                counts.fit(&head, self, &angular_rank, config.mode, &examples);
+                            report.proposals += 1;
+                            if loss + 1e-9 < best {
+                                best = loss;
+                                winner = proposal;
+                            }
+                        }
+                        field(&mut head, kind)[index] = winner;
+                        if winner != original {
+                            match kind {
+                                0 => report.accepted_query_moves += 1,
+                                1 => report.accepted_key_moves += 1,
+                                2 => report.accepted_value_moves += 1,
+                                _ => report.accepted_operator_moves += 1,
+                            }
+                        }
+                    }
+                }
+            }
+            report.final_conditional_nll.push(counts.fit(
+                &head,
+                self,
+                &angular_rank,
+                config.mode,
+                &examples,
+            ));
+            head.emissions = counts.emissions();
+            heads.push(head);
+        }
+        let block = RoutingBlock {
+            schema: SCHEMA.into(),
+            parent_artifact: self.artifact_cid.clone(),
+            mode: config.mode,
+            heads,
+            angular_rank,
+            training: receipts,
+            fit_config: config,
+        };
+        block.validate(self)?;
+        report.block_bytes = serde_json::to_vec(&block)
+            .map_err(|e| Error(e.to_string()))?
+            .len();
+        let mut model = self.clone();
+        model.learned_routing = Some(block);
+        model.refresh_identity()?;
+        report.elapsed_ms = started.elapsed().as_millis();
+        Ok((model, report))
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -11,6 +11,12 @@ pub use relation::RelationWork;
 pub use relation_admission::RelationAdmissionMode;
 pub use relation_training::{RelationExample, RelationLabel};
 mod anchors;
+mod learned_routing;
+#[cfg(test)]
+mod learned_routing_tests;
+mod learned_routing_training;
+pub use learned_routing::{RoutingDecision, RoutingHeadDecision, RoutingMode, RoutingWork};
+pub use learned_routing_training::{RoutingFitConfig, RoutingFitReport};
 mod completion_runtime;
 mod completion_training;
 mod completion_types;
@@ -165,6 +171,9 @@ pub enum Control {
     WordCopyDisabled,
     WordCopyGeometryDisabled,
     WordCopyDispatchDisabled,
+    LearnedRoutingDisabled,
+    LearnedRoutingSelectionDisabled,
+    LearnedRoutingTransformDisabled,
 }
 
 /// Explicit feature addresses, never content digests. Kinds 0/1 are full
@@ -211,6 +220,9 @@ impl Feature {
             | Control::ResponseEntryGeometryDisabled
             | Control::WordCopyDisabled
             | Control::WordCopyGeometryDisabled
+            | Control::LearnedRoutingDisabled
+            | Control::LearnedRoutingSelectionDisabled
+            | Control::LearnedRoutingTransformDisabled
             | Control::WordCopyDispatchDisabled => true,
             Control::GeometryDisabled => self.kind < 2,
             Control::ZetaDisabled => !(8..=15).contains(&self.kind) && self.kind != 5,
@@ -280,6 +292,8 @@ pub struct TrainingProgress {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "ModelWire")]
 pub struct Model {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    learned_routing: Option<learned_routing::RoutingBlock>,
     schema: String,
     artifact_cid: String,
     uor_model_address: String,
@@ -306,6 +320,8 @@ pub struct Model {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ModelWire {
+    #[serde(default)]
+    learned_routing: Option<learned_routing::RoutingBlock>,
     schema: String,
     artifact_cid: String,
     uor_model_address: String,
@@ -332,6 +348,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            learned_routing: wire.learned_routing,
             schema: wire.schema,
             artifact_cid: wire.artifact_cid,
             uor_model_address: wire.uor_model_address,
@@ -357,6 +374,8 @@ impl TryFrom<ModelWire> for Model {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Work {
+    #[serde(default, skip_serializing_if = "RoutingWork::is_empty")]
+    pub learned_routing: RoutingWork,
     #[serde(default, skip_serializing_if = "WordCopyWork::is_empty")]
     pub word_copy: WordCopyWork,
     #[serde(default, skip_serializing_if = "CompletionWork::is_empty")]

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -42,6 +42,7 @@ pub struct StateView {
 
 #[derive(Debug, Clone)]
 pub struct Session {
+    pub(super) routing_decision: Option<super::RoutingDecision>,
     pub(super) word_copy: Option<super::word_copy_types::WordCopyState>,
     pub(super) response_entry: Option<super::response_entry_types::ResponseEntryState>,
     pub(super) completion: Option<super::completion_types::CompletionState>,
@@ -73,6 +74,7 @@ impl Session {
             .capacity()
             .saturating_mul(std::mem::size_of::<Candidate>());
         Self {
+            routing_decision: None,
             word_copy: model
                 .response_entry
                 .as_ref()
@@ -170,6 +172,10 @@ impl Session {
     // NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
     // The source guard covers this region through gate_eighths, plus the
     // Feature methods called here. Keep new kernel helpers in a scanned region.
+    pub fn routing_decision(&self) -> Option<super::RoutingDecision> {
+        self.routing_decision
+    }
+
     /// Most recently predicted response action. This is transient; only an
     /// observation can commit the selected occurrence to response state.
     pub fn response_decision(&self) -> Option<super::ResponseDecision> {
@@ -443,6 +449,9 @@ impl Session {
         for (value, &gate) in groups.into_iter().zip(gates) {
             score += gate_eighths(value, gate);
         }
+        if let (Some(block), Some(decision)) = (&model.learned_routing, self.routing_decision) {
+            score += block.score(model, decision, token, &mut self.work.learned_routing);
+        }
         self.work.candidate_evaluations = self.work.candidate_evaluations.saturating_add(1);
         Candidate { token, score }
     }
@@ -471,6 +480,7 @@ impl Session {
     /// evaluation. The model never scans the vocabulary or retained prefix.
     pub fn predict(&mut self, model: &Model) -> Result<Prediction> {
         self.check_model(model)?;
+        self.routing_decision = None;
         self.work.word_copy.dispatch_checks = self
             .work
             .word_copy
@@ -525,6 +535,29 @@ impl Session {
                 }
             }
         }
+        if let Some(block) = &model.learned_routing {
+            if !matches!(
+                self.control,
+                Control::LearnedRoutingDisabled | Control::GeometryDisabled
+            ) {
+                let mut context = [BOS; super::learned_routing::WINDOW];
+                let count = self.length.min(context.len());
+                let mut cursor = self.cursor;
+                for token in context.iter_mut().take(count) {
+                    if cursor == 0 {
+                        cursor = self.ring.len();
+                    }
+                    cursor -= 1;
+                    *token = self.ring[cursor];
+                }
+                self.routing_decision = Some(block.route(
+                    model,
+                    &context[..count],
+                    self.control,
+                    &mut self.work.learned_routing,
+                ));
+            }
+        }
         let features = self.features(model);
         let gates = match model
             .readout
@@ -560,6 +593,13 @@ impl Session {
         for &index in rows {
             for &token in &model.rows[index].postings {
                 self.offer(model, token, rows, &gates);
+            }
+        }
+        if let (Some(block), Some(decision)) = (&model.learned_routing, self.routing_decision) {
+            for (head, selected) in block.heads.iter().zip(decision.heads) {
+                for token in &head.emissions[usize::from(selected.output)].postings {
+                    self.offer(model, *token, rows, &gates);
+                }
             }
         }
         if self.control != Control::MemoryDisabled {

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -89,7 +89,7 @@ fn build_codec(
     Ok((pieces, receipts))
 }
 
-fn exact_sign([a, b]: [i64; 2]) -> i8 {
+pub(super) fn exact_sign([a, b]: [i64; 2]) -> i8 {
     let p = i128::from(a) * 2 + i128::from(b);
     let q = i128::from(b);
     if q == 0 {
@@ -174,6 +174,7 @@ impl Trainer {
         let (lexical_pieces, receipts) = build_codec(&config, construction)?;
         let token_count = LEXICAL_BASE as usize + lexical_pieces.len();
         let mut template = Model {
+            learned_routing: None,
             schema: SCHEMA.into(),
             artifact_cid: String::new(),
             uor_model_address: String::new(),
@@ -506,18 +507,35 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        // The routing residual is fitted last. Inherited response heads remain
+        // bound to the exact model on which they were trained, including all
+        // of their original nested provenance checks.
+        let inherited = if let Some(block) = &self.learned_routing {
+            let mut parent = self.clone();
+            parent.learned_routing = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != block.parent_artifact {
+                return Err(Error(
+                    "learned routing frozen parent identity differs".into(),
+                ));
+            }
+            Some(parent)
+        } else {
+            None
+        };
+        let parent = inherited.as_ref().unwrap_or(self);
         if let Some(values) = &self.values {
             values.validate()?;
         }
         if let Some(completion) = &self.completion {
-            completion.validate(self)?;
+            completion.validate(parent)?;
         }
         if let Some(entry) = &self.response_entry {
-            entry.validate(self)?;
+            entry.validate(parent)?;
         }
-        self.readout.validate(self)?;
+        self.readout.validate(parent)?;
         if let Some(memory) = &self.memory_read {
-            memory.validate(self)?;
+            memory.validate(parent)?;
         }
         if self.schema != SCHEMA
             || self.lexical_pieces.is_empty()
@@ -548,6 +566,9 @@ impl Model {
         }
         if geometry(self.prior_scores.len(), self.config.context_tokens)? != self.geometry {
             return Err(Error("native artifact prime, H4, orientation or fixed-zeta tables differ from the named construction".into()));
+        }
+        if let Some(block) = &self.learned_routing {
+            block.validate(self)?;
         }
         let mut ids = BTreeSet::new();
         if self.construction.is_empty()
@@ -731,6 +752,11 @@ impl Model {
                     .chain(self.word_copy_training())
                     .chain(self.role_read_training())
                     .chain(self.relation_training())
+                    .chain(
+                        self.learned_routing
+                            .iter()
+                            .flat_map(|block| &block.training),
+                    )
                     .any(|known| known.id == candidate.id || known.text_cid == candidate.text_cid)
             {
                 return Err(Error(format!(
@@ -776,6 +802,7 @@ impl Model {
 }
 
 fn add_work(total: &mut Work, work: Work) {
+    total.learned_routing.add(work.learned_routing);
     add_completion_work(&mut total.word_copy.selector, work.word_copy.selector);
     total.word_copy.dictionary_lookups += work.word_copy.dictionary_lookups;
     total.word_copy.dictionary_comparisons += work.word_copy.dictionary_comparisons;

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -262,6 +262,10 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
         ("native completion runtime", completion),
         ("native response-entry runtime", response_entry),
         ("native retained-word copy runtime", word_copy),
+        (
+            "native learned routing runtime",
+            include_str!("../src/native_geometric/learned_routing.rs"),
+        ),
         ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
@@ -282,6 +286,58 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "{name}: no kernel allowances are permitted"
         );
     }
+}
+
+#[test]
+fn native_learned_routing_selection_and_transformation_are_allocation_free() {
+    use uor_r4_core::native_geometric::{RoutingFitConfig, RoutingMode};
+    let docs = [Document {
+        id: "routing-allocation".into(),
+        text: "Alice saved red. Bob saved blue. Alice gave Bob red.".into(),
+    }];
+    let mut trainer = Trainer::new(
+        Config {
+            context_tokens: 16,
+            ..Config::default()
+        },
+        &docs,
+    )
+    .unwrap();
+    trainer.train_documents(&docs).unwrap();
+    let (model, _) = trainer
+        .compile()
+        .unwrap()
+        .fit_routing_block(
+            &docs,
+            RoutingFitConfig {
+                max_positions: 32,
+                learned_tokens: 2,
+                passes: 1,
+                mode: RoutingMode::Angular,
+                ..RoutingFitConfig::default()
+            },
+        )
+        .unwrap();
+    let tokens = model.encode(&docs[0].text).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    ALLOCATIONS.with(|n| n.set(0));
+    BYTES.with(|n| n.set(0));
+    MEASURING.with(|v| v.set(true));
+    let result = (|| {
+        for _ in 0..3 {
+            for &token in &tokens {
+                session.observe(&model, token)?;
+                session.predict(&model)?;
+            }
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(())
+    })();
+    MEASURING.with(|v| v.set(false));
+    result.unwrap();
+    assert_eq!(ALLOCATIONS.with(Cell::get), 0);
+    assert_eq!(BYTES.with(Cell::get), 0);
+    assert!(session.work.learned_routing.payload_gathers > 0);
+    assert!(session.work.learned_routing.operator_executions > 0);
 }
 
 #[test]

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -2,6 +2,20 @@
 
 ## Latest native result — 2026-09-05
 
+[#1139's first learned H4 routing block](native_geometric_learned_routing_1139.md)
+is implemented and exercised but remains development only. On 735 authored
+OPEN prose/Rust next-token positions: parent 45 correct, learned angular 182,
+matched exact-code selector 223, fixed placement 177. The corpus substantially
+uses byte fallback; all eight target continuations fail. Both fitted selectors
+retain only 38/62 earlier correct responses. They retain 28/28 relation writes,
+but angular answers 16/28 and exact-code selection 28/28. The unchanged parent
+reproduces 62/62 complete generations. Keep parent `067adbf0`; angular
+superiority and the complete #1139 handoff remain unmet. Next integrate learned
+routing with response dispatch and stopping against actual final output.
+All prior evidence remains at its original scope.
+
+## Prior native admission result — 2026-09-05
+
 [#1139 exact NoWrite admission](native_geometric_relation_admission_1139.md)
 preserves 112/112 prior and 28/28 longer-context answers and exact writes.
 Both useful arms preserve 62+24 earlier responses, eight binding outputs and

--- a/docs/evidence/native_geometric_learned_routing_1139.json
+++ b/docs/evidence/native_geometric_learned_routing_1139.json
@@ -1,0 +1,1418 @@
+{
+  "schema": "uor-r4.native-learned-routing-evidence/1",
+  "decision": "DEVELOPMENT_ONLY_GENERATION_AND_PRESERVATION_FAIL; ANGULAR_ADVANTAGE_NOT_ESTABLISHED",
+  "selected_parent": "blake3:067adbf0a14d931d2ad98ca28a06a92aa1b963d0587183bf70b8085ffb7a4df6",
+  "source_cid": "85ebbe1e071c30f972367e1d3b11f7a17824af942bdd9a7aa7f9a6d8143abea3",
+  "scope": "Authored OPEN synthetic prose/Rust development; not broad natural-language or sealed qualification",
+  "source_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/learned-routing-corrected-comparison",
+  "token_exposure": {
+    "fit": {
+      "byte_fallback_tokens": 1902,
+      "document_end_targets": 24,
+      "lexical_tokens": 415
+    },
+    "prose": {
+      "byte_fallback_tokens": 383,
+      "document_end_targets": 4,
+      "lexical_tokens": 48
+    },
+    "rust": {
+      "byte_fallback_tokens": 176,
+      "document_end_targets": 4,
+      "lexical_tokens": 120
+    },
+    "vocabulary": 611
+  },
+  "parent_read_and_validate_ms": 2497.554417,
+  "parent": {
+    "control": "full",
+    "prose": {
+      "correct": 6,
+      "positions": 435,
+      "coverage": 0.08735632183908046,
+      "work": {
+        "observed_tokens": 439,
+        "evictions": 0,
+        "candidate_offers": 165698,
+        "candidate_evaluations": 49342,
+        "score_lookups": 1163757,
+        "feature_queries": 11310,
+        "memory_candidates": 32739
+      }
+    },
+    "rust": {
+      "correct": 39,
+      "positions": 300,
+      "coverage": 0.3233333333333333,
+      "work": {
+        "observed_tokens": 304,
+        "evictions": 0,
+        "candidate_offers": 114253,
+        "candidate_evaluations": 43165,
+        "score_lookups": 1037192,
+        "feature_queries": 7800,
+        "memory_candidates": 16078
+      }
+    },
+    "next_token_ms": 87.881417,
+    "generation": [
+      {
+        "id": "prose-continuation",
+        "prompt": "A useful answer selects the relevant information and",
+        "expected": " combines",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "rust-continuation",
+        "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+        "expected": " a + b }",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "prose-two-operations",
+        "prompt": "Start with five. Add two, then double the result. Answer:",
+        "expected": "14",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "rust-two-operations",
+        "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+        "expected": "14); }",
+        "text": "5);\n}\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "prose-binding",
+        "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+        "expected": "Rome",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "rust-binding",
+        "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+        "expected": "10",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "known-copy-shape",
+        "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+        "expected": "blue",
+        "text": " Unknown.\n",
+        "stop": "end_of_document",
+        "exact": false
+      },
+      {
+        "id": "known-number-shape",
+        "prompt": "left = 13; right = 4; total:",
+        "expected": "17",
+        "text": "13.\n",
+        "stop": "end_of_document",
+        "exact": false
+      }
+    ]
+  },
+  "arms": [
+    {
+      "name": "angular",
+      "cid": "blake3:09f9991cf769e3008d78a487c5115502f06cbca681577a81278401714a8edc2b",
+      "bytes": 10807631,
+      "deserialize_and_validate_ms": 2830.332791,
+      "fit": {
+        "accepted_key_moves": 25,
+        "accepted_operator_moves": 198,
+        "accepted_query_moves": 32,
+        "accepted_value_moves": 28,
+        "block_bytes": 79329,
+        "config": {
+          "learn_placement": true,
+          "learned_tokens": 24,
+          "max_positions": 2048,
+          "max_seconds": 15,
+          "mode": "angular",
+          "passes": 2,
+          "seed": 1139
+        },
+        "documents": 24,
+        "elapsed_ms": 531,
+        "final_conditional_nll": [
+          4.465000313529829,
+          4.402497688343417
+        ],
+        "initial_conditional_nll": [
+          4.755921602593922,
+          4.739500366346807
+        ],
+        "positions": 1890,
+        "proposals": 2304,
+        "schema": "uor-r4.learned-h4-routing/1",
+        "stopped_at_time_limit": false
+      },
+      "full": {
+        "control": "full",
+        "prose": {
+          "correct": 103,
+          "positions": 435,
+          "coverage": 0.7149425287356321,
+          "work": {
+            "observed_tokens": 439,
+            "evictions": 0,
+            "candidate_offers": 171850,
+            "candidate_evaluations": 81456,
+            "score_lookups": 1916531,
+            "feature_queries": 11310,
+            "memory_candidates": 32739,
+            "learned_routing": {
+              "code_reads": 11086,
+              "comparisons": 775003,
+              "context_tokens_read": 3368,
+              "emission_queries": 162912,
+              "logical_bytes_read": 4525332,
+              "operator_executions": 870,
+              "payload_gathers": 870,
+              "predictions": 435,
+              "sources_examined": 6736,
+              "table_reads": 356218
+            }
+          }
+        },
+        "rust": {
+          "correct": 79,
+          "positions": 300,
+          "coverage": 0.7666666666666667,
+          "work": {
+            "observed_tokens": 304,
+            "evictions": 0,
+            "candidate_offers": 118367,
+            "candidate_evaluations": 60577,
+            "score_lookups": 1447943,
+            "feature_queries": 7800,
+            "memory_candidates": 16078,
+            "learned_routing": {
+              "code_reads": 7576,
+              "comparisons": 546151,
+              "context_tokens_read": 2288,
+              "emission_queries": 121154,
+              "logical_bytes_read": 3231500,
+              "operator_executions": 600,
+              "payload_gathers": 600,
+              "predictions": 300,
+              "sources_examined": 4576,
+              "table_reads": 261612
+            }
+          }
+        },
+        "next_token_ms": 102.005417,
+        "generation": [
+          {
+            "id": "prose-continuation",
+            "prompt": "A useful answer selects the relevant information and",
+            "expected": " combines",
+            "text": " Unknown.\nstorom et an  rightor",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-continuation",
+            "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+            "expected": " a + b }",
+            "text": " Unknown.\nss  (r (leftl a (r (l",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "prose-two-operations",
+            "prompt": "Start with five. Add two, then double the result. Answer:",
+            "expected": "14",
+            "text": " Unknown.\nse  ,,n  ,rightorgeg:",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-two-operations",
+            "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+            "expected": "14); }",
+            "text": "5);\n}\n",
+            "stop": "end_of_document",
+            "exact": false
+          },
+          {
+            "id": "prose-binding",
+            "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+            "expected": "Rome",
+            "text": " Unknown.\nse                   ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-binding",
+            "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+            "expected": "10",
+            "text": " Unknown.\nstonte               ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-copy-shape",
+            "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+            "expected": "blue",
+            "text": " Unknown.\nse                   ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-number-shape",
+            "prompt": "left = 13; right = 4; total:",
+            "expected": "17",
+            "text": "13.\n",
+            "stop": "end_of_document",
+            "exact": false
+          }
+        ]
+      },
+      "controls": [
+        {
+          "control": "learned_routing_disabled",
+          "prose": {
+            "correct": 6,
+            "positions": 435,
+            "coverage": 0.08735632183908046,
+            "work": {
+              "observed_tokens": 439,
+              "evictions": 0,
+              "candidate_offers": 165698,
+              "candidate_evaluations": 49342,
+              "score_lookups": 1163757,
+              "feature_queries": 11310,
+              "memory_candidates": 32739
+            }
+          },
+          "rust": {
+            "correct": 39,
+            "positions": 300,
+            "coverage": 0.3233333333333333,
+            "work": {
+              "observed_tokens": 304,
+              "evictions": 0,
+              "candidate_offers": 114253,
+              "candidate_evaluations": 43165,
+              "score_lookups": 1037192,
+              "feature_queries": 7800,
+              "memory_candidates": 16078
+            }
+          },
+          "next_token_ms": 87.522375,
+          "generation": [
+            {
+              "id": "prose-continuation",
+              "prompt": "A useful answer selects the relevant information and",
+              "expected": " combines",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "rust-continuation",
+              "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+              "expected": " a + b }",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "prose-two-operations",
+              "prompt": "Start with five. Add two, then double the result. Answer:",
+              "expected": "14",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "rust-two-operations",
+              "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+              "expected": "14); }",
+              "text": "5);\n}\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "prose-binding",
+              "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+              "expected": "Rome",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "rust-binding",
+              "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+              "expected": "10",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "known-copy-shape",
+              "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+              "expected": "blue",
+              "text": " Unknown.\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "known-number-shape",
+              "prompt": "left = 13; right = 4; total:",
+              "expected": "17",
+              "text": "13.\n",
+              "stop": "end_of_document",
+              "exact": false
+            }
+          ]
+        },
+        {
+          "control": "learned_routing_selection_disabled",
+          "prose": {
+            "correct": 43,
+            "positions": 435,
+            "coverage": 0.5494252873563218,
+            "work": {
+              "observed_tokens": 439,
+              "evictions": 0,
+              "candidate_offers": 170965,
+              "candidate_evaluations": 81835,
+              "score_lookups": 1925365,
+              "feature_queries": 11310,
+              "memory_candidates": 32739,
+              "learned_routing": {
+                "code_reads": 11086,
+                "comparisons": 682850,
+                "context_tokens_read": 3368,
+                "emission_queries": 163670,
+                "logical_bytes_read": 4161896,
+                "operator_executions": 870,
+                "payload_gathers": 870,
+                "predictions": 435,
+                "sources_examined": 6736,
+                "table_reads": 357512
+              }
+            }
+          },
+          "rust": {
+            "correct": 42,
+            "positions": 300,
+            "coverage": 0.6433333333333333,
+            "work": {
+              "observed_tokens": 304,
+              "evictions": 0,
+              "candidate_offers": 117752,
+              "candidate_evaluations": 60705,
+              "score_lookups": 1450893,
+              "feature_queries": 7800,
+              "memory_candidates": 16078,
+              "learned_routing": {
+                "code_reads": 7576,
+                "comparisons": 487373,
+                "context_tokens_read": 2288,
+                "emission_queries": 121410,
+                "logical_bytes_read": 2999388,
+                "operator_executions": 600,
+                "payload_gathers": 600,
+                "predictions": 300,
+                "sources_examined": 4576,
+                "table_reads": 262362
+              }
+            }
+          },
+          "next_token_ms": 100.653334,
+          "generation": [
+            {
+              "id": "prose-continuation",
+              "prompt": "A useful answer selects the relevant information and",
+              "expected": " combines",
+              "text": " Unknown.\nir[ age tnes tn theor ri",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-continuation",
+              "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+              "expected": " a + b }",
+              "text": " Unknown.\nir i32tdrg tnes tnes tne",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "prose-two-operations",
+              "prompt": "Start with five. Add two, then double the result. Answer:",
+              "expected": "14",
+              "text": " Unknown.\nir:ln tnes tnes tnes ",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-two-operations",
+              "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+              "expected": "14); }",
+              "text": "5);\n}\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "prose-binding",
+              "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+              "expected": "Rome",
+              "text": " Unknown.\nir[ age tnes tnes tne",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-binding",
+              "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+              "expected": "10",
+              "text": " Unknown.\nir[ ag. nes tnes tnes",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "known-copy-shape",
+              "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+              "expected": "blue",
+              "text": " Unknown.\nir[ age tne is[:a.poe is[",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "known-number-shape",
+              "prompt": "left = 13; right = 4; total:",
+              "expected": "17",
+              "text": "13.\n",
+              "stop": "end_of_document",
+              "exact": false
+            }
+          ]
+        },
+        {
+          "control": "learned_routing_transform_disabled",
+          "prose": {
+            "correct": 66,
+            "positions": 435,
+            "coverage": 0.6252873563218391,
+            "work": {
+              "observed_tokens": 439,
+              "evictions": 0,
+              "candidate_offers": 171245,
+              "candidate_evaluations": 81345,
+              "score_lookups": 1913846,
+              "feature_queries": 11310,
+              "memory_candidates": 32739,
+              "learned_routing": {
+                "code_reads": 11086,
+                "comparisons": 706604,
+                "context_tokens_read": 3368,
+                "emission_queries": 162690,
+                "logical_bytes_read": 4242576,
+                "operator_executions": 870,
+                "payload_gathers": 870,
+                "predictions": 435,
+                "sources_examined": 6736,
+                "table_reads": 353928
+              }
+            }
+          },
+          "rust": {
+            "correct": 53,
+            "positions": 300,
+            "coverage": 0.6733333333333333,
+            "work": {
+              "observed_tokens": 304,
+              "evictions": 0,
+              "candidate_offers": 117957,
+              "candidate_evaluations": 60737,
+              "score_lookups": 1451720,
+              "feature_queries": 7800,
+              "memory_candidates": 16078,
+              "learned_routing": {
+                "code_reads": 7576,
+                "comparisons": 504751,
+                "context_tokens_read": 2288,
+                "emission_queries": 121474,
+                "logical_bytes_read": 3066828,
+                "operator_executions": 600,
+                "payload_gathers": 600,
+                "predictions": 300,
+                "sources_examined": 4576,
+                "table_reads": 261844
+              }
+            }
+          },
+          "next_token_ms": 100.781042,
+          "generation": [
+            {
+              "id": "prose-continuation",
+              "prompt": "A useful answer selects the relevant information and",
+              "expected": " combines",
+              "text": " Unknown.\nrni tes an  etosot st",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-continuation",
+              "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+              "expected": " a + b }",
+              "text": " Unknown.\nrrq smnuiirpis ang )m",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "prose-two-operations",
+              "prompt": "Start with five. Add two, then double the result. Answer:",
+              "expected": "14",
+              "text": " Unknown.\nrrqc: :etar. sm\ntiont",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-two-operations",
+              "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+              "expected": "14); }",
+              "text": "5);\n}\n",
+              "stop": "end_of_document",
+              "exact": false
+            },
+            {
+              "id": "prose-binding",
+              "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+              "expected": "Rome",
+              "text": " Unknown.\nrrqc: :etarm tes :e a",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "rust-binding",
+              "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+              "expected": "10",
+              "text": " Unknown.\nr bran  / / es a/ /na",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "known-copy-shape",
+              "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+              "expected": "blue",
+              "text": " Unknown.\nrrqc: :etarm tes :e a",
+              "stop": "token_budget",
+              "exact": false
+            },
+            {
+              "id": "known-number-shape",
+              "prompt": "left = 13; right = 4; total:",
+              "expected": "17",
+              "text": "13.\n",
+              "stop": "end_of_document",
+              "exact": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "equality",
+      "cid": "blake3:c6d3739db83e60f4e0f5d1ed25e261fb205fbca784fbf2bdfc3981aaebea85ad",
+      "bytes": 10803043,
+      "deserialize_and_validate_ms": 2843.435958,
+      "fit": {
+        "accepted_key_moves": 39,
+        "accepted_operator_moves": 183,
+        "accepted_query_moves": 27,
+        "accepted_value_moves": 22,
+        "block_bytes": 74741,
+        "config": {
+          "learn_placement": true,
+          "learned_tokens": 24,
+          "max_positions": 2048,
+          "max_seconds": 15,
+          "mode": "equality",
+          "passes": 2,
+          "seed": 1139
+        },
+        "documents": 24,
+        "elapsed_ms": 470,
+        "final_conditional_nll": [
+          4.33085460881351,
+          4.36158039441036
+        ],
+        "initial_conditional_nll": [
+          4.593070247262543,
+          4.59125370305555
+        ],
+        "positions": 1890,
+        "proposals": 2304,
+        "schema": "uor-r4.learned-h4-routing/1",
+        "stopped_at_time_limit": false
+      },
+      "full": {
+        "control": "full",
+        "prose": {
+          "correct": 127,
+          "positions": 435,
+          "coverage": 0.7793103448275862,
+          "work": {
+            "observed_tokens": 439,
+            "evictions": 0,
+            "candidate_offers": 171775,
+            "candidate_evaluations": 81382,
+            "score_lookups": 1914979,
+            "feature_queries": 11310,
+            "memory_candidates": 32739,
+            "learned_routing": {
+              "code_reads": 11086,
+              "comparisons": 756612,
+              "context_tokens_read": 3368,
+              "emission_queries": 162764,
+              "logical_bytes_read": 4356304,
+              "operator_executions": 870,
+              "payload_gathers": 870,
+              "predictions": 435,
+              "sources_examined": 6736,
+              "table_reads": 328984
+            }
+          }
+        },
+        "rust": {
+          "correct": 96,
+          "positions": 300,
+          "coverage": 0.8166666666666667,
+          "work": {
+            "observed_tokens": 304,
+            "evictions": 0,
+            "candidate_offers": 118368,
+            "candidate_evaluations": 61143,
+            "score_lookups": 1460747,
+            "feature_queries": 7800,
+            "memory_candidates": 16078,
+            "learned_routing": {
+              "code_reads": 7576,
+              "comparisons": 552639,
+              "context_tokens_read": 2288,
+              "emission_queries": 122286,
+              "logical_bytes_read": 3212844,
+              "operator_executions": 600,
+              "payload_gathers": 600,
+              "predictions": 300,
+              "sources_examined": 4576,
+              "table_reads": 248172
+            }
+          }
+        },
+        "next_token_ms": 101.193333,
+        "generation": [
+          {
+            "id": "prose-continuation",
+            "prompt": "A useful answer selects the relevant information and",
+            "expected": " combines",
+            "text": " Unknown.\ne strasser t ther3eoe3ce",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-continuation",
+            "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+            "expected": " a + b }",
+            "text": " Unknown.\ne it strasser thre st",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "prose-two-operations",
+            "prompt": "Start with five. Add two, then double the result. Answer:",
+            "expected": "14",
+            "text": " Unknown.\ne strasser: &[i32] ri",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-two-operations",
+            "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+            "expected": "14); }",
+            "text": "5);\n}\n",
+            "stop": "end_of_document",
+            "exact": false
+          },
+          {
+            "id": "prose-binding",
+            "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+            "expected": "Rome",
+            "text": " Unknown.\ne strasser: &: &::ttn",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-binding",
+            "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+            "expected": "10",
+            "text": " Unknown.\ne strasser thre st st",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-copy-shape",
+            "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+            "expected": "blue",
+            "text": " Unknown.\ne strasser: &: &::ttn",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-number-shape",
+            "prompt": "left = 13; right = 4; total:",
+            "expected": "17",
+            "text": "13.\n",
+            "stop": "end_of_document",
+            "exact": false
+          }
+        ]
+      },
+      "controls": []
+    },
+    {
+      "name": "fixed-placement",
+      "cid": "blake3:f7702f024ad505b2e1c08931907e94d49942aff4f17ec50d5e009087183e15e5",
+      "bytes": 10812953,
+      "deserialize_and_validate_ms": 2845.591958,
+      "fit": {
+        "accepted_key_moves": 0,
+        "accepted_operator_moves": 226,
+        "accepted_query_moves": 0,
+        "accepted_value_moves": 0,
+        "block_bytes": 84651,
+        "config": {
+          "learn_placement": false,
+          "learned_tokens": 24,
+          "max_positions": 2048,
+          "max_seconds": 15,
+          "mode": "angular",
+          "passes": 2,
+          "seed": 1139
+        },
+        "documents": 24,
+        "elapsed_ms": 471,
+        "final_conditional_nll": [
+          4.587485940493411,
+          4.5615394003318
+        ],
+        "initial_conditional_nll": [
+          4.755921602593922,
+          4.739500366346807
+        ],
+        "positions": 1890,
+        "proposals": 1440,
+        "schema": "uor-r4.learned-h4-routing/1",
+        "stopped_at_time_limit": false
+      },
+      "full": {
+        "control": "full",
+        "prose": {
+          "correct": 103,
+          "positions": 435,
+          "coverage": 0.7218390804597701,
+          "work": {
+            "observed_tokens": 439,
+            "evictions": 0,
+            "candidate_offers": 171939,
+            "candidate_evaluations": 81520,
+            "score_lookups": 1917937,
+            "feature_queries": 11310,
+            "memory_candidates": 32739,
+            "learned_routing": {
+              "code_reads": 11086,
+              "comparisons": 774006,
+              "context_tokens_read": 3368,
+              "emission_queries": 163040,
+              "logical_bytes_read": 4528200,
+              "operator_executions": 870,
+              "payload_gathers": 870,
+              "predictions": 435,
+              "sources_examined": 6736,
+              "table_reads": 357932
+            }
+          }
+        },
+        "rust": {
+          "correct": 74,
+          "positions": 300,
+          "coverage": 0.7933333333333333,
+          "work": {
+            "observed_tokens": 304,
+            "evictions": 0,
+            "candidate_offers": 118429,
+            "candidate_evaluations": 60967,
+            "score_lookups": 1457235,
+            "feature_queries": 7800,
+            "memory_candidates": 16078,
+            "learned_routing": {
+              "code_reads": 7576,
+              "comparisons": 564721,
+              "context_tokens_read": 2288,
+              "emission_queries": 121934,
+              "logical_bytes_read": 3322420,
+              "operator_executions": 600,
+              "payload_gathers": 600,
+              "predictions": 300,
+              "sources_examined": 4576,
+              "table_reads": 265772
+            }
+          }
+        },
+        "next_token_ms": 101.078791,
+        "generation": [
+          {
+            "id": "prose-continuation",
+            "prompt": "A useful answer selects the relevant information and",
+            "expected": " combines",
+            "text": " Unknown.\n    am a  tont gtat n",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-continuation",
+            "prompt": "fn sum(a: i32, b: i32) -> i32 {",
+            "expected": " a + b }",
+            "text": " Unknown.\n     (  (  (  (  (  (",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "prose-two-operations",
+            "prompt": "Start with five. Add two, then double the result. Answer:",
+            "expected": "14",
+            "text": " Unknown.\n  eeeee ch right     ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-two-operations",
+            "prompt": "fn main() { let x = 5 + 2; let y = x + x; assert_eq!(y,",
+            "expected": "14); }",
+            "text": "5);\n}\n",
+            "stop": "end_of_document",
+            "exact": false
+          },
+          {
+            "id": "prose-binding",
+            "prompt": "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+            "expected": "Rome",
+            "text": " Unknown.\n  eeeee ch right     ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "rust-binding",
+            "prompt": "let first = 5; let second = first + 2; let third = second + 3; // third =",
+            "expected": "10",
+            "text": " Unknown.\n   ing eetat nes eveo",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-copy-shape",
+            "prompt": "the orb is red. the cube is green. Now the orb is blue. Question: What color is the orb? Answer:",
+            "expected": "blue",
+            "text": " Unknown.\n  eeeee ch right     ",
+            "stop": "token_budget",
+            "exact": false
+          },
+          {
+            "id": "known-number-shape",
+            "prompt": "left = 13; right = 4; total:",
+            "expected": "17",
+            "text": "13.\n",
+            "stop": "end_of_document",
+            "exact": false
+          }
+        ]
+      },
+      "controls": []
+    }
+  ],
+  "preservation": {
+    "parent_exact_generation_objects": 62,
+    "total": 62,
+    "angular": {
+      "correct_responses": 38,
+      "total": 62,
+      "relation_answers": 16,
+      "relation_writes": 28,
+      "relation_total": 28,
+      "restore_state_equal": 28
+    },
+    "equality": {
+      "correct_responses": 38,
+      "total": 62,
+      "relation_answers": 28,
+      "relation_writes": 28,
+      "relation_total": 28,
+      "restore_state_equal": 28
+    }
+  },
+  "reload": {
+    "exact_generation_work_state": true
+  },
+  "correction": {
+    "initial_failed_command_ms": 4124,
+    "parameters_identical_except_parent_binding": true
+  },
+  "cli": {
+    "angular-full": {
+      "text": " Unknown.\nss  (r (leftl a (r (l",
+      "stop": "token_budget",
+      "work": {
+        "observed_tokens": 44,
+        "evictions": 0,
+        "candidate_offers": 9678,
+        "candidate_evaluations": 4700,
+        "score_lookups": 114746,
+        "feature_queries": 624,
+        "memory_candidates": 1432,
+        "learned_routing": {
+          "code_reads": 624,
+          "comparisons": 44780,
+          "context_tokens_read": 192,
+          "emission_queries": 9400,
+          "logical_bytes_read": 261616,
+          "operator_executions": 48,
+          "payload_gathers": 48,
+          "predictions": 24,
+          "sources_examined": 384,
+          "table_reads": 20624
+        }
+      }
+    },
+    "angular-no-entry": {
+      "text": " a)rt: i32] n) )c ))l3e i32eo i32",
+      "stop": "token_budget",
+      "work": {
+        "observed_tokens": 44,
+        "evictions": 0,
+        "candidate_offers": 9590,
+        "candidate_evaluations": 4593,
+        "score_lookups": 110092,
+        "feature_queries": 624,
+        "memory_candidates": 1626,
+        "learned_routing": {
+          "code_reads": 624,
+          "comparisons": 38703,
+          "context_tokens_read": 192,
+          "emission_queries": 9186,
+          "logical_bytes_read": 235596,
+          "operator_executions": 48,
+          "payload_gathers": 48,
+          "predictions": 24,
+          "sources_examined": 384,
+          "table_reads": 20196
+        }
+      }
+    },
+    "parent-no-entry": {
+      "text": "\n    let shifted =);\n}\n",
+      "stop": "end_of_document",
+      "work": {
+        "observed_tokens": 28,
+        "evictions": 0,
+        "candidate_offers": 3171,
+        "candidate_evaluations": 1769,
+        "score_lookups": 45667,
+        "feature_queries": 208,
+        "memory_candidates": 274
+      }
+    }
+  },
+  "resources": {
+    "model_used_ms": 46768,
+    "engineering_used_ms": 862744,
+    "model_cycle_limit_ms": 120000,
+    "engineering_cycle_limit_ms": 1200000,
+    "cumulative": {
+      "cumulative_ms": 1410652,
+      "limit_ms": 1800000
+    },
+    "peak_sampled_rss_bytes": 834306048,
+    "storage": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-06T03:12:40.640Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2416254976,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 729673728,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 5852442624,
+      "storage_limit_bytes": 6459228160,
+      "remaining_storage_bytes": 606785536,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 251379712,
+      "model_ledger": {
+        "cumulative_ms": 1410652,
+        "limit_ms": 1800000
+      },
+      "model_remaining_ms": 389348,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    }
+  },
+  "commands": [
+    {
+      "label": "learned-routing-comparison",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_routing_probe",
+      "args": [
+        "relation-admission-models/sparse.json",
+        "learned-routing-comparison"
+      ],
+      "elapsed_ms": 4124,
+      "code": 1,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-unit",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-b6cb98449c5266f9",
+      "args": [
+        "native_geometric::learned_routing_tests",
+        "--test-threads=1"
+      ],
+      "elapsed_ms": 4771,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-allocation",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/native_geometric_allocations-4cb90a603bd3f445",
+      "args": [
+        "native_learned_routing_selection_and_transformation_are_allocation_free",
+        "--exact",
+        "--test-threads=1"
+      ],
+      "elapsed_ms": 666,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-source-guard",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/native_geometric_allocations-4cb90a603bd3f445",
+      "args": [
+        "native_kernel_source_has_no_forbidden_arithmetic_or_float_types",
+        "--exact",
+        "--test-threads=1"
+      ],
+      "elapsed_ms": 9,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-corrected-comparison",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_routing_probe",
+      "args": [
+        "relation-admission-models/sparse.json",
+        "learned-routing-corrected-comparison"
+      ],
+      "elapsed_ms": 13546,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-preserve-parent",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "relation-admission-models/sparse.json",
+        "--source",
+        "role-read-source/development.json",
+        "--output-dir",
+        "learned-routing-preserve-parent",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "64",
+        "--max-seconds",
+        "30",
+        "--lexeme-cues",
+        "true"
+      ],
+      "elapsed_ms": 2666,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-preserve-angular",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "learned-routing-corrected-comparison/angular-model.json",
+        "--source",
+        "role-read-source/development.json",
+        "--output-dir",
+        "learned-routing-preserve-angular",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "64",
+        "--max-seconds",
+        "30",
+        "--lexeme-cues",
+        "true"
+      ],
+      "elapsed_ms": 3268,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-preserve-equality",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate",
+        "--model",
+        "learned-routing-corrected-comparison/equality-model.json",
+        "--source",
+        "role-read-source/development.json",
+        "--output-dir",
+        "learned-routing-preserve-equality",
+        "--controls",
+        "full",
+        "--generated-tokens",
+        "64",
+        "--max-seconds",
+        "30",
+        "--lexeme-cues",
+        "true"
+      ],
+      "elapsed_ms": 3180,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-relations-angular",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "learned-routing-corrected-comparison/angular-model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "learned-routing-relations-angular.json"
+      ],
+      "elapsed_ms": 3078,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-relations-equality",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "learned-routing-corrected-comparison/equality-model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "learned-routing-relations-equality.json"
+      ],
+      "elapsed_ms": 2910,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-cli-angular-full",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "learned-routing-corrected-comparison/angular-model.json",
+        "--prompt",
+        "fn sum(a: i32, b: i32) -> i32 {",
+        "--max-tokens",
+        "24",
+        "--control",
+        "full",
+        "--json"
+      ],
+      "elapsed_ms": 3261,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-cli-angular-no-entry",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "learned-routing-corrected-comparison/angular-model.json",
+        "--prompt",
+        "fn sum(a: i32, b: i32) -> i32 {",
+        "--max-tokens",
+        "24",
+        "--control",
+        "response-entry-disabled",
+        "--json"
+      ],
+      "elapsed_ms": 2824,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-cli-parent-no-entry",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "relation-admission-models/sparse.json",
+        "--prompt",
+        "fn sum(a: i32, b: i32) -> i32 {",
+        "--max-tokens",
+        "24",
+        "--control",
+        "response-entry-disabled",
+        "--json"
+      ],
+      "elapsed_ms": 2465,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-format",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt"
+      ],
+      "elapsed_ms": 3367,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-release",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_routing_probe",
+        "--example",
+        "native_geometric_value_probe"
+      ],
+      "elapsed_ms": 312129,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-format-correction",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt"
+      ],
+      "elapsed_ms": 3193,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-test-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "--test",
+        "native_geometric_allocations",
+        "--no-run"
+      ],
+      "elapsed_ms": 229361,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-final-format",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt"
+      ],
+      "elapsed_ms": 3236,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-corrected-release",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_routing_probe",
+        "--example",
+        "native_geometric_value_probe"
+      ],
+      "elapsed_ms": 311274,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "learned-routing-policy",
+      "command": "/tmp/r4-native-geometric-target/debug/r4-policy-check",
+      "args": [
+        "."
+      ],
+      "elapsed_ms": 184,
+      "code": 0,
+      "stopped": null
+    }
+  ],
+  "rust_compilation": "NOT_RUN for new generated snippets; previous Rust checks retain their earlier scope",
+  "next": "Train complete response dispatch and stopping with the routed predictor against final decoded continuation while retaining known memory behavior; do not expand route tables or context first.",
+  "raw_report_sha256": "cf560b4eb6f851b3d2943f3a0e4da5eefc43e88c56ea592021e44f1fc02a08be",
+  "counter_scope": "Compact selected counters here; every native work field remains in the bound full report at source_root/result.json."
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,45 @@
 # Current native geometric AI work
 
-## Geo-transformer direction — owner clarification after #1145
+## First learned routing block — #1139, 2026-09-05 local date
+
+**Implemented and exercised; development only. Retain accepted parent
+`067adbf0`.** The [new record](../native_geometric_learned_routing_1139.md)
+describes two learned H4 channels in `Model::predict`: ordered contextual query,
+bounded source selection, selected value transport, query-conditioned action
+and sparse token readout. Rust fitting executes the actual discrete route.
+Prediction uses integer/table operations and passes its allocation/source checks.
+The existing geometry, typed values, relation store and committed copy path remain.
+
+On 735 authored OPEN prose/Rust next-token positions, parent gets 45 correct,
+learned angular 182, exact-code selection 223 and fixed placement 177. Both
+source selection and the learned action affect accuracy, but angular advantage
+is not established. Much of this population uses byte fallback. All eight
+target continuations fail. Both fitted selectors retain only 38/62 older exact
+responses; parent reproduces all 62 complete Generation objects. Both preserve
+28/28 relation writes/restored states, while angular returns 16/28 answers and
+exact-code selection 28/28. No fitted block is promoted.
+
+**Next within #1139: train complete response dispatch and stopping together
+with routed prediction against actual final output.** The old response-entry
+head can force `Unknown` by adding a positive margin above Base; disabling it
+removes that prefix but leaves incoherent generation. The new independent
+conditional scores also disrupt EOS. Use ordinary prose/Rust continuations
+and the known memory cases to train/check this integration before increasing
+context or adding another abstraction stage. Keep the matched selector
+comparison. #1139 stays open and #1140 stays subsequent; cache growth is secondary.
+
+Artifacts and all attempts remain under
+`.uor-models/native-typed-value-2026-09-05/learned-routing-*`; angular is
+`09f9991c`, exact-code selection `c6d3739d`, fixed placement `f7702f02`.
+Four focused unit tests, allocation/source checks, artifact/session replay and
+the actual CLI pass at their stated mechanical scopes. A parent-binding reload
+bug was corrected without changing learned parameters; the failed attempt is
+retained and charged. Model work is 46.768/120 seconds this cycle, cumulative
+1,410.652/1,800 seconds, leaving 389.348. The post-evaluation storage sample is
+5,852,442,624 bytes with 251,379,712 before the existing tighter stop. No storage
+increase or deletion was needed. Refresh receipts before the next projection.
+
+## Prior geo-transformer direction — owner clarification after #1145
 
 **Next implementation: #1139's jointly learned geometric routing block.**
 The [canonical plan](project-track.md#immediate-build-sequence) now connects
@@ -9,7 +48,8 @@ transformations to raw-text language and composition. More NoWrite caching or
 residual score-bound optimization is secondary. #1140 remains the subsequent
 multi-operation qualification; short composition tasks supply a learning/check
 signal during #1139. This supersedes the then-next scheduling below, not any
-measurement. The new block is **NOT_IMPLEMENTED / NOT_RUN**.
+measurement. At that checkpoint the block was **NOT_IMPLEMENTED / NOT_RUN**;
+the implementation and measured limits are recorded above.
 
 PR #1145 merged through protected delivery at `219f572fd8e9fda1e6ca3254dddbc1f2715d92f0`.
 Sparse artifact `067adbf0` remains the selected bounded execution improvement;

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -168,6 +168,15 @@ state. Broader conversation, export/forget and product integration remain #962.
 
 ### Step 3: learn semantic placement and routed computation
 
+**Current implementation checkpoint:** the first two-channel learned H4 block
+is [implemented and measured](../native_geometric_learned_routing_1139.md), with
+improved small-population token prediction but failed generation/preservation
+and no angular advantage over exact-code selection. Its next build step trains
+response dispatch and stopping with routed prediction against final output,
+including ordinary prose/Rust and preserved memory behavior. Keep the selector
+comparison before expanding context or abstraction. The full handoff below
+remains unmet; this checkpoint does not replace its criteria.
+
 Implement one small jointly trained angular routing block inside the existing
 native language path. Learn token/ordered-n-let codes and contextual placement
 within fixed geometric structure, source admission and a selected state

--- a/docs/native_geometric_learned_routing_1139.md
+++ b/docs/native_geometric_learned_routing_1139.md
@@ -1,0 +1,235 @@
+# First learned H4 routing block — #1139
+
+This record follows the owner-directed geo-transformer plan delivered in #1146.
+It concerns one optional residual block in the existing native predictor. It
+does not replace the entire predictor or qualify a geo-transformer LLM.
+
+## Mechanism and retained information
+
+Each of two independent channels learns query, key and value codes for tokens
+in the existing artifact vocabulary. Codes identify full signed elements of the
+120-element binary icosahedral group. The channel composes the last two query
+codes in their observed order. It examines at most eight recent source keys,
+selects one source, gathers that source's value code and applies a learned
+query-conditioned group action. All group products read the existing exact H4
+product table. Sparse output rows contribute quantized residual token scores
+and at most eight candidate postings per channel to `Model::predict`.
+
+Angular selection ranks the signed real component of `query * inverse(key)`.
+Host construction orders the exact `Z[phi]` coefficients and emits a finite
+rank table. Serving reads that table; it computes no cosine, floating-point
+distance, multiplication or dense projection. Ties prefer the most recent
+source. The full selected key/value and transported output retain orientation;
+the scalar angular comparison alone does not distinguish every orientation.
+The exact-code comparator selects code equality, with the same code capacity,
+context limit, transport and readout. It is a selector comparison, not a wholly
+non-geometric model. The fixed-placement arm learns actions and emission rows
+while retaining the initialized token codes.
+
+Token identity remains the parent's lexical/byte codec and prime-addressed
+vocabulary. The new codebook does not replace canonical identity with a semantic
+hash. Query/key/value placement is learned from next-token loss. The fixed zeta
+phases, ordered base features, paired-H4/icosian witnesses, exact relation store,
+typed arithmetic and committed copy path remain in their existing roles; this
+block does not establish a new learned zeta or paired-H4 scoring advantage.
+Committed exact copying still bypasses ordinary prediction work.
+
+The eight-token window retains exact source token IDs until selection. Each
+channel then discards all unselected payloads. Identical token codes, angular
+ties and finite group products can collide. The two-token query is compressed
+to 120 states, and each selected/transported output is also one of 120 states.
+The readout sums independent channel scores, without a joint relation between
+the channels. Source offset is diagnostic; it is not an extra learned feature.
+The block does not encode older context, source revisions, or a persistent
+derived-value chain. Existing bounded memory remains separate.
+
+## Learning and comparison
+
+Rust fitting uses hard coordinate proposals evaluated by the actual serving
+selector and transport. For each channel, it adjusts query/key/value codes and
+query-conditioned actions, refitting route-conditional token counts after each
+proposal. The accepted objective is smoothed conditional next-token NLL for
+that channel. It is not end-to-end optimization of the parent's complete
+residual score or a soft attention surrogate. Quantized sparse emission scores
+are compiled from the final counts. No dense training library is needed here.
+
+The bounded example uses 24 authored raw-text documents, equally split between
+prose and Rust, and eight distinct development documents. It samples up to
+2,048 fit positions across complete documents, adjusts the 24 most frequent
+context token codes, and makes two passes with three proposals per coordinate.
+Each fit has a 15-second safety ceiling. Three arms share these limits and the
+initialization seed; a stopped fit must not be described as a completed matched
+search. Development text and generated prompts are OPEN, synthetic and small.
+They are not broad natural-language or sealed capability qualification.
+
+The unchanged parent and three fitted arms receive the same next-token and
+24-token generation checks. The angular artifact also runs with the block
+disabled, source selection forced to the most recent token, and the learned
+action replaced by identity. Selection-disabled still calculates all source
+ranks. Source hashes, fit reports, exact outputs, route examples and complete
+native work counters are retained. Artifact reload and session restoration are
+checked separately. No teacher or provider authors serving output.
+
+The routing block is fitted last and binds the exact parent artifact CID.
+Loading validates inherited response components against that unchanged parent,
+including their original nested identity checks, then validates the complete
+new artifact. Replacing or training a nested component under an already fitted
+routing block is not supported by this version. The first execution exposed a
+missing distinction between the new outer artifact and those older frozen
+parents: its reload failed after the first arm. Those diagnostic outputs and
+the failed 4.124-second command remain preserved. The correction adds explicit
+parent binding without changing learned route/scoring equations or weakening
+nested provenance checks. Final results must come from the corrected executable.
+
+## Cost boundary
+
+For vocabulary size V and up to W=8 sources, the new codebooks contain 6V u16
+entries, two 120-entry action tables and one 120-entry angular-rank table.
+Emission storage depends on observed token/root pairs; output postings are
+bounded by 2 * 120 * 8 token IDs. Existing shared H4 tables are reused. There
+is no online training, new persistent per-token cache, or vocabulary-wide scan.
+
+Each active prediction builds two ordered queries, examines at most 16 keys,
+gathers exactly two value codes and executes two query-conditioned actions.
+Each angular source requires an inverse, group-product and rank lookup. Each
+selected payload needs two further group products. Candidate scoring adds two
+bounded sparse-row searches per candidate; admission adds at most 16 postings.
+Thus selection/transport is O(W), and residual readout is O(A log V) for the
+number A of candidate evaluations during finite posting admission. A is not
+the final shortlist size: a dropped candidate can be offered and scored again.
+The existing feature, memory, write and
+decoding work remains and must be included in whole-path timing.
+
+`RoutingWork` reports code/table reads, comparisons, examined sources, payload
+gathers, executed actions, emission queries and logical operand bytes. These
+are algorithmic counters, not a complete CPU instruction or physical DRAM
+traffic census. The report retains the surrounding native counters as well.
+Host tokenization, artifact loading/validation and sparse-table construction
+remain outside the allocation-free prediction kernel. Existing startup geometry
+validation still uses floating point; whole-lifecycle integer-only execution
+is not claimed.
+
+The complete pre-execution projection is retained in
+`.uor-models/native-typed-value-2026-09-05/learned-routing-projection.json`:
+950 seconds engineering and 105 seconds model work, within cycle ceilings of
+1,200 and 120 seconds. The cumulative ledger starts at 1,363.884/1,800 seconds.
+Projected new storage is 288 MiB with approximately 307 MiB before the existing
+tighter stop. The 4 GiB sampled child-RSS target and one model process remain.
+Necessary storage increases are preauthorized; no material is deleted.
+
+## Executed result and decision
+
+**Keep this block as development code and artifacts. Retain parent `067adbf0`
+for the accepted bounded behavior.** The complete comparison executes from the
+corrected release binary. All three fits complete their configured passes;
+angular and equality each evaluate 2,304 proposals, fixed placement 1,440.
+Actual sampled fit positions are 1,890 from 24 documents. Angular accepts
+32 query-code, 25 key-code, 28 value-code and 198 action changes across the two
+channels. Its per-channel fit NLL changes from 4.756/4.740 to 4.465/4.402.
+Only the 24 most frequent context token codes are eligible for adjustment in
+this first fit; the vocabulary contains 611 token IDs.
+
+| Arm | Prose next-token correct | Rust next-token correct | Total | Target continuations |
+|---|---:|---:|---:|---:|
+| Unchanged parent | 6/435 | 39/300 | 45/735 | 0/8 |
+| Learned angular | 103/435 | 79/300 | 182/735 | 0/8 |
+| Learned exact-code selection | 127/435 | 96/300 | 223/735 | 0/8 |
+| Fixed placement, fitted actions/readout | 103/435 | 74/300 | 177/735 | 0/8 |
+| Angular, source selection disabled | 43/435 | 42/300 | 85/735 | 0/8 |
+| Angular, learned action disabled | 66/435 | 53/300 | 119/735 | 0/8 |
+
+Disabling the whole new block reproduces the parent's 45/735 result and eight
+generated byte sequences. The new representation/selection/action combination
+helps this token-prediction population; the learned angular placement increment
+over fixed placement is only five decisions. Exact-code selection performs
+better under the matched placement-search budget. No angular superiority,
+general semantic codebook or generation qualification follows. Prose contains
+383 byte-fallback tokens and only 48 lexical tokens; Rust contains 176 and 120,
+respectively, plus four EOS targets per family. These are substantially
+byte-level results on authored synthetic text.
+
+Both fitted selectors preserve only **38/62** previously correct responses.
+The old parent reproduces all **62/62 complete Generation objects**, including
+work and state, on the changed executable. On 28 earlier longer-context relation
+cases, both candidates retain all 28 exact write sequences and all 28 restored
+relation states. Angular returns 16/28 exact answers, equality 28/28. The
+angular failures include correct `Unknown` prefixes followed by unwanted text.
+This is output/termination regression despite correct retained facts.
+
+The actual CLI matches angular's probe output for the Rust continuation:
+` Unknown.\nss  (r (leftl a (r (l`. Disabling the existing response-entry
+head removes the forced prefix but yields ` a)rt: i32] n) )c ))l3e i32eo i32`,
+still incoherent. The parent under that same control produces
+`\n    let shifted =);\n}\n`. Inspection and the trace explain the prefix:
+the older entry head adds its positive margin above the base candidate's score.
+Separately, residual language scores disrupt the old stopping behavior. The
+block's per-channel conditional objective does not optimize either full-path
+competition or final decoded continuation.
+
+**Next within #1139:** train response dispatch and EOS together with the routed
+predictor against final output, including ordinary prose/Rust continuations and
+the preserved memory cases. Keep the selector comparison. Establish a useful
+continuation and preserved termination before increasing context, adding more
+channels or introducing another abstraction stage. The immediate problem is
+not missing cache capacity. #1139 stays open; #1140 remains subsequent. No
+larger language or frontier claim is admitted by this checkpoint.
+
+## Measured costs, artifacts and verification
+
+The angular artifact is `09f9991cf769e3008d78a487c5115502f06cbca681577a81278401714a8edc2b`
+(10,807,631 bytes, 79,348 bytes above parent). Equality is
+`c6d3739db83e60f4e0f5d1ed25e261fb205fbca784fbf2bdfc3981aaebea85ad`
+(10,803,043 bytes); fixed placement is
+`f7702f024ad505b2e1c08931907e94d49942aff4f17ec50d5e009087183e15e5`
+(10,812,953 bytes). Each has the same 8,052 bytes of u16 token/action/rank
+entries before container metadata. Angular adds 1,698 sparse emission scores
+and 1,268 postings; equality has 1,538/1,224, fixed placement 1,872/1,407.
+Prediction adds fixed inline decision/counter state and a 32-byte stack window;
+the focused allocation census measures zero heap allocations and zero bytes
+through repeated observation, selection and transformation.
+
+The 735 angular development positions examine 11,312 source keys, gather
+1,470 payloads and execute 1,470 actions. Residual scoring performs 284,066
+emission queries across 142,033 candidate evaluations, with 1,321,154 new
+comparisons and 7,756,832 logical operand bytes. The surrounding base still
+performs 3,364,474 feature-score lookups. Selected transport is a small part of
+this complete path; scoring candidates repeatedly remains substantial work.
+
+Single-pass next-token timing (encoding, observation and full prediction) is
+87.881 ms parent, 102.005 ms angular, 101.193 ms equality and 101.079 ms fixed
+placement. These are diagnostics, not repeated speed measurements. Parent file
+read/deserialization/validation is 2,497.554 ms; new in-memory artifact
+deserialization/validation is 2,830.333–2,845.592 ms. These startup boundaries
+differ by file reading and are stated separately. Fits take 531, 470 and
+471 ms. The full comparison, including three fitted artifacts and their reloads,
+takes 13.546 seconds under the monitor. Its peak sampled child RSS is
+834,306,048 bytes; this includes fitting and validation clones, not a minimal
+single-session serving footprint.
+
+Four focused learned-routing unit tests, the new allocation test and the
+integer-kernel source scan pass. They cover hard source choice, query action,
+code bounds, nested parent identity refusal, fitting-data overlap refusal,
+counter aggregation/saturation, disabled-parent preservation, artifact reload,
+retained tail and session checkpoint replay. The architecture-policy check
+passes. The changed release CLI and both examples compile and execute. New
+generated Rust is not compiled or executed as semantic evidence; it has already
+failed the target-continuation decision. Existing checked Rust evidence keeps
+its original scope.
+
+The [compact evidence](evidence/native_geometric_learned_routing_1139.json)
+binds the complete report, exact outputs and controls. Local receipts remain
+under `.uor-models/native-typed-value-2026-09-05/`: the initial failed
+`learned-routing-comparison/`, corrected `learned-routing-corrected-comparison/`,
+three `learned-routing-preserve-*` directories, two relation reports, three CLI
+logs and command ledgers. The correction preserves every learned parameter and
+configuration from the first angular fit, adding only parent provenance.
+
+Model work including the failed attempt and focused executions is
+**46.768/120 seconds** for this cycle. The cumulative ledger is
+**1,410.652/1,800 seconds**, leaving **389.348 seconds**. Engineering through
+the corrected build and architecture check is 862.744/1,200 seconds; final
+formatting/claim checks and delivery receipts are recorded separately. Storage
+after evaluation is 5,852,442,624 bytes against the unchanged 6,459,228,160 cap,
+with 251,379,712 bytes before the tighter existing stop. No storage increase,
+deletion, external model or paid compute was needed. Samples are not exact
+transient peaks or unique-extent measurements.


### PR DESCRIPTION
The native predictor used fixed lexical placement and lacked a learned selected-payload block. This adds an optional two-channel H4 residual: learned query/key/value codes select up to two recent payloads, execute query-conditioned table transports and contribute sparse token scores. Rust coordinate fitting runs the same hard selector and transport as serving. Existing artifacts retain their identities; the new block binds its exact parent and preserves nested provenance validation.

The result remains development only. On 735 authored OPEN prose/Rust next-token positions, parent scores 45 correct, learned angular 182, matched exact-code selection 223 and fixed placement 177. These are substantially byte-level synthetic results. All eight target continuations fail. Both fitted selectors preserve only 38/62 older exact responses; the unchanged parent reproduces all 62 complete generation records. Both preserve all 28 relation writes, with 16/28 angular and 28/28 exact-code answers. Retain accepted parent `067adbf0`; no angular superiority or capability promotion is claimed.

The observed successor is complete response dispatch and stopping trained with routed prediction against final output, including ordinary language and preserved memory behavior. The older entry head can force `Unknown`; bypassing it removes that prefix but does not yield coherent text. Independent residual scores also disrupt EOS. The roadmap and current-state pointer record that next step, keeping #1139 open and #1140 subsequent.

Validation: changed release CLI and both examples built offline; four focused routing/provenance/reload/session tests passed; the changed prediction path has zero measured heap allocations and passes the integer-kernel source scan. Architecture, formatting and claim-wording checks pass. The actual CLI matches the probe and exercises the entry-disabled comparison. New generated Rust did not meet its target and is not claimed as compiled/executed semantic evidence. An initial parent-binding reload failure is preserved and charged; the corrected comparison retains identical learned parameters.

Local resource use: 46.768 seconds model work this cycle, cumulative 1,410.652/1,800 seconds, leaving 389.348. The complete build/evaluation projection preceded execution. No extra storage allocation, deletion, external model or paid compute was needed. Full outputs, work counters, costs and artifact identities are linked from `docs/native_geometric_learned_routing_1139.md` and its compact evidence.

Refs #1139. This implements the first block; the full issue handoff remains unmet.
