### PR TITLE
Repair learned relation writes and record the NoWrite reuse regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ selection, with no whole-model speedup or broad language claim. The subsequent
 [dependent-source read](docs/native_geometric_dependent_source_1139.md) learns
 which exact relation to follow and copies its final value: 40/48 authored new
 answers versus 32/48 exact-code and 20/48 parent, preserving 62/62 earlier answers
-and 24/24 transfer. Eight revision-ingestion failures remain; the next change
-repairs the existing writer's owner binding and NoWrite on question text.
+and 24/24 transfer. The subsequent [writer repair](docs/native_geometric_writer_binding_1139.md)
+reaches 48/48 answers and exact writes, preserves those earlier results plus
+28 long-context cases and five persistent turns, and gets 28/28 reserved-name
+answers/writes after selection. Its new cue namespace loses effective NoWrite
+cache reuse, sharply increasing writer scoring work. The next step recompiles
+that existing admission metadata before expanding operator composition.
 
 ```sh
 cargo build --release --bin r4

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -25,6 +25,8 @@ mod relation_memory;
 mod role_read;
 #[path = "native_geometric_value_probe/wording.rs"]
 mod wording;
+#[path = "native_geometric_value_probe/writer_binding.rs"]
+mod writer_binding;
 const SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/1";
 const LEXEME_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/2";
 const WORD_COPY_SOURCE_SCHEMA: &str = "uor-r4.native-typed-value-source/3";
@@ -969,6 +971,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("writer-binding") {
+        return writer_binding::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("verify-relations") {
         return relation_memory::verify(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/writer_binding.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/writer_binding.rs
@@ -1,0 +1,319 @@
+//! Construction-only write labels and direct generated/state checks. No fixture
+//! parser or expected answers are linked into native inference.
+use super::*;
+use uor_r4_core::native_geometric::{DependentReadExample, RelationExample, RelationLabel};
+
+// The supplied dependent fixture declares simple leading assertions. This is
+// an offline label adapter, deliberately rejecting any other construction form.
+fn labeled(d: ValueExample) -> ProbeResult<RelationExample> {
+    let end = d
+        .prompt
+        .find("Question:")
+        .or_else(|| d.prompt.find("\nfn "))
+        .unwrap_or(d.prompt.len());
+    let mut writes = Vec::new();
+    let mut offset = 0;
+    for part in d.prompt[..end].split_inclusive('.') {
+        if !part.ends_with('.') {
+            break;
+        }
+        let words: Vec<_> = part
+            .trim_matches(|c: char| c.is_whitespace() || c == '/' || c == '.')
+            .split_whitespace()
+            .collect();
+        let (owner, value, action) = match words.as_slice() {
+            [o, "in", v] => (*o, *v, 1),
+            ["Now" | "now", o, "in", v] | [o, "now", "in", v] => (*o, *v, 2),
+            [o, "not", "in", v] => (*o, *v, 3),
+            _ => return Err(format!("undeclared construction statement: {part}").into()),
+        };
+        let oi = part.find(owner).ok_or("owner label absent")?;
+        let vi = part.rfind(value).ok_or("value label absent")?;
+        writes.push(RelationLabel {
+            owner_end_byte: (offset + oi + owner.len() - 1) as u64,
+            value_end_byte: (offset + vi + value.len() - 1) as u64,
+            action,
+        });
+        offset += part.len();
+    }
+    Ok(RelationExample {
+        id: d.id,
+        prompt: d.prompt,
+        response: d.response,
+        writes,
+    })
+}
+fn variant(d: &RelationExample) -> ProbeResult<RelationExample> {
+    let mut next = ValueExample {
+        id: format!("{}/owner-now", d.id),
+        prompt: d.prompt.clone(),
+        response: d.response.clone(),
+    };
+    let at = next.prompt.find("Now ").ok_or("revision cue absent")?;
+    let owner = next.prompt[at + 4..]
+        .split_whitespace()
+        .next()
+        .ok_or("owner absent")?
+        .to_string();
+    next.prompt = next
+        .prompt
+        .replacen(&format!("Now {owner} in"), &format!("{owner} now in"), 1);
+    labeled(next)
+}
+fn evaluate(model: &Model, docs: &[RelationExample]) -> ProbeResult<Value> {
+    let start = Instant::now();
+    let mut rows = Vec::new();
+    for d in docs {
+        let generation = model.generate(&d.prompt, 32, Control::Full)?;
+        let mut session = model.session(Control::Full)?;
+        session.observe(model, 0)?;
+        for t in model.encode(&d.prompt)? {
+            session.observe(model, t)?;
+        }
+        session.begin_response(model)?;
+        let wire: Value = serde_json::from_slice(&session.checkpoint()?)?;
+        let records = wire["values"]["relations"]["records"]
+            .as_array()
+            .ok_or("relation state absent")?;
+        let written: Vec<_> = records
+            .iter()
+            .filter(|r| r["id"].as_u64().unwrap_or(0) > 0)
+            .collect();
+        let writes_exact = written.len() == d.writes.len()
+            && d.writes.iter().all(|l| {
+                written.iter().any(|r| {
+                    r["owner"]["byte_end"] == l.owner_end_byte
+                        && r["value"]["byte_end"] == l.value_end_byte
+                        && r["action"] == l.action
+                })
+            });
+        rows.push(json!({"id":d.id,"prompt":d.prompt,"expected":d.response,"exact":generation.text==d.response,"writes_exact":writes_exact,"expected_writes":d.writes,"relations":wire["values"]["relations"],"generation":generation}));
+    }
+    Ok(
+        json!({"artifact":model.artifact_cid(),"exact":rows.iter().filter(|r|r["exact"]==true).count(),"writes_exact":rows.iter().filter(|r|r["writes_exact"]==true).count(),"total":rows.len(),"elapsed_ms":start.elapsed().as_millis(),"cases":rows}),
+    )
+}
+fn responses(model: &Model, docs: &[ValueExample]) -> ProbeResult<Value> {
+    let mut rows = Vec::new();
+    for d in docs {
+        let generation = model.generate(&d.prompt, 32, Control::Full)?;
+        rows.push(json!({"id":d.id,"exact":generation.text==d.response,"expected":d.response,"generation":generation}));
+    }
+    Ok(
+        json!({"artifact":model.artifact_cid(),"exact":rows.iter().filter(|r|r["exact"]==true).count(),"total":rows.len(),"cases":rows}),
+    )
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    let mode = args
+        .first()
+        .map(String::as_str)
+        .ok_or("writer-binding mode absent")?;
+    if mode == "continue-source" {
+        if args.len() != 3 {
+            return Err("writer-binding continue-source SOURCE NEW_SOURCE".into());
+        }
+        let mut source: Value = serde_json::from_slice(&fs::read(&args[1])?)?;
+        let fit: Vec<RelationExample> = serde_json::from_value(source["fit"].clone())?;
+        let mut next = fit.clone();
+        // Generated bytes are excluded from the writer's observed-word stream.
+        // The previous question therefore directly precedes the next assertion.
+        for (i, d) in fit.iter().take(28).enumerate() {
+            let prefix = if i % 2 == 0 {
+                "Where is cyra? Answer: "
+            } else {
+                "Question: Where is the location of crate? Answer: "
+            };
+            let mut d = d.clone();
+            d.id = format!("{}/after-question", d.id);
+            d.prompt = format!("{prefix}{}", d.prompt);
+            for w in &mut d.writes {
+                w.owner_end_byte += prefix.len() as u64;
+                w.value_end_byte += prefix.len() as u64;
+            }
+            next.push(d);
+        }
+        source["fit"] = serde_json::to_value(next)?;
+        source["opened_fresh"] = source["fresh"].clone();
+        let mut fresh: Vec<RelationExample> = serde_json::from_value(source["fresh"].clone())?;
+        let previous = serde_json::to_string(&source)?;
+        for (old, new) in [
+            ("valdrin", "vornel"),
+            ("wenrik", "ibren"),
+            ("Tersul", "Ordel"),
+            ("Poldex", "Quendal"),
+            ("zorvek", "azveth"),
+            ("ulveth", "dornek"),
+            ("Nerdux", "Velmur"),
+            ("Felsar", "Jorvax"),
+        ] {
+            if previous.contains(new) {
+                return Err(format!("new reserve overlaps supplied source: {new}").into());
+            }
+            for d in &mut fresh {
+                d.prompt = d.prompt.replace(old, new);
+                d.response = d.response.replace(old, new);
+            }
+        }
+        for d in &mut fresh {
+            d.id = d.id.replace("fresh", "reserved");
+        }
+        // Renamed byte lengths differ; regenerate only the offline source labels.
+        source["fresh"] = serde_json::to_value(
+            fresh
+                .into_iter()
+                .map(|d| {
+                    labeled(ValueExample {
+                        id: d.id,
+                        prompt: d.prompt,
+                        response: d.response,
+                    })
+                })
+                .collect::<ProbeResult<Vec<_>>>()?,
+        )?;
+        source["fresh_scope"] = json!("Replacement reserve after accidental opening of prior fresh set; familiar constructions, disjoint supplied vocabulary. Do not evaluate before final design selection.");
+        write_json(Path::new(&args[2]), &source)?;
+        println!("{}", json!({"fit":200,"new_reserved":28,"opened_fresh":28}));
+        return Ok(());
+    }
+    if mode == "prepare" {
+        if args.len() != 4 {
+            return Err("writer-binding prepare RELATION_SOURCE DEPENDENT_SOURCE OUTPUT".into());
+        }
+        let old: Value = serde_json::from_slice(&fs::read(&args[1])?)?;
+        let dep: Value = serde_json::from_slice(&fs::read(&args[2])?)?;
+        let mut fit: Vec<RelationExample> = serde_json::from_value(old["fit"].clone())?;
+        let prior_fit: Vec<DependentReadExample> = serde_json::from_value(dep["fit"].clone())?;
+        for d in prior_fit
+            .into_iter()
+            .filter(|d| d.example.id.starts_with("dependent/fit/"))
+        {
+            fit.push(labeled(d.example)?);
+        }
+        let variants: Vec<_> = fit
+            .iter()
+            .filter(|d| d.prompt.contains("Now "))
+            .map(variant)
+            .collect::<ProbeResult<_>>()?;
+        fit.extend(variants);
+        for (i, prompt) in [
+            "Question: Where is the location of crate? Answer:",
+            "Question: Where is ada? Answer:",
+            "Question: Which city is ada in? Answer:",
+            "Question: What city holds ada? Answer:",
+        ]
+        .iter()
+        .enumerate()
+        {
+            fit.push(RelationExample {
+                id: format!("writer/question/{i}"),
+                prompt: prompt.to_string(),
+                response: " Unknown.\n".into(),
+                writes: vec![],
+            });
+        }
+        let cases: Vec<DependentReadExample> = serde_json::from_value(dep["development"].clone())?;
+        let development: Vec<_> = cases
+            .into_iter()
+            .map(|d| labeled(d.example))
+            .collect::<ProbeResult<_>>()?;
+        let mut fresh = Vec::new();
+        let prior_text = serde_json::to_string(&old)? + &serde_json::to_string(&dep)?;
+        for (old, new) in [
+            ("casket", "valdrin"),
+            ("elvin", "wenrik"),
+            ("Bremen", "Tersul"),
+            ("Zurich", "Poldex"),
+            ("basket", "zorvek"),
+            ("freya", "ulveth"),
+            ("Turin", "Nerdux"),
+            ("Lagos", "Felsar"),
+        ] {
+            if prior_text.contains(new) {
+                return Err(format!("fresh name overlap: {new}").into());
+            }
+            let _ = old;
+        }
+        for d in development.iter().take(24) {
+            let mut p = d.prompt.clone();
+            let mut response = d.response.clone();
+            for (old, new) in [
+                ("casket", "valdrin"),
+                ("elvin", "wenrik"),
+                ("Bremen", "Tersul"),
+                ("Zurich", "Poldex"),
+                ("basket", "zorvek"),
+                ("freya", "ulveth"),
+                ("Turin", "Nerdux"),
+                ("Lagos", "Felsar"),
+            ] {
+                p = p.replace(old, new);
+                response = response.replace(old, new);
+            }
+            let d = labeled(ValueExample {
+                id: d.id.replace("development", "fresh"),
+                prompt: p,
+                response,
+            })?;
+            if d.prompt.contains("Now ") {
+                fresh.push(variant(&d)?);
+            }
+            fresh.push(d);
+        }
+        write_json(
+            Path::new(&args[3]),
+            &json!({"fit":fit,"development":development,"fresh":fresh,"preservation":dep["preservation"],"prior":dep["prior"],"acceptance":"Repair all8 OPEN revision failures while preserving40correct dependent,62prior,24transfer,28long-context exact answers/writes and5sessionturns. Require exact writes, not answers alone. Fresh28 familiar forms with names absent from supplied sources, run only after design selection; no general-language qualification."}),
+        )?;
+        println!(
+            "{}",
+            json!({"fit":fit.len(),"development":development.len(),"fresh":fresh.len()})
+        );
+        return Ok(());
+    }
+    if mode == "fit" {
+        if args.len() != 5 {
+            return Err("writer-binding fit MODEL SOURCE NEW_MODEL REPORT".into());
+        }
+        let model = Model::from_bytes(&fs::read(&args[1])?)?;
+        let source: Value = serde_json::from_slice(&fs::read(&args[2])?)?;
+        let docs: Vec<RelationExample> = serde_json::from_value(source["fit"].clone())?;
+        let (next, report) = model.refit_relation_writer(&docs, 64)?;
+        write_new(Path::new(&args[3]), &next.to_bytes()?)?;
+        write_json(Path::new(&args[4]), &report)?;
+        println!("{report}");
+        return Ok(());
+    }
+    if mode == "evaluate" || mode == "fresh" {
+        if args.len() != 4 {
+            return Err("writer-binding evaluate|fresh MODEL SOURCE NEW_OUTPUT_DIR".into());
+        }
+        let model = Model::from_bytes(&fs::read(&args[1])?)?;
+        let source: Value = serde_json::from_slice(&fs::read(&args[2])?)?;
+        let out = Path::new(&args[3]);
+        fs::create_dir(out)?;
+        let split = if mode == "fresh" {
+            "fresh"
+        } else {
+            "development"
+        };
+        let docs: Vec<RelationExample> = serde_json::from_value(source[split].clone())?;
+        let result = evaluate(&model, &docs)?;
+        write_json(&out.join(format!("{split}.json")), &result)?;
+        println!(
+            "{}",
+            json!({"split":split,"exact":result["exact"],"writes_exact":result["writes_exact"],"total":result["total"]})
+        );
+        if mode == "evaluate" {
+            for label in ["preservation", "prior"] {
+                let docs: Vec<ValueExample> = serde_json::from_value(source[label].clone())?;
+                let r = responses(&model, &docs)?;
+                write_json(&out.join(format!("{label}.json")), &r)?;
+                println!(
+                    "{}",
+                    json!({"split":label,"exact":r["exact"],"total":r["total"]})
+                );
+            }
+        }
+        return Ok(());
+    }
+    Err("unknown writer-binding mode".into())
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -310,6 +310,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    relation_writer: Option<relation_training::WriterRevision>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     dependent_read: Option<dependent_read::DependentRead>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source_routing: Option<source_routing::SourceRouting>,
@@ -342,6 +344,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    relation_writer: Option<relation_training::WriterRevision>,
+    #[serde(default)]
     dependent_read: Option<dependent_read::DependentRead>,
     #[serde(default)]
     source_routing: Option<source_routing::SourceRouting>,
@@ -373,6 +377,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            relation_writer: wire.relation_writer,
             dependent_read: wire.dependent_read,
             source_routing: wire.source_routing,
             learned_routing: wire.learned_routing,

--- a/crates/uor-r4-core/src/native_geometric/relation.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation.rs
@@ -147,13 +147,33 @@ pub(super) fn source_version(values: &ValueState, index: u8) -> Option<u64> {
 
 // NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
 pub(super) fn addresses(model: &Model, words: &[WordAtom], work: &mut ValueWork) -> [u32; 16] {
-    let mut out = [0; 16];
     let Some(read) = super::role_read::head(model) else {
-        return out;
+        return [0; 16];
     };
+    dictionary_addresses(&read.dictionary, words, work)
+}
+
+pub(super) fn writer_addresses(
+    model: &Model,
+    words: &[WordAtom],
+    work: &mut ValueWork,
+) -> [u32; 16] {
+    if let Some(writer) = &model.relation_writer {
+        dictionary_addresses(&writer.dictionary, words, work)
+    } else {
+        addresses(model, words, work)
+    }
+}
+
+fn dictionary_addresses(
+    dictionary: &[super::word_copy_types::WordCopyAddress],
+    words: &[WordAtom],
+    work: &mut ValueWork,
+) -> [u32; 16] {
+    let mut out = [0; 16];
     for (i, w) in words.iter().take(16).enumerate() {
         work.relations.record_reads = work.relations.record_reads.saturating_add(1);
-        let found = read.dictionary.binary_search_by(|d| {
+        let found = dictionary.binary_search_by(|d| {
             work.relations.dictionary_comparisons =
                 work.relations.dictionary_comparisons.saturating_add(1);
             for j in 0..usize::from(w.len.min(d.len)) {
@@ -166,7 +186,7 @@ pub(super) fn addresses(model: &Model, words: &[WordAtom], work: &mut ValueWork)
             }
             d.len.cmp(&w.len)
         });
-        out[i] = found.map_or(0, |j| read.dictionary[j].prime);
+        out[i] = found.map_or(0, |j| dictionary[j].prime);
     }
     out
 }
@@ -179,9 +199,15 @@ pub(super) fn write_features(
     value: usize,
     work: &mut ValueWork,
 ) -> ([ValueFeature; RELATION_FEATURES], usize) {
-    let context = head(model)
-        .filter(|h| h.schema == "uor-r4.exact-relation/2")
-        .map(|h| h.role_context.as_slice());
+    let context = model
+        .relation_writer
+        .as_ref()
+        .map(|w| w.role_context.as_slice())
+        .or_else(|| {
+            head(model)
+                .filter(|h| h.schema == "uor-r4.exact-relation/2")
+                .map(|h| h.role_context.as_slice())
+        });
     write_features_with_context(model, words, addr, owner, value, context, work)
 }
 
@@ -323,10 +349,14 @@ pub(super) fn write_choice(
 ) -> Option<(usize, usize, u8)> {
     let h = head(model)?;
     let words = &words[..words.len().min(8)];
-    let addr = addresses(model, words, work);
-    if h.admission
+    let addr = writer_addresses(model, words, work);
+    if model
+        .relation_writer
         .as_ref()
-        .is_some_and(|gate| super::relation_admission::skip(model, gate, words.len(), &addr, work))
+        .is_none_or(|w| w.reuse_admission)
+        && h.admission.as_ref().is_some_and(|gate| {
+            super::relation_admission::skip(model, gate, words.len(), &addr, work)
+        })
     {
         return None;
     }
@@ -349,7 +379,11 @@ pub(super) fn write_choice_from_addresses(
             }
             let (f, n) = write_features(model, words, addr, owner, value, work);
             for action in 1..=3 {
-                let s = score(&h.writer, &f[..n], action, work);
+                let rows = model
+                    .relation_writer
+                    .as_ref()
+                    .map_or(h.writer.as_slice(), |w| w.rows.as_slice());
+                let s = score(rows, &f[..n], action, work);
                 work.relations.candidates = work.relations.candidates.saturating_add(1);
                 if s > best_score {
                     best_score = s;

--- a/crates/uor-r4-core/src/native_geometric/relation_admission.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_admission.rs
@@ -203,6 +203,20 @@ fn admission_mut(model: &mut Model) -> Result<&mut Option<Admission>> {
 }
 
 impl Admission {
+    pub(super) fn compatible_writer(&self, model: &Model) -> bool {
+        self.entries.iter().all(|e| {
+            let mut addr = [0; 16];
+            addr[..8].copy_from_slice(&e.exact.primes);
+            write_choice_from_addresses(
+                model,
+                &[WordAtom::default(); 8][..usize::from(e.exact.len)],
+                &addr,
+                &mut ValueWork::default(),
+            )
+            .is_none()
+        })
+    }
+
     pub(super) fn validate(&self, model: &Model) -> Result<()> {
         if self.schema != "uor-r4.relation-admission/1"
             || self.entries.is_empty()

--- a/crates/uor-r4-core/src/native_geometric/relation_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_tests.rs
@@ -218,3 +218,50 @@ fn native_relation_role_path_keeps_context_order_and_direction() {
     );
     assert_eq!(root(&back[..k]), usize::from(g.inverses[root(&f[..n])]));
 }
+
+#[test]
+fn native_writer_cue_identity_is_exact_and_does_not_change_reader_addresses() {
+    use super::relation_training::WriterRevision;
+    use super::word_copy_types::WordCopyAddress;
+    let docs = [Document {
+        id: "writer-cue".into(),
+        text: "Now Question now".into(),
+    }];
+    let mut trainer = Trainer::new(Config::default(), &docs).unwrap();
+    trainer.train_documents(&docs).unwrap();
+    let mut model = trainer.compile().unwrap();
+    let word = |text: &str, prime| {
+        let mut bytes = [0; 32];
+        bytes[..text.len()].copy_from_slice(text.as_bytes());
+        WordCopyAddress {
+            bytes,
+            len: text.len() as u8,
+            prime,
+        }
+    };
+    model.relation_writer = Some(WriterRevision {
+        schema: "uor-r4.relation-writer/1".into(),
+        parent: String::new(),
+        dictionary: vec![word("Now", 2), word("Question", 3), word("now", 5)],
+        role_context: vec![],
+        rows: vec![],
+        training: vec![],
+        epochs: 1,
+        reuse_admission: false,
+    });
+    let words = [
+        atom("Now", 0),
+        atom("Question", 8),
+        atom("newname", 16),
+        atom("now", 24),
+    ];
+    let mut work = ValueWork::default();
+    assert_eq!(
+        &writer_addresses(&model, &words, &mut work)[..4],
+        &[2, 3, 0, 5]
+    );
+    assert_eq!(&addresses(&model, &words, &mut work)[..4], &[0, 0, 0, 0]);
+    assert!(work.relations.dictionary_byte_comparisons > 0);
+    // Exact word payloads, including unknown names and case, remain untouched.
+    assert_eq!(words[2], atom("newname", 16));
+}

--- a/crates/uor-r4-core/src/native_geometric/relation_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_training.rs
@@ -115,7 +115,7 @@ fn writer_frame(
 ) -> Result<Frame> {
     let words = &words.recent[..words.recent_len.min(8)];
     let mut work = ValueWork::default();
-    let addr = addresses(model, words, &mut work);
+    let addr = writer_addresses(model, words, &mut work);
     let mut alternatives = vec![Alternative {
         keys: Vec::new(),
         correct: label.is_none(),
@@ -212,8 +212,15 @@ impl RelationModel {
 fn compile_role_context(model: &Model) -> Result<Vec<TokenGeometry>> {
     let role = super::role_read::head(model)
         .ok_or_else(|| Error("relation role parent missing".into()))?;
-    let mut rows = Vec::with_capacity(role.dictionary.len());
-    for word in &role.dictionary {
+    compile_context(model, &role.dictionary)
+}
+
+fn compile_context(
+    model: &Model,
+    dictionary: &[super::word_copy_types::WordCopyAddress],
+) -> Result<Vec<TokenGeometry>> {
+    let mut rows = Vec::with_capacity(dictionary.len());
+    for word in dictionary {
         let text = std::str::from_utf8(&word.bytes[..usize::from(word.len)])
             .map_err(|e| Error(e.to_string()))?;
         let mut row = TokenGeometry {
@@ -244,7 +251,7 @@ impl Model {
         documents: &[RelationExample],
         epochs: usize,
     ) -> Result<(Model, serde_json::Value)> {
-        self.fit_relations_mode(documents, epochs, false)
+        self.fit_relations_mode(documents, epochs, false, false)
     }
 
     /// Learn participant-independent role context while preserving exact values.
@@ -253,7 +260,16 @@ impl Model {
         documents: &[RelationExample],
         epochs: usize,
     ) -> Result<(Model, serde_json::Value)> {
-        self.fit_relations_mode(documents, epochs, true)
+        self.fit_relations_mode(documents, epochs, true, false)
+    }
+
+    /// Replace only the writer; all reader/operator parameters remain frozen.
+    pub fn refit_relation_writer(
+        &self,
+        documents: &[RelationExample],
+        epochs: usize,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.fit_relations_mode(documents, epochs, true, true)
     }
 
     fn fit_relations_mode(
@@ -261,9 +277,12 @@ impl Model {
         documents: &[RelationExample],
         epochs: usize,
         role_paths: bool,
+        writer_only: bool,
     ) -> Result<(Model, serde_json::Value)> {
         self.validate()?;
-        if head(self).is_some()
+        if self.relation_writer.is_some()
+            || (writer_only && head(self).is_none_or(|h| h.schema != "uor-r4.exact-relation/2"))
+            || (!writer_only && head(self).is_some())
             || super::role_read::head(self).is_none()
             || documents.is_empty()
             || documents.len() > 256
@@ -276,7 +295,24 @@ impl Model {
         {
             return Err(Error("invalid relation fitting source/config".into()));
         }
-        let role_context = if role_paths {
+        let mut template = self.clone();
+        if writer_only {
+            let dictionary = writer_dictionary(self, documents)?;
+            let role_context = compile_context(self, &dictionary)?;
+            template.relation_writer = Some(WriterRevision {
+                schema: "uor-r4.relation-writer/1".into(),
+                parent: self.artifact_cid.clone(),
+                dictionary,
+                role_context,
+                rows: Vec::new(),
+                training: Vec::new(),
+                epochs,
+                reuse_admission: false,
+            });
+        }
+        let role_context = if let Some(writer) = &template.relation_writer {
+            writer.role_context.clone()
+        } else if role_paths {
             compile_role_context(self)?
         } else {
             Vec::new()
@@ -356,7 +392,7 @@ impl Model {
                         return Err(Error("multiple labels at one relation boundary".into()));
                     }
                     let label = labels.first().map(|(_, l)| *l);
-                    frames.insert(writer_frame(self, &words, label, context)?);
+                    frames.insert(writer_frame(&template, &words, label, context)?);
                     if let Some((i, l)) = labels.first() {
                         consumed.insert(*i);
                         let o = words
@@ -391,6 +427,30 @@ impl Model {
             return Err(Error("relation frame bound exceeded".into()));
         }
         let (writer, write_correct) = fit(&frames, epochs)?;
+        if writer_only {
+            let writer_head = template
+                .relation_writer
+                .as_mut()
+                .ok_or_else(|| Error("writer absent".into()))?;
+            writer_head.rows = writer;
+            writer_head.training = receipts;
+            let reuse = head(&template)
+                .and_then(|h| h.admission.as_ref())
+                .is_some_and(|g| g.compatible_writer(&template));
+            template
+                .relation_writer
+                .as_mut()
+                .ok_or_else(|| Error("writer absent".into()))?
+                .reuse_admission = reuse;
+            template.refresh_identity()?;
+            template.validate()?;
+            let h = template
+                .relation_writer
+                .as_ref()
+                .ok_or_else(|| Error("writer absent".into()))?;
+            let report = serde_json::json!({"schema":"uor-r4.writer-refit/1", "parent":self.artifact_cid(), "artifact":template.artifact_cid(), "documents":documents.len(), "writer_frames":frames.len(), "writer_correct":write_correct, "writer_rows":h.rows.len(), "dictionary":h.dictionary.len(), "epochs":epochs, "reuse_admission":reuse, "reader_parameters_unchanged":self.dependent_read==template.dependent_read && self.source_routing==template.source_routing && self.response_entry==template.response_entry});
+            return Ok((template, report));
+        }
         let mut reads = Vec::new();
         for (values, d) in &examples {
             let words = values
@@ -481,5 +541,136 @@ impl Model {
         report["operator_schema"] = serde_json::json!(h.schema);
         report["role_context_rows"] = serde_json::json!(h.role_context.len());
         Ok((model, report))
+    }
+}
+
+/// A replacement writer, with the complete previous model retained for lineage.
+/// Serving executes only this writer's rows, never both writer scorers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WriterRevision {
+    pub schema: String,
+    pub parent: String,
+    pub dictionary: Vec<super::word_copy_types::WordCopyAddress>,
+    pub role_context: Vec<TokenGeometry>,
+    pub rows: Vec<ValueRow>,
+    pub training: Vec<DocumentReceipt>,
+    pub epochs: usize,
+    pub reuse_admission: bool,
+}
+
+fn writer_dictionary(
+    _model: &Model,
+    documents: &[RelationExample],
+) -> Result<Vec<super::word_copy_types::WordCopyAddress>> {
+    let examples: Vec<_> = documents
+        .iter()
+        .map(|d| ValueExample {
+            id: d.id.clone(),
+            prompt: d.prompt.clone(),
+            response: d.response.clone(),
+        })
+        .collect();
+    let (words, omitted, _) = super::word_copy_training::dictionary(&examples)?;
+    if omitted != 0 {
+        return Err(Error(
+            "writer cue dictionary would omit construction words".into(),
+        ));
+    }
+    // Supervised payload identities must not become new contextual cues.
+    // They remain exact bytes in the relation records, including unseen names.
+    let mut payloads = BTreeSet::new();
+    for d in documents {
+        for label in &d.writes {
+            for end in [label.owner_end_byte, label.value_end_byte] {
+                let end = usize::try_from(end).map_err(|e| Error(e.to_string()))?;
+                let prefix = d
+                    .prompt
+                    .as_bytes()
+                    .get(..=end)
+                    .ok_or_else(|| Error("writer label outside prompt".into()))?;
+                let start = prefix
+                    .iter()
+                    .rposition(|b| !b.is_ascii_alphanumeric() && *b != b'_')
+                    .map_or(0, |i| i + 1);
+                payloads.insert(prefix[start..].to_vec());
+            }
+        }
+    }
+    // This vocabulary belongs to the writer. Inherited reader names must not
+    // acquire a different write role merely because they were seen elsewhere.
+    let mut dictionary = Vec::new();
+    let primes = crate::corpus_induced_spin_placement::first_primes(256)
+        .map_err(|e| Error(e.to_string()))?;
+    for mut word in words {
+        if payloads.contains(&word.bytes[..usize::from(word.len)]) {
+            continue;
+        }
+        if dictionary.len() >= 256 {
+            return Err(Error("writer cue dictionary bound exceeded".into()));
+        }
+        word.prime = primes[dictionary.len()] as u32;
+        dictionary.push(word);
+    }
+    dictionary.sort_by(|a, b| a.bytes[..usize::from(a.len)].cmp(&b.bytes[..usize::from(b.len)]));
+    Ok(dictionary)
+}
+
+impl WriterRevision {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        let valid_word = |d: &super::word_copy_types::WordCopyAddress| {
+            d.len > 0
+                && d.len <= 32
+                && d.bytes[..usize::from(d.len)]
+                    .iter()
+                    .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
+                && d.bytes[usize::from(d.len)..].iter().all(|b| *b == 0)
+        };
+        if self.schema != "uor-r4.relation-writer/1"
+            || !(1..=64).contains(&self.epochs)
+            || self.dictionary.is_empty()
+            || self.dictionary.len() > 256
+            || self.dictionary.iter().any(|d| !valid_word(d))
+            || !self
+                .dictionary
+                .windows(2)
+                .all(|p| p[0].bytes[..usize::from(p[0].len)] < p[1].bytes[..usize::from(p[1].len)])
+            || self.rows.is_empty()
+            || self.rows.len() > RELATION_ROWS
+            || !self.rows.windows(2).all(|p| p[0].feature < p[1].feature)
+            || self.rows.iter().any(|r| {
+                !(-1000000..=1000000).contains(&r.weight)
+                    || (r.feature.kind & 31) >= 20
+                    || !(1..=3).contains(&(r.feature.kind >> 5))
+            })
+            || self.training.is_empty()
+            || self.training.len() > 256
+            || self.training.iter().any(|d| d.id.is_empty())
+            || self
+                .training
+                .iter()
+                .map(|d| &d.id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                != self.training.len()
+        {
+            return Err(Error("invalid writer revision bounds or rows".into()));
+        }
+        let mut assigned: Vec<_> = self.dictionary.iter().map(|d| u64::from(d.prime)).collect();
+        assigned.sort_unstable();
+        if assigned
+            != crate::corpus_induced_spin_placement::first_primes(self.dictionary.len())
+                .map_err(|e| Error(e.to_string()))?
+            || self.role_context != compile_context(model, &self.dictionary)?
+            || (self.reuse_admission
+                && head(model)
+                    .and_then(|h| h.admission.as_ref())
+                    .is_none_or(|g| !g.compatible_writer(model)))
+        {
+            return Err(Error(
+                "writer cue geometry or NoWrite compatibility differs".into(),
+            ));
+        }
+        Ok(())
     }
 }

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -174,6 +174,7 @@ impl Trainer {
         let (lexical_pieces, receipts) = build_codec(&config, construction)?;
         let token_count = LEXICAL_BASE as usize + lexical_pieces.len();
         let mut template = Model {
+            relation_writer: None,
             dependent_read: None,
             source_routing: None,
             learned_routing: None,
@@ -509,6 +510,24 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(writer) = &self.relation_writer {
+            let mut parent = self.clone();
+            parent.relation_writer = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != writer.parent {
+                return Err(Error("writer revision parent differs".into()));
+            }
+            parent.validate()?;
+            writer.validate(self)?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("writer revision identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(block) = &self.dependent_read {
             let mut parent = self.clone();
             parent.dependent_read = None;

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,6 +1,24 @@
 # Research: what is measured, what is closed, what is open
 
-## Dependent source result — current checkpoint, 2026-09-06
+## Writer binding — current checkpoint, 2026-09-06
+
+The [writer repair](native_geometric_writer_binding_1139.md) retains `8dbf1367`
+as a functional development artifact, preserving `8070c006` as the reader/cost
+comparator. It gets 48/48 dependent answers and exact writes, preserves 62/62
+earlier answers, 24/24 transfer, 28/28 long-context answers/writes and 5/5
+persistent turns, and passes 28/28 replacement reserved-name cases after design
+selection. The writer learns sparse integer weights over 23 construction cues
+and existing signed-H4/zeta context, while exact payloads and reader parameters
+remain unchanged. The broader owner-of-box question still returns Unknown.
+
+This is not an efficiency promotion: old NoWrite signatures no longer hit the
+new cue namespace. Long-context writer row comparisons rise from 580,944 to
+226,101,330. Recompile existing bounded exact admission metadata for the new
+writer before expanding composition. Earlier failures and the accidentally
+opened first reserve remain explicitly OPEN evidence. The record and
+[current state](integration/current-state.md) preserve full limits and costs.
+
+## Dependent source result — previous checkpoint, 2026-09-06
 
 The [native dependent-source read](native_geometric_dependent_source_1139.md)
 connects a learned H4 first-source/operator choice to one exact dependent owner
@@ -15,7 +33,7 @@ turns; its actual dependent copy path measures zero allocations.
 This is authored OPEN evidence, not general composition or frontier
 qualification. The eight remaining development failures expose revision-owner
 binding in the unchanged writer; spurious writes from question text are also
-observed. Repair that writer while preserving this reader. Full artifacts,
+observed. That writer repair is now recorded above. Full artifacts,
 controls, checks and resource limits are in the record and
 [current state](integration/current-state.md).
 

--- a/docs/evidence/native_geometric_writer_binding_1139.json
+++ b/docs/evidence/native_geometric_writer_binding_1139.json
@@ -1,0 +1,797 @@
+{
+  "schema": "uor-r4.writer-binding-evidence/1",
+  "at": "2026-09-06T17:09:05.667Z",
+  "base": "fae76313dac3dd3c173a30426a3e44fbcbc1ae66",
+  "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "decision": "RETAIN_FUNCTIONAL_WRITER_REPAIR_NOWRITE_REUSE_BEFORE_COMPOSITION",
+  "artifact": "blake3:8dbf136752b6b5f2e52a528dfff300a703503cd5d49fd78b4e66910c16efcc84",
+  "artifact_path": "writer-binding-continuation-model.json",
+  "artifact_bytes": 11045747,
+  "writer_json_bytes": 159892,
+  "fit": {
+    "artifact": "blake3:8dbf136752b6b5f2e52a528dfff300a703503cd5d49fd78b4e66910c16efcc84",
+    "dictionary": 23,
+    "documents": 200,
+    "epochs": 64,
+    "parent": "blake3:8070c006cf924e4a55007b6c1114ecad99ef6d1f3be2f0d08fc5f137ff89b2c1",
+    "reader_parameters_unchanged": true,
+    "reuse_admission": true,
+    "schema": "uor-r4.writer-refit/1",
+    "writer_correct": 128,
+    "writer_frames": 128,
+    "writer_rows": 2505
+  },
+  "source": {
+    "path": "writer-binding-continuation-source.json",
+    "sha256": "f63bb2cb0a0173461679272fc38c4817ecb86cb2536ed1c40e8cacbacd4e7de7"
+  },
+  "selection": {
+    "at": "2026-09-06T17:00:54.735Z",
+    "artifact": "blake3:8dbf136752b6b5f2e52a528dfff300a703503cd5d49fd78b4e66910c16efcc84",
+    "decision": "SELECT_BEFORE_REPLACEMENT_RESERVED_NAMES",
+    "development": "48/48 answers and exact writes",
+    "preservation": [
+      62,
+      24,
+      28,
+      5
+    ],
+    "fresh": "NOT_RUN",
+    "source": "writer-binding-continuation-source.json",
+    "no_parameter_changes_after_fresh": true
+  },
+  "first_use_boundary": {
+    "at": "2026-09-06T16:50:58.271Z",
+    "status": "OPEN_NOT_POST_SELECTION",
+    "reason": "Session preservation check found4/5; the shell continued to fresh evaluation after the Node selection guard failed. No selection receipt was written. This set is now OPEN and is not a post-selection result."
+  },
+  "results": [
+    {
+      "path": "writer-binding-continuation-development/development.json",
+      "exact": 48,
+      "writes_exact": 48,
+      "total": 48
+    },
+    {
+      "path": "writer-binding-continuation-development/preservation.json",
+      "exact": 62,
+      "total": 62
+    },
+    {
+      "path": "writer-binding-continuation-development/prior.json",
+      "exact": 24,
+      "total": 24
+    },
+    {
+      "path": "writer-binding-continuation-long.json",
+      "exact": 28,
+      "writes_exact": 28,
+      "total": 28
+    },
+    {
+      "path": "writer-binding-reserved/fresh.json",
+      "exact": 28,
+      "writes_exact": 28,
+      "total": 28
+    }
+  ],
+  "sessions": {
+    "path": "writer-binding-continuation-session.json",
+    "exact": 5,
+    "total": 5,
+    "restore_and_isolation": true
+  },
+  "cli": {
+    "path": "writer-binding-cli.stdout.log",
+    "text": " Zurich.\n"
+  },
+  "broader_language": {
+    "path": "writer-binding-language-boundary.stdout.log",
+    "text": " Unknown.\n"
+  },
+  "rust": {
+    "at": "2026-09-06T17:05:52.171Z",
+    "artifact": "blake3:8dbf136752b6b5f2e52a528dfff300a703503cd5d49fd78b4e66910c16efcc84",
+    "unchanged_generated_functions": 4,
+    "source": "dependent-read-generated.rs",
+    "check": "Every full prompt plus generated response is present unchanged in the previously retained four-function semantic test source."
+  },
+  "cost": {
+    "parent": {
+      "generation_us": 34500,
+      "evaluation_elapsed_ms": 81,
+      "work": {
+        "abstentions": 0,
+        "admission_exact_comparisons": 1126484,
+        "admission_fallbacks": 112,
+        "admission_metadata_bytes": 4045889,
+        "admission_queries": 21907,
+        "admission_signature_writes": 197163,
+        "admission_skips": 21795,
+        "candidates": 2352,
+        "conflicts": 12,
+        "dictionary_byte_comparisons": 1836668,
+        "dictionary_comparisons": 1395776,
+        "directory_reads": 2284,
+        "directory_writes": 80,
+        "feature_queries": 44688,
+        "feature_writes": 14896,
+        "no_writes": 21827,
+        "phase_subtractions": 3136,
+        "reads": 0,
+        "record_evictions": 0,
+        "record_reads": 174524,
+        "record_writes": 80,
+        "revisions": 12,
+        "role_path_comparisons": 14336,
+        "role_path_probes": 1792,
+        "role_path_steps": 880,
+        "role_phase_additions": 7040,
+        "row_comparisons": 580944,
+        "score_lookups": 44688,
+        "source_presence_checks": 0,
+        "word_boundaries": 21907
+      }
+    },
+    "writer": {
+      "generation_us": 767387,
+      "evaluation_elapsed_ms": 1632,
+      "work": {
+        "abstentions": 0,
+        "admission_exact_comparisons": 306152,
+        "admission_fallbacks": 21907,
+        "admission_metadata_bytes": 764561,
+        "admission_queries": 21907,
+        "admission_signature_writes": 197163,
+        "candidates": 915390,
+        "conflicts": 12,
+        "dictionary_byte_comparisons": 2086930,
+        "dictionary_comparisons": 1046832,
+        "directory_reads": 2284,
+        "directory_writes": 80,
+        "feature_queries": 17392410,
+        "feature_writes": 5797470,
+        "no_writes": 21827,
+        "phase_subtractions": 1220520,
+        "reads": 0,
+        "record_evictions": 0,
+        "record_reads": 174524,
+        "record_writes": 80,
+        "revisions": 12,
+        "role_path_comparisons": 5482932,
+        "role_path_probes": 913822,
+        "role_path_steps": 908698,
+        "role_phase_additions": 7269584,
+        "row_comparisons": 226101330,
+        "score_lookups": 17392410,
+        "source_presence_checks": 0,
+        "word_boundaries": 21907
+      }
+    },
+    "scope": "Same28 prompts and same80 writes/answers; recorded descriptive timing, no controlled wall-time speed claim. Full traces/counters include other model processing."
+  },
+  "attempts": [
+    {
+      "artifact": "blake3:212dba628d1b08659fd0b2ef6a2021e25bc10816ba689ba775a806d5ed5728b8",
+      "dictionary": 127,
+      "documents": 172,
+      "epochs": 64,
+      "parent": "blake3:8070c006cf924e4a55007b6c1114ecad99ef6d1f3be2f0d08fc5f137ff89b2c1",
+      "reader_parameters_unchanged": true,
+      "reuse_admission": false,
+      "schema": "uor-r4.writer-refit/1",
+      "writer_correct": 1112,
+      "writer_frames": 1118,
+      "writer_rows": 9552
+    },
+    {
+      "artifact": "blake3:e1e66e2d264e7d0c36d1f110c1f4b147cd298fcc557b7cddc0a98ec3f1db707d",
+      "dictionary": 90,
+      "documents": 172,
+      "epochs": 64,
+      "parent": "blake3:8070c006cf924e4a55007b6c1114ecad99ef6d1f3be2f0d08fc5f137ff89b2c1",
+      "reader_parameters_unchanged": true,
+      "reuse_admission": false,
+      "schema": "uor-r4.writer-refit/1",
+      "writer_correct": 551,
+      "writer_frames": 551,
+      "writer_rows": 4164
+    },
+    {
+      "artifact": "blake3:f9a2a2730d5a28a938aa8a832b0d7c5de1e8b53f19fe24102f4e81159bf11e98",
+      "dictionary": 23,
+      "documents": 172,
+      "epochs": 64,
+      "parent": "blake3:8070c006cf924e4a55007b6c1114ecad99ef6d1f3be2f0d08fc5f137ff89b2c1",
+      "reader_parameters_unchanged": true,
+      "reuse_admission": true,
+      "schema": "uor-r4.writer-refit/1",
+      "writer_correct": 106,
+      "writer_frames": 106,
+      "writer_rows": 2343
+    }
+  ],
+  "verification": {
+    "focused_relation_tests": 5,
+    "actual_artifact_allocations": 0,
+    "actual_artifact_allocated_bytes": 0,
+    "allocation_scope": "release ingest/select/observe/copy, excludes startup",
+    "rust_functions": 4,
+    "rust_assertions": 12,
+    "ci": "PENDING_PROTECTED_PR",
+    "format": "PASS",
+    "architecture_policy": "PASS",
+    "claim_wording": "PASS"
+  },
+  "resources": {
+    "cycle_model_ms": 123484,
+    "cycle_model_limit_ms": 150000,
+    "engineering_ms": 1048088,
+    "engineering_limit_ms": 1200000,
+    "model_peak_rss_sample_bytes": 880656384,
+    "storage_increment_bytes": 134217728,
+    "snapshot": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-06T17:10:32.173Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2473988096,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 964505600,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 6145007616,
+      "storage_limit_bytes": 6660554752,
+      "remaining_storage_bytes": 515547136,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 160141312,
+      "model_ledger": {
+        "cumulative_ms": 1731154,
+        "limit_ms": 1800000
+      },
+      "model_remaining_ms": 68846,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    }
+  },
+  "commands": [
+    {
+      "label": "writer-binding-prepare",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "prepare",
+        "relation-admission-source.json",
+        "dependent-read-angular/source.json",
+        "writer-binding-source.json"
+      ],
+      "elapsed_ms": 369,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fit",
+        "dependent-read-angular/model.json",
+        "writer-binding-source.json",
+        "writer-binding-model.json",
+        "writer-binding-fit.json"
+      ],
+      "elapsed_ms": 16220,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "evaluate",
+        "writer-binding-model.json",
+        "writer-binding-source.json",
+        "writer-binding-development"
+      ],
+      "elapsed_ms": 4790,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-corrected-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fit",
+        "dependent-read-angular/model.json",
+        "writer-binding-source.json",
+        "writer-binding-corrected-model.json",
+        "writer-binding-corrected-fit.json"
+      ],
+      "elapsed_ms": 14466,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-corrected-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "evaluate",
+        "writer-binding-corrected-model.json",
+        "writer-binding-source.json",
+        "writer-binding-corrected-development"
+      ],
+      "elapsed_ms": 4817,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-final-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fit",
+        "dependent-read-angular/model.json",
+        "writer-binding-source.json",
+        "writer-binding-final-model.json",
+        "writer-binding-final-fit.json"
+      ],
+      "elapsed_ms": 12583,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-final-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "evaluate",
+        "writer-binding-final-model.json",
+        "writer-binding-source.json",
+        "writer-binding-final-development"
+      ],
+      "elapsed_ms": 4788,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-long-context",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "writer-binding-final-model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "writer-binding-long-context.json"
+      ],
+      "elapsed_ms": 6210,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-session",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "verify-relations",
+        "writer-binding-final-model.json",
+        "writer-binding-session.json"
+      ],
+      "elapsed_ms": 4852,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-fresh",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fresh",
+        "writer-binding-final-model.json",
+        "writer-binding-source.json",
+        "writer-binding-fresh"
+      ],
+      "elapsed_ms": 4511,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-prepare",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "continue-source",
+        "writer-binding-source.json",
+        "writer-binding-continuation-source.json"
+      ],
+      "elapsed_ms": 153,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fit",
+        "dependent-read-angular/model.json",
+        "writer-binding-continuation-source.json",
+        "writer-binding-continuation-model.json",
+        "writer-binding-continuation-fit.json"
+      ],
+      "elapsed_ms": 12512,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-session",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "verify-relations",
+        "writer-binding-continuation-model.json",
+        "writer-binding-continuation-session.json"
+      ],
+      "elapsed_ms": 4742,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "evaluate",
+        "writer-binding-continuation-model.json",
+        "writer-binding-continuation-source.json",
+        "writer-binding-continuation-development"
+      ],
+      "elapsed_ms": 4740,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-long",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "writer-binding-continuation-model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "writer-binding-continuation-long.json"
+      ],
+      "elapsed_ms": 6113,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-reserved",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "fresh",
+        "writer-binding-continuation-model.json",
+        "writer-binding-continuation-source.json",
+        "writer-binding-reserved"
+      ],
+      "elapsed_ms": 5061,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-unit",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_geometric::relation_tests",
+        "--nocapture"
+      ],
+      "elapsed_ms": 1149,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-allocation",
+      "command": "env",
+      "args": [
+        "R4_DEPENDENT_READ_MODEL=/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/writer-binding-continuation-model.json",
+        "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+        "native_dependent_artifact_copy_is_allocation_free",
+        "--ignored",
+        "--exact",
+        "--nocapture"
+      ],
+      "elapsed_ms": 5319,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-cli",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "writer-binding-continuation-model.json",
+        "--prompt",
+        "casket in elvin. elvin in Bremen. Now elvin in Zurich. Question: Where is the location of casket? Answer:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 4860,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-rust-check",
+      "command": "/Users/casey.allard/.cargo/bin/rustc",
+      "args": [
+        "--edition=2021",
+        "dependent-read-generated.rs",
+        "-o",
+        "writer-binding-generated-check"
+      ],
+      "elapsed_ms": 576,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-rust-execute",
+      "command": "./writer-binding-generated-check",
+      "args": [],
+      "elapsed_ms": 111,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-language-boundary",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "writer-binding-continuation-model.json",
+        "--prompt",
+        "The red box belongs to Alice. Alice lives in Rome. Where does the owner of the red box live? Answer:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 4542,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 357201,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-format",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--all"
+      ],
+      "elapsed_ms": 4138,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-format-fix",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--all"
+      ],
+      "elapsed_ms": 3708,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-corrected-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe"
+      ],
+      "elapsed_ms": 145422,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-policy",
+      "command": "/tmp/r4-native-geometric-target/debug/r4-policy-check",
+      "args": [
+        "."
+      ],
+      "elapsed_ms": 14,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-final-format",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--all"
+      ],
+      "elapsed_ms": 3671,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-final-probe-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe"
+      ],
+      "elapsed_ms": 144292,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-format",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--all"
+      ],
+      "elapsed_ms": 3435,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-continuation-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 353942,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-unit-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "native_geometric::relation_tests",
+        "--config",
+        "profile.test.package.uor-r4-core.opt-level=0",
+        "--no-run"
+      ],
+      "elapsed_ms": 22709,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-allocation-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--test",
+        "native_geometric_allocations",
+        "--no-run"
+      ],
+      "elapsed_ms": 5713,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-format-check",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--all",
+        "--check"
+      ],
+      "elapsed_ms": 3582,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-final-policy",
+      "command": "/tmp/r4-native-geometric-target/debug/r4-policy-check",
+      "args": [
+        "."
+      ],
+      "elapsed_ms": 6,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "writer-binding-claims",
+      "command": "python3",
+      "args": [
+        "scripts/check_claim_wording.py"
+      ],
+      "elapsed_ms": 255,
+      "code": 0,
+      "stopped": null
+    }
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,33 @@
 # Current native geometric AI work
 
+## Learned writer binding — #1139, 2026-09-06
+
+**Retain `8dbf1367` as a functional development improvement; preserve `8070c006`
+as the reader/cost comparator.** The [writer record](../native_geometric_writer_binding_1139.md)
+and [evidence](../evidence/native_geometric_writer_binding_1139.json) bind the scope.
+A construction-only cue vocabulary and the existing sparse integer writer
+learner now select exact owner/value/action writes without importing payload
+spelling as a cue. Tokenization, reader parameters, exact records, version
+semantics and copying remain fixed; no runtime matrix operation is added.
+
+The final continuation artifact gets **48/48** dependent answers and exact writes,
+**62/62** earlier answers, **24/24** transfer, **28/28** long-context answers/writes
+and **5/5** persistent-session turns. A replacement reserved-name set gets
+**28/28** answers/writes after selection. Four unchanged generated Rust functions
+compile and pass 12 semantic assertions; actual-artifact copying is allocation
+free. The broader owner-of-box question still returns Unknown. Three earlier
+attempts and an accidentally opened evaluation set are preserved as development
+evidence, not relabeled as final qualification.
+
+**Immediate next: restore exact NoWrite reuse for this writer.** Its new cue
+namespace makes all 21,907 long-context admission queries fall through. Writer
+row comparisons rise from 580,944 to 226,101,330 despite correct equal writes and
+answers. Recompile the existing bounded admission metadata against the frozen
+new writer; preserve exact safety guards and measure restored avoided work.
+Only then expand learned read/operator/derived-write composition. This is a
+functional checkpoint with a measured compute regression, not a serving-speed
+or frontier-capability promotion. Full #1139/#1140 handoffs remain unmet.
+
 ## Geometric dependent source read — #1139, 2026-09-06
 
 **Retain angular `8070c006` for the next development step, with `55e602a0`
@@ -34,7 +62,7 @@ payloads. The first attempt and its corrected unreachable-target accounting
 remain separately preserved. No sealed general-language, broader operator,
 frontier capability or whole-model speedup is established.
 
-**Next within #1139:** repair learned revision-owner binding and NoWrite on
+**Historical successor, now executed above:** repair learned revision-owner binding and NoWrite on
 question text in the current writer. Preserve the new dependent reader, exact
 identity/version semantics and previous one-read behavior. Use the observed
 revision failures and a small fresh-name check before expanding depth or corpus.

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -180,9 +180,15 @@ scope. The [dependent-source read](../native_geometric_dependent_source_1139.md)
 now follows a geometrically selected exact relation into a second owner lookup:
 40/48 new complete answers versus 32/48 exact-code and 20/48 parent, preserving
 62/62 prior answers and 24/24 transfer. Eight revision-ingestion failures remain.
-Follow current-state.md for artifacts and complete limits. The next implementation
-repairs the current writer's revision-owner binding and NoWrite on question text,
-with this dependent reader preserved. The full handoff remains unmet.
+The [writer repair](../native_geometric_writer_binding_1139.md) now gets 48/48
+answers and exact writes, preserves the earlier response, transfer, long-context
+and persistent-session results, and passes 28/28 replacement reserved-name
+cases. Its cue namespace invalidates effective reuse of the old exact NoWrite
+cache, increasing long-context writer row comparisons from 580,944 to
+226,101,330. Recompile that existing bounded admission metadata against the
+frozen new writer before expanding learned read/operator/derived-write
+composition. Follow current-state.md for artifacts and complete limits.
+The full handoff remains unmet.
 
 #### Immediate recurrent attention revision — owner adoption 2026-09-05
 

--- a/docs/native_geometric_writer_binding_1139.md
+++ b/docs/native_geometric_writer_binding_1139.md
@@ -1,0 +1,168 @@
+# Learned relation-writer binding — #1139, 2026-09-06
+
+This continues protected PR #1150 (`fae76313`) toward useful transformerless
+geometric language processing. The existing dependent reader, source router,
+relation directory, version semantics and copy operator remain unchanged.
+The owner authorized this writer repair and necessary incremental storage.
+
+## Representation and learned operation
+
+The native tokenizer already uses reversible lexical pieces and byte fallback.
+Tokens have prime identities and fixed signed-H4/zeta state. The writer receives
+completed exact words from that stream. Its old dictionary recognized `now` but
+collapsed `Now` and `Question` to the same zero key as unfamiliar names.
+
+The writer revision has its own construction-bound prime cue dictionary.
+Words labeled as owner/value payloads anywhere in its construction examples are
+excluded from that cue vocabulary; inherited reader vocabulary is not imported.
+This is an offline supervised vocabulary decision, not a serving entity parser.
+It intentionally erases payload spelling from writer scoring. Exact spelling,
+case, source endpoints and current versions remain in relation records, and the
+reader retains its own unchanged dictionaries and learned H4 codes. Unseen cues
+still collapse to zero. A word that serves both as a payload name and as a cue
+is not given context-dependent lexical meaning by this implementation.
+
+The existing writer margin learner fits sparse integer weights over candidate
+owner/value-relative cue keys, ordered interior H4 products, signed orientation
+and fixed-zeta phase bins. It jointly chooses NoWrite, assertion, explicit
+revision or contradiction, with exact source endpoints for the selected pair.
+This fits weights over existing geometric/context features; it does not learn
+new continuous embeddings or establish a new angular advantage. Both word
+orders are construction-supervised. Questions receive NoWrite supervision;
+there is no hard-coded serving rule for `Now`, `Question`, cities or answers.
+
+The artifact stores one replacement writer plus the entire frozen parent for
+lineage. Only the replacement writer scores at runtime. Parent reconstruction,
+cue geometry, rows, dimensions and UOR/content identity are validated on load.
+Existing exact NoWrite caches may be reused only after every cached signature
+is verified against the replacement scorer. Otherwise they are bypassed.
+Exact signature checks remain mandatory; geometry never authorizes merging
+unequal writer inputs. Reader parameters are compared unchanged in the fit report.
+
+The writer retains the eight-word candidate window: at most fourteen directed
+owner/value pairs, each involving the latest completed word, and three actions
+per pair. Each pair supplies nineteen active features to the existing binary
+row lookups. The fixed feature buffer has sixty-four slots. At full capacity,
+that is 42 scored choices and 798 feature queries per completed word before
+NoWrite admission. The model permits at most 16,384 writer rows and 256 cue
+words. Existing counters account for dictionary/row comparisons, path/table
+work, phase operations and record/directory work. They are logical-operation
+counters, not a complete machine-instruction or memory-bandwidth census.
+
+There are still sixteen exact relation records, one untyped value per owner,
+32-byte word payloads and the inherited 512-token native context. No new
+persistent session state, transformer, matrix operation, provider or dense
+fallback is added. Startup validation still uses floating point. Fixed zeta,
+exact signed geometry/Z[phi], paired-H4 representation and UOR identity retain
+their declared roles; this change does not separately qualify each mechanism.
+
+## Development history and evaluation boundary
+
+All artifacts and reports are retained under
+`.uor-models/native-typed-value-2026-09-05/writer-binding-*` in the original
+checkout. The initial 172 construction documents preserve 112 earlier relation
+examples, add 48 dependent examples, eight revision-order variants and four
+question-only examples. Write labels are offline byte endpoints; serving sees
+raw tokens. The fixture label adapter lives only in the existing evaluation
+example, outside the native inference library.
+
+1. `212dba62`: adding all construction names to inherited writer context gives
+   23/48 dependent answers and 4/48 exact write sequences. It repairs explicit
+   revisions but invents premature writes such as `casket -> in`. Construction
+   is 1112/1118 distinct decision frames; the vocabulary has 127 words.
+2. `e1e66e2d`: excluding newly added labeled payloads gives 43/48 answers and
+   42/48 writes, fitting 551/551 frames. Its 90-word dictionary still inherits
+   `Bath`; all remaining write mismatches involve that known-versus-unseen
+   spelling distinction. Both attempts preserve 62/62 earlier responses and
+   24/24 transfer.
+3. `f9a2a273`: using only construction non-payload cues gives 48/48 answers and
+   writes, preserving 62/62, 24/24 and 28/28 long-context answers/writes. It fits
+   106/106 frames with 23 cues and 2343 rows, but only 4/5 persistent turns pass.
+   A conflicting assertion following previous question turns is not written.
+   Generated response bytes do not enter the writer source stream; fitting
+   lacked the resulting question-to-next-assertion adjacency.
+
+The first 28 renamed cases scored 28/28 answers and exact writes, but a shell
+continued into that evaluation after the session-preservation guard failed.
+No selection receipt was written. That population is therefore explicitly OPEN,
+not post-selection evidence. The boundary error is retained in
+`writer-binding-first-use-boundary.json`. It is not used for fitting.
+
+The continuation source adds 28 construction examples with prior question
+prefixes, preserving exact source labels with shifted byte endpoints and the
+same runtime representation. A replacement reserved vocabulary is checked
+against the supplied source and kept out of training. Fresh evaluation must
+follow a successful separate selection check. This remains familiar grammar
+with changed names, not sealed broad language or frontier qualification.
+
+## Selected functional result and cost regression
+
+Retain `8dbf136752b6b5f2e52a528dfff300a703503cd5d49fd78b4e66910c16efcc84`
+as the functional development artifact. Preserve `8070c006` as the frozen
+working reader and cost comparator; this is not a serving-speed promotion.
+The 200-document continuation fit reaches 128/128 distinct construction frames
+with 23 cues and 2505 writer rows. All reader parameters remain unchanged.
+
+| Check | Result |
+|---|---:|
+| Original dependent development, complete answers | 48/48, versus parent 40/48 |
+| Same development, exact owner/value/action writes | 48/48 |
+| Earlier response preservation | 62/62 |
+| Earlier transfer | 24/24 |
+| Raw-window eviction cases, answers and writes | 28/28 both |
+| Persistent session turns, including conflict | 5/5, with restore and isolation |
+| Replacement reserved vocabulary, after selection | 28/28 answers and writes |
+| Unchanged generated Rust functions | 4, compiled and 12 semantic assertions rerun |
+
+The replacement reserved set was evaluated after the separate successful
+`writer-binding-selection.json` check. No parameters changed after opening it.
+Its eight replacement names are absent from the supplied prior source; its
+construction forms remain familiar. The former accidentally opened set retains
+its OPEN status. The actual CLI now answers ` Zurich.\n` after
+`casket in elvin. elvin in Bremen. Now elvin in Zurich.` and a dependent
+location question. The broader red-box/owner question still returns `Unknown`.
+
+**The new writer loses effective NoWrite reuse on the longer-context cases.**
+The inherited signatures remain safe under startup rechecking, but use the old
+cue namespace. All 21,907 admission queries fall through, versus 21,795 skips
+for the parent. On the same 28 prompts, writer row comparisons increase from
+580,944 to 226,101,330; feature queries increase from 44,688 to 17,392,410.
+Both artifacts commit the same 80 records, including 12 revisions and 12
+conflicts, with the same expected answers. Recorded generation subtotals are
+34,500 microseconds for the parent and 767,387 for this writer, around 22 times
+higher. These are descriptive samples from different runs, not a controlled
+wall-time speedup/slowdown benchmark. The exact work counters expose the
+mechanism of the regression independently of timing noise.
+
+The artifact is 11,045,747 bytes, including a 159,892-byte serialized writer
+block and its frozen parent. The relation state remains 2840 bytes with
+168-byte records. The actual loaded-artifact ingest/select/observe/copy test
+reports zero allocations and zero allocated bytes; loading is outside that
+census. Existing full-path counters and generated traces remain in the reports.
+No whole-model efficiency advantage or expanded natural-language capability
+is claimed.
+
+## Next implementation and delivery
+
+Within #1139, recompile the existing bounded exact NoWrite admission metadata
+against this writer's actual cue dictionary and scorer. Bind and validate it
+at that operator boundary, including exact guards; do not simply trust or
+rename old unknown-key signatures. Reuse the existing compiler/cache mechanism.
+Keep writer weights, reader parameters and exact payloads fixed. Require the
+current answer/write/session results and a restored reduction in actual scoring
+work on the same prompts. This is repair of a measured compute regression,
+not a new cache search or benchmark programme.
+
+Then resume the planned learned read/operator/derived-write composition using
+existing typed operators. Full #1139 joint learned-block qualification and
+#1140 broader multi-operation qualification remain unmet. Tokenization is
+already reversible; broader learned lexical/phrase abstraction is still a
+separate capability question.
+
+Local verification compiled the release native path, ran five focused relation
+state/geometry/cue tests, exercised the actual artifact's zero-allocation path,
+and ran actual CLI and unchanged generated Rust code. Formatting, architecture
+policy and claim checks accompany protected delivery. The machine-readable
+[evidence](evidence/native_geometric_writer_binding_1139.json) records exact
+resources and commands. CI/merge status belongs to the protected PR and live
+GitHub; compatibility acknowledgements are not broad QA evidence.


### PR DESCRIPTION
The learned writer previously attached some `Now owner in value` revisions to `Now`, and question text could create spurious records. This change gives the writer a construction-bound cue vocabulary, excludes labeled payload spelling from cue scoring, and refits the existing sparse integer owner/value/action learner. It also trains the missing adjacency between a previous question and the next user assertion. Exact records, version semantics, dependent reader parameters and copying remain unchanged.

Retain artifact `8dbf1367` as a functional development result, preserving `8070c006` as the reader/cost comparator:

- 48/48 dependent answers and exact write sequences, repairing all eight prior revision failures.
- 62/62 earlier responses, 24/24 transfer, 28/28 long-context answers/writes and 5/5 persistent turns, with restore and isolation.
- 28/28 replacement reserved-name answers/writes after selection; familiar grammar, not general-language qualification.
- Actual CLI returns ` Zurich.\n` after the second link is revised. Four unchanged generated Rust functions compile and pass 12 semantic assertions. The broader owner-of-box question remains Unknown.

**Cost regression:** the new cue namespace produces no hits in the old exact NoWrite cache on the long-context set. Writer row comparisons rise from 580,944 to 226,101,330 despite equal correct writes/answers; descriptive generation subtotals rise from 34.5 ms to 767.4 ms. This is not a serving-efficiency promotion. The immediate next #1139 task recompiles existing bounded admission metadata for this frozen writer before expanding composition. No transformer or runtime matrix operation is added; startup validation still uses floating point.

Three unsuccessful attempts are preserved. An earlier fresh set was accidentally evaluated after a failed session-preservation guard; it remains explicitly OPEN. A separately named replacement reserve was evaluated only after successful selection. Full #1139 and #1140 handoffs remain unmet.

Validation: release core/example/native CLI build; five focused relation state/geometry/cue tests; the actual artifact's ingest/select/observe/copy allocation census (0 allocations, 0 bytes); generated Rust compile/execution; formatting, architecture policy and claim wording checks. Protected CI is pending; its compatibility-only statuses do not run broad audit/fuzz/WASM/Gate-C checks.

Local cycle model work: 123.484/150 s; cumulative 1731.154/1800 s, leaving 68.846 s. Engineering commands: 1048.088/1200 s. Necessary +128 MiB storage recorded under standing owner authorization; material preserved, no deletion or paid compute.

See `docs/native_geometric_writer_binding_1139.md`, its evidence JSON, and the updated current-state/roadmap. Continues #1139; does not close it.
