### PR TITLE
Select typed operations before execution; record failed follow-up composition

### DIFF
--- a/crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs
@@ -369,7 +369,9 @@ fn native_response_entry_reuses_no_write_only_during_committed_response() {
     assert_eq!(session.values.as_ref().unwrap().sources.len(), 2);
     let first = session.predict(&model).unwrap();
     assert!(session.work.values.proposals > 0);
-    assert!(session.work.values.additions > 0);
+    assert_eq!(session.work.values.additions, 0);
+    assert_eq!(session.work.values.operator_executions, 0);
+    assert!(session.work.values.selection_comparisons > 0);
     assert!(session.work.values.feature_lookups > 0);
     session.observe(&model, first.token).unwrap();
     assert!(session.response_entry.as_ref().unwrap().active);
@@ -395,7 +397,9 @@ fn native_response_entry_reuses_no_write_only_during_committed_response() {
             )
             .is_none());
         assert!(hypothetical_work.proposals > 0);
-        assert!(hypothetical_work.additions > 0);
+        assert_eq!(hypothetical_work.additions, 0);
+        assert_eq!(hypothetical_work.operator_executions, 0);
+        assert!(hypothetical_work.selection_comparisons > 0);
         assert!(hypothetical_work.feature_lookups > 0);
 
         let before = session.work.values;
@@ -426,7 +430,8 @@ fn native_response_entry_reuses_no_write_only_during_committed_response() {
     let after_cap = session.work.values;
     session.predict(&model).unwrap();
     assert!(session.work.values.proposals > after_cap.proposals);
-    assert!(session.work.values.additions > after_cap.additions);
+    assert_eq!(session.work.values.operator_executions, 0);
+    assert!(session.work.values.selection_comparisons > after_cap.selection_comparisons);
     assert!(session.work.values.feature_lookups > after_cap.feature_lookups);
     assert!(session.response_entry_decision().is_none());
 
@@ -439,7 +444,8 @@ fn native_response_entry_reuses_no_write_only_during_committed_response() {
     let before_new_query = session.work.values;
     let first = session.predict(&model).unwrap();
     assert!(session.work.values.proposals > before_new_query.proposals);
-    assert!(session.work.values.additions > before_new_query.additions);
+    assert_eq!(session.work.values.operator_executions, 0);
+    assert!(session.work.values.selection_comparisons > before_new_query.selection_comparisons);
     assert!(session.work.values.feature_lookups > before_new_query.feature_lookups);
     assert_eq!(
         session.response_entry_decision().unwrap().action,

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -873,6 +873,9 @@ fn add_work(total: &mut Work, work: Work) {
     total.values.literal_writes += work.values.literal_writes;
     total.values.record_evictions += work.values.record_evictions;
     total.values.proposals += work.values.proposals;
+    total.values.operator_executions += work.values.operator_executions;
+    total.values.selection_comparisons += work.values.selection_comparisons;
+    total.values.selection_passes += work.values.selection_passes;
     total.values.additions += work.values.additions;
     total.values.overflow_rejections += work.values.overflow_rejections;
     total.values.feature_lookups += work.values.feature_lookups;
@@ -961,6 +964,9 @@ mod work_tests {
         // so the independent JSON oracle covers every current counter.
         let seed = Work {
             values: ValueWork {
+                operator_executions: 1,
+                selection_comparisons: 1,
+                selection_passes: 1,
                 lexical_comparisons: 1,
                 lexical_byte_comparisons: 1,
                 lexical_writes: 1,

--- a/crates/uor-r4-core/src/native_geometric/value_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime.rs
@@ -326,33 +326,56 @@ impl ValueState {
         if self.consumed || self.query_len == 0 || self.next_id == u64::MAX {
             return None;
         }
-        let mut selected = None;
-        let mut best = 0_i64;
-        for index in 0..272 {
-            let Some((action, a, b)) = self.proposal(index) else {
-                continue;
-            };
-            work.proposals = work.proposals.saturating_add(1);
-            let Some(value) = execute(action, a.value, b.value, work) else {
-                continue;
-            };
-            let (features, len) = self.features(model, action, a, b, control, work);
-            let mut score = 0_i64;
-            for feature in &features[..len] {
-                work.feature_lookups = work.feature_lookups.saturating_add(1);
-                if let Ok(index) = head.rows.binary_search_by(|row| {
-                    work.feature_comparisons = work.feature_comparisons.saturating_add(1);
-                    row.feature.cmp(feature)
-                }) {
-                    score += i64::from(head.rows[index].weight);
+        // Score geometry/cues before materializing a result. Only exact failure
+        // causes another pass, below the last rejected (score, proposal-order)
+        // choice. This preserves first-valid ties without a score buffer.
+        let mut ceiling: Option<(i64, usize)> = None;
+        let (action, a, b, value, best) = loop {
+            work.selection_passes = work.selection_passes.saturating_add(1);
+            let mut selected = None;
+            let mut best = 0_i64;
+            for index in 0..272 {
+                let Some((action, a, b)) = self.proposal(index) else {
+                    continue;
+                };
+                work.proposals = work.proposals.saturating_add(1);
+                let (features, len) = self.features(model, action, a, b, control, work);
+                let mut score = 0_i64;
+                for feature in &features[..len] {
+                    work.feature_lookups = work.feature_lookups.saturating_add(1);
+                    if let Ok(index) = head.rows.binary_search_by(|row| {
+                        work.feature_comparisons = work.feature_comparisons.saturating_add(1);
+                        row.feature.cmp(feature)
+                    }) {
+                        score += i64::from(head.rows[index].weight);
+                    }
+                }
+                if let Some((limit, rejected)) = ceiling {
+                    work.selection_comparisons = work.selection_comparisons.saturating_add(1);
+                    match score.cmp(&limit) {
+                        std::cmp::Ordering::Greater => continue,
+                        std::cmp::Ordering::Equal => {
+                            work.selection_comparisons =
+                                work.selection_comparisons.saturating_add(1);
+                            if index <= rejected {
+                                continue;
+                            }
+                        }
+                        std::cmp::Ordering::Less => {}
+                    }
+                }
+                work.selection_comparisons = work.selection_comparisons.saturating_add(1);
+                if score > best {
+                    best = score;
+                    selected = Some((index, action, a, b));
                 }
             }
-            if score > best {
-                best = score;
-                selected = Some((action, a, b, value));
+            let (index, action, a, b) = selected?;
+            if let Some(value) = execute(action, a.value, b.value, work) {
+                break (action, a, b, value, best);
             }
-        }
-        let (action, a, b, value) = selected?;
+            ceiling = Some((best, index));
+        };
         let numeral = Numeral::from_zphi(ZPhi::new(value, 0))?;
         // Exact spelling has nineteen place visits plus one subtraction per
         // digit value; this counter is the fixed worst-case visit bound.
@@ -449,6 +472,7 @@ impl ValueState {
     }
 }
 pub(super) fn execute(action: ValueAction, a: i64, b: i64, work: &mut ValueWork) -> Option<i64> {
+    work.operator_executions = work.operator_executions.saturating_add(1);
     match action {
         ValueAction::Copy => Some(a),
         ValueAction::Add => {

--- a/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
@@ -349,3 +349,233 @@ fn native_value_document_boundaries_do_not_join_numerals() {
         .collect();
     assert_eq!(values, vec![1, 2]);
 }
+
+#[test]
+fn native_value_selected_execution_runs_one_of_256_scored_choices() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(
+        &model,
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 total:",
+        Control::Full,
+    );
+    session.predict(&model).unwrap();
+    let d = session.value_decision().unwrap();
+    assert_eq!(d.value, 3);
+    assert_eq!(d.operands.map(|v| v.value), [2, 1]);
+    assert_eq!(session.work.values.proposals, 256);
+    assert_eq!(session.work.values.operator_executions, 1);
+    assert_eq!(session.work.values.additions, 1);
+    assert_eq!(session.work.values.selection_comparisons, 256);
+    assert_eq!(session.work.values.selection_passes, 1);
+    assert_eq!(session.work.values.derived_writes, 0);
+}
+
+#[test]
+fn native_value_selected_execution_preserves_overflow_fallback_order() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "9223372036854775807 1 -2 total:", Control::Full);
+    session.predict(&model).unwrap();
+    let d = session.value_decision().unwrap();
+    assert_eq!(d.value, i64::MAX - 2);
+    assert_eq!(d.operands.map(|v| v.value), [-2, i64::MAX]);
+    assert_eq!(session.work.values.operator_executions, 2);
+    assert_eq!(session.work.values.overflow_rejections, 1);
+    assert_eq!(session.work.values.selection_passes, 2);
+    assert_eq!(session.work.values.proposals, 18);
+}
+
+#[test]
+fn native_value_selected_execution_abstention_does_no_arithmetic() {
+    let mut model = mechanical_model(ValueAction::Add);
+    for row in &mut model.values.as_mut().unwrap().rows {
+        row.weight = 0;
+    }
+    model.refresh_identity().unwrap();
+    let mut session = prefix(&model, "13 4 total:", Control::Full);
+    session.predict(&model).unwrap();
+    assert!(session.value_decision().is_none());
+    assert_eq!(session.work.values.proposals, 4);
+    assert_eq!(session.work.values.operator_executions, 0);
+    assert_eq!(session.work.values.additions, 0);
+}
+
+#[test]
+fn native_value_selected_execution_reuses_only_committed_derived_values() {
+    // Mechanical role weights isolate causal state reuse, not language learning.
+    let mut model = mechanical_model(ValueAction::Add);
+    model.values.as_mut().unwrap().rows.extend([
+        ValueRow {
+            feature: ValueFeature {
+                kind: 1,
+                a: 1,
+                b: 256,
+            },
+            weight: 16384,
+        },
+        ValueRow {
+            feature: ValueFeature {
+                kind: 2,
+                a: 1,
+                b: 1,
+            },
+            weight: 8192,
+        },
+    ]);
+    model
+        .values
+        .as_mut()
+        .unwrap()
+        .rows
+        .sort_by_key(|r| r.feature);
+    model.refresh_identity().unwrap();
+    for committed in [false, true] {
+        let mut session = prefix(&model, "left = 13; right = 4; total:", Control::Full);
+        session.predict(&model).unwrap();
+        assert_eq!(session.value_decision().unwrap().value, 17);
+        if committed {
+            for _ in 0..2 {
+                let token = session.predict(&model).unwrap().token;
+                session.observe(&model, token).unwrap();
+            }
+        }
+        session.end_response(&model).unwrap();
+        for token in model.encode("next = 5; total:").unwrap() {
+            session.observe(&model, token).unwrap();
+        }
+        session.begin_response(&model).unwrap();
+        let saved = session.checkpoint().unwrap();
+        let mut restored = model.restore_session(&saved).unwrap();
+        session.predict(&model).unwrap();
+        restored.predict(&model).unwrap();
+        assert_eq!(session.value_decision(), restored.value_decision());
+        let decision = session.value_decision().unwrap();
+        assert_eq!(decision.value, if committed { 22 } else { 9 });
+        assert_eq!(decision.operands[0].derived, committed);
+        assert_eq!(decision.operands[1].value, 5);
+        let mut emitted = Vec::new();
+        for _ in 0..if committed { 2 } else { 1 } {
+            let token = session.predict(&model).unwrap().token;
+            emitted.push(token);
+            session.observe(&model, token).unwrap();
+        }
+        assert_eq!(
+            model.decode(&emitted).unwrap(),
+            if committed {
+                b"22".as_slice()
+            } else {
+                b"9".as_slice()
+            }
+        );
+        let last = session.values.as_ref().unwrap().records.last().unwrap();
+        assert_eq!(last.value, decision.value);
+        assert_eq!(
+            last.derivation.unwrap().operand_ids,
+            decision.operands.map(|v| v.id)
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires an admitted local model allowance and R4_TYPED_ADMISSION_MODEL artifact"]
+fn native_value_selected_execution_learned_chain_diagnostic() {
+    // OPEN evaluation only: this records the frozen learned model's behavior,
+    // separately from the deliberately weighted causal tests above.
+    fn generate(model: &Model, session: &mut Session) -> (Option<ValueDecision>, Vec<u8>, bool) {
+        let mut decision = None;
+        let mut tokens = Vec::new();
+        for _ in 0..32 {
+            let token = session.predict(model).unwrap().token;
+            if let Some(d) = session.value_decision().filter(|d| d.cursor == 0) {
+                decision = Some(d);
+            }
+            session.observe(model, token).unwrap();
+            if token == EOS {
+                return (decision, model.decode(&tokens).unwrap(), true);
+            }
+            tokens.push(token);
+        }
+        (decision, model.decode(&tokens).unwrap(), false)
+    }
+
+    let path = std::env::var("R4_TYPED_ADMISSION_MODEL").unwrap();
+    let model = Model::from_bytes(&std::fs::read(path).unwrap()).unwrap();
+    let mut exact_chains = 0;
+    // The first two worlds change one input under identical query wording.
+    // Each world's follow-ups share state and delta but require Copy versus Add.
+    for (a, b, delta) in [(13, 4, 5), (14, 4, 5), (-3, 8, 4)] {
+        let prompt = format!("User: suri has {a} coins. orin has {b} coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:");
+        let mut session = prefix(&model, &prompt, Control::Full);
+        let (first, first_bytes, first_eos) = generate(&model, &mut session);
+        session.end_response(&model).unwrap();
+        let first_expected = format!("{}.\n", a + b);
+        let first_correct = first.is_some_and(|d| d.value == a + b && d.action == ValueAction::Add)
+            && first_bytes == first_expected.as_bytes()
+            && first_eos;
+        let saved = session.checkpoint().unwrap();
+        for action in [ValueAction::Copy, ValueAction::Add] {
+            let question = match action {
+                ValueAction::Copy => "Repeat the previous total without adding the new coins.",
+                ValueAction::Add => "Add the new coins to the previous total.",
+            };
+            let query = format!("User: There are {delta} new coins. {question}\nAssistant:");
+            let expected = a + b + if action == ValueAction::Add { delta } else { 0 };
+            let expected_text = format!("{expected}.\n");
+            let mut full_correct = false;
+            let mut control_changes_output = false;
+            let mut full_bytes = Vec::new();
+            for remove_intermediate in [false, true] {
+                let mut branch = model.restore_session(&saved).unwrap();
+                // Evaluator-only deletion of the one actual derived record.
+                // Keep transcript/geometric state and all other records intact.
+                // No supplied value, answer injection or serving rule is added.
+                let removed = if remove_intermediate {
+                    first.is_some_and(|d| {
+                        let values = branch.values.as_mut().unwrap();
+                        let before = values.records.len();
+                        values.records.retain(|r| r.id != d.write_id);
+                        before != values.records.len()
+                    })
+                } else {
+                    false
+                };
+                for token in model.encode(&query).unwrap() {
+                    branch.observe(&model, token).unwrap();
+                }
+                branch.begin_response(&model).unwrap();
+                let source_records = branch.values.as_ref().unwrap().sources.clone();
+                let (second, bytes, eos) = generate(&model, &mut branch);
+                let uses_intermediate = first.zip(second).is_some_and(|(x, y)| {
+                    y.operands.iter().any(|v| v.derived && v.id == x.write_id)
+                });
+                let second_correct = second
+                    .is_some_and(|d| d.value == expected && d.action == action)
+                    && bytes == expected_text.as_bytes()
+                    && eos;
+                if remove_intermediate {
+                    control_changes_output = removed && bytes != full_bytes;
+                } else {
+                    full_correct = first_correct && second_correct && uses_intermediate;
+                    full_bytes = bytes.clone();
+                }
+                println!(
+                    "{}",
+                    serde_json::json!({"artifact_cid":model.artifact_cid,
+                    "operands":[a,b,delta],"prompt":prompt,"query":query,"required_action":action,
+                    "first":first,"second":second,"first_expected":first_expected,
+                    "first_text":String::from_utf8_lossy(&first_bytes),
+                    "expected":expected_text,"second_text":String::from_utf8_lossy(&bytes),
+                    "first_correct":first_correct,"second_correct":second_correct,"terminated":eos,
+                    "source_records":source_records,"uses_intermediate":uses_intermediate,
+                    "remove_intermediate_control":remove_intermediate,"record_removed":removed,
+                    "work":branch.work,"shared_prefix_work":session.work,
+                    "scope":"OPEN frozen learned artifact, untrained follow-up wording; no refit or supplied derived value. Branch work includes shared prefix work; subtract it before summing physical work."})
+                );
+            }
+            exact_chains += usize::from(full_correct && control_changes_output);
+        }
+    }
+    assert_eq!(
+        exact_chains, 6,
+        "learned generated composition remains unqualified; inspect reachability, selection, emission and intermediate control separately"
+    );
+}

--- a/crates/uor-r4-core/src/native_geometric/value_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_types.rs
@@ -27,6 +27,14 @@ pub struct ValueWork {
     pub literal_writes: u64,
     pub record_evictions: u64,
     pub proposals: u64,
+    /// Exact Copy/Add calls, including rejected overflow attempts.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub operator_executions: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub selection_comparisons: u64,
+    /// Scoring passes, including reselection after an invalid exact operation.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub selection_passes: u64,
     pub additions: u64,
     pub overflow_rejections: u64,
     pub feature_lookups: u64,

--- a/docs/evidence/native_geometric_typed_admission_1139.json
+++ b/docs/evidence/native_geometric_typed_admission_1139.json
@@ -1,0 +1,521 @@
+{
+  "schema": "uor-r4.typed-admission-evidence/1",
+  "source_commit": "cab1ba4b87244cc0c9853def3bd8392d6b9ec2d8",
+  "artifact_cid": "blake3:2600b95bbb160dd70a14b7ae05306e3b6b9607377919db0414fc529519eb9635",
+  "runtime_decision": "RETAIN_SELECTED_EXECUTION_AT_PRESERVATION_SCOPE",
+  "learning_decision": "FAIL_FOLLOWUP_COMPOSITION_ADVANCE_QUERY_CONDITIONED_OPERATOR_OPERAND_LEARNING",
+  "diagnostic": {
+    "scope": "OPEN new follow-up wording; frozen artifact, no refit. Exact full text/EOS/operator/provenance/control acceptance. Not a sealed or general-language evaluation.",
+    "first_sums_exact": 3,
+    "first_sums_total": 3,
+    "followups_exact": 0,
+    "followups_total": 6,
+    "all_intermediate_values_captured": true,
+    "observations": [
+      {
+        "operands": [
+          13,
+          4,
+          5
+        ],
+        "required_action": "copy",
+        "first_text": "17.\n",
+        "second_text": "21.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": true,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          13,
+          4,
+          5
+        ],
+        "required_action": "copy",
+        "first_text": "17.\n",
+        "second_text": " the.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      },
+      {
+        "operands": [
+          13,
+          4,
+          5
+        ],
+        "required_action": "add",
+        "first_text": "17.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          13,
+          4,
+          5
+        ],
+        "required_action": "add",
+        "first_text": "17.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      },
+      {
+        "operands": [
+          14,
+          4,
+          5
+        ],
+        "required_action": "copy",
+        "first_text": "18.\n",
+        "second_text": "22.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": true,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          14,
+          4,
+          5
+        ],
+        "required_action": "copy",
+        "first_text": "18.\n",
+        "second_text": " the.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      },
+      {
+        "operands": [
+          14,
+          4,
+          5
+        ],
+        "required_action": "add",
+        "first_text": "18.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          14,
+          4,
+          5
+        ],
+        "required_action": "add",
+        "first_text": "18.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      },
+      {
+        "operands": [
+          -3,
+          8,
+          4
+        ],
+        "required_action": "copy",
+        "first_text": "5.\n",
+        "second_text": "13.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": true,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          -3,
+          8,
+          4
+        ],
+        "required_action": "copy",
+        "first_text": "5.\n",
+        "second_text": " the.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      },
+      {
+        "operands": [
+          -3,
+          8,
+          4
+        ],
+        "required_action": "add",
+        "first_text": "5.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": false,
+        "record_removed": false
+      },
+      {
+        "operands": [
+          -3,
+          8,
+          4
+        ],
+        "required_action": "add",
+        "first_text": "5.\n",
+        "second_text": " Unknown.\n",
+        "first_correct": true,
+        "second_correct": false,
+        "uses_intermediate": false,
+        "remove_intermediate_control": true,
+        "record_removed": true
+      }
+    ]
+  },
+  "preservation": {
+    "sessions.json": {
+      "complete_behavior_equal_excluding_work_and_wall": true,
+      "exact_turns": 5
+    },
+    "exposed-names.json": {
+      "complete_behavior_equal_excluding_work_and_wall": true,
+      "total": 28,
+      "before": {
+        "proposals": 0,
+        "additions": 0,
+        "operator_executions": 0,
+        "feature_comparisons": 0,
+        "selection_comparisons": 0,
+        "selection_passes": 0
+      },
+      "after": {
+        "proposals": 0,
+        "additions": 0,
+        "operator_executions": 0,
+        "feature_comparisons": 0,
+        "selection_comparisons": 0,
+        "selection_passes": 28
+      }
+    },
+    "development.json": {
+      "complete_behavior_equal_excluding_work_and_wall": true,
+      "total": 48,
+      "before": {
+        "proposals": 0,
+        "additions": 0,
+        "operator_executions": 0,
+        "feature_comparisons": 0,
+        "selection_comparisons": 0,
+        "selection_passes": 0
+      },
+      "after": {
+        "proposals": 0,
+        "additions": 0,
+        "operator_executions": 0,
+        "feature_comparisons": 0,
+        "selection_comparisons": 0,
+        "selection_passes": 48
+      }
+    },
+    "preservation.json": {
+      "complete_behavior_equal_excluding_work_and_wall": true,
+      "total": 62,
+      "before": {
+        "proposals": 360,
+        "additions": 236,
+        "operator_executions": 0,
+        "feature_comparisons": 272116,
+        "selection_comparisons": 0,
+        "selection_passes": 0
+      },
+      "after": {
+        "proposals": 360,
+        "additions": 16,
+        "operator_executions": 24,
+        "feature_comparisons": 272116,
+        "selection_comparisons": 360,
+        "selection_passes": 62
+      }
+    },
+    "prior.json": {
+      "complete_behavior_equal_excluding_work_and_wall": true,
+      "total": 24,
+      "before": {
+        "proposals": 16,
+        "additions": 8,
+        "operator_executions": 0,
+        "feature_comparisons": 12376,
+        "selection_comparisons": 0,
+        "selection_passes": 0
+      },
+      "after": {
+        "proposals": 16,
+        "additions": 0,
+        "operator_executions": 0,
+        "feature_comparisons": 12376,
+        "selection_comparisons": 16,
+        "selection_passes": 24
+      }
+    }
+  },
+  "long_context": {
+    "total": 28,
+    "exact": 28,
+    "writes_exact": 28,
+    "complete_generation_equal_except_work": true,
+    "outer_report_schema_equal": false
+  },
+  "verification": {
+    "selected_causal_tests_passed": 4,
+    "response_cache_passed": true,
+    "nested_counter_aggregation_passed": true,
+    "numeric_allocation_passed": true,
+    "actual_artifact_dependent_allocations": 0,
+    "actual_artifact_dependent_allocated_bytes": 0,
+    "cli_response": " Zurich.\n",
+    "generated_rust_functions": 4,
+    "generated_rust_semantic_assertions_passed": 12,
+    "compilation_format_policy_wording": "PASS",
+    "CI": "Separate protected check results; compatibility acknowledgements are not audits."
+  },
+  "resources": {
+    "model_ms": 74262,
+    "engineering_build_ms": 382586,
+    "cumulative_model_ms": 1871006,
+    "model_limit_ms": 1890000,
+    "model_increments_ms": [
+      60000,
+      30000
+    ],
+    "storage": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-06T19:00:36.385Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2480775168,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 1035124736,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 6222413824,
+      "storage_limit_bytes": 6727663616,
+      "remaining_storage_bytes": 505249792,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 149843968,
+      "model_ledger": {
+        "cumulative_ms": 1871006,
+        "limit_ms": 1890000
+      },
+      "model_remaining_ms": 18994,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "authorization_receipts": [
+      "typed-admission-allowance-authorization.json",
+      "typed-admission-allowance-extension-02.json"
+    ],
+    "external_compute_cost": 0
+  },
+  "commands": [
+    {
+      "label": "typed-admission-causal-tests",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_value_selected_execution",
+        "--nocapture"
+      ],
+      "elapsed_ms": 1279,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-learned-composition",
+      "command": "env",
+      "args": [
+        "R4_TYPED_ADMISSION_MODEL=writer-admission-periodic-model.json",
+        "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+        "native_value_selected_execution_learned_chain_diagnostic",
+        "--ignored",
+        "--nocapture"
+      ],
+      "elapsed_ms": 45682,
+      "code": 101,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-candidate-preservation",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "preserve",
+        "writer-admission-periodic-model.json",
+        "writer-binding-continuation-source.json",
+        "typed-admission-candidate-preservation"
+      ],
+      "elapsed_ms": 5129,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-reference-preservation",
+      "command": "./typed-admission-reference-probe",
+      "args": [
+        "writer-binding",
+        "preserve",
+        "writer-admission-periodic-model.json",
+        "writer-binding-continuation-source.json",
+        "typed-admission-reference-preservation"
+      ],
+      "elapsed_ms": 5061,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-long",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "writer-admission-periodic-model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "typed-admission-long.json"
+      ],
+      "elapsed_ms": 4886,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-allocation",
+      "command": "env",
+      "args": [
+        "R4_DEPENDENT_READ_MODEL=writer-admission-periodic-model.json",
+        "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-68a49c874fa101f2",
+        "native_dependent_artifact_copy_is_allocation_free",
+        "--ignored",
+        "--exact",
+        "--nocapture"
+      ],
+      "elapsed_ms": 4930,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-cli",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "writer-admission-periodic-model.json",
+        "--prompt",
+        "casket in elvin. elvin in Bremen. Now elvin in Zurich. Question: Where is the location of casket? Answer:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 5065,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-response-cache",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_response_entry_reuses_no_write_only_during_committed_response",
+        "--nocapture"
+      ],
+      "elapsed_ms": 1230,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-work-counters",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_evaluation_adds_every_nested_work_counter",
+        "--nocapture"
+      ],
+      "elapsed_ms": 8,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-numeric-allocation",
+      "command": "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-68a49c874fa101f2",
+      "args": [
+        "native_typed_value_ingest_write_emission_and_eviction_are_allocation_free",
+        "--exact",
+        "--nocapture"
+      ],
+      "elapsed_ms": 297,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-rust-compile",
+      "command": "/Users/casey.allard/.cargo/bin/rustc",
+      "args": [
+        "--edition=2021",
+        "dependent-read-generated.rs",
+        "-o",
+        "typed-admission-generated-check"
+      ],
+      "elapsed_ms": 516,
+      "code": 0,
+      "stopped": null
+    },
+    {
+      "label": "typed-admission-rust-execute",
+      "command": "./typed-admission-generated-check",
+      "args": [],
+      "elapsed_ms": 179,
+      "code": 0,
+      "stopped": null
+    }
+  ],
+  "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "files": {
+    "typed-admission-learned-composition.stdout.log": {
+      "sha256": "9eacc0e00aa62c1048b5bab7e82596374cc9386434d87b0c12f52e41ec24d592",
+      "bytes": 166086
+    },
+    "typed-admission-learned-composition.stderr.log": {
+      "sha256": "9fa652e9682c2a04e382211daeb8f3fbd17fde6731c89e723dcc04131ca308ef",
+      "bytes": 459
+    },
+    "typed-admission-preservation-comparison.json": {
+      "sha256": "58a356c47bf3cbcaabe4f76f4e75e8efa2aaaf1ae7fe22d463d25c2fc8d480b8",
+      "bytes": 2107
+    },
+    "typed-admission-long-comparison.json": {
+      "sha256": "13bbdea570eda3ea5c00912154e3837b45a03aa5e30faa7aa25fcb0d1c012f39",
+      "bytes": 4087
+    }
+  },
+  "next_mechanism_status": "NOT_IMPLEMENTED: learned geometric typed operator/operand selection; full #1139/#1140 handoffs unmet"
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,25 +1,43 @@
 # Current native geometric AI work
 
-## Prepared generated-composition decision — #1139, 2026-09-06
+## Selected execution passes; learned composition fails — #1139, 2026-09-06
 
-**Retain `2600b95b`; new behavior is NOT_RUN.** Following the owner's capability
-and direction check, the next decision is learned use of an intermediate result
-in a complete generated answer. The [prepared change](../native_geometric_typed_admission_1139.md)
-adds a six-branch actual-artifact diagnostic: generate a sum, then either recall
-it or add a new value. Matched removal of the one derived record checks causal
-dependence; exact emitted bytes, EOS, source availability and operator choice
-remain separate observations. There is no supplied intermediate answer or LLM
-repair. This is OPEN development, not general prose or reasoning qualification.
+**Retain `2600b95b` with the checked selected-execution runtime.** The
+[result](../native_geometric_typed_admission_1139.md#executed-result--2026-09-06)
+and [evidence](../evidence/native_geometric_typed_admission_1139.json) preserve
+**3/3 exact initial sums but 0/6 correct follow-ups**. All required literals and
+actual derived sums remain captured. Repeat instructions wrongly add an old
+operand to the sum; removing the derived record changes that output. Add-new-
+value instructions abstain. This is a valid OPEN operator/operand selection
+negative, not missing storage, unavailable execution or general language evidence.
 
-Supporting Rust code scores the existing typed candidates before executing the
-selected Copy/Add operation, preserving overflow fallback and exact commits.
-It uses the existing sparse scorer; a new learned angular typed selector is
-not implemented by this change. Compilation is complete for the runtime/probe/
-CLI; local behavioral execution remains pending. The concrete complete cycle
-projects 45 seconds of model work plus 15 seconds reserve and requests a
-60-second cumulative extension. The ledger remains 1796.744/1800 seconds.
-The capability result must choose the next learning change; further cache work
-is secondary and the full #1139/#1140 handoffs remain unmet.
+The runtime now scores the existing typed candidates before executing selected
+Copy/Add, preserving overflow fallback and exact commit semantics. Its existing
+sparse scorer is unchanged; no newly learned angular typed selector is claimed.
+Same-artifact pre-change/rebuilt executions preserve 48/48 dependent, 62/62
+prior, 24/24 transfer, 28/28 exposed-name and 5/5 persistent cases. The 28 longer-
+context answers/writes also pass with identical generation objects except work.
+Six focused causal/cache/counter tests, numeric and actual-artifact allocation
+checks, the CLI revision answer and four unchanged generated Rust functions with
+12 semantic assertions pass. On the 62-case set, additions fall 236 to 16;
+feature comparisons remain 272,116. No whole-model speedup is established.
+
+**Next: learn query-conditioned geometric operator/operand choice over literal
+and derived references.** Reuse the signed-H4 source-routing learner and existing
+exact execution/commit path, train the joint candidate/action decision on
+causally generated intermediate states, and inspect actual query features before
+fit to avoid the earlier indistinguishable-input failure. The six exposed
+negatives are development data; new wording/composition evaluation follows
+selection. This learning change is not implemented yet. No new store or cache
+campaign is warranted by these retained-but-misselected values.
+
+The owner now authorizes necessary project-resource extensions. Record explicit
+projections and increments without asking for the same authorization again.
+This evaluation used 74.262 seconds after recorded +60 and +30 second increments;
+cumulative model use is 1871.006/1890 seconds. The diagnostic's unoptimized build
+exceeded its initial time projection; its negative was not rerun. Storage stayed
+within the existing allowance, material is preserved and paid external compute
+is zero. Protected delivery is PR #1153; the full #1139/#1140 handoffs remain unmet.
 
 ## Corrected-writer NoWrite reuse — #1139, 2026-09-06
 

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,26 @@
 # Current native geometric AI work
 
+## Prepared generated-composition decision — #1139, 2026-09-06
+
+**Retain `2600b95b`; new behavior is NOT_RUN.** Following the owner's capability
+and direction check, the next decision is learned use of an intermediate result
+in a complete generated answer. The [prepared change](../native_geometric_typed_admission_1139.md)
+adds a six-branch actual-artifact diagnostic: generate a sum, then either recall
+it or add a new value. Matched removal of the one derived record checks causal
+dependence; exact emitted bytes, EOS, source availability and operator choice
+remain separate observations. There is no supplied intermediate answer or LLM
+repair. This is OPEN development, not general prose or reasoning qualification.
+
+Supporting Rust code scores the existing typed candidates before executing the
+selected Copy/Add operation, preserving overflow fallback and exact commits.
+It uses the existing sparse scorer; a new learned angular typed selector is
+not implemented by this change. Compilation is complete for the runtime/probe/
+CLI; local behavioral execution remains pending. The concrete complete cycle
+projects 45 seconds of model work plus 15 seconds reserve and requests a
+60-second cumulative extension. The ledger remains 1796.744/1800 seconds.
+The capability result must choose the next learning change; further cache work
+is secondary and the full #1139/#1140 handoffs remain unmet.
+
 ## Corrected-writer NoWrite reuse — #1139, 2026-09-06
 
 **Retain `2600b95b`; the NoWrite compute regression is repaired.** The

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -186,10 +186,16 @@ and persistent-session results, and passes 28/28 replacement reserved-name
 cases. The subsequent [NoWrite repair](../native_geometric_writer_admission_1139.md)
 keeps that writer fixed and reduces long-context writer row comparisons from
 226,101,330 to 539,448, preserving all measured answers and writes. The immediate
-next build returns to learned operator/operand admission before execution,
-committed derived values and their use in a subsequent decision. No additional
-cache campaign is active. Follow current-state.md for artifacts and the nearly
-exhausted cumulative model allowance; a new issue does not reset it.
+next build returned to operator/operand admission before execution and committed
+derived-value use. The [selected-execution result](../native_geometric_typed_admission_1139.md)
+preserves prior behavior but gets 0/6 new follow-ups after 3/3 correct first sums.
+The exact intermediate and new operand are retained; the current sparse selector
+chooses the wrong operation/operand or abstains. Next learn query-conditioned
+geometric selection over those typed references, adapting the existing signed-H4
+source learner's joint candidate/action objective to causally generated states.
+This new angular typed selector is not implemented by the execution repair.
+No additional cache campaign is active. Follow current-state.md for artifacts
+and cumulative resources; a new issue does not reset the spent amount.
 The full handoff remains unmet.
 
 #### Immediate recurrent attention revision — owner adoption 2026-09-05
@@ -441,6 +447,14 @@ cost. Save useful checkpoints and stop cleanly at the configured limits. Before
 lengthy work, use a representative timing sample or existing measurements to
 select a feasible run; do not build an elaborate supervision system for a short
 experiment.
+
+**Owner authorization, 2026-09-06:** necessary project allowance extensions are
+preauthorized. Record the concrete complete projection, reason, increment and
+updated cumulative limit before using each extension. Do not repeatedly ask the
+owner to approve the same class of necessary resource increase. Continue the
+budget-friendly cadence, preserve all material, and distinguish local resource
+allowances from paid external purchases. This is not a requirement to spend the
+remaining allowance or expand a task whose result already resolves its question.
 
 ## Verification and preservation
 

--- a/docs/native_geometric_typed_admission_1139.md
+++ b/docs/native_geometric_typed_admission_1139.md
@@ -1,9 +1,9 @@
 # Generated composition check and selected typed execution — #1139, 2026-09-06
 
-Status: implementation prepared; compilation/check status is recorded below.
-Model execution and behavioral acceptance are NOT_RUN pending the additional
-local-model allowance. This record does not supersede accepted artifact
-`2600b95b` or qualify broader #1140 composition.
+Status: selected execution and preservation pass; learned follow-up composition
+fails **0/6**. Retain artifact `2600b95b` with the checked runtime change, without
+promoting broader #1140 composition. The initial preparation below is preserved;
+the executed result and resource reconciliation follow it.
 
 ## Capability decision after owner direction check
 
@@ -103,7 +103,7 @@ mechanism choice when the evidence calls for it.
   where applicable. Keep existing preservation and new diagnostic outcomes
   separate; no general-language or frontier claim follows automatically.
 
-## Resource proposal
+## Initial resource proposal — superseded by execution below
 
 The inherited ledger is still 1796.744/1800 seconds. Request an additional
 **60 seconds of cumulative local model execution**, increasing the ceiling to
@@ -128,7 +128,7 @@ explicit authorization for the additional cumulative allowance. Deliver admitted
 results through a protected PR, retaining `2600b95b` until actual checks justify
 acceptance.
 
-## Prepared build evidence
+## Prepared build evidence — historical pre-execution checkpoint
 
 The release library, existing preservation probe and native `r4` CLI compiled
 offline in 314.115 seconds. The focused unit test binary and release allocation
@@ -140,3 +140,89 @@ seconds. Total monitored build work is 382.586/600 seconds; latest measured
 storage growth headroom is 155.5 MiB. Compilation is not execution: local
 mechanical tests, preservation, composition and allocation reruns remain
 NOT_RUN until the cumulative model allowance is extended. No new fit is proposed.
+
+## Executed result — 2026-09-06
+
+The actual-artifact diagnostic completed with **3/3 exact first sums and 0/6
+correct follow-up chains**. It exited 101 on its explicit six-chain acceptance
+assertion; this is a model behavior negative, not an unavailable run or a reason
+to weaken the assertion. All twelve Full/control observations are preserved.
+
+| Inputs | First generated answer | Repeat previous total: expected / generated | Add new value: expected / generated |
+| --- | --- | --- | --- |
+| 13, 4; new 5 | `17.\n` | `17.\n` / `21.\n` | `22.\n` / ` Unknown.\n` |
+| 14, 4; new 5 | `18.\n` | `18.\n` / `22.\n` | `23.\n` / ` Unknown.\n` |
+| -3, 8; new 4 | `5.\n` | `5.\n` / `13.\n` | `9.\n` / ` Unknown.\n` |
+
+Every second decision captures the two original literals, the actual derived
+sum and the new literal. Each repeat instruction incorrectly selects Add over
+the derived sum and the old second operand. Removing only the derived record
+changes those answers to ` the.\n`. Each add instruction selects no typed
+operation and returns ` Unknown.\n` with or without the intermediate. The
+successful first sums and retained records exclude absent intermediate storage
+as the cause on these cases. They localize the failure to instruction-sensitive
+operator/operand selection and its admission to the assembled output. They do
+not prove that the current feature map can learn the required distinction.
+
+The same frozen artifact through preserved pre-change and rebuilt executables
+matches complete generation/state/trace and expected-write results on **48/48**
+dependent, **62/62** earlier, **24/24** transfer and **28/28** exposed-name cases,
+plus **5/5** persistent turns with restore/isolation. The 28 longer-context
+Generation objects also match the historical combined verifier except work;
+both reports certify exact writes. Their outer report schemas differ, so this
+does not claim whole-report equality.
+
+Across the 62 earlier cases, typed additions fall **236 → 16**, with **24**
+selected Copy/Add executions. Feature comparisons remain **272,116** and the new
+selector counts 360 ranking comparisons. Across 24 transfer cases, additions
+fall 8 → 0. These small arithmetic savings are not whole-model speedup evidence.
+The overflow path's repeated scoring remains counted and bounded.
+
+Four focused selected-execution/causal-state tests, the response-cache test and
+the complete nested-counter aggregation test pass. Numeric ingest/emission/
+eviction and actual-artifact dependent copying both pass allocation checks;
+the actual-artifact measured path has zero allocations/bytes. Native CLI revision
+generation returns ` Zurich.\n`. The four new generated Rust function texts
+exactly match the retained semantic-check source; recompilation and all twelve
+semantic assertions pass. These preserve familiar coding behavior, not new
+general syntax or multi-operation Rust reasoning.
+
+## Decision and next learning change
+
+Admit the selected-execution implementation at its preservation scope. Keep the
+six follow-ups as exposed negative evidence. **Next: learn query-conditioned
+operator and operand choice over literal and derived typed references**, reusing
+the existing signed-H4 source-routing learner and exact execution/commit path.
+Use causally generated intermediate states during construction. Fit the joint
+candidate/action decision, not independent token NLL terms; retain source IDs
+until the selected operation executes and its bytes are committed.
+
+Before fitting, inspect the actual candidate-relative query/derived features at
+this boundary to avoid repeating the earlier indistinguishable-input failure.
+Compare learned angular choice with the same-capacity exact-code/sparse control
+and keep the assembled output decision visible. Preserve existing responses,
+introduce construction wording variation and reserve a small new composition
+check after design selection. The mechanism and its fit are **NOT_IMPLEMENTED**
+here. Do not add a new store, parser, cache campaign or wider corpus to address
+these already reachable but misselected values. General language remains open.
+
+## Actual resources and standing owner authorization
+
+The owner authorized necessary project allowance extensions on 2026-09-06:
+“yes you may extend any allowances necessary for our project's goal”. Record
+each justified increment and its complete projection; do not request this same
+resource authorization again. Preserve cumulative accounting and material.
+
+This cycle recorded +60 seconds, then +30 seconds because the unoptimized
+actual-artifact diagnostic took **45.682 seconds**, exceeding its 10-second
+projection. The negative was not repeated. Total model work is **74.262 seconds**;
+cumulative use is **1871.006/1890 seconds**, leaving **18.994 seconds**. Monitored
+build work remains **382.586/600 seconds**. No new storage allowance was needed;
+known retained storage is 6,222,413,824 bytes with 149,843,968 bytes growth room
+before the tighter stop. No paid external compute or deletion occurred.
+
+The compact [evidence](evidence/native_geometric_typed_admission_1139.json)
+binds commands, results and scope. Full logs, paired preservation reports,
+control records and allowance receipts remain under the existing artifact root
+with prefix `typed-admission-`. CI's actual native checks are separate from its
+four compatibility acknowledgement statuses; protected delivery is PR #1153.

--- a/docs/native_geometric_typed_admission_1139.md
+++ b/docs/native_geometric_typed_admission_1139.md
@@ -1,0 +1,142 @@
+# Generated composition check and selected typed execution — #1139, 2026-09-06
+
+Status: implementation prepared; compilation/check status is recorded below.
+Model execution and behavioral acceptance are NOT_RUN pending the additional
+local-model allowance. This record does not supersede accepted artifact
+`2600b95b` or qualify broader #1140 composition.
+
+## Capability decision after owner direction check
+
+The next decision is whether the actual learned model can generate an
+intermediate result and then choose Copy versus Add over that result. The
+execute-after-selection implementation below is supporting work, not the
+language-learning milestone. Its scorer remains the existing learned sparse
+typed-value head; this change does not connect the signed-H4 source router to
+numeric operator choices or train a new geometric representation.
+
+One ignored Rust diagnostic loads the retained artifact once and generates
+three initial sums. The first two worlds change one operand with identical
+wording; the third includes a negative operand. Each saved generated state is
+followed by two instructions with the same new value: repeat the previous
+total, or add the new value to it. For each instruction, a matched control
+removes only the actual derived record before ingesting the next query, keeping
+the transcript, geometric state and other records. No expected intermediate is
+inserted into the model. The new follow-up wording is OPEN diagnostic input,
+not a claimed independently sealed language population.
+
+Acceptance requires six complete exact answer chains with EOS, the requested
+operator, exact intermediate provenance and a changed output when that record
+is removed. Numeric decision correctness, full emitted bytes, captured sources
+and the control are also reported separately. A latent correct numeral with
+broken prose cannot pass. Branch counters include their inherited prefix;
+reports expose that prefix so physical work can be summed without duplication.
+
+This check chooses the next learning change: missing source state calls for a
+retention/binding repair; accessible but misselected sources call for learning
+operator/operand selection; correct decisions with broken text call for
+assembled output learning. A failed new wording alone does not disprove the
+geometry. Do not start another cache campaign or tune a feature map that cannot
+distinguish the cases. General language remains unqualified even if this passes.
+
+## Direction and observed source behavior
+
+The immediate project goal is a learned geo-transformer whose bounded geometric
+routing chooses useful computation and retains exact results for subsequent
+reasoning and generated output. The repaired NoWrite cache is retained. This
+step uses the existing numeric typed-value scorer and Copy/Add operators;
+no cache tuning, tokenizer redesign, new corpus, provider, dense matrix
+operation, new geometric embedding or training campaign is introduced.
+
+In `value_runtime.rs`, `ValueState::offer` previously called `execute` for every
+candidate before scoring it. With sixteen source records that permits sixteen
+Copy calls and 240 ordered Add calls per initial decision. The learned scorer
+uses sparse integer rows over action, relative recency, literal/derived flags,
+query/source cues and relative H4/zeta features. Its features do not consume the
+computed result, so it can choose a candidate before execution.
+
+Exact records and causal state reuse already exist. Observing the first selected
+numeral token commits its value, exact operand IDs and provenance. A later
+response boundary captures that committed record as a possible operand.
+Prediction without observation cannot create that record. This step preserves
+those semantics and tests their use; it does not present them as newly invented.
+
+## Prepared implementation
+
+Each pass scores the same bounded candidate set and selects the highest positive
+score with the original ascending-proposal tie order. Only that candidate is
+executed. If exact execution rejects it, a scalar `(score, proposal index)`
+ceiling restricts the next pass to lower-ranked choices. This preserves the
+original highest-scoring valid candidate and abstention behavior. No result
+cache, score array, persistent state or new allocation is introduced.
+
+The valid common case performs one scoring pass and one exact Copy/Add call.
+An overflow can require rescoring; this is an explicit cost, not free fallback.
+With at most 256 offered candidates, at most 256 executions and 257 scoring
+passes are possible (the last pass may establish that no positive choice remains).
+Existing counters count every repeated proposal, feature lookup and geometric
+operation. New optional backward-compatible counters count actual operator
+calls, scoring passes and ranking comparisons; work aggregation includes them.
+Older report/checkpoint counters remain readable with zero defaults.
+
+This supports selected computation. It does not establish learned angular
+advantage or general reasoning, and cheap-addition elimination alone is not a
+whole-model latency claim. The existing full sparse scorer remains a cost to
+measure; replacing that scorer with learned geometric routing is a separate
+mechanism choice when the evidence calls for it.
+
+## Prepared acceptance
+
+- Preserve the frozen artifact's complete responses, exact writes and session
+  semantics using the existing combined preservation probe. Keep a preserved
+  pre-change executable for a same-artifact comparison, including total work.
+- Check one execution among 256 offered choices, exact overflow fallback and
+  tie order, abstention without arithmetic, and counter aggregation.
+- Check that only an observed committed intermediate value feeds the next
+  operation, with restoration, exact provenance and generated numeral bytes.
+  Deliberately weighted causal tests are mechanism tests, not learned behavior.
+- Run the separately ignored OPEN actual-artifact diagnostic above on six
+  follow-up branches and six matched intermediate-removal controls. It checks
+  complete output, termination, operator choice and actual intermediate write ID.
+  A negative means learned composition remains unqualified; it cannot be repaired
+  by injecting a derived value or claiming the mechanical test passed it.
+- Exercise allocation and the rebuilt native CLI, plus unchanged generated Rust
+  where applicable. Keep existing preservation and new diagnostic outcomes
+  separate; no general-language or frontier claim follows automatically.
+
+## Resource proposal
+
+The inherited ledger is still 1796.744/1800 seconds. Request an additional
+**60 seconds of cumulative local model execution**, increasing the ceiling to
+1860 seconds without resetting the spent amount. The projected complete model
+work is 45 seconds: paired preserved/candidate evaluation 14, focused tests 6,
+actual-artifact chain diagnostic 10, allocation/CLI 13, generated Rust 2. The
+remaining 15 seconds are a bounded correction reserve, not an automatic refit.
+These are local model seconds, not Codex token/dollar accounting. No paid
+external compute is proposed.
+
+Engineering projection: 450 seconds under a 600-second cycle ceiling, including
+release library/example/CLI and focused-test compilation plus checks. Projected
+peak new storage is 140 MiB within the initially verified 157.9 MiB tighter headroom;
+no storage increase is currently needed. Retain the existing 128 MiB stop margin,
+one model process and 4 GiB model RSS target. The old executable is preserved via
+an APFS clone and remains conservatively charged; no user material is deleted.
+
+Projection and command logs live under the existing artifact root with prefix
+`typed-admission-`. No model allowance has been increased and no model run has
+been launched for this step. Before any execution, refresh the ledger and record
+explicit authorization for the additional cumulative allowance. Deliver admitted
+results through a protected PR, retaining `2600b95b` until actual checks justify
+acceptance.
+
+## Prepared build evidence
+
+The release library, existing preservation probe and native `r4` CLI compiled
+offline in 314.115 seconds. The focused unit test binary and release allocation
+test binary also compiled (21.736 and 5.248 seconds, respectively). An earlier
+20.469-second build of the first selection draft is retained in engineering
+accounting. Formatting, architecture policy, claim wording and diff whitespace
+checks passed. The refined composition diagnostic compiled in a further 21.018
+seconds. Total monitored build work is 382.586/600 seconds; latest measured
+storage growth headroom is 155.5 MiB. Compilation is not execution: local
+mechanical tests, preservation, composition and allocation reruns remain
+NOT_RUN until the cumulative model allowance is extended. No new fit is proposed.


### PR DESCRIPTION
The numeric selector executes every candidate before scoring even though its features do not depend on the result. This change scores first, executes the selected Copy/Add candidate, and preserves stable overflow fallback with explicit execution/rescoring counters. The learned numeric scorer and retained artifact 2600b95b remain unchanged.

The actual-artifact composition check gives **3/3 correct initial sums but 0/6 follow-ups**. All intermediate values and new operands are retained. Repeat instructions choose Add over the sum plus an old operand; removing the intermediate changes those outputs. Add-new-value instructions abstain. This localizes the next learning work to query-conditioned operator/operand choice; it is not missing storage or general reasoning qualification. Twelve Full/control observations and the failed acceptance assertion are preserved.

Validation:

- Same-artifact pre-change/rebuilt executions preserve complete output/state/traces: 48/48 dependent, 62/62 earlier, 24/24 transfer, 28/28 exposed-name and 5/5 persistent-session cases. The 28 longer-context Generation objects also match historical evidence except work, with exact writes.
- Four selected-execution/causal tests, response-cache and nested-counter tests pass. Numeric and actual-artifact dependent allocation checks pass with zero allocations. Native CLI returns the revised Zurich value.
- Four newly generated Rust function texts match the retained check source; recompilation and all 12 semantic assertions pass. This is preservation of familiar functions, not new composition evidence.
- Offline runtime/probe/CLI builds, formatting, architecture policy and claim wording pass. Required protected CI remains separately visible; compatibility acknowledgements do not certify audit/fuzz/WASM/Gate C.

On the 62-case set, additions fall 236 to 16 with 24 selected operations; 272,116 feature comparisons remain. No whole-model speedup or new angular typed selector is claimed. The ignored learned diagnostic was explicitly executed and failed its behavioral acceptance; its negative does not invalidate the separately verified execution-preservation change.

The owner authorized necessary allowance extensions. Recorded +60 and +30 seconds cover 74.262 seconds of actual model work; cumulative use is 1871.006/1890 seconds. The unoptimized diagnostic exceeded its initial time projection and was not repeated. Build work is 382.586 seconds, storage fits, paid external compute is zero and all material is preserved.

See docs/native_geometric_typed_admission_1139.md and its compact evidence. Next: adapt the existing signed-H4 source learner to joint typed operator/operand selection on causally generated intermediate states, with complete output and matched controls. That learning change is not implemented here. Refs #1139, #1140; neither full handoff is closed.
