### PR TITLE
Learn geometric typed selection and reuse generated intermediates

### DIFF
--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -23,6 +23,8 @@ type ProbeResult<T> = Result<T, Box<dyn Error>>;
 mod relation_memory;
 #[path = "native_geometric_value_probe/role_read.rs"]
 mod role_read;
+#[path = "native_geometric_value_probe/typed_routing.rs"]
+mod typed_routing_probe;
 #[path = "native_geometric_value_probe/wording.rs"]
 mod wording;
 #[path = "native_geometric_value_probe/writer_binding.rs"]
@@ -971,6 +973,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("typed-routing") {
+        return typed_routing_probe::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("writer-binding") {
         return writer_binding::run(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
@@ -1,0 +1,93 @@
+use super::*;
+use uor_r4_core::native_geometric::{
+    RoutingMode, SourceRoutingConfig, TypedRoutingExample, ValueAction,
+};
+
+fn example(
+    id: String,
+    a: i64,
+    b: i64,
+    delta: i64,
+    question: &str,
+    action: Option<ValueAction>,
+) -> TypedRoutingExample {
+    let value = if action == Some(ValueAction::Add) {
+        a + b + delta
+    } else {
+        a + b
+    };
+    TypedRoutingExample {id,
+        initial_prompt:format!("User: suri has {a} coins. orin has {b} coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:"),
+        initial_response:format!("{}.\n",a+b),query:format!("User: There are {delta} new coins. {question}\nAssistant:"),
+        response:if action.is_some(){format!("{value}.\n")}else{" Unknown.\n".into()},
+        action,operands:action.map(|op|if op==ValueAction::Copy{[a+b,a+b]}else{[a+b,delta]}),
+    }
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    match args.first().map(String::as_str) {
+        Some("prepare") if args.len()==2 => {
+            let phrases=[
+                ("Repeat the previous total without adding the new coins.",Some(ValueAction::Copy)),
+                ("Return the previous total.",Some(ValueAction::Copy)),
+                ("Copy the previous total.",Some(ValueAction::Copy)),
+                ("Add the new coins to the previous total.",Some(ValueAction::Add)),
+                ("What is the sum of the previous total and the new coins?",Some(ValueAction::Add)),
+                ("Return the previous total plus the new coins.",Some(ValueAction::Add)),
+                ("Where is the location of suri?",None),
+            ];
+            let mut fit=Vec::new();
+            for (i,(a,b,d)) in [(13,4,5),(8,7,6),(-3,8,4),(21,3,7),(10,6,2),(4,9,3)].into_iter().enumerate(){
+                for (j,(q,op)) in phrases.iter().enumerate(){fit.push(example(format!("fit/{i}/{j}"),a,b,d,q,*op));}
+            }
+            let mut development=Vec::new();
+            for (i,(a,b,d)) in [(13,4,5),(14,4,5),(-3,8,4)].into_iter().enumerate(){
+                for j in [0,3]{development.push(example(format!("open/{i}/{j}"),a,b,d,phrases[j].0,phrases[j].1));}
+            }
+            let mut first_use=Vec::new();
+            for (i,(a,b,d)) in [(31,6,4),(17,9,3),(-6,14,7)].into_iter().enumerate(){
+                for (j,(q,op)) in [
+                    ("Please copy the previous total.",ValueAction::Copy),
+                    ("Please return the sum of the new coins and the previous total.",ValueAction::Add),
+                ].into_iter().enumerate(){first_use.push(example(format!("reserved/{i}/{j}"),a,b,d,q,Some(op)));}
+            }
+            let source=json!({"schema":"uor-r4.typed-routing-source/1","fit":fit,"development":development,"first_use":first_use,"scope":"42 authored construction follow-ups. Six previously exposed development failures may inform design. Six predeclared operand/wording transfers are opened only after design selection; they are not broad language qualification. First responses are generated, not supplied to serving."});
+            write_json(Path::new(&args[1]),&source)?;
+        }
+        Some("case-source") if args.len()==3 => {
+            let mut source:Value=serde_json::from_slice(&fs::read(&args[1])?)?;
+            source["exposed_first_use"]=source["first_use"].clone();
+            let mut reserved=Vec::new();
+            for (i,(a,b,d)) in [(19,12,5),(23,8,6),(-4,15,3)].into_iter().enumerate(){
+                for (j,(q,op)) in [
+                    ("Please repeat the previous total without adding the new coins.",ValueAction::Copy),
+                    ("Please add the new coins to the previous total.",ValueAction::Add),
+                ].into_iter().enumerate(){reserved.push(example(format!("case-reserved/{i}/{j}"),a,b,d,q,Some(op)));}
+            }
+            source["first_use"]=serde_json::to_value(reserved)?;
+            source["scope"]=json!("Case-fold revision: original construction and development unchanged; prior3/6 first-use failures are exposed repair checks, not held out. New six predeclared operands/wording cases remain unopened until revised design selection. No general language qualification.");
+            write_json(Path::new(&args[2]),&source)?;
+        }
+        Some("fit") if args.len()==5=>{
+            let mode=match args[4].as_str(){"angular"|"angular-folded"=>RoutingMode::Angular,"equality"|"equality-folded"=>RoutingMode::Equality,_=>return Err("typed fit mode".into())};
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs:Vec<TypedRoutingExample>=serde_json::from_value(source["fit"].clone())?;
+            let (candidate,report)=model.fit_typed_routing(&docs,SourceRoutingConfig{learned_features:128,passes:4,proposals:12,max_seconds:30,mode,..SourceRoutingConfig::default()},args[4].ends_with("-folded"))?;
+            let out=Path::new(&args[3]);fs::create_dir(out)?;
+            write_new(&out.join("model.json"),&candidate.to_bytes()?)?;
+            write_json(&out.join("fit.json"),&report)?;println!("{report}");
+        }
+        Some("evaluate") if args.len()==6=>{
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            if !["fit","development","first_use","exposed_first_use"].contains(&args[3].as_str()){return Err("typed evaluation split".into());}
+            let docs:Vec<TypedRoutingExample>=serde_json::from_value(source[&args[3]].clone())?;
+            let remove=match args[5].as_str(){"full"=>false,"remove-intermediate"=>true,_=>return Err("typed control".into())};
+            let report=model.evaluate_typed_routing(&docs,remove)?;
+            write_json(Path::new(&args[4]),&report)?;
+            println!("{}",json!({"artifact":report["artifact"],"split":args[3],"control":args[5],"exact":report["exact"],"total":report["total"]}));
+        }
+        _=>return Err("typed-routing prepare SOURCE | fit MODEL SOURCE NEW_DIR angular|equality | evaluate MODEL SOURCE SPLIT NEW_REPORT full|remove-intermediate".into()),
+    }
+    Ok(())
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -20,6 +20,9 @@ mod source_routing;
 mod source_routing_tests;
 mod source_routing_training;
 pub use source_routing_training::SourceRoutingConfig;
+mod typed_routing;
+mod typed_routing_training;
+pub use typed_routing_training::TypedRoutingExample;
 mod anchors;
 mod learned_routing;
 #[cfg(test)]
@@ -310,6 +313,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    typed_routing: Option<typed_routing::TypedRouting>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     relation_writer: Option<relation_training::WriterRevision>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     dependent_read: Option<dependent_read::DependentRead>,
@@ -344,6 +349,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    typed_routing: Option<typed_routing::TypedRouting>,
+    #[serde(default)]
     relation_writer: Option<relation_training::WriterRevision>,
     #[serde(default)]
     dependent_read: Option<dependent_read::DependentRead>,
@@ -377,6 +384,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            typed_routing: wire.typed_routing,
             relation_writer: wire.relation_writer,
             dependent_read: wire.dependent_read,
             source_routing: wire.source_routing,

--- a/crates/uor-r4-core/src/native_geometric/source_routing_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_routing_training.rs
@@ -52,22 +52,34 @@ impl SourceRouting {
         self.config.validate()?;
         let read = role_read::head(model)
             .ok_or_else(|| Error("source routing requires retained-word reader".into()))?;
+        self.validate_shape(
+            model,
+            read.actions.len(),
+            if self.config.role_context_only {
+                20
+            } else {
+                30
+            },
+        )
+    }
+    pub(super) fn validate_shape(
+        &self,
+        model: &Model,
+        actions: usize,
+        feature_kinds: u8,
+    ) -> Result<()> {
+        self.config.validate()?;
         if self.schema != "uor-r4.geometric-source-routing/1"
             || self.codes.is_empty()
             || self.codes.len() > self.config.learned_features
             || self.codes.windows(2).any(|p| p[0].feature >= p[1].feature)
-            || self.codes.iter().any(|c| {
-                c.feature.kind
-                    >= if self.config.role_context_only {
-                        20
-                    } else {
-                        30
-                    }
-                    || c.roots.iter().any(|&r| r >= 120)
-            })
-            || self.landmarks.len() != read.actions.len()
+            || self
+                .codes
+                .iter()
+                .any(|c| c.feature.kind >= feature_kinds || c.roots.iter().any(|&r| r >= 120))
+            || self.landmarks.len() != actions
             || self.landmarks.iter().flatten().any(|&r| r >= 120)
-            || self.biases.len() != read.actions.len()
+            || self.biases.len() != actions
             || self.biases.iter().any(|b| !(-32..=32).contains(b))
             || self.ranks != super::learned_routing_training::ranks(model)
             || self.training.is_empty()

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -176,6 +176,7 @@ impl Trainer {
         let mut template = Model {
             relation_writer: None,
             dependent_read: None,
+            typed_routing: None,
             source_routing: None,
             learned_routing: None,
             schema: SCHEMA.into(),
@@ -510,6 +511,24 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(block) = &self.typed_routing {
+            let mut parent = self.clone();
+            parent.typed_routing = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != block.router.parent_artifact {
+                return Err(Error("typed routing parent differs".into()));
+            }
+            parent.validate()?;
+            block.validate(self)?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("typed routing identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(writer) = &self.relation_writer {
             let mut parent = self.clone();
             parent.relation_writer = None;
@@ -873,6 +892,7 @@ fn add_work(total: &mut Work, work: Work) {
     total.values.literal_writes += work.values.literal_writes;
     total.values.record_evictions += work.values.record_evictions;
     total.values.proposals += work.values.proposals;
+    total.values.routing.add(work.values.routing);
     total.values.operator_executions += work.values.operator_executions;
     total.values.selection_comparisons += work.values.selection_comparisons;
     total.values.selection_passes += work.values.selection_passes;
@@ -964,6 +984,10 @@ mod work_tests {
         // so the independent JSON oracle covers every current counter.
         let seed = Work {
             values: ValueWork {
+                routing: RoutingWork {
+                    predictions: 1,
+                    ..RoutingWork::default()
+                },
                 operator_executions: 1,
                 selection_comparisons: 1,
                 selection_passes: 1,

--- a/crates/uor-r4-core/src/native_geometric/typed_routing.rs
+++ b/crates/uor-r4-core/src/native_geometric/typed_routing.rs
@@ -1,0 +1,149 @@
+//! Learned geometric metadata selection; exact numeric payloads remain separate.
+use super::source_routing::SourceRouting;
+use super::value_types::{ValueFeature, ValueRecord, ValueState, ValueWork, VALUES};
+use super::word_copy_types::WordCopyAddress;
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct TypedRouting {
+    pub router: SourceRouting,
+    pub dictionary: Vec<WordCopyAddress>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fold_ascii_case: bool,
+}
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+pub(super) fn context(
+    model: &Model,
+    values: &ValueState,
+    control: Control,
+    work: &mut ValueWork,
+) -> Option<[u32; 16]> {
+    let block = model.typed_routing.as_ref()?;
+    if matches!(
+        control,
+        Control::LearnedRoutingDisabled | Control::GeometryDisabled | Control::H4Disabled
+    ) {
+        return None;
+    }
+    let mut derived = false;
+    for source in &values.sources {
+        work.routing.sources_examined += 1;
+        derived |= source.derived;
+    }
+    // Structural scope: initial literal-only decisions retain their parent.
+    if !derived {
+        return None;
+    }
+    Some(addresses(block, values, work))
+}
+
+pub(super) fn addresses(
+    block: &TypedRouting,
+    values: &ValueState,
+    work: &mut ValueWork,
+) -> [u32; 16] {
+    let mut out = [0; 16];
+    let Some(words) = &values.lexemes else {
+        return out;
+    };
+    for (i, word) in words.queries[..words.query_len].iter().enumerate() {
+        work.routing.context_tokens_read += 1;
+        let found = block.dictionary.binary_search_by(|d| {
+            work.routing.comparisons += 1;
+            for j in 0..usize::from(word.len.min(d.len)) {
+                work.lexical_byte_comparisons += 1;
+                work.routing.logical_bytes_read += 2;
+                let byte = if block.fold_ascii_case {
+                    word.bytes[j].to_ascii_lowercase()
+                } else {
+                    word.bytes[j]
+                };
+                let cmp = d.bytes[j].cmp(&byte);
+                if !cmp.is_eq() {
+                    return cmp;
+                }
+            }
+            d.len.cmp(&word.len)
+        });
+        out[i] = found.map_or(0, |i| block.dictionary[i].prime);
+    }
+    out
+}
+
+pub(super) fn features(
+    values: &ValueState,
+    operands: Option<(ValueRecord, ValueRecord)>,
+    addr: &[u32; 16],
+    work: &mut ValueWork,
+) -> ([ValueFeature; 36], usize) {
+    let mut out = [ValueFeature::default(); 36];
+    let (flags, rank_a, rank_b) = if let Some((a, b)) = operands {
+        let mut ra = VALUES;
+        let mut rb = VALUES;
+        for (rank, r) in values.sources.iter().rev().enumerate() {
+            work.routing.sources_examined += 1;
+            work.routing.comparisons += 2;
+            if r.id == a.id {
+                ra = rank;
+            }
+            if r.id == b.id {
+                rb = rank;
+            }
+        }
+        (u64::from(a.derived) | (u64::from(b.derived) << 1), ra, rb)
+    } else {
+        (0, VALUES, VALUES)
+    };
+    out[0] = ValueFeature {
+        kind: 0,
+        a: flags,
+        b: 0,
+    };
+    out[1] = ValueFeature {
+        kind: 1,
+        a: rank_a as u64,
+        b: rank_b as u64,
+    };
+    let mut n = 2;
+    // Ordered exact word identities, not distances computed from hash bits.
+    for (position, &prime) in addr.iter().enumerate() {
+        if prime == 0 {
+            continue;
+        }
+        out[n] = ValueFeature {
+            kind: 2,
+            a: u64::from(prime),
+            b: 0,
+        };
+        n += 1;
+        out[n] = ValueFeature {
+            kind: 3,
+            a: position as u64,
+            b: u64::from(prime),
+        };
+        n += 1;
+    }
+    (out, n)
+}
+
+pub(super) fn score(
+    model: &Model,
+    values: &ValueState,
+    operands: Option<(ValueRecord, ValueRecord)>,
+    action: usize,
+    addr: &[u32; 16],
+    control: Control,
+    work: &mut ValueWork,
+) -> i64 {
+    let Some(block) = &model.typed_routing else {
+        return 0;
+    };
+    let (f, n) = features(values, operands, addr, work);
+    let state = block
+        .router
+        .encode(model, &f[..n], control, &mut work.routing);
+    block.router.score(model, state, action, &mut work.routing)
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END

--- a/crates/uor-r4-core/src/native_geometric/typed_routing_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/typed_routing_training.rs
@@ -1,0 +1,342 @@
+//! Offline joint operator/operand learning over causally generated states.
+use super::source_routing::{SourceCode, SourceRouting};
+use super::source_routing_training::{learn, Alternative, Frame};
+use super::typed_routing::{self, TypedRouting};
+use super::value_types::{ValueAction, ValueFeature};
+use super::word_copy_types::WordCopyAddress;
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TypedRoutingExample {
+    pub id: String,
+    pub initial_prompt: String,
+    pub initial_response: String,
+    pub query: String,
+    pub response: String,
+    /// Offline action/operand supervision, never passed into serving.
+    pub action: Option<ValueAction>,
+    pub operands: Option<[i64; 2]>,
+}
+
+impl TypedRouting {
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        self.router.validate_shape(model, 3, 4)?;
+        let primes = crate::corpus_induced_spin_placement::first_primes(self.dictionary.len())
+            .map_err(|e| Error(e.to_string()))?;
+        if model.values.is_none()
+            || self.dictionary.is_empty()
+            || self.dictionary.len() > 256
+            || self.dictionary.iter().zip(primes).any(|(w, p)| {
+                w.len == 0
+                    || w.len > 32
+                    || u64::from(w.prime) != p
+                    || !w.bytes[..usize::from(w.len)]
+                        .iter()
+                        .any(|b| b.is_ascii_alphabetic() || *b == b'_')
+                    || w.bytes[..usize::from(w.len)]
+                        .iter()
+                        .any(|b| !b.is_ascii_alphanumeric() && *b != b'_')
+                    || w.bytes[usize::from(w.len)..].iter().any(|b| *b != 0)
+                    || (self.fold_ascii_case
+                        && w.bytes[..usize::from(w.len)]
+                            .iter()
+                            .any(u8::is_ascii_uppercase))
+            })
+            || self
+                .dictionary
+                .windows(2)
+                .any(|p| p[0].bytes[..usize::from(p[0].len)] >= p[1].bytes[..usize::from(p[1].len)])
+        {
+            return Err(Error("invalid geometric typed routing artifact".into()));
+        }
+        Ok(())
+    }
+}
+
+fn generate(model: &Model, s: &mut Session) -> Result<(Vec<u8>, Option<ValueDecision>, bool)> {
+    let mut out = Vec::new();
+    let mut decision = None;
+    for _ in 0..32 {
+        let token = s.predict(model)?.token;
+        if let Some(d) = s.value_decision().filter(|d| d.cursor == 0) {
+            decision = Some(d);
+        }
+        s.observe(model, token)?;
+        if token == EOS {
+            return Ok((model.decode(&out)?, decision, true));
+        }
+        out.push(token);
+    }
+    Ok((model.decode(&out)?, decision, false))
+}
+
+fn initial(model: &Model, d: &TypedRoutingExample) -> Result<(Session, ValueDecision)> {
+    let mut s = model.session(Control::Full)?;
+    s.observe(model, BOS)?;
+    for t in model.encode(&d.initial_prompt)? {
+        s.observe(model, t)?;
+    }
+    s.begin_response(model)?;
+    let (bytes, decision, eos) = generate(model, &mut s)?;
+    if bytes != d.initial_response.as_bytes() || !eos {
+        return Err(Error(format!(
+            "initial generated response failed: {}: {}",
+            d.id,
+            String::from_utf8_lossy(&bytes)
+        )));
+    }
+    let first =
+        decision.ok_or_else(|| Error("initial response has no committed typed decision".into()))?;
+    s.end_response(model)?;
+    for t in model.encode(&d.query)? {
+        s.observe(model, t)?;
+    }
+    s.begin_response(model)?;
+    Ok((s, first))
+}
+
+impl Model {
+    pub fn fit_typed_routing(
+        &self,
+        docs: &[TypedRoutingExample],
+        config: SourceRoutingConfig,
+        fold_ascii_case: bool,
+    ) -> Result<(Self, serde_json::Value)> {
+        config.validate()?;
+        self.validate()?;
+        if self.typed_routing.is_some()
+            || docs.is_empty()
+            || docs.len() > 256
+            || docs.iter().any(|d| {
+                d.id.is_empty()
+                    || d.initial_prompt.len() + d.query.len() > 4096
+                    || d.response.len() > 128
+                    || d.initial_response.len() > 128
+                    || d.action.is_some() != d.operands.is_some()
+            })
+        {
+            return Err(Error("invalid typed routing construction input".into()));
+        }
+        let mut words = BTreeSet::<Vec<u8>>::new();
+        for d in docs {
+            for w in d
+                .query
+                .as_bytes()
+                .split(|b| !b.is_ascii_alphanumeric() && *b != b'_')
+            {
+                if !w.is_empty()
+                    && w.len() <= 32
+                    && w.iter().any(|b| b.is_ascii_alphabetic() || *b == b'_')
+                {
+                    words.insert(if fold_ascii_case {
+                        w.to_ascii_lowercase()
+                    } else {
+                        w.to_vec()
+                    });
+                }
+            }
+        }
+        if words.len() > 256 {
+            return Err(Error("typed dictionary exceeds256".into()));
+        }
+        let primes = crate::corpus_induced_spin_placement::first_primes(words.len())
+            .map_err(|e| Error(e.to_string()))?;
+        let dictionary = words
+            .into_iter()
+            .zip(primes)
+            .map(|(w, p)| {
+                let mut bytes = [0; 32];
+                bytes[..w.len()].copy_from_slice(&w);
+                WordCopyAddress {
+                    bytes,
+                    len: w.len() as u8,
+                    prime: p as u32,
+                }
+            })
+            .collect();
+        let mut rng = config.seed;
+        let mut block = TypedRouting {
+            fold_ascii_case,
+            dictionary,
+            router: SourceRouting {
+                schema: "uor-r4.geometric-source-routing/1".into(),
+                parent_artifact: self.artifact_cid.clone(),
+                codes: Vec::new(),
+                landmarks: (0..3)
+                    .map(|_| {
+                        std::array::from_fn(|_| {
+                            (super::learned_routing_training::next_random(&mut rng) % 120) as u16
+                        })
+                    })
+                    .collect(),
+                biases: vec![0; 3],
+                ranks: super::learned_routing_training::ranks(self),
+                training: Vec::new(),
+                config: config.clone(),
+            },
+        };
+        let started = Instant::now();
+        let mut frequency = BTreeMap::<ValueFeature, usize>::new();
+        let mut frames = Vec::new();
+        for d in docs {
+            let (s, first) = initial(self, d)?;
+            let values = s
+                .values
+                .as_ref()
+                .ok_or_else(|| Error("typed state absent".into()))?;
+            let addr = typed_routing::addresses(&block, values, &mut Default::default());
+            let (f, n) = typed_routing::features(values, None, &addr, &mut Default::default());
+            let mut alternatives = vec![Alternative {
+                features: f[..n].to_vec(),
+                codes: Vec::new(),
+                action: 2,
+                correct: d.action.is_none(),
+            }];
+            for i in 0..272 {
+                let Some((action, a, b)) = values.proposal(i) else {
+                    continue;
+                };
+                let correct = d.action == Some(action)
+                    && d.operands.is_some_and(|pair| {
+                        ([a.value, b.value] == pair
+                            || (action == ValueAction::Add && [b.value, a.value] == pair))
+                            && (a.id == first.write_id || b.id == first.write_id)
+                    });
+                let (f, n) =
+                    typed_routing::features(values, Some((a, b)), &addr, &mut Default::default());
+                alternatives.push(Alternative {
+                    features: f[..n].to_vec(),
+                    codes: Vec::new(),
+                    action: if action == ValueAction::Copy { 0 } else { 1 },
+                    correct,
+                });
+            }
+            if !alternatives.iter().any(|a| a.correct) {
+                return Err(Error(format!(
+                    "unreachable typed construction target: {}",
+                    d.id
+                )));
+            }
+            for a in &alternatives {
+                for f in &a.features {
+                    *frequency.entry(*f).or_default() += 1;
+                }
+            }
+            frames.push(Frame { alternatives });
+            let bytes = serde_json::to_vec(d).map_err(|e| Error(e.to_string()))?;
+            block.router.training.push(DocumentReceipt {
+                id: d.id.clone(),
+                bytes: bytes.len(),
+                text_cid: format!("blake3:{}", blake3::hash(&bytes).to_hex()),
+            });
+        }
+        let mut vocab: Vec<_> = frequency.iter().map(|(f, n)| (*f, *n)).collect();
+        vocab.sort_by(|a, b| {
+            (a.0.kind >= 2)
+                .cmp(&(b.0.kind >= 2))
+                .then(b.1.cmp(&a.1))
+                .then(a.0.cmp(&b.0))
+        });
+        vocab.truncate(config.learned_features);
+        vocab.sort_by_key(|p| p.0);
+        block.router.codes = vocab
+            .iter()
+            .map(|(feature, _)| SourceCode {
+                feature: *feature,
+                roots: [self.geometry.identity; 2],
+            })
+            .collect();
+        // Exact effective-feature collisions are inspected before the fit.
+        let mut signatures = BTreeMap::<Vec<(usize, Vec<ValueFeature>)>, BTreeSet<usize>>::new();
+        for frame in &frames {
+            let signature = frame
+                .alternatives
+                .iter()
+                .map(|a| {
+                    (
+                        a.action,
+                        a.features
+                            .iter()
+                            .copied()
+                            .filter(|f| {
+                                block
+                                    .router
+                                    .codes
+                                    .binary_search_by_key(f, |c| c.feature)
+                                    .is_ok()
+                            })
+                            .collect(),
+                    )
+                })
+                .collect();
+            let correct = frame
+                .alternatives
+                .iter()
+                .enumerate()
+                .filter_map(|(i, a)| a.correct.then_some(i))
+                .collect::<BTreeSet<_>>();
+            let joint = signatures
+                .entry(signature)
+                .or_insert_with(|| correct.clone());
+            *joint = joint.intersection(&correct).copied().collect();
+            if joint.is_empty() {
+                return Err(Error("typed effective feature collision before fit".into()));
+            }
+        }
+        let construction_ms = started.elapsed().as_millis();
+        let fit = learn(self, &mut block.router, &mut frames, Instant::now());
+        let block_bytes = serde_json::to_vec(&block)
+            .map_err(|e| Error(e.to_string()))?
+            .len();
+        let dictionary_words = block.dictionary.len();
+        let mut model = self.clone();
+        model.typed_routing = Some(block);
+        model.refresh_identity()?;
+        model.validate()?;
+        let artifact = model.artifact_cid().to_owned();
+        Ok((
+            model,
+            serde_json::json!({"parent":self.artifact_cid(),"artifact":artifact,"frames":frames.len(),"effective_query_classes":signatures.len(),"incompatible_feature_classes":0,"feature_universe":frequency.len(),"features":vocab.len(),"dictionary_words":dictionary_words,"block_bytes":block_bytes,"construction_ms":construction_ms,"fit":fit,"config":config,"scope":"Joint typed operator/operand labels over actual generated intermediates; source values and numeric query words are not encoded as geometric scoring features. Construction fit is not generated transfer."}),
+        ))
+    }
+
+    pub fn evaluate_typed_routing(
+        &self,
+        docs: &[TypedRoutingExample],
+        remove_intermediate: bool,
+    ) -> Result<serde_json::Value> {
+        if docs.is_empty() || docs.len() > 256 {
+            return Err(Error("typed evaluation document bound".into()));
+        }
+        let started = Instant::now();
+        let mut cases = Vec::new();
+        for d in docs {
+            let (mut s, first) = initial(self, d)?;
+            if remove_intermediate {
+                if let Some(v) = &mut s.values {
+                    v.records.retain(|r| r.id != first.write_id);
+                    v.sources.retain(|r| r.id != first.write_id);
+                }
+            }
+            let captured = s.values.as_ref().map(|v| v.sources.clone());
+            let (bytes, decision, eos) = generate(self, &mut s)?;
+            let used = decision.is_some_and(|x| {
+                x.operands
+                    .iter()
+                    .any(|r| r.derived && r.id == first.write_id)
+            });
+            let action = decision.map(|d| d.action);
+            let exact = bytes == d.response.as_bytes()
+                && eos
+                && action == d.action
+                && (d.action.is_none() || used);
+            cases.push(serde_json::json!({"id":d.id,"query":d.query,"expected":d.response,"text":String::from_utf8_lossy(&bytes),"expected_action":d.action,"exact":exact,"used_intermediate":used,"terminated":eos,"decision":decision,"first_decision":first,"captured":captured,"work":s.work}));
+        }
+        Ok(
+            serde_json::json!({"artifact":self.artifact_cid(),"total":cases.len(),"exact":cases.iter().filter(|r|r["exact"]==true).count(),"remove_intermediate_control":remove_intermediate,"elapsed_ms":started.elapsed().as_millis(),"cases":cases}),
+        )
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/value_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime.rs
@@ -330,6 +330,14 @@ impl ValueState {
         // causes another pass, below the last rejected (score, proposal-order)
         // choice. This preserves first-valid ties without a score buffer.
         let mut ceiling: Option<(i64, usize)> = None;
+        let routed = super::typed_routing::context(model, self, control, work);
+        let no_op = routed
+            .as_ref()
+            .map(|addr| {
+                work.routing.predictions += 1;
+                super::typed_routing::score(model, self, None, 2, addr, control, work)
+            })
+            .unwrap_or(0);
         let (action, a, b, value, best) = loop {
             work.selection_passes = work.selection_passes.saturating_add(1);
             let mut selected = None;
@@ -339,15 +347,28 @@ impl ValueState {
                     continue;
                 };
                 work.proposals = work.proposals.saturating_add(1);
-                let (features, len) = self.features(model, action, a, b, control, work);
                 let mut score = 0_i64;
-                for feature in &features[..len] {
-                    work.feature_lookups = work.feature_lookups.saturating_add(1);
-                    if let Ok(index) = head.rows.binary_search_by(|row| {
-                        work.feature_comparisons = work.feature_comparisons.saturating_add(1);
-                        row.feature.cmp(feature)
-                    }) {
-                        score += i64::from(head.rows[index].weight);
+                if let Some(addr) = &routed {
+                    let action_index = if action == ValueAction::Copy { 0 } else { 1 };
+                    score = super::typed_routing::score(
+                        model,
+                        self,
+                        Some((a, b)),
+                        action_index,
+                        addr,
+                        control,
+                        work,
+                    ) - no_op;
+                } else {
+                    let (features, len) = self.features(model, action, a, b, control, work);
+                    for feature in &features[..len] {
+                        work.feature_lookups = work.feature_lookups.saturating_add(1);
+                        if let Ok(index) = head.rows.binary_search_by(|row| {
+                            work.feature_comparisons = work.feature_comparisons.saturating_add(1);
+                            row.feature.cmp(feature)
+                        }) {
+                            score += i64::from(head.rows[index].weight);
+                        }
                     }
                 }
                 if let Some((limit, rejected)) = ceiling {

--- a/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
@@ -371,6 +371,86 @@ fn native_value_selected_execution_runs_one_of_256_scored_choices() {
 }
 
 #[test]
+fn native_typed_routing_preserves_role_information_without_encoding_values() {
+    let model = mechanical_model(ValueAction::Add);
+    let session = prefix(&model, "13 4 total:", Control::Full);
+    let values = session.values.as_ref().unwrap();
+    let mut a = values.sources[0];
+    let b = values.sources[1];
+    let mut addr = [0; 16];
+    addr[0] = 2;
+    addr[1] = 3;
+    let first =
+        super::typed_routing::features(values, Some((a, b)), &addr, &mut Default::default());
+    a.value = 999;
+    assert_eq!(
+        first,
+        super::typed_routing::features(values, Some((a, b)), &addr, &mut Default::default())
+    );
+    a.derived = true;
+    assert_ne!(
+        first,
+        super::typed_routing::features(values, Some((a, b)), &addr, &mut Default::default())
+    );
+    a.derived = false;
+    addr.swap(0, 1);
+    assert_ne!(
+        first,
+        super::typed_routing::features(values, Some((a, b)), &addr, &mut Default::default())
+    );
+}
+
+#[test]
+fn native_typed_routing_case_fold_changes_metadata_only() {
+    use super::source_routing::SourceRouting;
+    use super::typed_routing::TypedRouting;
+    use super::word_copy_types::WordCopyAddress;
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "13 4 total:", Control::Full);
+    let values = session.values.as_mut().unwrap();
+    let mut bytes = [0; 32];
+    bytes[..4].copy_from_slice(b"copy");
+    let mut block = TypedRouting {
+        fold_ascii_case: true,
+        dictionary: vec![WordCopyAddress {
+            bytes,
+            len: 4,
+            prime: 2,
+        }],
+        router: SourceRouting {
+            schema: String::new(),
+            parent_artifact: String::new(),
+            codes: Vec::new(),
+            landmarks: Vec::new(),
+            biases: Vec::new(),
+            ranks: Vec::new(),
+            training: Vec::new(),
+            config: SourceRoutingConfig::default(),
+        },
+    };
+    for spelling in [b"copy", b"Copy", b"COPY"] {
+        let mut words = super::value_lexemes::LexemeState {
+            query_len: 1,
+            ..Default::default()
+        };
+        words.queries[0].len = 4;
+        words.queries[0].bytes[..4].copy_from_slice(spelling);
+        values.lexemes = Some(words);
+        block.fold_ascii_case = true;
+        assert_eq!(
+            super::typed_routing::addresses(&block, values, &mut Default::default())[0],
+            2
+        );
+        assert_eq!(values.lexemes, Some(words));
+        block.fold_ascii_case = false;
+        assert_eq!(
+            super::typed_routing::addresses(&block, values, &mut Default::default())[0],
+            if spelling == b"copy" { 2 } else { 0 }
+        );
+    }
+}
+
+#[test]
 fn native_value_selected_execution_preserves_overflow_fallback_order() {
     let model = mechanical_model(ValueAction::Add);
     let mut session = prefix(&model, "9223372036854775807 1 -2 total:", Control::Full);

--- a/crates/uor-r4-core/src/native_geometric/value_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_types.rs
@@ -18,6 +18,8 @@ pub enum ValueAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ValueWork {
+    #[serde(default, skip_serializing_if = "RoutingWork::is_empty")]
+    pub routing: RoutingWork,
     #[serde(
         default,
         skip_serializing_if = "super::relation::RelationWork::is_empty"

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -278,6 +278,10 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "native dependent read",
             include_str!("../src/native_geometric/dependent_read.rs"),
         ),
+        (
+            "native typed routing",
+            include_str!("../src/native_geometric/typed_routing.rs"),
+        ),
         ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
@@ -1171,4 +1175,43 @@ fn native_dependent_artifact_copy_is_allocation_free() {
     assert!(selected, "dependent path was not exercised");
     assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
     println!("dependent exact two-link ingest/select/observe/copy: allocations=0 bytes=0");
+}
+
+#[test]
+#[ignore = "requires R4_TYPED_ROUTING_MODEL learned development artifact"]
+fn native_typed_artifact_routing_is_allocation_free() {
+    let path = std::env::var("R4_TYPED_ROUTING_MODEL").expect("named model path");
+    let model =
+        uor_r4_core::native_geometric::Model::from_bytes(&std::fs::read(path).unwrap()).unwrap();
+    let first=model.encode("User: suri has 13 coins. orin has 4 coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:").unwrap();
+    let second = model
+        .encode("User: There are 5 new coins. Add the new coins to the previous total.\nAssistant:")
+        .unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    ALLOCATIONS.with(|v| v.set(0));
+    BYTES.with(|v| v.set(0));
+    MEASURING.with(|v| v.set(true));
+    let result = (|| {
+        session.observe(&model, BOS)?;
+        for prompt in [&first, &second] {
+            for &token in prompt {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)?;
+            for _ in 0..32 {
+                let token = session.predict(&model)?.token;
+                session.observe(&model, token)?;
+                if token == EOS {
+                    break;
+                }
+            }
+            session.end_response(&model)?;
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(())
+    })();
+    MEASURING.with(|v| v.set(false));
+    result.unwrap();
+    assert!(session.work.values.routing.predictions > 0);
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    println!("actual typed geometric routing/commit: allocations=0 bytes=0");
 }

--- a/docs/evidence/native_geometric_typed_routing_1139.json
+++ b/docs/evidence/native_geometric_typed_routing_1139.json
@@ -1,0 +1,925 @@
+{
+  "schema": "uor-r4.typed-routing-evidence/1",
+  "decision": "RETAIN_CASE_FOLDED_ANGULAR_TYPED_SELECTION_AT_BOUNDED_COMPOSITION_SCOPE",
+  "source_base": "14a4c85e360f1c3738b1a4364048e83a1c622783",
+  "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "artifact": "blake3:bb79456b2dd7187005a3501d437fdc17215429bd4fff0671c31a44583d2918c7",
+  "parent": "blake3:2600b95bbb160dd70a14b7ae05306e3b6b9607377919db0414fc529519eb9635",
+  "angular_fit": {
+    "artifact": "blake3:bb79456b2dd7187005a3501d437fdc17215429bd4fff0671c31a44583d2918c7",
+    "block_bytes": 13865,
+    "config": {
+      "learned_features": 128,
+      "max_seconds": 30,
+      "mode": "angular",
+      "passes": 4,
+      "proposals": 12,
+      "seed": 1139
+    },
+    "construction_ms": 61,
+    "dictionary_words": 25,
+    "effective_query_classes": 7,
+    "feature_universe": 109,
+    "features": 109,
+    "fit": {
+      "accepted": [
+        12,
+        0,
+        4
+      ],
+      "final_correct": 42,
+      "final_hinge": 0,
+      "initial_correct": 6,
+      "initial_hinge": 108,
+      "proposals": 14027,
+      "stopped_at_time_limit": false
+    },
+    "frames": 42,
+    "incompatible_feature_classes": 0,
+    "parent": "blake3:2600b95bbb160dd70a14b7ae05306e3b6b9607377919db0414fc529519eb9635",
+    "scope": "Joint typed operator/operand labels over actual generated intermediates; source values and numeric query words are not encoded as geometric scoring features. Construction fit is not generated transfer."
+  },
+  "equality_fit": {
+    "artifact": "blake3:a66209fffb60f693b3f5ff859e34aa050f713754ca97692a52fd6b8cbf93dd75",
+    "block_bytes": 13869,
+    "config": {
+      "learned_features": 128,
+      "max_seconds": 30,
+      "mode": "equality",
+      "passes": 4,
+      "proposals": 12,
+      "seed": 1139
+    },
+    "construction_ms": 60,
+    "dictionary_words": 25,
+    "effective_query_classes": 7,
+    "feature_universe": 109,
+    "features": 109,
+    "fit": {
+      "accepted": [
+        5,
+        0,
+        0
+      ],
+      "final_correct": 24,
+      "final_hinge": 18,
+      "initial_correct": 6,
+      "initial_hinge": 42,
+      "proposals": 14007,
+      "stopped_at_time_limit": false
+    },
+    "frames": 42,
+    "incompatible_feature_classes": 0,
+    "parent": "blake3:2600b95bbb160dd70a14b7ae05306e3b6b9607377919db0414fc529519eb9635",
+    "scope": "Joint typed operator/operand labels over actual generated intermediates; source values and numeric query words are not encoded as geometric scoring features. Construction fit is not generated transfer."
+  },
+  "results": {
+    "construction_generated": [
+      42,
+      42
+    ],
+    "exposed_development": [
+      6,
+      6
+    ],
+    "exposed_v1_failure_repair": [
+      6,
+      6
+    ],
+    "new_first_use_angular": [
+      6,
+      6
+    ],
+    "new_first_use_equality": [
+      3,
+      6
+    ],
+    "intermediate_removal": [
+      0,
+      6
+    ],
+    "dependent": [
+      48,
+      48
+    ],
+    "earlier": [
+      62,
+      62
+    ],
+    "prior_transfer": [
+      24,
+      24
+    ],
+    "exposed_names": [
+      28,
+      28
+    ],
+    "long_context": [
+      28,
+      28
+    ],
+    "persistent_turns": [
+      5,
+      5
+    ]
+  },
+  "v1_negative": {
+    "angular_first_use": [
+      3,
+      6
+    ],
+    "equality_first_use": [
+      3,
+      6
+    ],
+    "decision": "NOT_ADOPTED",
+    "cause": "Case-sensitive query dictionary omitted lowercase instruction identity. V2 case-folds metadata only; V1 transfer now exposed, not held-out."
+  },
+  "transfer_scope": "Six authored new numeric/wording cases after design selection. Not sealed general language; no sweep or seed robustness claim.",
+  "examples": [
+    {
+      "id": "case-reserved/0/0",
+      "query": "User: There are 5 new coins. Please repeat the previous total without adding the new coins.\nAssistant:",
+      "expected": "31.\n",
+      "text": "31.\n",
+      "used_intermediate": true,
+      "terminated": true
+    },
+    {
+      "id": "case-reserved/0/1",
+      "query": "User: There are 5 new coins. Please add the new coins to the previous total.\nAssistant:",
+      "expected": "36.\n",
+      "text": "36.\n",
+      "used_intermediate": true,
+      "terminated": true
+    },
+    {
+      "id": "case-reserved/1/0",
+      "query": "User: There are 6 new coins. Please repeat the previous total without adding the new coins.\nAssistant:",
+      "expected": "31.\n",
+      "text": "31.\n",
+      "used_intermediate": true,
+      "terminated": true
+    },
+    {
+      "id": "case-reserved/1/1",
+      "query": "User: There are 6 new coins. Please add the new coins to the previous total.\nAssistant:",
+      "expected": "37.\n",
+      "text": "37.\n",
+      "used_intermediate": true,
+      "terminated": true
+    },
+    {
+      "id": "case-reserved/2/0",
+      "query": "User: There are 3 new coins. Please repeat the previous total without adding the new coins.\nAssistant:",
+      "expected": "11.\n",
+      "text": "11.\n",
+      "used_intermediate": true,
+      "terminated": true
+    },
+    {
+      "id": "case-reserved/2/1",
+      "query": "User: There are 3 new coins. Please add the new coins to the previous total.\nAssistant:",
+      "expected": "14.\n",
+      "text": "14.\n",
+      "used_intermediate": true,
+      "terminated": true
+    }
+  ],
+  "cost": {
+    "scope": "Totals for six complete two-response sessions; includes regenerating each first sum. New routing logical bytes are not physical DRAM traffic or complete instruction counts. No whole-model speed claim.",
+    "typed_values": {
+      "operator_executions": 12,
+      "additions": 9,
+      "proposals": 120,
+      "selection_passes": 12
+    },
+    "new_routing": {
+      "code_reads": 6120,
+      "comparisons": 27456,
+      "context_tokens_read": 96,
+      "emission_queries": 3264,
+      "logical_bytes_read": 523692,
+      "operator_executions": 0,
+      "payload_gathers": 0,
+      "predictions": 6,
+      "sources_examined": 420,
+      "table_reads": 13362
+    }
+  },
+  "checks": {
+    "focused_tests": 7,
+    "kernel_source_check": "PASS",
+    "actual_typed_allocation_count": 0,
+    "actual_typed_allocated_bytes": 0,
+    "generated_rust_bodies_unchanged": 4,
+    "generated_rust_semantic_assertions": 12,
+    "cli_revision_text": " Zurich.\n",
+    "artifact_reload_identity": "PASS"
+  },
+  "resources": {
+    "cycle_model_ms": 162033,
+    "cycle_engineering_ms": 686095,
+    "cumulative_model_ms": 2033039,
+    "model_limit_ms": 2130000,
+    "model_increment_ms": 240000,
+    "storage_increment_bytes": 134217728,
+    "cycle_model_limit_ms": 240000,
+    "engineering_limit_ms": 900000,
+    "maximum_sampled_known_bytes": 6329102336,
+    "effective_storage_ceiling_bytes": 6506475520,
+    "sampled_model_rss_max_bytes": 853278720,
+    "paid_external_compute": 0,
+    "deletions": 0,
+    "sampling_limit": "Periodic known-root and child-process samples, not exact transient peaks."
+  },
+  "commands": [
+    {
+      "label": "typed-routing-prepare",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "prepare",
+        "typed-routing-source.json"
+      ],
+      "elapsed_ms": 168,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-angular-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "fit",
+        "writer-admission-periodic-model.json",
+        "typed-routing-source.json",
+        "typed-routing-angular",
+        "angular"
+      ],
+      "elapsed_ms": 15754,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-equality-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "fit",
+        "writer-admission-periodic-model.json",
+        "typed-routing-source.json",
+        "typed-routing-equality",
+        "equality"
+      ],
+      "elapsed_ms": 16414,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-angular-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-angular/model.json",
+        "typed-routing-source.json",
+        "development",
+        "typed-routing-angular-development.json",
+        "full"
+      ],
+      "elapsed_ms": 5455,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-equality-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-equality/model.json",
+        "typed-routing-source.json",
+        "development",
+        "typed-routing-equality-development.json",
+        "full"
+      ],
+      "elapsed_ms": 5496,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-preservation",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "preserve",
+        "typed-routing-angular/model.json",
+        "writer-binding-continuation-source.json",
+        "typed-routing-preservation"
+      ],
+      "elapsed_ms": 5613,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-removal",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-angular/model.json",
+        "typed-routing-source.json",
+        "development",
+        "typed-routing-removal.json",
+        "remove-intermediate"
+      ],
+      "elapsed_ms": 5426,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-angular-construction-output",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-angular/model.json",
+        "typed-routing-source.json",
+        "fit",
+        "typed-routing-angular-construction-output.json",
+        "full"
+      ],
+      "elapsed_ms": 5496,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-angular-first-use",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-angular/model.json",
+        "typed-routing-source.json",
+        "first_use",
+        "typed-routing-angular-first-use.json",
+        "full"
+      ],
+      "elapsed_ms": 5467,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-equality-first-use",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-equality/model.json",
+        "typed-routing-source.json",
+        "first_use",
+        "typed-routing-equality-first-use.json",
+        "full"
+      ],
+      "elapsed_ms": 5467,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-source",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "case-source",
+        "typed-routing-source.json",
+        "typed-routing-case-source.json"
+      ],
+      "elapsed_ms": 194,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-angular-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "fit",
+        "writer-admission-periodic-model.json",
+        "typed-routing-case-source.json",
+        "typed-routing-case-angular",
+        "angular-folded"
+      ],
+      "elapsed_ms": 16094,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-equality-fit",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "fit",
+        "writer-admission-periodic-model.json",
+        "typed-routing-case-source.json",
+        "typed-routing-case-equality",
+        "equality-folded"
+      ],
+      "elapsed_ms": 16031,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-development",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-angular/model.json",
+        "typed-routing-case-source.json",
+        "development",
+        "typed-routing-case-development.json",
+        "full"
+      ],
+      "elapsed_ms": 5498,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-exposed",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-angular/model.json",
+        "typed-routing-case-source.json",
+        "exposed_first_use",
+        "typed-routing-case-exposed.json",
+        "full"
+      ],
+      "elapsed_ms": 5470,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-construction",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-angular/model.json",
+        "typed-routing-case-source.json",
+        "fit",
+        "typed-routing-case-construction.json",
+        "full"
+      ],
+      "elapsed_ms": 5565,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-first-use",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-angular/model.json",
+        "typed-routing-case-source.json",
+        "first_use",
+        "typed-routing-case-first-use.json",
+        "full"
+      ],
+      "elapsed_ms": 5512,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-equality-first-use",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-equality/model.json",
+        "typed-routing-case-source.json",
+        "first_use",
+        "typed-routing-case-equality-first-use.json",
+        "full"
+      ],
+      "elapsed_ms": 5520,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-preservation",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "writer-binding",
+        "preserve",
+        "typed-routing-case-angular/model.json",
+        "writer-binding-continuation-source.json",
+        "typed-routing-case-preservation"
+      ],
+      "elapsed_ms": 6002,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-long",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "evaluate-relations",
+        "typed-routing-case-angular/model.json",
+        "relation-admission-source.json",
+        "first_use",
+        "typed-routing-case-long.json"
+      ],
+      "elapsed_ms": 5891,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-removal",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "typed-routing",
+        "evaluate",
+        "typed-routing-case-angular/model.json",
+        "typed-routing-case-source.json",
+        "first_use",
+        "typed-routing-case-removal.json",
+        "remove-intermediate"
+      ],
+      "elapsed_ms": 5809,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-unit-check",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_typed_routing",
+        "--nocapture"
+      ],
+      "elapsed_ms": 1178,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-counter-check",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_evaluation_adds_every_nested_work_counter",
+        "--nocapture"
+      ],
+      "elapsed_ms": 8,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-execution-check",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "native_value_selected_execution",
+        "--nocapture"
+      ],
+      "elapsed_ms": 924,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-cli",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "typed-routing-case-angular/model.json",
+        "--prompt",
+        "casket in elvin. elvin in Bremen. Now elvin in Zurich. Question: Where is the location of casket? Answer:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 5788,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-kernel-check",
+      "command": "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-68a49c874fa101f2",
+      "args": [
+        "native_kernel_source_has_no_forbidden_arithmetic_or_float_types",
+        "--exact",
+        "--nocapture"
+      ],
+      "elapsed_ms": 155,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-allocation-check",
+      "command": "env",
+      "args": [
+        "R4_TYPED_ROUTING_MODEL=typed-routing-case-angular/model.json",
+        "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-68a49c874fa101f2",
+        "native_typed_artifact_routing_is_allocation_free",
+        "--exact",
+        "--ignored",
+        "--nocapture"
+      ],
+      "elapsed_ms": 5561,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-rust-execution",
+      "command": "./typed-routing-generated",
+      "args": [],
+      "elapsed_ms": 77,
+      "code": 0,
+      "engineering_only": false,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-unit-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "native_typed_routing",
+        "--config",
+        "profile.test.package.uor-r4-core.opt-level=0",
+        "--no-run"
+      ],
+      "elapsed_ms": 20534,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-release",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 310374,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-case-release",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 326667,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-final-unit-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "native_typed_routing",
+        "--config",
+        "profile.test.package.uor-r4-core.opt-level=0",
+        "--no-run"
+      ],
+      "elapsed_ms": 23186,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-allocation-build",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "-p",
+        "uor-r4-wasm-router",
+        "--test",
+        "native_geometric_allocations",
+        "--no-run"
+      ],
+      "elapsed_ms": 5224,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    },
+    {
+      "label": "typed-routing-rust-compile",
+      "command": "/Users/casey.allard/.cargo/bin/rustc",
+      "args": [
+        "--edition=2021",
+        "typed-routing-generated.rs",
+        "-o",
+        "typed-routing-generated"
+      ],
+      "elapsed_ms": 110,
+      "code": 0,
+      "engineering_only": true,
+      "stopped": null
+    }
+  ],
+  "source_sha256": {
+    "crates/uor-r4-core/src/native_geometric/learned_routing_training.rs": "58553ac81135950af1810786da65ae8450963e2b27bc6b84aee03f6c3fad206a",
+    "crates/uor-r4-core/src/native_geometric/completion_runtime.rs": "036cdd7efa717aeb27518ae75fc7604823bb0c8b15897b4d000fbd74d67d3053",
+    "crates/uor-r4-core/src/native_geometric/runtime.rs": "d956b891b654ab385680dfb56fc391cf4227af6fcefd48622ac9eb1f1eeb54bb",
+    "crates/uor-r4-core/src/native_geometric/role_read_training.rs": "5cadf639c522d4ce2df45f62e00ef70ef5733627da64129568a8363ffcf63808",
+    "crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs": "f2c1425cb58b4d8d3c20ab7d877fbc9153938ffbf15a6a1a018b5afa1f4a8c08",
+    "crates/uor-r4-core/src/native_geometric/response_runtime.rs": "79548be47acc125a6025ae946bb07a5a12ef06ac805766a0233711f8360dabd9",
+    "crates/uor-r4-core/src/native_geometric/recurrent_routing_tests.rs": "a4c78c5faf33be5f80d69a54203cdad810700d4c8da20a93f975bac16a693926",
+    "crates/uor-r4-core/src/native_geometric/recurrent_routing.rs": "d663c4ebbbf828d98d52fbcbf20e1e39005f17ada6e26a6b3244c105e898681d",
+    "crates/uor-r4-core/src/native_geometric/source_routing_training.rs": "831a6d70e97f4e3bea1f13facf41133419729b9d2cce16d71897df336167e1df",
+    "crates/uor-r4-core/src/native_geometric/relation_admission.rs": "c831aa567460389cd0930d70d503cf917eab58436caab5341db29d3957b0e24d",
+    "crates/uor-r4-core/src/native_geometric/value_training.rs": "0b056cc7bc210e1201f84f09eae925752954db291aa0d4a095f64a595589602d",
+    "crates/uor-r4-core/src/native_geometric/dependent_read.rs": "4885e6b1e2518c934e9cd8d2701b7b1295dac5aed60f65c4086bc0a44115f3d3",
+    "crates/uor-r4-core/src/native_geometric/completion_types.rs": "f27c88bf1d8f359ff1e40a56fd241144f7b032a55e379fc5f2e1bb06694446ca",
+    "crates/uor-r4-core/src/native_geometric/response_entry_runtime_tests.rs": "01c624d9d2e72d6d847e1a68e5df4361acf7de89539d3fb760afc8c1a25d0a43",
+    "crates/uor-r4-core/src/native_geometric/memory_training.rs": "304d76de48a42c3d8ee0b4c626210cd95131a600c01f82c1c4ed34609484eb7d",
+    "crates/uor-r4-core/src/native_geometric/response_runtime_tests.rs": "b9b26a58ac3026e6307ecfa49de92027b23fc48d380f53f76c1f79ddcda3bea6",
+    "crates/uor-r4-core/src/native_geometric/value_snapshot.rs": "c22f17bb4f19e1a3c96c3cd774b85434f5063891c7c061757776d5477a3d91c6",
+    "crates/uor-r4-core/src/native_geometric/response_entry_types.rs": "770a37fddfbf98bb8f3f35ba7a87fad556eb816791e0fe8d708fd042ae9617e3",
+    "crates/uor-r4-core/src/native_geometric/value_runtime.rs": "1cf48ad54c7e18a7dbc9452ae85db38f736f35c88960919751815096831d8761",
+    "crates/uor-r4-core/src/native_geometric/typed_routing_training.rs": "fe8a46a0d787d0c6e1037eb3ff288b57eba655ed0fe22dc96d4ca219c62fcd54",
+    "crates/uor-r4-core/src/native_geometric/word_copy_tests.rs": "2a48dc255b240f0ec3e4f339ed401b2760398c9f8ff2e842f50d73209cc76e98",
+    "crates/uor-r4-core/src/native_geometric/relation_tests.rs": "55584fa1a5e986dd7679b061771057c7c8d642178aa30ba4e32e377eece5d350",
+    "crates/uor-r4-core/src/native_geometric/learned_routing.rs": "e6810d1e9ec40ebebd1da8fe724f9edfcbfe44ff97c7b8543549c6f6a70ce0b8",
+    "crates/uor-r4-core/src/native_geometric/numeral.rs": "2c0012a595d87e653051b067d586d98e93fe1394f9651d75725144cf0ef330fb",
+    "crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs": "5f7de876ddfb5d0e2907129c934664dba2e4e65ec5c3543448fc311a331029ea",
+    "crates/uor-r4-core/src/native_geometric/mixture.rs": "cf89e5a634ea48fc027f4e08fadea2af42e2be396d6501f4f34ac4fba704a581",
+    "crates/uor-r4-core/src/native_geometric/memory_types.rs": "64b235ebb196b95a7e7125f8083893a0ea7b86b78dc3a97ebc831b6fd433a998",
+    "crates/uor-r4-core/src/native_geometric/value_lexemes.rs": "dc79fa8e1c4f0fadb14af0d8153155b4e874a3178f8d33042b3515460467f5e9",
+    "crates/uor-r4-core/src/native_geometric/relation.rs": "9c33cb38d1512fa4550bc3294a6e11896a1e3aba650c20bc46012d6142555ab5",
+    "crates/uor-r4-core/src/native_geometric/typed_routing.rs": "6a63f3894ffb8cd33c8a9bb311ae506055af5212c5331ce194db864815f149ad",
+    "crates/uor-r4-core/src/native_geometric/dependent_read_training.rs": "2ea2596612201b2f37f48b1e2ee4afa1946e501941c787a919e302cafc67b711",
+    "crates/uor-r4-core/src/native_geometric/training.rs": "97fba60a8f2adb5a50fa3f34784385f1eb48c93ec71ac80c57c99df8b82ac7bc",
+    "crates/uor-r4-core/src/native_geometric/response_snapshot_tests.rs": "b0035296cb47ed804afa2be292b8fed3d540268c8062b8a38673e37a6a36631d",
+    "crates/uor-r4-core/src/native_geometric/relation_training.rs": "4b24ff3f4d02a2309cd7570cd0c623c5d521f91fe152eedfe0fd83fefd59b9cb",
+    "crates/uor-r4-core/src/native_geometric/completion_runtime_tests.rs": "00a6678f7c4f9db1cdd78598e4e63e2219ef3ccb86dcd07b716b07b2df4f3a68",
+    "crates/uor-r4-core/src/native_geometric/recurrent_routing_training.rs": "8e41d7781677349ee2f33935dcdbdf7b751e8c84f10416fe6f1af112b8129b6b",
+    "crates/uor-r4-core/src/native_geometric/mod.rs": "9049b3d605d3819052e3b0367827facf61db57e59d87e995c95b42cf57966322",
+    "crates/uor-r4-core/src/native_geometric/snapshot.rs": "bee614505d2df39f2b8ebdecedfe12a63c578c6dc8e330f594556ffc301411cd",
+    "crates/uor-r4-core/src/native_geometric/value_snapshot_tests.rs": "49a0cdd1ea033e32209594e4eaf2973c8e7c4a094ead42444b34a6dd7753babe",
+    "crates/uor-r4-core/src/native_geometric/response_entry_snapshot.rs": "20776a856bc9ef2bfcd62dc92e55b2d889219902fa211543ccdea880ea8d7f52",
+    "crates/uor-r4-core/src/native_geometric/response_entry_training_tests.rs": "ab388e1e8ce45b34989cfd9f0182ef3e3a5faf0c7cbdee07d68cd9946e5ccc2a",
+    "crates/uor-r4-core/src/native_geometric/memory_runtime_tests.rs": "ccb1293f2e66ef78e7d0f047b4f512d132d0e4edbb307b9907b8b7421268e6a8",
+    "crates/uor-r4-core/src/native_geometric/response_entry_training.rs": "722560a989f02345959c56742161d5a76cbcc334bc8149db7a86ccd0f4294494",
+    "crates/uor-r4-core/src/native_geometric/tests.rs": "11da699221ff0982b5ea0302b4ede6b890d0e73546333fc05602f6f903c91c49",
+    "crates/uor-r4-core/src/native_geometric/word_copy_types.rs": "805cfe15d5d5a5502b9e312ace03d122f2ddf91ea73884cf7e03472d9453f5d1",
+    "crates/uor-r4-core/src/native_geometric/completion_snapshot_tests.rs": "b11acf8d489c9c9fa15f428f1b3fd0d56b91180e624142e6ba6d77459695090c",
+    "crates/uor-r4-core/src/native_geometric/value_types.rs": "fbdb3c0635d1efa0400a85fea2d8eafde357859505f6a0d7b8d19b4bb146209d",
+    "crates/uor-r4-core/src/native_geometric/role_read_tests.rs": "eb1d2164ac806e370adeb8f3f6f41977874743ab8a601e85990ed073eecd20d5",
+    "crates/uor-r4-core/src/native_geometric/learned_routing_tests.rs": "6474ccae0aea4315a1a7e26f8707857e3003f5351163f3e69f694836ebdc6fb6",
+    "crates/uor-r4-core/src/native_geometric/memory_runtime.rs": "ba649539cf17774041cec34b4fa5b77a495293004766d36cb9ffccf1956ceb68",
+    "crates/uor-r4-core/src/native_geometric/word_copy_snapshot.rs": "e0d3dc5d8f690e7485a1a252ec98d8048017366553807f19537747434ddb5447",
+    "crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs": "1e87be5b00185fde35fb5e4781bb5facc0f849d6b0a8aca7838751bbaf39469e",
+    "crates/uor-r4-core/src/native_geometric/completion_training.rs": "c674dfac58c9d135ac6f15f5b493aa0078149ec501b7655c0874dd4eac8bc27e",
+    "crates/uor-r4-core/src/native_geometric/role_read.rs": "aaaca896674a9f7f82b6da5bbc3fe89fc340384b9e98cddda178afb89c660601",
+    "crates/uor-r4-core/src/native_geometric/completion_snapshot.rs": "0701775ec18cc2c2efe4d9c916cba51cbc49100f6bf07f4921812278d0729edf",
+    "crates/uor-r4-core/src/native_geometric/word_copy_training.rs": "916bb0848cc71a9caaa3178060ff0bb8d4893d625608b4033d4fe81dcbe6781b",
+    "crates/uor-r4-core/src/native_geometric/source_routing_tests.rs": "f19c78f1fd6e684ce8d8e2e758701ea54dde8bba8759d2fa49b00889fb45a526",
+    "crates/uor-r4-core/src/native_geometric/anchors.rs": "eb653f80cb3160ad083cc16d10952218454bbaefeb9bdd02b38e92c34a32ba8a",
+    "crates/uor-r4-core/src/native_geometric/source_routing.rs": "7201fce3f0267e27a37aadcfdb39a4a526219b16787b7b730b460703a6904460",
+    "crates/uor-r4-core/src/native_geometric/dependent_read_tests.rs": "2e7a322f52888a0064e0cbe7027e8dc40129655befd8bc3d49e49dc69bd2ca0c"
+  },
+  "retained_reports_sha256": {
+    "typed-routing-angular-construction-output.json": "99acfb81e30f8e8e241ef71bdefad0a99d0b07d743e1b8a9e57f32b8b7a8c962",
+    "typed-routing-angular-development.json": "e502b7dad574c9c4994a4f57bcbbf79db963d18b82d2d66adf32d82eb0d3f31f",
+    "typed-routing-angular-first-use.json": "659141ff56108f176bace15e737b32e1333c98ec2d4f39b54ea4393243f26152",
+    "typed-routing-angular/fit.json": "be5cd14c29fdfaadbc34c85887af7fc68ec226b3fd986715fa920431c84763a8",
+    "typed-routing-angular/model.json": "42d55b688395e955f1a62de0bfa2997a64764a3569deae5a25a3d61cd9e67ad8",
+    "typed-routing-case-angular/fit.json": "6b80b6b4d444a5404b035eec5c8eabec1fd9d595ecd1368347bf1ee9b6df5dcc",
+    "typed-routing-case-angular/model.json": "9f877725abf3ef8c02c882fdc2b9ee4fc405d256ad765730e3a43414ee608e77",
+    "typed-routing-case-construction.json": "ec6774457d4c450b42c796473c5e7aeb6716205c8cd272980438c526c6b8c117",
+    "typed-routing-case-design-selection.json": "21ffef3fe4e0d237f4e10d02e5082436a59305b450f1a834f07e48d385687532",
+    "typed-routing-case-development.json": "bec373177c808c0ad6ab37fa817e16799326ff8105140f80f6411515eac83d47",
+    "typed-routing-case-equality-first-use.json": "5d99c6d74c231841e1baac7298060edc249855996d5682a11ba94e3c93cd4468",
+    "typed-routing-case-equality/fit.json": "e8599e8c1615aef64ec7eec8f529203b6f9b3bbbb5ff99cf6ee7290f6dbad55f",
+    "typed-routing-case-equality/model.json": "f08c0e7da0749270c607833c407182f859a0e2a82b95a07d82cc0c76fc67ac35",
+    "typed-routing-case-exposed.json": "a945e11fcdb02fa79c42d0c691933d00b446255f953be38bb6abc66c32366cd6",
+    "typed-routing-case-first-use.json": "7a82d19270bb2aed4d751381cc886fa931170c0affc132f7e890cf9718fccb68",
+    "typed-routing-case-long.json": "0804d3fae47ccd16bf76fc8c944b08af196cbc1edad646f5b30cc409e92f90e0",
+    "typed-routing-case-preservation/development.json": "4ba0a1aad73b37876adfddb91876df773e3008df9d5bc268b44c77ea6db0205d",
+    "typed-routing-case-preservation/exposed-names.json": "ce7d527bfe9387c23ef026dc8b6488490ac04a7b6488c447dd532810762efe42",
+    "typed-routing-case-preservation/preservation.json": "68f39dccbebf393798922b9214fb4e84efe91f57a56ec7e21ed058bd2367674e",
+    "typed-routing-case-preservation/prior.json": "c701064244c0d04ef6f2763cea3365748d213883a30edb3c99edc69511d57a42",
+    "typed-routing-case-preservation/sessions.json": "8619a9f1856451831518145742cdc8967d96c6c5bdd4e4124907c2d57c37a9dc",
+    "typed-routing-case-removal.json": "f9ab98ca61695c2a1ec3e3177a02dd745ad085e741d6e4dc5340bab9a7b7133c",
+    "typed-routing-case-source.json": "a2478621e8aa7d0ece07a678dc2508f33c5e76adfe4ed91826754386da0c2afe",
+    "typed-routing-design-selection.json": "b70abde5c5a4fae69a9af7241cc0b0265410f9d71e7174d06159cd4e44dd5691",
+    "typed-routing-equality-development.json": "64880b5a9df803fe08966a705e7ad543c109a5091a436be49e38095505796c8b",
+    "typed-routing-equality-first-use.json": "573467de832cf6e687cdc4bcec949330bcea043c8bcf705fae0031c6a7b3fa3b",
+    "typed-routing-equality/fit.json": "485502683e974e1802d2025d8a7df5006d5d887066fc939320e0dcdb0858b27d",
+    "typed-routing-equality/model.json": "42e576b7e9be3550f45db6146c96bf6e098900d7e4c57d60630274ece8f72e47",
+    "typed-routing-issue1139-before.json": "31a3ce8ec7d7fc65645989b7f24adcf561c2a6fd78fb58da8eef71eb08f150e0",
+    "typed-routing-issue1140-before.json": "1ab24c4f73d36f6215989bff071f84ba82caf654bd5fa1f15d076d74e9de667a",
+    "typed-routing-preservation/development.json": "c4cd68d613d398bd9559e4cd8cf8dc47adae89651c1efe2fc3b47a6ab73061b9",
+    "typed-routing-preservation/exposed-names.json": "b2d4c92ecf4dbab4bb85ed999f6c19997287db018a4d294211e84c5c65aaedb5",
+    "typed-routing-preservation/preservation.json": "f41b19f66e7317ae075b789e78288da428e308e1e7e907a6f11eb29bb56568ee",
+    "typed-routing-preservation/prior.json": "f3df293a2aafd972b23e6f9600f841f236b50d55e031e7053ab375b2760ce4ec",
+    "typed-routing-preservation/sessions.json": "804cf8c5b3c7e616c05a00570e3fcff1cc498fb03222efc160d0aec835e5c2dd",
+    "typed-routing-projection.json": "9b1126e28685b5fa96c747514cccbcad2a2c3965f9c30211655a72374e53aeec",
+    "typed-routing-removal.json": "cc2c21cdc47929b886183e6bd45a020c462c806386f8093e84fb2061ca97fd85",
+    "typed-routing-source.json": "e4bbb44e3a4d2430f14428dd47ae9412c3b334cc5716bfa501d694085bf95db4",
+    "typed-routing-storage-before.json": "cb22b08f50d346de0f7b91ac1665b9dc037db633ff3ae695798070420dde061e"
+  },
+  "boundaries": [
+    "No serving provider, LLM answer correction, dense transformer or matrix multiplication introduced. Offline labels only.",
+    "Exact Copy/Add operations pre-exist; learned geometric selection is new.",
+    "One derived-source eligibility gate, 16 query words, <=256 proposals, recency-based operand features. Multiple-intermediate role binding is unqualified.",
+    "Syntax, broad prose, general reasoning, frontier capability and laptop whole-model speed remain unqualified."
+  ],
+  "next": "Use two competing derived results and changed operand order to test and learn role-sensitive selection through this same path; retain causal provenance, held-out selection discipline and existing behavior."
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,42 @@
 # Current native geometric AI work
 
-## Selected execution passes; learned composition fails — #1139, 2026-09-06
+## Learned geometric typed selection passes its bounded transfer — #1139, 2026-09-06
+
+**Retain `bb79456b` over exact parent `2600b95b`.** The
+[result](../native_geometric_typed_routing_1139.md#executed-result--2026-09-06)
+and [evidence](../evidence/native_geometric_typed_routing_1139.json) bind scope.
+A learned signed-H4 query/operand selector now chooses Copy, Add or NoOperation
+before the existing exact execution and derived-value commit. Its optional
+case-folded query metadata component is13,865 serialized bytes; no serving LLM,
+dense attention, matrix multiplication or floating-point projection is added.
+
+Angular generates42/42 construction,6/6 exposed development and6/6 new authored
+numeric/wording transfers, versus3/6 new transfers for the matched exact-code
+fit. Removing the intermediate yields0/6. An earlier exact-case version failed
+3/6 transfer and remains preserved; its repaired cases are explicitly exposed.
+The new checks use small authored cases after design selection, not sealed general
+language.19+12 ->31 now supports repeat ->31 and add5 ->36, using its own result.
+
+All48/48 dependent,62/62 earlier,24/24 prior-transfer,28/28 exposed-name,28/28
+long-context and5/5 persistent checks pass. Seven focused tests, the kernel
+source check, actual typed zero-allocation check, CLI revision and four unchanged
+generated Rust functions with12 semantic assertions pass. No new general Rust
+reasoning, syntax, prose, frontier capability or whole-model speed is established.
+
+**Next: role-sensitive selection among competing intermediate results.** Vary
+which derived result is requested and their order, inspect role features, and
+learn the same joint choice against the observed failure. The current recency-
+based metadata is insufficient evidence of general binding. Reuse exact state,
+operators and the existing learner; no new cache/store campaign. Full #1139 and
+#1140 remain open at their broader acceptance scope.
+
+This cycle uses162.033 seconds of local model work and686.095 seconds of monitored
+engineering work. Cumulative model use is2033.039/2130 seconds, with96.961 seconds
+remaining. Recorded extensions are+240 model seconds and+128MiB storage under the
+owner's standing authorization. All material is preserved; paid external compute
+is zero. Source and delivery state are recorded through the protected PR.
+
+## Previous checkpoint: selected execution passes; learned composition fails — #1139, 2026-09-06
 
 **Retain `2600b95b` with the checked selected-execution runtime.** The
 [result](../native_geometric_typed_admission_1139.md#executed-result--2026-09-06)
@@ -28,7 +64,7 @@ exact execution/commit path, train the joint candidate/action decision on
 causally generated intermediate states, and inspect actual query features before
 fit to avoid the earlier indistinguishable-input failure. The six exposed
 negatives are development data; new wording/composition evaluation follows
-selection. This learning change is not implemented yet. No new store or cache
+selection. This was the next change at that checkpoint; it is now implemented above. No new store or cache
 campaign is warranted by these retained-but-misselected values.
 
 The owner now authorizes necessary project-resource extensions. Record explicit

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -189,11 +189,17 @@ keeps that writer fixed and reduces long-context writer row comparisons from
 next build returned to operator/operand admission before execution and committed
 derived-value use. The [selected-execution result](../native_geometric_typed_admission_1139.md)
 preserves prior behavior but gets 0/6 new follow-ups after 3/3 correct first sums.
-The exact intermediate and new operand are retained; the current sparse selector
-chooses the wrong operation/operand or abstains. Next learn query-conditioned
-geometric selection over those typed references, adapting the existing signed-H4
-source learner's joint candidate/action objective to causally generated states.
-This new angular typed selector is not implemented by the execution repair.
+The exact intermediate and new operand were retained; that sparse selector chose
+the wrong operation/operand or abstained. The subsequent
+[learned typed selector](../native_geometric_typed_routing_1139.md) now generates
+6/6 new authored numeric/wording transfers versus3/6 for its matched exact-code
+fit, with0/6 after intermediate removal and all prior checks preserved. Its
+case-sensitive predecessor remains a3/6 transfer negative. This is learned
+signed-H4 query/operator/operand choice through actual intermediate state,
+not broad language or reasoning qualification. Next test and learn role-sensitive
+choice between competing derived results while changing their order, using the
+same learner, exact records and operators. Current relative-recency features do
+not establish role binding independent of order.
 No additional cache campaign is active. Follow current-state.md for artifacts
 and cumulative resources; a new issue does not reset the spent amount.
 The full handoff remains unmet.

--- a/docs/native_geometric_typed_routing_1139.md
+++ b/docs/native_geometric_typed_routing_1139.md
@@ -1,0 +1,167 @@
+# Learned geometric typed selection — #1139, 2026-09-06
+
+## Mechanism and pre-run decision
+
+The parent `2600b95b` generates three initial sums but fails all six subsequent
+Copy/Add instructions. Their intermediate values and new operands are captured;
+the prior result therefore calls for operator/operand selection learning.
+
+This implementation adds an optional outer artifact component, preserving the
+entire exact parent identity. Initial literal-only decisions retain the existing
+numeric head. When a derived source exists, the new head scores NoOperation and
+all existing Copy/Add operand proposals before executing the winner. NoOperation
+does not fall back to the old numeric scorer; ordinary response mechanisms still
+handle its output. Exact overflow reselects in the existing bounded score order.
+
+The new head reuses `SourceRouting::encode`, signed relative-cosine rank scoring
+and the discrete joint candidate/action learner. Its two independently learned
+signed-H4 states fold ordered features by existing group-table products. Learned
+action landmarks and integer biases choose the operation and operands together.
+This is not a new paired-icosian/E8 construction or a whole-language decoder.
+
+Represented metadata: derived flags for both operands, relative source ranks,
+and ordered whole-word query identities plus position/identity features. At most
+16 recent query words are matched against a construction-only prime dictionary;
+numeric words are excluded. Literal numeric values never enter these geometric
+scoring features. Query words outside the dictionary contribute no feature.
+Feature selection retains structural entries first, then construction frequency,
+up to 128 entries. The fold can collide in 120 x 120 states. It retains neither exact
+payloads nor all raw query history; exact values, source IDs and derivations stay
+in the existing typed records. Required fixed-zeta and paired-H4 state remains
+inherited, without claiming a new predictive contribution from those fields.
+
+The hot path uses integer comparisons, table reads and ordered group operations;
+no runtime matrix multiplication, floating-point projection or response provider
+is introduced. Startup validation retains its existing host floating-point scope.
+The candidate scan remains bounded, not sublinear: at most 256 valid Copy/Add
+proposals, each with bounded feature/dictionary/scoring work. Existing work counts
+all proposal passes, exact executions and overflow fallback; a nested RoutingWork
+counts the new source scans, comparisons, code/table reads and logical operand
+bytes. Logical bytes are not measured DRAM traffic or an instruction census.
+
+## Construction and evaluation
+
+Rust prepares 42 authored follow-ups: six numeric worlds across three Copy,
+three Add and one NoOperation wording. The initial response is actually generated
+and observed; a supplied correct initial answer cannot populate training state.
+Offline labels supervise the joint operator/operand choice. Initial generation
+must match its expected complete answer before a frame is admitted. No expected
+follow-up answer is supplied to serving. Before fit, effective feature signatures
+must not have incompatible target sets; this checks only these actual frames.
+
+Angular and exact-code arms use 128 feature slots, four passes, twelve sampled
+code proposals, the same seed, and 30-second per-arm search caps. Their realized
+search trajectories can differ. Fitting the hard joint choice is separate from
+success of the assembled response generation. Complete text, EOS, operator and
+intermediate provenance are required by evaluation.
+
+Six previously exposed failures remain OPEN development. Six operand/wording
+transfers are predeclared in the same source and opened after design selection;
+they are small transfer checks, not broad or independently sealed language data.
+Adoption requires 6/6 development, 6/6 transfers and previous response/write/session
+preservation, plus focused arithmetic/counter/serialization/allocation checks.
+Intermediate removal checks causal dependence. A failed transfer cannot be
+silently reused as a held-out success after revision. No general reasoning,
+prose, syntax or whole-model speed claim follows from this bounded step.
+
+## Resource projection
+
+Under the owner's standing necessary-allowance authorization, the recorded cycle
+adds 240 seconds of cumulative local model allowance (1890 to 2130 seconds), with
+160 seconds projected work plus 80 reserve. The build projects 600 seconds under
+a 900-second ceiling. A recorded 128 MiB storage increment supports a 256 MiB peak
+growth projection while preserving the existing stop margin. One model process,
+4 GiB RSS target, no paid external compute and no deletion. Charge retries and
+preserve all artifacts/results under the existing root with `typed-routing-`
+prefix. The pre-run projection does not claim execution or capability success.
+
+## Initial result and materially revised case handling
+
+The first angular artifact `50eff8ad` fits 42/42 choices and generates 42/42
+construction and 6/6 exposed answers; exact-code `9adf0cb5` fits 36/42 choices
+and also generates 6/6 exposed answers. The angular intermediate-removal control
+gets 0/6. Earlier 48/62/24/28 and five-session preservation all pass.
+
+Both artifacts then get only 3/6 on the predeclared transfer set. All Add outputs
+are correct, but `Please copy ...` selects Add. Construction dictionary metadata
+contains `Copy` (prime 5) and has no lowercase `copy` entry. These failures remain
+first-use negatives; neither initial artifact meets the 6/6 adoption criterion.
+
+The revised artifact explicitly binds `fold_ascii_case: true`. It folds ASCII
+case only for query metadata dictionary construction/lookup; exact typed values,
+source identity and payload spelling remain unchanged. Older artifacts omit
+this optional field and retain exact-case behavior and identity. The same 42
+construction labels are refit with the same capacity and search schedule. This
+is a new metadata normalization mechanism, not fitting on the failed transfer
+answers or a serving grammar rule. Case distinctions in query scoring are lost;
+case-sensitive identifier reasoning is not qualified by this numeric-word task.
+
+The old six transfer cases become exposed repair checks. A new predeclared set
+uses three new operand triples with `Please repeat ...` and `Please add ...`
+wording. It stays unopened until revised construction/development selection.
+Require 6/6 new transfers plus preservation before adopting the revised artifact.
+Results, resources and final decision will be appended after actual execution.
+
+
+## Executed result — 2026-09-06
+
+**Retain case-folded angular `bb79456b` at bounded composition scope.** The
+[evidence receipt](evidence/native_geometric_typed_routing_1139.json) binds the
+full artifact IDs, source digests, command results and local report hashes.
+Its parent remains exactly `2600b95b`; the optional component is 13, 865 serialized
+bytes, with 109 learned features and 25 construction word identities. The same 42
+construction records collapse to seven effective query classes with no detected
+incompatible targets before fit. They are not 42 independent language patterns.
+
+The revised angular arm fits 42/42 joint choices and generates 42/42 construction,
+6/6 OPEN development, and 6/6 exposed V1 repair outputs. After that design selection,
+it generates 6/6 new numeric/wording transfers with full text, EOS, correct operator
+and actual intermediate provenance. The matched exact-code arm fits 24/42 and
+gets 3/6 new transfers: Add works, while Copy abstains. This supports the selected
+angular fit over this exact-code fit; one seed and six authored cases establish
+neither universal angular superiority nor broad language generalization.
+
+Actual new cases include 19+12 ->31, then repeat ->31 or add 5 ->36; 23+8 ->31,
+then repeat ->31 or add 6 ->37; and-4+15 ->11, then repeat ->11 or add 3 ->14.
+Every full-path follow-up consumes the actually generated intermediate. Removing
+that record gives Unknown on 6/6, hence 0/6 exact. Removal also disables the derived-
+source eligibility gate, so this is a whole-intermediate causal control, not an
+isolated angular-score ablation. Initial-response generation is included in each
+complete session's work; expected answers are only offline labels/comparisons.
+
+Preservation passes 48/48 dependent, 62/62 earlier, 24/24 prior transfer, 28/28
+exposed-name and 28/28 longer-context answers/writes, plus 5/5 persistent turns.
+Four exact unchanged generated Rust bodies compile and pass 12 semantic assertions.
+The CLI revision produces ` Zurich.\n`. Two metadata tests, four selected-execution
+arithmetic/commit/overflow tests and one nested-counter test pass. The current
+kernel source check passes, and actual two-turn typed routing/commit measures
+zero allocations and zero allocated bytes. Loading each artifact validates its
+identity and parent. The older ignored chain diagnostic is deliberately not rerun.
+Release probe/CLI and final focused test binaries compile; formatting, architecture
+policy and claim wording are checked locally. Broad release QA is NOT_RUN.
+
+Across the six new two-response sessions there are 120 typed proposals, 12 selection
+passes, 12 exact operator executions and 9 additions (six first sums and three new
+adds). New routing counts 6 predictions, 420 source examinations, 27, 456 comparisons,
+6, 120 code reads, 13, 362 table reads and 523, 692 logical bytes read. Full inherited
+writer/readout/state/output counters remain in the retained reports. Routing is
+bounded scanning, not demonstrated sublinear retrieval or a whole-model speedup.
+
+The complete cycle charges 162.033 seconds of model/preparation/evaluation/check
+work and 686.095 seconds of monitored engineering work. Model use is 2033.039/2130
+seconds cumulative, leaving 96.961 seconds; the cycle ceilings were 240 and 900
+seconds. Builds exceeded the 600-second point projection but stayed within 900.
+The recorded 128 MiB storage increase is applied. Peak sampled known accounting is
+6, 329, 102, 336 bytes below the effective 6, 506, 475, 520-byte ceiling; sampled model
+child RSS is at most 853, 278, 720 bytes. These are periodic samples, not exact peaks.
+No user material was deleted and no paid external compute was used.
+
+**Next: role-sensitive choice among competing intermediate results.** This head
+uses query identities, derived flags and relative source ranks. Its tiny numeric
+transfer establishes a useful causal chain but cannot show that it selects a
+named intermediate independently of recency. Start with two retained derived
+results, change their order and the later operand, inspect captured query/role
+features, and train the same joint geometric choice only where the comparison
+exposes a failure. Reuse the current exact records/operators and existing Rust
+checks. No additional cache, store, tokenizer or broad corpus campaign is needed.
+Full #1139/#1140 acceptance and general syntax/prose/reasoning remain unmet.


### PR DESCRIPTION
After an initial sum, the retained model had the right intermediate and new literal but failed all six exposed Copy/Add follow-ups. This change learns the joint operator/operand choice through the existing signed-H4 router, then uses the existing exact execution and commit path. It adds a parent-bound optional artifact component, bounded whole-word query metadata, truthful routing counters and a Rust fit/evaluation entry point. Serving introduces no provider, matrix multiplication or floating-point projection.

The selected case-folded angular artifact generates 6/6 new authored numeric/wording transfers, versus 3/6 for the matched exact-code fit and 0/6 after intermediate removal. Example: 19+12 produces 31, followed by repeat →31 or add5 →36, consuming the actual generated result. An earlier case-sensitive version failed 3/6 and is preserved as negative evidence; its repair cases are explicitly exposed. This is bounded composition evidence, not general language or reasoning qualification.

Validation: release probe/CLI compile; 7 focused metadata, execution/overflow/commit and counter tests pass; integer-kernel source check passes; actual two-turn typed routing/commit measures zero allocations. Preservation is 48/48 dependent, 62/62 earlier, 24/24 prior transfer, 28/28 exposed-name, 28/28 long-context and 5/5 persistent turns. Four unchanged generated Rust functions pass 12 semantic assertions; CLI revision returns Zurich. Formatting, architecture policy and claim wording pass. Broad release QA was not run.

The record and evidence bind source/artifact/report identities, failed and selected fits, full command accounting and scope. Cycle cost: 162.033s model work, 686.095s monitored engineering; cumulative model 2033.039/2130s. Recorded +240s model and +128MiB storage use the owner's standing authorization. No deletions or paid external compute.

Next: role-sensitive choice among competing intermediate results with changed order, using this same path. Current recency features do not establish general binding. Refs #1139, #1140; neither broader issue is completed by this step.
