### PR TITLE
Learn geometric selection between derived totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ answers/writes after selection. Its NoWrite regression is now
 [repaired](docs/native_geometric_writer_admission_1139.md): exact skips are
 21,799/21,907 and writer row comparisons fall from 226,101,330 to 539,448 on the
 same long-context prompts, with unchanged answers, writes and learned parameters.
-The next step is learned admission of typed operators and use of committed
-derived values. This exact-cache result is not broad language qualification.
+Learned typed selection and [competing-intermediate use](docs/native_geometric_typed_roles_1139.md)
+now produce 12/12 complete authored operand/refresh transfers versus 2/12 for the
+matched exact-code fit, with previous failures and preservation checks recorded.
+The model selects exact derived values using learned H4 metadata, canonical Copy
+identity and an explicit query boundary. Independent computations at equal depth,
+general prose/syntax/reasoning and frontier capability remain unqualified. Follow
+the current-state pointer for artifacts, costs and the next implementation.
 
 ```sh
 cargo build --release --bin r4

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
@@ -1,6 +1,6 @@
 use super::*;
 use uor_r4_core::native_geometric::{
-    RoutingMode, SourceRoutingConfig, TypedRoutingExample, ValueAction,
+    RoutingMode, SourceRoutingConfig, TypedRoutingExample, TypedRoutingTurn, ValueAction,
 };
 
 fn example(
@@ -16,15 +16,176 @@ fn example(
     } else {
         a + b
     };
-    TypedRoutingExample {id,
+    TypedRoutingExample {id, continuation: None, refresh: Vec::new(), target_intermediate: 0,
         initial_prompt:format!("User: suri has {a} coins. orin has {b} coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:"),
         initial_response:format!("{}.\n",a+b),query:format!("User: There are {delta} new coins. {question}\nAssistant:"),
         response:if action.is_some(){format!("{value}.\n")}else{" Unknown.\n".into()},
         action,operands:action.map(|op|if op==ValueAction::Copy{[a+b,a+b]}else{[a+b,delta]}),
     }
 }
+fn role_example(
+    id: String,
+    a: i64,
+    b: i64,
+    delta: i64,
+    extra: i64,
+    kind: usize,
+    refresh: bool,
+) -> TypedRoutingExample {
+    let questions = [
+        "Repeat the original total.",
+        "Repeat the updated total.",
+        "Copy the total before the new coins.",
+        "Copy the total after the new coins.",
+        "Add the extra coins to the original total.",
+        "Add the extra coins to the updated total.",
+        "Where is the location of suri?",
+    ];
+    let target = usize::from(kind == 1 || kind == 3 || kind == 5);
+    let value = a + b + if target == 1 { delta } else { 0 };
+    let action = if kind == 6 {
+        None
+    } else if kind >= 4 {
+        Some(ValueAction::Add)
+    } else {
+        Some(ValueAction::Copy)
+    };
+    let mut d = example(id, a, b, delta, questions[kind], action);
+    d.continuation=Some(TypedRoutingTurn {prompt:format!("User: There are {delta} new coins. Add the new coins to the previous total.\nAssistant:"),response:format!("{}.\n",a+b+delta)});
+    d.target_intermediate = target;
+    d.query = if kind == 4 || kind == 5 {
+        format!(
+            "User: There are {extra} extra coins. {}\nAssistant:",
+            questions[kind]
+        )
+    } else {
+        format!("User: {}\nAssistant:", questions[kind])
+    };
+    d.operands = action.map(|op| {
+        if op == ValueAction::Copy {
+            [value, value]
+        } else {
+            [value, extra]
+        }
+    });
+    d.response = if action.is_none() {
+        " Unknown.\n".into()
+    } else {
+        format!(
+            "{}.\n",
+            value
+                + if action == Some(ValueAction::Add) {
+                    extra
+                } else {
+                    0
+                }
+        )
+    };
+    if refresh {
+        d.refresh.push(TypedRoutingTurn {
+            prompt: "User: Repeat the original total.\nAssistant:".into(),
+            response: format!("{}.\n", a + b),
+        });
+    }
+    d
+}
+
 pub(super) fn run(args: &[String]) -> ProbeResult<()> {
     match args.first().map(String::as_str) {
+        Some("canonical-roles") if args.len()==3 => {
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let candidate=model.canonicalize_typed_role_aliases()?;
+            write_new(Path::new(&args[2]),&candidate.to_bytes()?)?;
+            println!("{}",json!({"before":model.artifact_cid(),"artifact":candidate.artifact_cid(),"change":"Exact Copy aliases cannot introduce a reflexive Add candidate; learned parameters unchanged."}));
+        }
+        Some("alias-source") if args.len()==3 => {
+            let mut source:Value=serde_json::from_slice(&fs::read(&args[1])?)?;
+            source["exposed_first_use"]=source["first_use"].clone();
+            let mut reserved=Vec::new();
+            for (i,(a,b,d,e)) in [(11,7,4,3),(16,5,8,4),(-5,13,6,2)].into_iter().enumerate() {
+                for kind in [0,1,4,5] {
+                    let mut case=role_example(format!("roles-alias-transfer/{i}/{kind}"),a,b,d,e,kind,true);
+                    if i != 1 {case.refresh[0]=TypedRoutingTurn {prompt:"User: Repeat the updated total.\nAssistant:".into(),response:format!("{}.\n",a+b+d)};}
+                    reserved.push(case);
+                }
+            }
+            source["first_use"]=serde_json::to_value(reserved)?;
+            source["scope"]=json!("Alias-admission revision: construction and development unchanged; old9/12 transfer remains an exposed negative. Twelve new operands/refresh cases after selection; refreshes original or updated. No refit or broad language qualification.");
+            write_json(Path::new(&args[2]),&source)?;
+        }
+        Some("query-source") if args.len()==3 => {
+            let mut source:Value=serde_json::from_slice(&fs::read(&args[1])?)?;
+            source["exposed_alias_first_use"]=source["first_use"].clone();
+            let mut reserved=Vec::new();
+            for (i,(a,b,d,e)) in [(20,3,7,2),(9,8,4,6),(-6,16,5,3)].into_iter().enumerate() {
+                for kind in [0,1,4,5] {
+                    let mut case=role_example(format!("roles-query-transfer/{i}/{kind}"),a,b,d,e,kind,true);
+                    if i != 1 {case.refresh[0]=TypedRoutingTurn {prompt:"User: Repeat the updated total.\nAssistant:".into(),response:format!("{}.\n",a+b+d)};}
+                    reserved.push(case);
+                }
+            }
+            source["first_use"]=serde_json::to_value(reserved)?;
+            source["scope"]=json!("Explicit query-boundary revision: same construction; prior9/12 and8/12 transfers remain exposed negatives. Twelve new operand/refresh cases after selection. No supplied intermediates or sealed-language claim.");
+            write_json(Path::new(&args[2]),&source)?;
+        }
+        Some("roles-source") if args.len()==2 => {
+            let mut fit=Vec::new();
+            for (i,(a,b,d,e)) in [(13,4,5,2),(8,7,6,3),(-3,8,4,5),(21,3,7,4),(10,6,2,7),(4,9,3,6)].into_iter().enumerate() {
+                for kind in 0..7 {fit.push(role_example(format!("roles-fit/{i}/{kind}"),a,b,d,e,kind,false));}
+            }
+            let mut development=Vec::new();
+            for (i,(a,b,d,e)) in [(13,4,5,2),(14,4,6,3),(-3,8,4,5)].into_iter().enumerate() {
+                for kind in [0,1,4,5] {development.push(role_example(format!("roles-open/{i}/{kind}"),a,b,d,e,kind,false));}
+            }
+            let mut first_use=Vec::new();
+            for (i,(a,b,d,e)) in [(19,12,5,4),(23,8,6,2),(-4,15,3,7)].into_iter().enumerate() {
+                for kind in [0,1,4,5] {first_use.push(role_example(format!("roles-transfer/{i}/{kind}"),a,b,d,e,kind,true));}
+            }
+            write_json(Path::new(&args[1]),&json!({"schema":"uor-r4.typed-roles-source/1","fit":fit,"development":development,"first_use":first_use,"scope":"42 construction cases, 12 OPEN development, 12 after-selection transfers with changed operands and an actually generated original-total refresh that reverses derived recency. No intermediate insertion. Small authored scope, not general language."}))?;
+        }
+        Some("roles-fit"|"roles-fit-local") if args.len()==5 => {
+            let mode=match args[4].as_str(){"angular"=>RoutingMode::Angular,"equality"=>RoutingMode::Equality,_=>return Err("typed role fit mode".into())};
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs:Vec<TypedRoutingExample>=serde_json::from_value(source["fit"].clone())?;
+            let config=SourceRoutingConfig{learned_features:192,passes:4,proposals:12,max_seconds:30,mode,..SourceRoutingConfig::default()};
+            let (candidate,report)=if args[0]=="roles-fit-local" {model.fit_typed_roles_local(&docs,config)?} else {model.fit_typed_roles(&docs,config)?};
+            let out=Path::new(&args[3]);fs::create_dir(out)?;
+            write_new(&out.join("model.json"),&candidate.to_bytes()?)?;
+            write_json(&out.join("fit.json"),&report)?;println!("{report}");
+        }
+        Some("competition") if args.len()==3 => {
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let mut cases=Vec::new();
+            for (a,b,delta) in [(13,4,5),(14,4,6),(-3,8,4)] {
+                for (question,wanted) in [("Repeat the original total.",a+b),("Repeat the updated total.",a+b+delta),("Repeat the previous total.",a+b+delta),("Copy the total before the new coins.",a+b)] {
+                    let mut session=model.session(Control::Full)?;
+                    session.observe(&model,uor_r4_core::native_geometric::BOS)?;
+                    let mut turns=Vec::new();
+                    let first=format!("User: suri has {a} coins. orin has {b} coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:");
+                    let second=format!("User: There are {delta} new coins. Add the new coins to the previous total.\nAssistant:");
+                    let third=format!("User: {question}\nAssistant:");
+                    for (prompt,expected) in [(first,a+b),(second,a+b+delta),(third,wanted)] {
+                        for token in model.encode(&prompt)? {session.observe(&model,token)?;}
+                        session.begin_response(&model)?;
+                        let mut tokens=Vec::new();let mut decision=None;let mut eos=false;
+                        for _ in 0..32 {
+                            let token=session.predict(&model)?.token;
+                            if let Some(d)=session.value_decision().filter(|d|d.cursor==0){decision=Some(d);}
+                            session.observe(&model,token)?;
+                            if token==uor_r4_core::native_geometric::EOS {eos=true;break;}
+                            tokens.push(token);
+                        }
+                        let text=String::from_utf8(model.decode(&tokens)?)?;
+                        turns.push(json!({"prompt":prompt,"expected":format!("{expected}.\n"),"exact":text==format!("{expected}.\n")&&eos,"text":text,"eos":eos,"decision":decision}));
+                        session.end_response(&model)?;
+                    }
+                    cases.push(json!({"turns":turns,"work":session.work}));
+                }
+            }
+            let report=json!({"artifact":model.artifact_cid(),"scope":"OPEN actual three-turn generation, original versus updated total. No expected intermediate is inserted.","cases":cases});
+            write_json(Path::new(&args[2]),&report)?;
+        }
         Some("prepare") if args.len()==2 => {
             let phrases=[
                 ("Repeat the previous total without adding the new coins.",Some(ValueAction::Copy)),
@@ -80,7 +241,7 @@ pub(super) fn run(args: &[String]) -> ProbeResult<()> {
         Some("evaluate") if args.len()==6=>{
             let model=Model::from_bytes(&fs::read(&args[1])?)?;
             let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
-            if !["fit","development","first_use","exposed_first_use"].contains(&args[3].as_str()){return Err("typed evaluation split".into());}
+            if !["fit","development","first_use","exposed_first_use","exposed_alias_first_use"].contains(&args[3].as_str()){return Err("typed evaluation split".into());}
             let docs:Vec<TypedRoutingExample>=serde_json::from_value(source[&args[3]].clone())?;
             let remove=match args[5].as_str(){"full"=>false,"remove-intermediate"=>true,_=>return Err("typed control".into())};
             let report=model.evaluate_typed_routing(&docs,remove)?;

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -22,7 +22,7 @@ mod source_routing_training;
 pub use source_routing_training::SourceRoutingConfig;
 mod typed_routing;
 mod typed_routing_training;
-pub use typed_routing_training::TypedRoutingExample;
+pub use typed_routing_training::{TypedRoutingExample, TypedRoutingTurn};
 mod anchors;
 mod learned_routing;
 #[cfg(test)]
@@ -315,6 +315,8 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_routing: Option<typed_routing::TypedRouting>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    typed_roles: Option<typed_routing::TypedRouting>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     relation_writer: Option<relation_training::WriterRevision>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     dependent_read: Option<dependent_read::DependentRead>,
@@ -350,6 +352,8 @@ pub struct Model {
 struct ModelWire {
     #[serde(default)]
     typed_routing: Option<typed_routing::TypedRouting>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    typed_roles: Option<typed_routing::TypedRouting>,
     #[serde(default)]
     relation_writer: Option<relation_training::WriterRevision>,
     #[serde(default)]
@@ -385,6 +389,7 @@ impl TryFrom<ModelWire> for Model {
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
             typed_routing: wire.typed_routing,
+            typed_roles: wire.typed_roles,
             relation_writer: wire.relation_writer,
             dependent_read: wire.dependent_read,
             source_routing: wire.source_routing,

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -177,6 +177,7 @@ impl Trainer {
             relation_writer: None,
             dependent_read: None,
             typed_routing: None,
+            typed_roles: None,
             source_routing: None,
             learned_routing: None,
             schema: SCHEMA.into(),
@@ -511,6 +512,24 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(block) = &self.typed_roles {
+            let mut parent = self.clone();
+            parent.typed_roles = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != block.router.parent_artifact {
+                return Err(Error("typed routing parent differs".into()));
+            }
+            parent.validate()?;
+            block.validate(self, true)?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("typed routing identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(block) = &self.typed_routing {
             let mut parent = self.clone();
             parent.typed_routing = None;
@@ -519,7 +538,7 @@ impl Model {
                 return Err(Error("typed routing parent differs".into()));
             }
             parent.validate()?;
-            block.validate(self)?;
+            block.validate(self, false)?;
             let mut duplicate = self.clone();
             duplicate.refresh_identity()?;
             if duplicate.artifact_cid != self.artifact_cid
@@ -892,6 +911,7 @@ fn add_work(total: &mut Work, work: Work) {
     total.values.literal_writes += work.values.literal_writes;
     total.values.record_evictions += work.values.record_evictions;
     total.values.proposals += work.values.proposals;
+    total.values.alias_self_add_rejections += work.values.alias_self_add_rejections;
     total.values.routing.add(work.values.routing);
     total.values.operator_executions += work.values.operator_executions;
     total.values.selection_comparisons += work.values.selection_comparisons;
@@ -988,6 +1008,7 @@ mod work_tests {
                     predictions: 1,
                     ..RoutingWork::default()
                 },
+                alias_self_add_rejections: 1,
                 operator_executions: 1,
                 selection_comparisons: 1,
                 selection_passes: 1,

--- a/crates/uor-r4-core/src/native_geometric/typed_routing.rs
+++ b/crates/uor-r4-core/src/native_geometric/typed_routing.rs
@@ -11,32 +11,161 @@ pub(super) struct TypedRouting {
     pub dictionary: Vec<WordCopyAddress>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub fold_ascii_case: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub canonical_copy_aliases: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub local_query: bool,
+}
+
+pub(super) struct TypedContext {
+    pub addresses: [u32; 16],
+    pub depths: Option<[u8; 16]>,
+    pub origins: Option<[u64; 16]>,
 }
 
 // NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+/// Depth of exact Add computation, preserving depth across Copy aliases.
+/// Unknown/evicted ancestry remains 255. Fixed-capacity relaxation does not
+/// assume source order and terminates after at most VALUES passes.
+pub(super) fn lineage_depths(values: &ValueState, work: &mut ValueWork) -> [u8; 16] {
+    let mut depth = [255; 16];
+    for (i, r) in values.sources.iter().enumerate() {
+        work.routing.sources_examined += 1;
+        if !r.derived {
+            depth[i] = 0;
+        }
+    }
+    for _ in 0..VALUES {
+        let mut changed = false;
+        for (i, r) in values.sources.iter().enumerate() {
+            work.routing.sources_examined += 1;
+            if depth[i] != 255 {
+                continue;
+            }
+            let Some(d) = r.derivation else {
+                continue;
+            };
+            let mut parents = [255; 2];
+            for (j, source) in values.sources.iter().enumerate() {
+                work.routing.sources_examined += 1;
+                for k in 0..2 {
+                    work.routing.comparisons += 1;
+                    work.routing.logical_bytes_read += 16;
+                    if source.id == d.operand_ids[k] && source.id < r.id {
+                        parents[k] = depth[j];
+                    }
+                }
+            }
+            let value = if d.action == ValueAction::Copy {
+                parents[0]
+            } else if parents[0] != 255 && parents[1] != 255 {
+                parents[0].max(parents[1]) + 1
+            } else {
+                255
+            };
+            if value != 255 {
+                depth[i] = value;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    depth
+}
+
+pub(super) fn copy_origins(values: &ValueState, work: &mut ValueWork) -> [u64; 16] {
+    let mut out = [u64::MAX; 16];
+    for (i, record) in values.sources.iter().enumerate() {
+        let mut id = record.id;
+        for _ in 0..VALUES {
+            let found = values.sources.iter().find(|r| {
+                work.routing.sources_examined += 1;
+                work.routing.comparisons += 1;
+                work.routing.logical_bytes_read += 16;
+                r.id == id
+            });
+            let Some(d) = found
+                .and_then(|r| r.derivation)
+                .filter(|d| d.action == ValueAction::Copy)
+            else {
+                break;
+            };
+            if d.operand_ids[0] >= id {
+                break;
+            }
+            id = d.operand_ids[0];
+        }
+        out[i] = id;
+    }
+    out
+}
+
+/// Same operation support as the original i != j candidate contract: observing
+/// a Copy must not manufacture a reflexive Add edge for one computation.
+pub(super) fn alias_self_add(
+    values: &ValueState,
+    a: ValueRecord,
+    b: ValueRecord,
+    origins: Option<&[u64; 16]>,
+    work: &mut ValueWork,
+) -> bool {
+    let Some(origins) = origins else {
+        return false;
+    };
+    let mut pair = [u64::MAX; 2];
+    for (i, r) in values.sources.iter().enumerate() {
+        work.routing.sources_examined += 1;
+        work.routing.comparisons += 2;
+        work.routing.logical_bytes_read += 32;
+        if r.id == a.id {
+            pair[0] = origins[i];
+        }
+        if r.id == b.id {
+            pair[1] = origins[i];
+        }
+    }
+    pair[0] != u64::MAX && pair[0] == pair[1]
+}
+
 pub(super) fn context(
     model: &Model,
     values: &ValueState,
     control: Control,
     work: &mut ValueWork,
-) -> Option<[u32; 16]> {
-    let block = model.typed_routing.as_ref()?;
+) -> Option<TypedContext> {
+    let mut block = model.typed_routing.as_ref()?;
     if matches!(
         control,
         Control::LearnedRoutingDisabled | Control::GeometryDisabled | Control::H4Disabled
     ) {
         return None;
     }
-    let mut derived = false;
+    let mut derived = 0;
     for source in &values.sources {
         work.routing.sources_examined += 1;
-        derived |= source.derived;
+        derived += usize::from(source.derived);
     }
     // Structural scope: initial literal-only decisions retain their parent.
-    if !derived {
+    if derived == 0 {
         return None;
     }
-    Some(addresses(block, values, work))
+    let depths = if derived >= 2 {
+        model.typed_roles.as_ref().map(|roles| {
+            block = roles;
+            lineage_depths(values, work)
+        })
+    } else {
+        None
+    };
+    let origins =
+        (depths.is_some() && block.canonical_copy_aliases).then(|| copy_origins(values, work));
+    Some(TypedContext {
+        addresses: addresses(block, values, work),
+        depths,
+        origins,
+    })
 }
 
 pub(super) fn addresses(
@@ -50,6 +179,13 @@ pub(super) fn addresses(
     };
     for (i, word) in words.queries[..words.query_len].iter().enumerate() {
         work.routing.context_tokens_read += 1;
+        if block.local_query {
+            work.routing.comparisons += 1;
+            work.routing.logical_bytes_read += 16;
+            if values.query_boundary.is_some_and(|start| word.end < start) {
+                continue;
+            }
+        }
         let found = block.dictionary.binary_search_by(|d| {
             work.routing.comparisons += 1;
             for j in 0..usize::from(word.len.min(d.len)) {
@@ -72,10 +208,21 @@ pub(super) fn addresses(
     out
 }
 
+#[cfg(test)]
 pub(super) fn features(
     values: &ValueState,
     operands: Option<(ValueRecord, ValueRecord)>,
     addr: &[u32; 16],
+    work: &mut ValueWork,
+) -> ([ValueFeature; 36], usize) {
+    features_with_depths(values, operands, addr, None, work)
+}
+
+pub(super) fn features_with_depths(
+    values: &ValueState,
+    operands: Option<(ValueRecord, ValueRecord)>,
+    addr: &[u32; 16],
+    depths: Option<&[u8; 16]>,
     work: &mut ValueWork,
 ) -> ([ValueFeature; 36], usize) {
     let mut out = [ValueFeature::default(); 36];
@@ -107,6 +254,34 @@ pub(super) fn features(
         b: rank_b as u64,
     };
     let mut n = 2;
+    if let Some(depths) = depths {
+        let mut pair = [255_u64; 2];
+        if let Some((a, b)) = operands {
+            for (i, r) in values.sources.iter().enumerate() {
+                work.routing.sources_examined += 1;
+                work.routing.comparisons += 2;
+                if r.id == a.id {
+                    pair[0] = u64::from(depths[i]);
+                }
+                if r.id == b.id {
+                    pair[1] = u64::from(depths[i]);
+                }
+            }
+            // Retain recency for literals only; derived candidates use lineage.
+            if a.derived {
+                out[1].a = VALUES as u64;
+            }
+            if b.derived {
+                out[1].b = VALUES as u64;
+            }
+        }
+        out[n] = ValueFeature {
+            kind: 4,
+            a: pair[0],
+            b: pair[1],
+        };
+        n += 1;
+    }
     // Ordered exact word identities, not distances computed from hash bits.
     for (position, &prime) in addr.iter().enumerate() {
         if prime == 0 {
@@ -133,14 +308,24 @@ pub(super) fn score(
     values: &ValueState,
     operands: Option<(ValueRecord, ValueRecord)>,
     action: usize,
-    addr: &[u32; 16],
+    context: &TypedContext,
     control: Control,
     work: &mut ValueWork,
 ) -> i64 {
-    let Some(block) = &model.typed_routing else {
+    let Some(block) = (if context.depths.is_some() {
+        &model.typed_roles
+    } else {
+        &model.typed_routing
+    }) else {
         return 0;
     };
-    let (f, n) = features(values, operands, addr, work);
+    let (f, n) = features_with_depths(
+        values,
+        operands,
+        &context.addresses,
+        context.depths.as_ref(),
+        work,
+    );
     let state = block
         .router
         .encode(model, &f[..n], control, &mut work.routing);

--- a/crates/uor-r4-core/src/native_geometric/typed_routing_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/typed_routing_training.rs
@@ -2,7 +2,7 @@
 use super::source_routing::{SourceCode, SourceRouting};
 use super::source_routing_training::{learn, Alternative, Frame};
 use super::typed_routing::{self, TypedRouting};
-use super::value_types::{ValueAction, ValueFeature};
+use super::value_types::{ValueAction, ValueFeature, ValueState};
 use super::word_copy_types::WordCopyAddress;
 use super::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -10,10 +10,24 @@ use std::time::Instant;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct TypedRoutingTurn {
+    pub prompt: String,
+    pub response: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TypedRoutingExample {
     pub id: String,
     pub initial_prompt: String,
     pub initial_response: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<TypedRoutingTurn>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refresh: Vec<TypedRoutingTurn>,
+    /// Which actually generated intermediate is the supervised role, 0 or 1.
+    #[serde(default, skip_serializing_if = "typed_zero")]
+    pub target_intermediate: usize,
     pub query: String,
     pub response: String,
     /// Offline action/operand supervision, never passed into serving.
@@ -21,12 +35,18 @@ pub struct TypedRoutingExample {
     pub operands: Option<[i64; 2]>,
 }
 
+fn typed_zero(n: &usize) -> bool {
+    *n == 0
+}
+
 impl TypedRouting {
-    pub(super) fn validate(&self, model: &Model) -> Result<()> {
-        self.router.validate_shape(model, 3, 4)?;
+    pub(super) fn validate(&self, model: &Model, roles: bool) -> Result<()> {
+        self.router
+            .validate_shape(model, 3, if roles { 5 } else { 4 })?;
         let primes = crate::corpus_induced_spin_placement::first_primes(self.dictionary.len())
             .map_err(|e| Error(e.to_string()))?;
-        if model.values.is_none()
+        if (roles && model.typed_routing.is_none())
+            || model.values.is_none()
             || self.dictionary.is_empty()
             || self.dictionary.len() > 256
             || self.dictionary.iter().zip(primes).any(|(w, p)| {
@@ -73,7 +93,11 @@ fn generate(model: &Model, s: &mut Session) -> Result<(Vec<u8>, Option<ValueDeci
     Ok((model.decode(&out)?, decision, false))
 }
 
-fn initial(model: &Model, d: &TypedRoutingExample) -> Result<(Session, ValueDecision)> {
+fn initial(
+    model: &Model,
+    d: &TypedRoutingExample,
+    local_query: bool,
+) -> Result<(Session, ValueDecision)> {
     let mut s = model.session(Control::Full)?;
     s.observe(model, BOS)?;
     for t in model.encode(&d.initial_prompt)? {
@@ -88,9 +112,33 @@ fn initial(model: &Model, d: &TypedRoutingExample) -> Result<(Session, ValueDeci
             String::from_utf8_lossy(&bytes)
         )));
     }
-    let first =
+    let mut first =
         decision.ok_or_else(|| Error("initial response has no committed typed decision".into()))?;
     s.end_response(model)?;
+    for (i, turn) in d.continuation.iter().chain(d.refresh.iter()).enumerate() {
+        for t in model.encode(&turn.prompt)? {
+            s.observe(model, t)?;
+        }
+        s.begin_response(model)?;
+        let (bytes, decision, eos) = generate(model, &mut s)?;
+        if bytes != turn.response.as_bytes() || !eos {
+            return Err(Error(format!(
+                "generated intermediate failed: {} turn{}: {}",
+                d.id,
+                i,
+                String::from_utf8_lossy(&bytes)
+            )));
+        }
+        if i == 0 && d.target_intermediate == 1 {
+            first = decision.ok_or_else(|| Error("continuation has no typed decision".into()))?;
+        }
+        s.end_response(model)?;
+    }
+    if local_query {
+        if let Some(v) = &mut s.values {
+            v.query_boundary = Some(v.seen);
+        }
+    }
     for t in model.encode(&d.query)? {
         s.observe(model, t)?;
     }
@@ -98,17 +146,77 @@ fn initial(model: &Model, d: &TypedRoutingExample) -> Result<(Session, ValueDeci
     Ok((s, first))
 }
 
+// Offline provenance checks follow exact Copy aliases only. Add remains a new
+// computation even when its numeric output happens to equal an earlier value.
+fn copy_origin(values: &ValueState, mut id: u64) -> u64 {
+    for _ in 0..16 {
+        let Some(r) = values.sources.iter().find(|r| r.id == id) else {
+            break;
+        };
+        let Some(d) = r.derivation.filter(|d| d.action == ValueAction::Copy) else {
+            break;
+        };
+        if d.operand_ids[0] >= id {
+            break;
+        }
+        id = d.operand_ids[0];
+    }
+    id
+}
+
 impl Model {
+    pub fn canonicalize_typed_role_aliases(&self) -> Result<Self> {
+        self.validate()?;
+        let mut model = self.clone();
+        let block = model
+            .typed_roles
+            .as_mut()
+            .ok_or_else(|| Error("typed role block absent".into()))?;
+        if block.canonical_copy_aliases {
+            return Err(Error("typed aliases already canonical".into()));
+        }
+        block.canonical_copy_aliases = true;
+        model.refresh_identity()?;
+        model.validate()?;
+        Ok(model)
+    }
     pub fn fit_typed_routing(
         &self,
         docs: &[TypedRoutingExample],
         config: SourceRoutingConfig,
         fold_ascii_case: bool,
     ) -> Result<(Self, serde_json::Value)> {
+        self.fit_typed(docs, config, fold_ascii_case, false, false)
+    }
+    pub fn fit_typed_roles(
+        &self,
+        docs: &[TypedRoutingExample],
+        config: SourceRoutingConfig,
+    ) -> Result<(Self, serde_json::Value)> {
+        self.fit_typed(docs, config, true, true, false)
+    }
+    pub fn fit_typed_roles_local(
+        &self,
+        docs: &[TypedRoutingExample],
+        config: SourceRoutingConfig,
+    ) -> Result<(Self, serde_json::Value)> {
+        self.fit_typed(docs, config, true, true, true)
+    }
+    fn fit_typed(
+        &self,
+        docs: &[TypedRoutingExample],
+        config: SourceRoutingConfig,
+        fold_ascii_case: bool,
+        roles: bool,
+        local_query: bool,
+    ) -> Result<(Self, serde_json::Value)> {
         config.validate()?;
         self.validate()?;
-        if self.typed_routing.is_some()
-            || docs.is_empty()
+        if (if roles {
+            self.typed_roles.is_some() || self.typed_routing.is_none()
+        } else {
+            self.typed_routing.is_some()
+        }) || docs.is_empty()
             || docs.len() > 256
             || docs.iter().any(|d| {
                 d.id.is_empty()
@@ -116,6 +224,13 @@ impl Model {
                     || d.response.len() > 128
                     || d.initial_response.len() > 128
                     || d.action.is_some() != d.operands.is_some()
+                    || d.target_intermediate > 1
+                    || d.refresh.len() > 1
+                    || (d.target_intermediate == 1 && d.continuation.is_none())
+                    || d.continuation
+                        .iter()
+                        .chain(d.refresh.iter())
+                        .any(|t| t.prompt.len() > 4096 || t.response.len() > 128)
             })
         {
             return Err(Error("invalid typed routing construction input".into()));
@@ -160,6 +275,8 @@ impl Model {
         let mut rng = config.seed;
         let mut block = TypedRouting {
             fold_ascii_case,
+            canonical_copy_aliases: local_query,
+            local_query,
             dictionary,
             router: SourceRouting {
                 schema: "uor-r4.geometric-source-routing/1".into(),
@@ -182,13 +299,26 @@ impl Model {
         let mut frequency = BTreeMap::<ValueFeature, usize>::new();
         let mut frames = Vec::new();
         for d in docs {
-            let (s, first) = initial(self, d)?;
+            let (s, first) = initial(self, d, local_query)?;
             let values = s
                 .values
                 .as_ref()
                 .ok_or_else(|| Error("typed state absent".into()))?;
+            if roles && values.sources.iter().filter(|r| r.derived).count() < 2 {
+                return Err(Error(
+                    "typed role frame has fewer than two derived sources".into(),
+                ));
+            }
+            let depths =
+                roles.then(|| typed_routing::lineage_depths(values, &mut Default::default()));
             let addr = typed_routing::addresses(&block, values, &mut Default::default());
-            let (f, n) = typed_routing::features(values, None, &addr, &mut Default::default());
+            let (f, n) = typed_routing::features_with_depths(
+                values,
+                None,
+                &addr,
+                depths.as_ref(),
+                &mut Default::default(),
+            );
             let mut alternatives = vec![Alternative {
                 features: f[..n].to_vec(),
                 codes: Vec::new(),
@@ -205,8 +335,13 @@ impl Model {
                             || (action == ValueAction::Add && [b.value, a.value] == pair))
                             && (a.id == first.write_id || b.id == first.write_id)
                     });
-                let (f, n) =
-                    typed_routing::features(values, Some((a, b)), &addr, &mut Default::default());
+                let (f, n) = typed_routing::features_with_depths(
+                    values,
+                    Some((a, b)),
+                    &addr,
+                    depths.as_ref(),
+                    &mut Default::default(),
+                );
                 alternatives.push(Alternative {
                     features: f[..n].to_vec(),
                     codes: Vec::new(),
@@ -235,8 +370,8 @@ impl Model {
         }
         let mut vocab: Vec<_> = frequency.iter().map(|(f, n)| (*f, *n)).collect();
         vocab.sort_by(|a, b| {
-            (a.0.kind >= 2)
-                .cmp(&(b.0.kind >= 2))
+            (a.0.kind >= 2 && a.0.kind != 4)
+                .cmp(&(b.0.kind >= 2 && b.0.kind != 4))
                 .then(b.1.cmp(&a.1))
                 .then(a.0.cmp(&b.0))
         });
@@ -293,7 +428,11 @@ impl Model {
             .len();
         let dictionary_words = block.dictionary.len();
         let mut model = self.clone();
-        model.typed_routing = Some(block);
+        if roles {
+            model.typed_roles = Some(block);
+        } else {
+            model.typed_routing = Some(block);
+        }
         model.refresh_identity()?;
         model.validate()?;
         let artifact = model.artifact_cid().to_owned();
@@ -314,19 +453,38 @@ impl Model {
         let started = Instant::now();
         let mut cases = Vec::new();
         for d in docs {
-            let (mut s, first) = initial(self, d)?;
+            let (mut s, first) = match initial(
+                self,
+                d,
+                self.typed_roles.as_ref().is_some_and(|b| b.local_query),
+            ) {
+                Ok(state) => state,
+                Err(error) => {
+                    cases.push(serde_json::json!({"id":d.id,"exact":false,"initial_generation_failed":error.to_string(),"used_intermediate":false}));
+                    continue;
+                }
+            };
             if remove_intermediate {
                 if let Some(v) = &mut s.values {
-                    v.records.retain(|r| r.id != first.write_id);
-                    v.sources.retain(|r| r.id != first.write_id);
+                    let target = copy_origin(v, first.write_id);
+                    let removed: Vec<u64> = v
+                        .sources
+                        .iter()
+                        .filter(|r| copy_origin(v, r.id) == target)
+                        .map(|r| r.id)
+                        .collect();
+                    v.records.retain(|r| !removed.contains(&r.id));
+                    v.sources.retain(|r| !removed.contains(&r.id));
                 }
             }
             let captured = s.values.as_ref().map(|v| v.sources.clone());
             let (bytes, decision, eos) = generate(self, &mut s)?;
             let used = decision.is_some_and(|x| {
-                x.operands
-                    .iter()
-                    .any(|r| r.derived && r.id == first.write_id)
+                s.values.as_ref().is_some_and(|v| {
+                    x.operands.iter().any(|r| {
+                        r.derived && copy_origin(v, r.id) == copy_origin(v, first.write_id)
+                    })
+                })
             });
             let action = decision.map(|d| d.action);
             let exact = bytes == d.response.as_bytes()

--- a/crates/uor-r4-core/src/native_geometric/value_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime.rs
@@ -171,6 +171,9 @@ impl ValueState {
         }
     }
     pub(super) fn end(&mut self) {
+        if self.query_boundary.is_some() {
+            self.query_boundary = Some(self.seen);
+        }
         self.active = false;
         self.pending = None;
         self.emission = None;
@@ -347,6 +350,18 @@ impl ValueState {
                     continue;
                 };
                 work.proposals = work.proposals.saturating_add(1);
+                if action == ValueAction::Add
+                    && super::typed_routing::alias_self_add(
+                        self,
+                        a,
+                        b,
+                        routed.as_ref().and_then(|c| c.origins.as_ref()),
+                        work,
+                    )
+                {
+                    work.alias_self_add_rejections += 1;
+                    continue;
+                }
                 let mut score = 0_i64;
                 if let Some(addr) = &routed {
                     let action_index = if action == ValueAction::Copy { 0 } else { 1 };

--- a/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
@@ -412,6 +412,8 @@ fn native_typed_routing_case_fold_changes_metadata_only() {
     bytes[..4].copy_from_slice(b"copy");
     let mut block = TypedRouting {
         fold_ascii_case: true,
+        canonical_copy_aliases: false,
+        local_query: false,
         dictionary: vec![WordCopyAddress {
             bytes,
             len: 4,
@@ -442,12 +444,45 @@ fn native_typed_routing_case_fold_changes_metadata_only() {
             2
         );
         assert_eq!(values.lexemes, Some(words));
+        block.local_query = true;
+        values.query_boundary = Some(1);
+        assert_eq!(
+            super::typed_routing::addresses(&block, values, &mut Default::default())[0],
+            0
+        );
+        values.lexemes.as_mut().unwrap().queries[0].end = 1;
+        assert_eq!(
+            super::typed_routing::addresses(&block, values, &mut Default::default())[0],
+            2
+        );
+        values.lexemes = Some(words);
+        values.query_boundary = None;
+        block.local_query = false;
         block.fold_ascii_case = false;
         assert_eq!(
             super::typed_routing::addresses(&block, values, &mut Default::default())[0],
             if spelling == b"copy" { 2 } else { 0 }
         );
     }
+}
+
+#[test]
+fn native_typed_roles_query_boundary_tracks_end_and_roundtrips() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "13 4 total:", Control::Full);
+    let v = session.values.as_mut().unwrap();
+    v.query_boundary = Some(0);
+    let end = v.seen;
+    v.end();
+    assert_eq!(v.query_boundary, Some(end));
+    let saved = serde_json::to_vec(v).unwrap();
+    let restored: ValueState = serde_json::from_slice(&saved).unwrap();
+    assert_eq!(restored.query_boundary, Some(end));
+    // Old state has no boundary field and remains boundary-free.
+    let mut wire = serde_json::to_value(&restored).unwrap();
+    wire.as_object_mut().unwrap().remove("query_boundary");
+    let old: ValueState = serde_json::from_value(wire).unwrap();
+    assert_eq!(old.query_boundary, None);
 }
 
 #[test]
@@ -658,4 +693,135 @@ fn native_value_selected_execution_learned_chain_diagnostic() {
         exact_chains, 6,
         "learned generated composition remains unqualified; inspect reachability, selection, emission and intermediate control separately"
     );
+}
+
+#[test]
+fn native_typed_roles_lineage_is_order_and_copy_invariant() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "13 4 total:", Control::Full);
+    let v = session.values.as_mut().unwrap();
+    let literal = |id, value| ValueRecord {
+        id,
+        value,
+        ..Default::default()
+    };
+    let derived = |id, value, action, ids, nums| ValueRecord {
+        id,
+        value,
+        derived: true,
+        derivation: Some(ValueDerivation {
+            action,
+            operand_ids: ids,
+            operand_values: nums,
+        }),
+        ..Default::default()
+    };
+    v.sources = vec![
+        literal(0, 13),
+        literal(1, 4),
+        derived(2, 17, ValueAction::Add, [0, 1], [13, 4]),
+        literal(3, 5),
+        derived(4, 22, ValueAction::Add, [2, 3], [17, 5]),
+        derived(5, 17, ValueAction::Copy, [2, 2], [17, 17]),
+    ];
+    let d = super::typed_routing::lineage_depths(v, &mut Default::default());
+    assert_eq!(&d[..6], &[0, 0, 1, 0, 2, 1]);
+    let a = v.sources[2];
+    let b = v.sources[4];
+    let features = super::typed_routing::features_with_depths(
+        v,
+        Some((a, b)),
+        &[0; 16],
+        Some(&d),
+        &mut Default::default(),
+    );
+    v.sources.reverse();
+    let reversed = super::typed_routing::lineage_depths(v, &mut Default::default());
+    assert_eq!(&reversed[..6], &[1, 2, 0, 1, 0, 0]);
+    assert_eq!(
+        features,
+        super::typed_routing::features_with_depths(
+            v,
+            Some((a, b)),
+            &[0; 16],
+            Some(&reversed),
+            &mut Default::default()
+        )
+    );
+    // Numeric values are payloads, not lineage metadata.
+    for r in &mut v.sources {
+        r.value = -999;
+    }
+    assert_eq!(
+        reversed,
+        super::typed_routing::lineage_depths(v, &mut Default::default())
+    );
+    // Missing ancestors are explicit unknown, never silently depth zero.
+    v.sources.retain(|r| r.id != 0);
+    let missing = super::typed_routing::lineage_depths(v, &mut Default::default());
+    for (i, r) in v.sources.iter().enumerate() {
+        if r.derived {
+            assert_eq!(missing[i], 255);
+        }
+    }
+}
+
+#[test]
+fn native_typed_roles_alias_admission_uses_identity_not_numeric_equality() {
+    let model = mechanical_model(ValueAction::Add);
+    let mut session = prefix(&model, "13 4 total:", Control::Full);
+    let v = session.values.as_mut().unwrap();
+    let original = ValueRecord {
+        id: 2,
+        value: 17,
+        derived: true,
+        derivation: Some(ValueDerivation {
+            action: ValueAction::Add,
+            operand_ids: [0, 1],
+            operand_values: [13, 4],
+        }),
+        ..Default::default()
+    };
+    let alias = ValueRecord {
+        id: 3,
+        derivation: Some(ValueDerivation {
+            action: ValueAction::Copy,
+            operand_ids: [2, 2],
+            operand_values: [17, 17],
+        }),
+        ..original
+    };
+    let other = ValueRecord { id: 4, ..original };
+    v.sources.extend([original, alias, other]);
+    let origins = super::typed_routing::copy_origins(v, &mut Default::default());
+    assert!(super::typed_routing::alias_self_add(
+        v,
+        original,
+        alias,
+        Some(&origins),
+        &mut Default::default()
+    ));
+    assert!(!super::typed_routing::alias_self_add(
+        v,
+        original,
+        other,
+        Some(&origins),
+        &mut Default::default()
+    ));
+    assert!(!super::typed_routing::alias_self_add(
+        v,
+        original,
+        alias,
+        None,
+        &mut Default::default()
+    ));
+    v.sources.reverse();
+    let reversed = super::typed_routing::copy_origins(v, &mut Default::default());
+    assert!(super::typed_routing::alias_self_add(
+        v,
+        alias,
+        original,
+        Some(&reversed),
+        &mut Default::default()
+    ));
 }

--- a/crates/uor-r4-core/src/native_geometric/value_snapshot.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_snapshot.rs
@@ -103,7 +103,10 @@ impl Session {
             .values
             .as_ref()
             .is_some_and(|head| head.schema == LEXEME_VALUE_SCHEMA);
-        if saved.seen != observed
+        if saved.query_boundary.is_some()
+            != model.typed_roles.as_ref().is_some_and(|b| b.local_query)
+            || saved.query_boundary.is_some_and(|start| start > observed)
+            || saved.seen != observed
             || saved.lexemes.is_some() != lexical
             || saved.recent_len != observed.min(32) as usize
             || saved.recent_cursor != (observed & 31) as usize

--- a/crates/uor-r4-core/src/native_geometric/value_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_types.rs
@@ -29,6 +29,8 @@ pub struct ValueWork {
     pub literal_writes: u64,
     pub record_evictions: u64,
     pub proposals: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub alias_self_add_rejections: u64,
     /// Exact Copy/Add calls, including rejected overflow attempts.
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub operator_executions: u64,
@@ -159,6 +161,8 @@ pub(super) struct ValueState {
     pub active: bool,
     pub consumed: bool,
     pub started_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_boundary: Option<u64>,
     pub queries: [ValueEntry; QUERY],
     pub query_len: usize,
     pub emission: Option<ValueEmission>,
@@ -188,6 +192,11 @@ impl ValueState {
             active: false,
             consumed: false,
             started_at: 0,
+            query_boundary: model
+                .typed_roles
+                .as_ref()
+                .filter(|b| b.local_query)
+                .map(|_| 0),
             queries: [ValueEntry::default(); QUERY],
             query_len: 0,
             emission: None,

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -1215,3 +1215,65 @@ fn native_typed_artifact_routing_is_allocation_free() {
     assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
     println!("actual typed geometric routing/commit: allocations=0 bytes=0");
 }
+
+#[test]
+#[ignore = "requires R4_TYPED_ROLES_MODEL retained role selection artifact"]
+fn native_typed_role_artifact_is_allocation_free() {
+    let path = std::env::var("R4_TYPED_ROLES_MODEL").expect("named model path");
+    let model =
+        uor_r4_core::native_geometric::Model::from_bytes(&std::fs::read(path).unwrap()).unwrap();
+    let prompts=[
+        "User: suri has 13 coins. orin has 4 coins.\nUser: What is the sum of suri's and orin's coins?\nAssistant:",
+        "User: There are 5 new coins. Add the new coins to the previous total.\nAssistant:",
+        "User: Repeat the original total.\nAssistant:",
+        "User: There are 2 extra coins. Add the extra coins to the updated total.\nAssistant:",
+    ].map(|p|model.encode(p).unwrap());
+    let mut s = model.session(Control::Full).unwrap();
+    let mut answers = [None; 4];
+    ALLOCATIONS.with(|v| v.set(0));
+    BYTES.with(|v| v.set(0));
+    MEASURING.with(|v| v.set(true));
+    let result = (|| {
+        s.observe(&model, BOS)?;
+        for (i, prompt) in prompts.iter().enumerate() {
+            for &token in prompt {
+                s.observe(&model, token)?;
+            }
+            s.begin_response(&model)?;
+            for _ in 0..32 {
+                let token = s.predict(&model)?.token;
+                if let Some(d) = s.value_decision().filter(|d| d.cursor == 0) {
+                    answers[i] = Some(d.value);
+                }
+                s.observe(&model, token)?;
+                if token == EOS {
+                    break;
+                }
+            }
+            s.end_response(&model)?;
+        }
+        Ok::<_, uor_r4_core::native_geometric::Error>(())
+    })();
+    MEASURING.with(|v| v.set(false));
+    result.unwrap();
+    assert_eq!(answers, [Some(17), Some(22), Some(17), Some(24)]);
+    assert!(s.work.values.alias_self_add_rejections > 0);
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    let checkpoint = s.checkpoint().unwrap();
+    let restored = model.restore_session(&checkpoint).unwrap();
+    assert_eq!(restored.checkpoint().unwrap(), checkpoint);
+    let mut forged: serde_json::Value = serde_json::from_slice(&checkpoint).unwrap();
+    assert!(forged["values"]["query_boundary"].is_number());
+    forged["values"]
+        .as_object_mut()
+        .unwrap()
+        .remove("query_boundary");
+    assert!(model
+        .restore_session(&serde_json::to_vec(&forged).unwrap())
+        .is_err());
+    forged["values"]["query_boundary"] = serde_json::json!(u64::MAX);
+    assert!(model
+        .restore_session(&serde_json::to_vec(&forged).unwrap())
+        .is_err());
+    println!("actual competing typed roles: four committed values correct; allocations=0 bytes=0; boundary restore and rejection checks PASS");
+}

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -12,6 +12,13 @@ geometric operators through bounded state, routing and integer/table lookup.
 Working generation or session persistence does not establish either required
 alpha capability group: conversation/memory and coding/reasoning.
 
+The optional [typed-role selector](native_geometric_typed_roles_1139.md) uses
+`Session::end_response` to mark the start boundary for the next query's metadata.
+Continue to call the explicit begin/end response API around each generated turn;
+a raw concatenated transcript does not supply the same boundary contract.
+Exact retained values and derivations remain available across that boundary.
+Artifacts enabling this behavior require the boundary in restored checkpoints.
+
 ## Historical and retained reference lifecycles
 
 The material below preserves source-model, TLA, R4G1 and earlier geometric

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,6 +1,19 @@
 # Research: what is measured, what is closed, what is open
 
-## NoWrite reuse — current checkpoint, 2026-09-06
+## Competing derived values — current checkpoint, 2026-09-06
+
+The [typed-role record](native_geometric_typed_roles_1139.md) retains `43c54db3`
+at bounded causal-depth scope: 12/12 complete new four-turn operand/refresh
+transfers versus 2/12 for the matched exact-code fit. Exact derivation depth,
+Copy-alias admission and query metadata cut at explicit response boundaries
+address the observed failures. Earlier 9/12 and 8/12 transfers remain exposed
+negatives. Removal gives 0/12 full operator/provenance successes but 2/12 matching
+texts through recomputation. Existing conversation, memory and familiar Rust
+checks pass; no general named-role, prose, syntax, reasoning or frontier claim.
+The [current state](integration/current-state.md) carries cumulative resources
+and the next equal-depth operand/owner-binding implementation.
+
+## NoWrite reuse — previous checkpoint, 2026-09-06
 
 The [corrected-writer cache](native_geometric_writer_admission_1139.md) retains
 `2600b95b`. All learned parameters remain fixed; construction contributes 140

--- a/docs/evidence/native_geometric_typed_roles_1139.json
+++ b/docs/evidence/native_geometric_typed_roles_1139.json
@@ -1,0 +1,879 @@
+{
+  "schema": "uor-r4.typed-roles-evidence/1",
+  "decision": "RETAIN_LOCAL_QUERY_CANONICAL_ALIAS_ANGULAR_AT_BOUNDED_CAUSAL_DEPTH_SCOPE",
+  "source_parent": "eb7bfbb8deee0d2c70a18dc7dbf3299b57b448e4",
+  "artifact_root": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+  "artifact": "blake3:43c54db3c7addcca7eaf82e975969968d031fba7ef6ba7b0e0628dc5b9779b76",
+  "parent": "blake3:bb79456b2dd7187005a3501d437fdc17215429bd4fff0671c31a44583d2918c7",
+  "angular_fit": {
+    "artifact": "blake3:43c54db3c7addcca7eaf82e975969968d031fba7ef6ba7b0e0628dc5b9779b76",
+    "block_bytes": 13609,
+    "config": {
+      "learned_features": 192,
+      "max_seconds": 30,
+      "mode": "angular",
+      "passes": 4,
+      "proposals": 12,
+      "seed": 1139
+    },
+    "construction_ms": 100,
+    "dictionary_words": 22,
+    "effective_query_classes": 7,
+    "feature_universe": 105,
+    "features": 105,
+    "fit": {
+      "accepted": [
+        15,
+        0,
+        4
+      ],
+      "final_correct": 42,
+      "final_hinge": 0,
+      "initial_correct": 6,
+      "initial_hinge": 120,
+      "proposals": 13653,
+      "stopped_at_time_limit": false
+    },
+    "frames": 42,
+    "incompatible_feature_classes": 0,
+    "parent": "blake3:bb79456b2dd7187005a3501d437fdc17215429bd4fff0671c31a44583d2918c7",
+    "scope": "Joint typed operator/operand labels over actual generated intermediates; source values and numeric query words are not encoded as geometric scoring features. Construction fit is not generated transfer."
+  },
+  "equality_fit": {
+    "artifact": "blake3:ca7d7f98dccd7c204b1b9c645a8f03c9825e4d7745500272d7863225fb38e818",
+    "block_bytes": 13609,
+    "config": {
+      "learned_features": 192,
+      "max_seconds": 30,
+      "mode": "equality",
+      "passes": 4,
+      "proposals": 12,
+      "seed": 1139
+    },
+    "construction_ms": 100,
+    "dictionary_words": 22,
+    "effective_query_classes": 7,
+    "feature_universe": 105,
+    "features": 105,
+    "fit": {
+      "accepted": [
+        11,
+        0,
+        7
+      ],
+      "final_correct": 25,
+      "final_hinge": 30,
+      "initial_correct": 6,
+      "initial_hinge": 42,
+      "proposals": 13634,
+      "stopped_at_time_limit": false
+    },
+    "frames": 42,
+    "incompatible_feature_classes": 0,
+    "parent": "blake3:bb79456b2dd7187005a3501d437fdc17215429bd4fff0671c31a44583d2918c7",
+    "scope": "Joint typed operator/operand labels over actual generated intermediates; source values and numeric query words are not encoded as geometric scoring features. Construction fit is not generated transfer."
+  },
+  "results": {
+    "parent_development": [
+      3,
+      12
+    ],
+    "construction_generated": [
+      42,
+      42
+    ],
+    "development": [
+      12,
+      12
+    ],
+    "exposed_alias_failure_repair": [
+      12,
+      12
+    ],
+    "new_transfer_angular": [
+      12,
+      12
+    ],
+    "new_transfer_equality": [
+      2,
+      12
+    ],
+    "equality_prefix_failures": 8,
+    "removal_full_criterion": [
+      0,
+      12
+    ],
+    "removal_matching_texts": [
+      2,
+      12
+    ],
+    "dependent": [
+      48,
+      48
+    ],
+    "earlier": [
+      62,
+      62
+    ],
+    "prior_transfer": [
+      24,
+      24
+    ],
+    "exposed_names": [
+      28,
+      28
+    ],
+    "long_context": [
+      28,
+      28
+    ],
+    "persistent_turns": [
+      5,
+      5
+    ],
+    "earlier_numeric_transfer": [
+      6,
+      6
+    ]
+  },
+  "negative_history": [
+    {
+      "artifact": "blake3:4f1ffd80c0299e9c790a38b4d17d09bd822693de04cb2de387330c029cb27c2f",
+      "transfer": [
+        9,
+        12
+      ],
+      "cause": "Copy aliases created reflexive Add candidates; no promotion."
+    },
+    {
+      "artifact": "blake3:94fc7f8f3328282ef907ae9e1f35a07a5dde436ae96a16b52bbc718538bde58d",
+      "transfer": [
+        8,
+        12
+      ],
+      "cause": "Recent-word query crossed response boundaries; no promotion."
+    }
+  ],
+  "scope": "Small authored cases. Same42 construction records across boundary refit. Earlier9/12 and8/12 transfers explicitly exposed;12 new operands/refresh cases opened after design selection. No sealed/general-language or multi-seed claim.",
+  "examples": [
+    {
+      "id": "roles-query-transfer/0/0",
+      "query": "User: Repeat the original total.\nAssistant:",
+      "text": "23.\n",
+      "expected": "23.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/0/1",
+      "query": "User: Repeat the updated total.\nAssistant:",
+      "text": "30.\n",
+      "expected": "30.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/0/4",
+      "query": "User: There are 2 extra coins. Add the extra coins to the original total.\nAssistant:",
+      "text": "25.\n",
+      "expected": "25.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/0/5",
+      "query": "User: There are 2 extra coins. Add the extra coins to the updated total.\nAssistant:",
+      "text": "32.\n",
+      "expected": "32.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/1/0",
+      "query": "User: Repeat the original total.\nAssistant:",
+      "text": "17.\n",
+      "expected": "17.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/1/1",
+      "query": "User: Repeat the updated total.\nAssistant:",
+      "text": "21.\n",
+      "expected": "21.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/1/4",
+      "query": "User: There are 6 extra coins. Add the extra coins to the original total.\nAssistant:",
+      "text": "23.\n",
+      "expected": "23.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/1/5",
+      "query": "User: There are 6 extra coins. Add the extra coins to the updated total.\nAssistant:",
+      "text": "27.\n",
+      "expected": "27.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/2/0",
+      "query": "User: Repeat the original total.\nAssistant:",
+      "text": "10.\n",
+      "expected": "10.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/2/1",
+      "query": "User: Repeat the updated total.\nAssistant:",
+      "text": "15.\n",
+      "expected": "15.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/2/4",
+      "query": "User: There are 3 extra coins. Add the extra coins to the original total.\nAssistant:",
+      "text": "13.\n",
+      "expected": "13.\n",
+      "used_intermediate": true
+    },
+    {
+      "id": "roles-query-transfer/2/5",
+      "query": "User: There are 3 extra coins. Add the extra coins to the updated total.\nAssistant:",
+      "text": "18.\n",
+      "expected": "18.\n",
+      "used_intermediate": true
+    }
+  ],
+  "complete_work_sum": {
+    "anchor_table_reads": 2504,
+    "candidate_evaluations": 33382,
+    "candidate_offers": 88072,
+    "completion": {
+      "anchors": 48,
+      "base_steps": 0,
+      "candidate_comparisons": 12992,
+      "candidate_drops": 0,
+      "candidate_evaluations": 864,
+      "candidate_writes": 864,
+      "commits": 144,
+      "feature_queries": 2304,
+      "h4_reads": 288,
+      "matched_rows": 2288,
+      "metadata_reads": 528,
+      "mismatches": 0,
+      "observations": 2264,
+      "orientation_reads": 144,
+      "phase_subtractions": 1152,
+      "posting_offers": 5152,
+      "row_comparisons": 20736,
+      "score_comparisons": 25728,
+      "score_lookups": 13728,
+      "state_copies": 7416,
+      "step_limits": 0,
+      "stops": 48
+    },
+    "evictions": 0,
+    "feature_queries": 6240,
+    "h4_table_reads": 2264,
+    "matched_rows": 5360,
+    "memory_candidates": 19698,
+    "memory_composed_candidates": 10836,
+    "memory_composition_comparisons": 2747932,
+    "memory_composition_duplicate_features": 107098,
+    "memory_composition_feature_moves": 580737,
+    "memory_composition_feature_offers": 354564,
+    "memory_cue_reads": 39656,
+    "memory_h4_reads": 140150,
+    "memory_index_reads": 57528,
+    "memory_index_writes": 35744,
+    "memory_phase_updates": 490864,
+    "memory_score_lookups": 247466,
+    "memory_stale_rejections": 0,
+    "mixture_gate_reads": 240,
+    "observed_tokens": 2264,
+    "orientation_table_reads": 240,
+    "phase_additions": 18112,
+    "radial_square_reads": 27168,
+    "response_entry": {
+      "anchors": 48,
+      "base_steps": 0,
+      "candidate_comparisons": 0,
+      "candidate_drops": 0,
+      "candidate_evaluations": 0,
+      "candidate_writes": 0,
+      "commits": 0,
+      "feature_queries": 0,
+      "h4_reads": 0,
+      "matched_rows": 0,
+      "metadata_reads": 48,
+      "mismatches": 0,
+      "observations": 2264,
+      "orientation_reads": 0,
+      "phase_subtractions": 0,
+      "posting_offers": 0,
+      "row_comparisons": 0,
+      "score_comparisons": 0,
+      "score_lookups": 0,
+      "state_copies": 7320,
+      "step_limits": 0,
+      "stops": 0
+    },
+    "score_lookups": 764105,
+    "values": {
+      "additions": 30,
+      "alias_self_add_rejections": 24,
+      "cue_comparisons": 3072,
+      "derived_writes": 48,
+      "emission_commits": 96,
+      "emission_mismatches": 0,
+      "feature_comparisons": 37440,
+      "feature_lookups": 2880,
+      "h4_reads": 22328,
+      "input_bytes": 3460,
+      "lexical_byte_comparisons": 8668,
+      "lexical_comparisons": 6144,
+      "lexical_writes": 600,
+      "literal_writes": 42,
+      "numeral_steps": 18240,
+      "operator_executions": 48,
+      "overflow_rejections": 0,
+      "phase_updates": 18880,
+      "proposals": 1050,
+      "record_evictions": 0,
+      "relations": {
+        "abstentions": 0,
+        "admission_exact_comparisons": 12378,
+        "admission_fallbacks": 600,
+        "admission_metadata_bytes": 33312,
+        "admission_queries": 600,
+        "admission_signature_writes": 5400,
+        "candidates": 23184,
+        "conflicts": 0,
+        "dictionary_byte_comparisons": 34978,
+        "dictionary_comparisons": 26784,
+        "directory_reads": 0,
+        "directory_writes": 0,
+        "feature_queries": 440496,
+        "feature_writes": 146832,
+        "no_writes": 600,
+        "phase_subtractions": 30912,
+        "reads": 0,
+        "record_evictions": 0,
+        "record_reads": 4464,
+        "record_writes": 0,
+        "revisions": 0,
+        "role_path_comparisons": 135072,
+        "role_path_probes": 22512,
+        "role_path_steps": 4140,
+        "role_phase_additions": 33120,
+        "row_comparisons": 5726448,
+        "score_lookups": 434376,
+        "source_presence_checks": 0,
+        "word_boundaries": 600
+      },
+      "routing": {
+        "code_reads": 47184,
+        "comparisons": 221890,
+        "context_tokens_read": 576,
+        "emission_queries": 23694,
+        "logical_bytes_read": 3990420,
+        "operator_executions": 0,
+        "payload_gathers": 0,
+        "predictions": 36,
+        "sources_examined": 15712,
+        "table_reads": 105522
+      },
+      "selection_comparisons": 1026,
+      "selection_passes": 48
+    },
+    "word_copy": {
+      "bound_rejections": 0,
+      "byte_reads": 0,
+      "dictionary_byte_comparisons": 0,
+      "dictionary_comparisons": 0,
+      "dictionary_lookups": 0,
+      "dispatch_checks": 240,
+      "equality_byte_comparisons": 0,
+      "forced_dispatches": 0,
+      "selector": {
+        "anchors": 0,
+        "base_steps": 0,
+        "candidate_comparisons": 0,
+        "candidate_drops": 0,
+        "candidate_evaluations": 0,
+        "candidate_writes": 0,
+        "commits": 0,
+        "feature_queries": 0,
+        "h4_reads": 0,
+        "matched_rows": 0,
+        "metadata_reads": 0,
+        "mismatches": 0,
+        "observations": 2264,
+        "orientation_reads": 0,
+        "phase_subtractions": 0,
+        "posting_offers": 0,
+        "row_comparisons": 0,
+        "score_comparisons": 0,
+        "score_lookups": 0,
+        "state_copies": 0,
+        "step_limits": 0,
+        "stops": 0
+      },
+      "word_candidates": 0,
+      "word_record_reads": 0
+    }
+  },
+  "cost_scope": "Complete four-turn sessions; includes initial sums, update, actual refresh, final output. Logical byte counters cover instrumented loads, not physical DRAM traffic or a complete instruction census. No whole-model speedup claim.",
+  "checks": {
+    "focused_tests": 10,
+    "kernel_source": "PASS",
+    "actual_serving_allocations": 0,
+    "actual_serving_allocated_bytes": 0,
+    "actual_checkpoint_roundtrip_and_boundary_rejections": "PASS",
+    "unchanged_generated_rust_functions": 4,
+    "rust_semantic_assertions": 12,
+    "cli_revision_text": " Zurich.\n",
+    "format_policy_wording": "PASS",
+    "broad_release_QA": "NOT_RUN"
+  },
+  "resources": {
+    "cycle_model_ms": 283472,
+    "cycle_engineering_ms": 1397998,
+    "cumulative_model_ms": 2316511,
+    "model_limit_ms": 2370000,
+    "cycle_model_limit_ms": 330000,
+    "engineering_limit_ms": 1500000,
+    "model_increment_ms": 240000,
+    "storage_increment_bytes": 0,
+    "peak_sampled_known_bytes": 6425583616,
+    "storage_ceiling_bytes": 6506475520,
+    "peak_model_child_rss_bytes": 878673920,
+    "paid_external_compute": 0,
+    "deletions": 0,
+    "scope": "Cumulative monitored wall time including preparation, fits, controls, tests and retries; engineering includes one failed missing-import compile. Periodic storage/RSS samples are not exact transient peaks."
+  },
+  "command_receipts": [
+    {
+      "label": "typed-roles-parent-competition",
+      "elapsed_ms": 5753,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-metadata-tests",
+      "elapsed_ms": 1168,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-prepare",
+      "elapsed_ms": 228,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-parent-development",
+      "elapsed_ms": 5684,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-angular-fit",
+      "elapsed_ms": 18831,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-equality-fit",
+      "elapsed_ms": 18868,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-development",
+      "elapsed_ms": 6488,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-construction",
+      "elapsed_ms": 6303,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-equality-development",
+      "elapsed_ms": 6190,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-first-use",
+      "elapsed_ms": 6201,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-equality-first-use",
+      "elapsed_ms": 6178,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-removal",
+      "elapsed_ms": 6177,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-tests",
+      "elapsed_ms": 1241,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-counter-test",
+      "elapsed_ms": 7,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-execution-tests",
+      "elapsed_ms": 935,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-artifact",
+      "elapsed_ms": 19098,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-equality-artifact",
+      "elapsed_ms": 18664,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-source",
+      "elapsed_ms": 7,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-exposed",
+      "elapsed_ms": 6159,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-development",
+      "elapsed_ms": 6152,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-first-use",
+      "elapsed_ms": 6303,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-equality-first-use",
+      "elapsed_ms": 6164,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-alias-removal",
+      "elapsed_ms": 6165,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-preservation",
+      "elapsed_ms": 6318,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-prior-composition",
+      "elapsed_ms": 6139,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-tests",
+      "elapsed_ms": 1369,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-source",
+      "elapsed_ms": 167,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-angular-fit",
+      "elapsed_ms": 18702,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-equality-fit",
+      "elapsed_ms": 18853,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-development",
+      "elapsed_ms": 6282,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-exposed",
+      "elapsed_ms": 6288,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-first-use",
+      "elapsed_ms": 6254,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-equality-first-use",
+      "elapsed_ms": 6174,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-removal",
+      "elapsed_ms": 6203,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-construction",
+      "elapsed_ms": 6258,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-preservation",
+      "elapsed_ms": 6320,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-prior-composition",
+      "elapsed_ms": 6781,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-long",
+      "elapsed_ms": 6597,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-allocation",
+      "elapsed_ms": 6727,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-kernel",
+      "elapsed_ms": 9,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-query-cli",
+      "elapsed_ms": 6726,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-rust-execution",
+      "elapsed_ms": 121,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-final-unit-tests",
+      "elapsed_ms": 1345,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-final-counter",
+      "elapsed_ms": 7,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-final-execution",
+      "elapsed_ms": 868,
+      "code": 0,
+      "engineering": false
+    },
+    {
+      "label": "typed-roles-diagnostic-build",
+      "elapsed_ms": 325185,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-unit-build",
+      "elapsed_ms": 10548,
+      "code": 101,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-unit-build-fixed",
+      "elapsed_ms": 19312,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-release",
+      "elapsed_ms": 309019,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-allocation-build",
+      "elapsed_ms": 5131,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-final-unit-build",
+      "elapsed_ms": 20113,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-alias-unit-build",
+      "elapsed_ms": 19372,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-alias-release",
+      "elapsed_ms": 309620,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-final-allocation-build",
+      "elapsed_ms": 5062,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-query-unit-build",
+      "elapsed_ms": 19680,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-query-release",
+      "elapsed_ms": 326077,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-query-allocation-build",
+      "elapsed_ms": 6107,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-final-check-build",
+      "elapsed_ms": 22644,
+      "code": 0,
+      "engineering": true
+    },
+    {
+      "label": "typed-roles-rust-compile",
+      "elapsed_ms": 128,
+      "code": 0,
+      "engineering": true
+    }
+  ],
+  "command_log_paths": [
+    "commands.jsonl",
+    "engineering-commands.jsonl"
+  ],
+  "source_sha256": {
+    "crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs": "38bca5df6ce2e574d9f16a6bc543ff768ead8c7d822de64cda10b7f63f9e0049",
+    "crates/uor-r4-core/src/native_geometric/mod.rs": "0c025deab21c11f76125a7cb4eca12d9040071f37065eb7c7157f4e1ac0802a0",
+    "crates/uor-r4-core/src/native_geometric/training.rs": "396a838b65bb5174935633c071ca6709eccec894fd4f11bbcc4d24a08132d580",
+    "crates/uor-r4-core/src/native_geometric/typed_routing.rs": "8abe64d5bedee0afe9cde5403c8f87ea0aaa9edca8f774d530ce3aa144960140",
+    "crates/uor-r4-core/src/native_geometric/typed_routing_training.rs": "4c7491f131e4ac2d96d186b947939a5784dacaeae15979d1d1655c3901b74b6b",
+    "crates/uor-r4-core/src/native_geometric/value_runtime.rs": "ec1c4ffc0dccf9b8f14851ca2d502f7d5246dc99bb9d84c32c8dfb0034da700c",
+    "crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs": "def482a9c3f1fa98893374812593cade3a4e4fa81078db39474a7a8ba3228fee",
+    "crates/uor-r4-core/src/native_geometric/value_snapshot.rs": "c2a698c8eff01737014f130d7074a71bebe32aa27180288f711952cda7e467f8",
+    "crates/uor-r4-core/src/native_geometric/value_types.rs": "b4fe6f8000bcca7054fd39ed55c7dfa2157d9e565fdfce8a45a41ecc5eb553a1",
+    "crates/uor-r4-core/tests/native_geometric_allocations.rs": "3c9e97fafa635929048e4fec4ef0d4f932402c67e660c981c3fcbfe693b5db06"
+  },
+  "local_reports_sha256": {
+    "typed-roles-alias-development.json": "c136e5755f32659aa86ebb1e26c5340ffa3c4cea134fd38d080ef0f5cdd8a313",
+    "typed-roles-alias-equality-first-use.json": "1f1b48c1578516f62101c0466a97c246144b24e6e18221bff0296caab641c5db",
+    "typed-roles-alias-exposed.json": "ff50377d1b8c0e2b46e65b5cf1b15ce4f42f6173f4068f79c5b44db38b11461c",
+    "typed-roles-alias-first-use.json": "d23de6836b507b4fbfaf1940ac16f27c54c207196e71089cccdacd2d64a2777b",
+    "typed-roles-alias-projection.json": "c4dfa52af92810c4caa6892bede2f5acd04916f22298470e69fa4d28ed11ddd0",
+    "typed-roles-alias-removal.json": "47a7408c9f673b5fe8c02b71dd67f96df2b9913d3864590288296c2e999282bb",
+    "typed-roles-alias-selection.json": "a0d211c8637f9fca58ab890a2cec0ae10cb9d4317316993da588d3588ba5dabd",
+    "typed-roles-alias-source.json": "79217a5d9bc19f480f67580e6cb810cede12bb24ebeb330e144c98ac419aa2bd",
+    "typed-roles-angular/fit.json": "4e447f5c7a44dd90f82fd6e6f4b051b19f8adf0ebac81072f02aa9d84096b191",
+    "typed-roles-angular/model.json": "b0b2f5cce8a42e69a99bc2a6753a9d20836f2b2ad1ad412ca02a389766d52a2b",
+    "typed-roles-canonical-equality-model.json": "dcfed4d353d0bcd3caccfd44b96514bc62d436a83fb30f82d85c382db6840b8c",
+    "typed-roles-canonical-model.json": "b470f4577254c249e5fb60f603ef6b2ef60a20c6492c74c062f492320c98cd87",
+    "typed-roles-construction.json": "fe3bc6fd384541afc3c8e0349510b8834f744ca065b98bc87351402502f9a319",
+    "typed-roles-design-selection.json": "bc8c9b3d41cefc042ba0775411d824c11d90ac35ba9168bbf3d4a45b36dd7d74",
+    "typed-roles-development.json": "9aef2b52a1180a159ef33602f63e7ad0ea9410c3a38e8ef2095b221e54fa09a9",
+    "typed-roles-equality/fit.json": "23426005c40509820c1ee3be9b4cdec3f38100504a0e850cb7e40fd02ab7353a",
+    "typed-roles-equality/model.json": "3f6bacb0e6ba5dac56f17cd2a1d1ce9f50a5faa5ddbb07e13450124b5afd262b",
+    "typed-roles-equality-development.json": "4c3cfceff2222be18366bb97d6d4be07cacf04a033e4f0252fe1b2c9872aa1d8",
+    "typed-roles-equality-first-use.json": "488f08fb53c3ebf895ce460ea6de35d2423cbefc4f16b8e146a620d0dd3c1357",
+    "typed-roles-first-use.json": "6ff19299784e71eb9a3e5ca2c8f307a094af02654107eaa8dd02e86b03caa714",
+    "typed-roles-mid-resource.json": "e124912fe5b47e4981b9695826b39e48b7ec95e6e3899d96b356b1abf290b1fc",
+    "typed-roles-parent-competition.json": "b0d26ceb0bbe80651208f16a23c825ce9d250c9757d7da3028d03e12c17d30f3",
+    "typed-roles-parent-development.json": "6e11536fbe21adfc158a72be331bf6ee3efa68de7a7448679ccf2f534147b3d4",
+    "typed-roles-preservation/development.json": "d6d9041fc9249e93147b209e877a288ed2eb8d83452e8daa07903af4e19e58b0",
+    "typed-roles-preservation/exposed-names.json": "0d29b362fb3723c2c3e289dbb83a22793018bfdc461aefb582821f0d08ee2757",
+    "typed-roles-preservation/preservation.json": "0ea33cadf046a4f070e1b0fe73b2841502575a2d8baf5a3f27dfedcfd5783969",
+    "typed-roles-preservation/prior.json": "3ad1af1a647499739d87ecb1af806f2bed3ea19cc18a0f0c2666c1b1a7c1f284",
+    "typed-roles-preservation/sessions.json": "c93e0f58f11d11c55018c0ec314bd7d91ad024bbeebadce17afe700732cc0ec7",
+    "typed-roles-prior-composition.json": "4828b93cea09b2ef4d96901c6dd55dec2508d7a2dd20d7e7a179fb94e9aeabd0",
+    "typed-roles-projection.json": "ecf5a97e1e1d6b8260ee61b2c25de802925ae5fb6ae875c777fe986bc8edf121",
+    "typed-roles-query-angular/fit.json": "ab34aeb2d7de53bf62e252676d27921d0742cb1b5dbaf44387796f98942fadb3",
+    "typed-roles-query-angular/model.json": "170715bee68900e7977600ec545badb897645ff8c05b2881792054bedd78ba82",
+    "typed-roles-query-construction.json": "5ddda6d5e6a7913e9ac95aec117c487914ad74227b2ed3d29d74fa4dfc3b623c",
+    "typed-roles-query-development.json": "c9183cbe8ddb535963730e1bc28f61abe15c0981c6c21b543490bfb1539eb612",
+    "typed-roles-query-equality/fit.json": "9bb0925053b93a7c0167b935d6fc9951eea0715472188743a4c81ecbdb413f6f",
+    "typed-roles-query-equality/model.json": "e34e1c5a03889e9818d2a8f600ecf6fbba901470ff13f1ae66ed335347674d1e",
+    "typed-roles-query-equality-first-use.json": "49aa12ae8d39b37a00e72a91e4ba2769b4bd63d6f5a9d4d7467582668f3bd119",
+    "typed-roles-query-exposed.json": "c79780255b9f4098e454a87f64300d95b1709f89275f3c6578011db974a9a662",
+    "typed-roles-query-first-use.json": "14bbd69bb0f28d16cd72b2c0a0af44e3f5247ebdd18e9361dcaec851732d7ac1",
+    "typed-roles-query-long.json": "36a93132823ba2c6d7a2dd746264ef2e3f578a27ce7c9b74f112af1d81d054c9",
+    "typed-roles-query-preservation/development.json": "7b1c4f230ac10e581fbbeb343c0f0b98c1e45e8a761e9c2ea64562e6a8bdf22b",
+    "typed-roles-query-preservation/exposed-names.json": "0cedf39f55ba4674509482c600bb9c314c172f39cdb64682ab8db634d9ca77e4",
+    "typed-roles-query-preservation/preservation.json": "d773232f2414a6e68c0d304e82f971581c09de3b6e2465a24a82e29cec3545a4",
+    "typed-roles-query-preservation/prior.json": "33ccdcc726e5b64b65545fd583598bea612210e2b37d17bd3a94a61d0d7f808c",
+    "typed-roles-query-preservation/sessions.json": "1f7df6d8da30996c3d241d72acbb4a04bb41d2da47b11704d7f57aae65062301",
+    "typed-roles-query-prior-composition.json": "69385aca9cd48fe1ab6d737ffd35759deb92a51a06ec93eefc8dd3f81b99ea77",
+    "typed-roles-query-projection.json": "db5fbfdcc31f0b1159e648ae1443cde8965fd8b9c3f1ec9596977de6a18740c6",
+    "typed-roles-query-removal.json": "279272882733a337e9ec3ef348befca922ee0efc2f72c08febb5118e4669b139",
+    "typed-roles-query-selection.json": "a0c284f230dfe37336eb58b736ad22fbcc68975c86d9f762bf0a20f5cafaa98d",
+    "typed-roles-query-source.json": "9e30c886c9aa4fd16b2fcbd8a819a3530b2093f89232ccdb68c5b22129efabc2",
+    "typed-roles-removal.json": "3d61b946635188f559247b52ce866199b8662a6d9144a36fc3e78b824b22afac",
+    "typed-roles-source.json": "108987c8d9276f9630a61370e42bf3b91d95f9a090ca55b9b149a00650993ec7"
+  },
+  "next": "Test and learn distinctions between independent computations at equal depth, grounded in exact operand/owner provenance; reuse this selector and state instead of adding more depth-specific special cases. General Rust reasoning, syntax, prose and frontier capability remain unqualified."
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,45 @@
 # Current native geometric AI work
 
-## Learned geometric typed selection passes its bounded transfer — #1139, 2026-09-06
+## Competing intermediate selection passes — #1139 / #1140, 2026-09-06
+
+**Retain `43c54db3` over exact parent `bb79456b`.** The
+[result](../native_geometric_typed_roles_1139.md#executed-decision--retain-43c54db3-at-bounded-causal-depth-scope)
+and [evidence](../evidence/native_geometric_typed_roles_1139.json) bind scope.
+The learned H4 selector now uses exact derivation depth, canonical Copy identity
+for alias admission, and an explicit response boundary for query metadata. The
+13,609-byte optional role component applies with two or more derived sources;
+exact values and operators remain unchanged. No serving matrix multiplication,
+floating projection, dense transformer or LLM/provider correction is added.
+
+Angular fits/generates 42/42 construction and gets 12/12 development and 12/12
+new complete four-turn operand/refresh transfers. The matched exact-code fit
+gets 2/12 complete transfers, including eight failed generated refresh turns.
+After 20+3 ->23 and +7 ->30, refreshing updated ->30 still permits original
+->23 or original+2 ->25. Both refresh directions pass. Previous 9/12 and 8/12
+transfer failures remain exposed negatives. This is small authored evidence,
+not sealed general-language or general semantic-role qualification.
+
+The intermediate-removal control has 0/12 full operator/provenance successes,
+but **2/12 answer texts remain correct through recomputation**. Full-path
+provenance passes 12/12. All 48 dependent, 62 earlier, 24 prior-transfer, 28
+exposed-name, 28 long-context, five persistent and six prior numeric cases pass.
+Ten focused tests, integer-kernel and actual zero-allocation checks pass, as do
+checkpoint boundary restoration/rejection, CLI revision and four unchanged
+Rust functions with 12 semantic assertions. New general Rust reasoning is not
+established by preservation of those functions.
+
+**Next: equal-depth independent computations, selected through exact operand/
+owner provenance under changed names and order.** Reuse this selector and state;
+causal depth alone cannot distinguish arbitrary named results. Carry a successful
+selection into generated Rust and execute it. Full #1139/#1140 remain open.
+
+This cycle uses 283.472 seconds model work and 1397.998 seconds monitored
+engineering work. Cumulative model use is 2316.511/2370 seconds; 53.489 remain.
+Recorded revisions extend the cycle ceilings to 330/1500 seconds under standing
+owner authorization. Storage fits its existing allowance; all artifacts and
+user material are preserved. No paid external compute occurred.
+
+## Previous checkpoint: learned geometric typed selection passes its bounded transfer — #1139, 2026-09-06
 
 **Retain `bb79456b` over exact parent `2600b95b`.** The
 [result](../native_geometric_typed_routing_1139.md#executed-result--2026-09-06)

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -196,10 +196,16 @@ the wrong operation/operand or abstained. The subsequent
 fit, with0/6 after intermediate removal and all prior checks preserved. Its
 case-sensitive predecessor remains a3/6 transfer negative. This is learned
 signed-H4 query/operator/operand choice through actual intermediate state,
-not broad language or reasoning qualification. Next test and learn role-sensitive
+not broad language or reasoning qualification. That checkpoint selected role-sensitive
 choice between competing derived results while changing their order, using the
-same learner, exact records and operators. Current relative-recency features do
-not establish role binding independent of order.
+same learner, exact records and operators. The subsequent
+[competing-intermediate revision](../native_geometric_typed_roles_1139.md) now
+gets 12/12 complete changed-operand/refresh transfers versus 2/12 exact-code,
+with its 9/12 and 8/12 predecessors preserved. Derivation depth, canonical Copy
+identity and a local query boundary support this bounded result. Next distinguish
+independent results at equal depth through exact operand/owner provenance, then
+use the same demonstrated selection in generated Rust. General named-role
+binding remains unqualified.
 No additional cache campaign is active. Follow current-state.md for artifacts
 and cumulative resources; a new issue does not reset the spent amount.
 The full handoff remains unmet.
@@ -339,8 +345,9 @@ programme or inherited capability claims. No dependency pin changes here.
 Learn which operands and operators are required before executing them. Start
 with existing copy, exact arithmetic and bounded relation traversal. Commit
 intermediate values that causally influence later choices and output through
-the same native model. The current numeric path computes admitted additions
-before selection; learned admission should remove unnecessary proposals.
+the same native model. Selected execution and bounded causal-depth selection
+are now implemented; the current record names their measured scope. Extend
+learned operand/owner binding without redoing those completed mechanisms.
 
 Demonstrate at least two supported operations with an intermediate state, both
 in grounded conversation and generated Rust under changed operands, names or

--- a/docs/native_geometric_typed_roles_1139.md
+++ b/docs/native_geometric_typed_roles_1139.md
@@ -1,0 +1,188 @@
+# Competing derived-value selection — #1139 / #1140
+
+## Observed cause and implementation, 2026-09-06
+
+Accepted `bb79456b` succeeds on one-intermediate Copy/Add, but the actual
+three-turn diagnostic generates both first results correctly on 12/12 cases
+and only 3/12 final requested results. For 13+4 ->17, then +5 ->22, both
+"repeat the original total" and "repeat the updated total" produce27. Both
+values exist. The prior construction dictionary lacks original/updated and its
+candidate metadata distinguishes derived values mainly by recency.
+
+The optional `typed_roles` artifact component reuses the existing discrete
+signed-H4 candidate/action learner. It preserves the entire exact parent.
+The component applies only when at least two derived sources are captured;
+the existing typed selector still handles the earlier scope. Construction
+adds the actual instruction words; serving has no hardcoded original/updated
+rule. Its operators remain exact Copy/Add selected before execution.
+
+The new metadata is computation depth from exact retained derivation IDs:
+literals have depth0, Copy preserves its operand's depth, and Add has depth
+one above the deeper operand. Missing or invalid ancestry is255, not depth0.
+A fixed 16-entry scratch array is computed once per typed selection. At most
+16 relaxation passes scan at most16 sources and their two exact parent IDs;
+convergence ends the loop early. No numeric payload is used as a depth or
+semantic distance. Existing derived flags remain; derived-candidate recency
+is replaced by a fixed sentinel, and literal recency remains for choosing the
+new literal. Up to16 query words and192 construction-selected features are
+folded into the existing two signed-H4 states. The learned angular/equality
+score selects the existing action and operand references jointly.
+
+This represents causal depth, not arbitrary named roles. Two independent
+calculations at equal depth can still collide. Exact values, provenance and
+payload spelling stay in the existing typed records; unknown query words,
+case distinctions and missing ancestry are not recovered by the geometric
+fold. No new store, tokenizer, dense transformer, serving matrix product,
+floating-point projection or provider/LLM correction is introduced.
+
+## Learning and decision
+
+Rust prepares42 authored construction cases: six numeric worlds across seven
+Copy/Add/NoOperation instructions. Both initial answers are actually generated;
+expected intermediates are checked but never inserted. Offline labels select
+which committed intermediate is required. The same four-pass, twelve-proposal,
+192-feature, 30-second-cap learner compares angular and exact-code modes.
+Twelve exposed development cases guide selection. Twelve predeclared new
+operand cases remain unopened until selection; each actually generates a new
+copy of the original result before its final query. That makes the original
+more recent than the updated result and defeats a newest-derived shortcut.
+Copy aliases are followed exactly for evaluation provenance, not by matching
+numeric values. Intermediate removal removes that result and its Copy aliases.
+
+Require complete text/EOS/action/provenance on12/12 development and12/12 new
+transfers, plus prior preservation. Retain negatives at their exact scope;
+no general syntax, prose, reasoning or frontier-capability claim follows.
+The focused test checks order/copy invariance, numeric independence and
+explicit unknown ancestry. Actual allocation and generated-behavior checks
+follow build and fit. Full counters include lineage scans/comparisons in the
+existing RoutingWork; logical bytes are not measured physical memory traffic.
+
+## Resources
+
+The recorded projection adds240 seconds to the cumulative local model ceiling
+under standing owner authorization:2130 ->2370 seconds, with2033.039 already
+spent. This cycle projects180 model seconds under300, and700 engineering
+seconds under900. Projected128MiB growth fits existing storage headroom; no
+storage increment, deletion or paid external compute. Charge preparation,
+failed builds, fits, evaluation, controls and retries. Full artifacts and logs
+use the existing local root with `typed-roles-` names.
+
+Results and delivery will be appended after execution.
+
+## First transfer negative and alias-admission revision
+
+Both initial fits reach42/42 construction decisions and12/12 development
+answers. Angular `4f1ffd80` then gets9/12 changed-recency transfers, while
+exact-code `098dd52f` gets6/12. Neither passes the12/12 gate. All angular
+failures are the updated-total Add query: it adds the original result to its
+Copy alias, yielding62 instead of40 in the first case. These are different
+record IDs for the same computation. Such an Add candidate did not exist before
+Copy because the original proposal contract excludes an operand paired with
+itself. Intermediate-removal results are0/12, with0/12 matching answer texts.
+
+The revision binds `canonical_copy_aliases: true` in the artifact. It follows
+exact Copy ancestry once per decision in fixed scratch, then rejects Add
+proposals whose operands have the same canonical computation ID. Independent
+records with equal numeric values remain eligible; this is exact identity,
+not numeric equality or geometric similarity. Other supported candidates and
+learned parameters remain unchanged. Counting includes all examined proposals,
+origin scans/comparisons and explicit alias-self-add rejections. Copies can
+still be emitted and committed. Deliberate doubling of one computation is not
+added as a new operator by this repair.
+
+No refit occurs. The old twelve transfers remain an exposed9/12 negative.
+The revision first checks these exposed failures and preservation, then uses
+new operand triples with an actual refresh of either original or updated.
+These are another small after-selection transfer check, not a sealed corpus.
+The engineering cycle ceiling is explicitly increased900 ->1200 seconds under
+the existing owner authorization, with a330-second additional build projection.
+The model and storage ceilings are unchanged; sufficient allowance remains.
+
+## Query-boundary localization and revision
+
+Alias-aware `94fc7f8f` repairs12/12 exposed cases, but the new transfer reaches
+only8/12; exact-code reaches6/12. The four angular failures occur after refreshing
+the updated result before a short Copy request. The query code used the most
+recent16 words across response boundaries, carrying the preceding instruction
+into the current request. Preserve this8/12 result and its0/12 removal control.
+
+The `local_query` artifact flag adds one optional token boundary to existing
+typed session state. It advances on the explicit native `end_response` call;
+word metadata ending before it is excluded from this selector's query code.
+Retained values, literal scanning, provenance and other routing components are
+unchanged. It does not parse a User/Assistant string, erase context or hardcode
+role words. Checkpoint restoration requires the boundary for a local-query
+artifact and rejects a future boundary. Older artifacts omit the field and
+keep their previous query behavior. Construction frames use the same explicit
+boundary after actual generated prefixes; expected answers are never inserted.
+
+The same42 construction cases are refit in angular and exact-code modes, with
+canonical alias admission enabled. Earlier9/12 and8/12 transfers remain exposed
+negatives. Twelve new operand/refresh cases follow design selection. The recorded
+engineering ceiling increases1200 ->1500 seconds for a350-second build projection;
+the model cycle uses330 seconds within the unchanged2370-second cumulative
+ceiling. Projected additional model work is120 seconds. No storage increase or
+paid external compute is needed.
+
+
+## Executed decision — retain `43c54db3` at bounded causal-depth scope
+
+The [evidence receipt](evidence/native_geometric_typed_roles_1139.json) binds
+full artifact identities, source/report hashes, controls and cumulative work.
+The final angular artifact retains exact parent `bb79456b`; its optional role
+component is 13,609 serialized bytes with 105 learned features. It fits 42/42
+construction choices, generates 42/42 construction answers, and gets 12/12 OPEN
+development and 12/12 exposed alias-repair answers. After that design selection,
+it gets **12/12 new complete four-turn trajectories**. The exact-code fit reaches
+25/42 construction and **2/12 complete transfers**, including eight failures in
+the required generated refresh turn. This is one bounded fit comparison, not a
+universal angular advantage or a multi-seed/sealed language result.
+
+Actual trajectories include 20+3 ->23, +7 ->30, refresh updated ->30, then
+repeat original ->23 or add2 to original ->25. Another uses 9+8 ->17, +4 ->21,
+refresh original ->17, then repeat updated ->21 or add6 to updated ->27. The
+requested intermediate is selected through its actual Copy provenance on all
+12 full-path cases. The removal control satisfies 0/12 full operator/provenance
+criteria but preserves **2/12 answer texts by recomputing the sums** (7+23 and
+5+10). Do not call that zero answer accuracy or universal inability to recover.
+Removal changes available ancestry and sometimes selector eligibility as well;
+it is a whole-intermediate intervention, not an isolated angular-score ablation.
+
+Preservation passes 48/48 dependent, 62/62 earlier, 24/24 prior transfer, 28/28
+exposed-name, 28/28 long-context and 5/5 persistent turns, plus the preceding
+6/6 numeric transfers. Four unchanged generated Rust bodies compile and pass
+12 semantic assertions. Ten focused metadata, boundary, alias, arithmetic,
+commit and counter tests pass. The kernel source check passes. The actual
+four-turn path generates 17,22,17,24, rejects alias self-add, and measures zero
+allocations/bytes. Its checkpoint round-trips exactly; absent/future query
+boundaries are rejected. The CLI revision returns Zurich. Formatting,
+architecture policy and claim wording pass; broad release QA is NOT_RUN.
+
+Across the twelve four-turn transfers: 48 exact operator executions, 30 Add
+executions and 24 rejected alias self-add proposals. Nested routing counts
+36 predictions, 15,712 source examinations, 221,890 comparisons, 47,184 code
+reads, 105,522 table reads and 3,990,420 instrumented logical bytes. Complete
+state/writer/readout/output work is retained. This is bounded scanning with
+explicit costs, not a demonstrated whole-model speedup.
+
+The full cycle consumes **283.472 seconds model work** and **1397.998 seconds
+monitored engineering work**, including one corrected missing-import compile
+and all fits/controls/revisions. Cumulative model use is **2316.511/2370 seconds**,
+leaving **53.489 seconds**. The original 180/700-second point projections were
+exceeded; recorded ceilings were extended to 330 model-cycle and 1500 engineering
+seconds before the respective revisions. The cumulative model allowance rose
+by 240 seconds; storage needed no increase. Peak sampled known storage was
+6,425,583,616 bytes under the effective 6,506,475,520-byte ceiling. Peak sampled
+model-child RSS was 878,673,920 bytes. Preserve every failed artifact/report;
+no material was deleted and paid external compute was zero.
+
+**Next: distinguish independent computations at equal depth using exact
+operand/owner provenance.** Causal depth cannot identify arbitrary named roles
+or two independent sums of the same depth. Use two such results, change their
+order and names, and learn selection in this same geometric route. Then carry
+the demonstrated selection into generated Rust and execute it semantically.
+Do not add more depth-specific cases or another store. For economical iteration,
+compile the changed core/probe first and reserve the CLI build for selected
+behavior when its feature configuration permits that separation. Full #1139
+and #1140 acceptance, general syntax/prose/reasoning and frontier capability
+remain unmet.


### PR DESCRIPTION
After computing an original total and an updated total, the previous model gets only 3/12 final role requests correct. This change learns query-conditioned geometric selection using exact derivation depth, preserves Copy identity during candidate admission, and isolates query metadata at the explicit end_response boundary. Numeric values remain exact payloads; existing Copy/Add execute after selection. The optional component preserves parent bb79456b and introduces no serving matrix multiplication, dense transformer or LLM/provider correction.

Selected artifact 43c54db3 generates 12/12 new complete four-turn operand/refresh transfers, versus 2/12 for the matched exact-code fit (eight comparator failures occur in required refresh generation). Both refresh directions pass. Example: 20+3 ->23, +7 ->30, refresh updated ->30, then original+2 ->25. Earlier 9/12 and 8/12 failures remain exposed negatives, not relabeled held-out successes. The removal control has 0/12 full operator/provenance successes but 2/12 matching texts through recomputation; no zero-answer-accuracy claim.

Validation: 42/42 generated construction and 12/12 development; preservation 48/48 dependent,62/62 earlier,24/24 prior-transfer,28/28 exposed-name,28/28 long-context,5/5 persistent and6/6 preceding numeric transfers. Ten focused tests pass. Actual four-turn routing/commit is allocation-free, checkpoint round-trip preserves the query boundary, and absent/future boundaries are rejected. Kernel source, formatting, architecture and wording checks pass. CLI revision returns Zurich; four unchanged generated Rust functions pass 12 semantic assertions. Broad release QA was not run.

The implementation record/evidence retain every fit, failed transfer, control, artifact/source/report identity and cumulative resource receipt. Model work 283.472s; monitored engineering 1397.998s including failed build and revisions. Cumulative model 2316.511/2370s, 53.489s remaining. Standing authorization supports the recorded extensions; no storage increase, deletions or paid external compute.

Update current-state, README, research, lifecycle and roadmap to distinguish completed work from the next equal-depth operand/owner-provenance selection. This is bounded causal-depth behavior, not general named-role binding, new Rust reasoning, general prose/syntax, frontier capability or whole-model speedup. Refs #1139, #1140; both broader issues remain open.
