### PR TITLE
Complete learned NoRead answers in literal numeric contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ improves new complete transfers8/16 to16/16 but regresses computed-result and
 identifier-copy cases. The [protected admission repair](docs/native_geometric_literal_admission_1139.md)
 now retains a separate literal table with inherited computed roles unchanged:
 all prior preservation is restored, new complete transfer is16/16, and eight
-identifier-return functions execute24 assertions. Four abstention texts still
-fail; routing to an appropriate word answer or abstention is next.
+identifier-return functions execute24 assertions. The subsequent
+[committed NoRead completion](docs/native_geometric_no_read_completion_1139.md)
+preserves that model and repairs looping literal-context abstentions: the exposed
+set improves12/16 to14/16 and a new set14/16 to15/16. Identifier returns remain8/8
+and complete three-turn computations16/16. The remaining failure selects a
+retained but unsupported word; joint source/NoRead selection is next.
 General prose/syntax/reasoning and frontier capability remain unqualified. Follow
 the current-state pointer for artifacts, costs and the next implementation.
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs
@@ -204,6 +204,47 @@ fn literal_example(
 
 pub(super) fn run(args: &[String]) -> ProbeResult<()> {
     match args.first().map(String::as_str) {
+        Some("answer-fit") if args.len() == 4 => {
+            let model = Model::from_bytes(&fs::read(&args[1])?)?;
+            let source: Value = serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs: Vec<TypedRoutingExample> = serde_json::from_value(source["fit"].clone())?;
+            let docs: Vec<ValueExample> = docs.into_iter().filter(|d| d.literal_only)
+                .map(|d| ValueExample { id:d.id, prompt:d.query, response:d.response }).collect();
+            let (fitted, report) = model.fit_no_read_completion(&docs, ResponseEntryFitConfig::default())?;
+            let root = Path::new(&args[3]); fs::create_dir(root)?;
+            write_new(&root.join("model.json"), &fitted.to_bytes()?)?;
+            write_json(&root.join("fit.json"), &report)?;
+            println!("{}", json!({"artifact":fitted.artifact_cid(),"report":report}));
+        }
+        Some("answer-source") if args.len() == 3 => {
+            let mut source: Value = serde_json::from_slice(&fs::read(&args[1])?)?;
+            let mut first = Vec::new();
+            // New names/numbers and one new short query form, saved before fit.
+            for (i,(names,numbers)) in [(["feni","mavo"],[23,-8]),(["daro","nesa"],[-13,41])].into_iter().enumerate() {
+                for reverse in [false,true] { for kind in 0..4 {
+                    let mut d = literal_example(format!("answer-new/{i}/{reverse}/{kind}"), names,numbers,reverse,kind);
+                    if kind == 3 && i == 1 { d.query=d.query.replace("Where is the location of", "Where is"); }
+                    first.push(d);
+                }}
+            }
+            source["exposed_answers"] = source["first_use"].clone();
+            source["first_use"] = serde_json::to_value(first)?;
+            source["scope"] = json!("Construction unchanged:103 earlier literal/identifier examples. Only actual selected NoRead continuations fitted. Four prior failed location outputs exposed; new16 cases prepared before fit, including one shorter query form. No full held-out capability claim.");
+            write_json(Path::new(&args[2]), &source)?;
+        }
+
+        Some("answer-trace") if args.len() == 4 => {
+            let model = Model::from_bytes(&fs::read(&args[1])?)?;
+            let source: Value = serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs: Vec<TypedRoutingExample> = serde_json::from_value(source["first_use"].clone())?;
+            let mut rows = Vec::new();
+            for d in docs.into_iter().filter(|d| d.action.is_none()) {
+                let generated = model.generate(&d.query, 48, Control::Full)?;
+                rows.push(json!({"id":d.id,"prompt":d.query,"expected":d.response,"generated":generated}));
+            }
+            write_json(Path::new(&args[3]), &rows)?;
+        }
+
         Some("admission-source") if args.len()==4 => {
             let prior:Value=serde_json::from_slice(&fs::read(&args[1])?)?;
             let old:Source=serde_json::from_slice(&fs::read(&args[2])?)?;

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -313,6 +313,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    no_read_completion: Option<response_entry_types::ResponseEntryModel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_routing: Option<typed_routing::TypedRouting>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_roles: Option<typed_routing::TypedRouting>,
@@ -353,6 +355,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    no_read_completion: Option<response_entry_types::ResponseEntryModel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_routing: Option<typed_routing::TypedRouting>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_roles: Option<typed_routing::TypedRouting>,
@@ -392,6 +396,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            no_read_completion: wire.no_read_completion,
             typed_routing: wire.typed_routing,
             typed_roles: wire.typed_roles,
             typed_literals: wire.typed_literals,

--- a/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs
@@ -1,7 +1,7 @@
 //! Integer/table response transitions anchored to an actual query boundary.
 //! Entry commits only when its selected token is observed; no answer buffer,
 //! numeric write or target-derived state is synthesized.
-use super::completion_runtime::{candidate_rows, score_rows};
+use super::completion_runtime::{candidate_rows_bounded, score_rows};
 use super::completion_types::CompletionWork;
 use super::response_entry_types::*;
 use super::value_types::ValueState;
@@ -216,6 +216,25 @@ impl ResponseEntryState {
         control: Control,
         work: &mut CompletionWork,
     ) -> Option<Candidate> {
+        self.offer_head(
+            model,
+            values,
+            baseline,
+            control,
+            work,
+            model.response_entry.as_ref()?,
+        )
+    }
+
+    pub(super) fn offer_head(
+        &mut self,
+        model: &Model,
+        values: &ValueState,
+        baseline: Candidate,
+        control: Control,
+        work: &mut CompletionWork,
+        head: &ResponseEntryModel,
+    ) -> Option<Candidate> {
         self.pending = None;
         if !eligible(model, values, control)
             || values.pending.is_some()
@@ -224,7 +243,6 @@ impl ResponseEntryState {
         {
             return None;
         }
-        let head = model.response_entry.as_ref()?;
         let anchor = self.boundary?;
         if anchor.at_seen != values.started_at
             || (!self.active && (self.steps != 0 || self.seen != anchor.at_seen))
@@ -232,8 +250,43 @@ impl ResponseEntryState {
             return None;
         }
         let (features, len) = self.features(model, values, control, work);
+        self.offer_features::<RESPONSE_ENTRY_FEATURES>(
+            model,
+            values,
+            baseline,
+            control,
+            work,
+            head,
+            &features[..len],
+        )
+    }
+
+    pub(super) fn offer_features<const N: usize>(
+        &mut self,
+        model: &Model,
+        values: &ValueState,
+        baseline: Candidate,
+        control: Control,
+        work: &mut CompletionWork,
+        head: &ResponseEntryModel,
+        features: &[Feature],
+    ) -> Option<Candidate> {
+        self.pending = None;
+        if !eligible(model, values, control)
+            || values.pending.is_some()
+            || self.steps >= RESPONSE_ENTRY_STEPS
+            || self.seen != values.seen
+        {
+            return None;
+        }
+        let anchor = self.boundary?;
+        if anchor.at_seen != values.started_at
+            || (!self.active && (self.steps != 0 || self.seen != anchor.at_seen))
+        {
+            return None;
+        }
         let (tokens, count, rows, row_count) =
-            candidate_rows(&head.rows, &head.global_postings, &features[..len], work);
+            candidate_rows_bounded::<N>(&head.rows, &head.global_postings, features, work);
         let mut best = None;
         let mut best_score = 0_i64;
         for token in tokens[..count].iter().copied() {

--- a/crates/uor-r4-core/src/native_geometric/response_entry_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_training.rs
@@ -59,15 +59,15 @@ pub struct ResponseEntryFitReport {
 }
 
 impl ResponseEntryModel {
-    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+    pub(super) fn validate_shape(
+        &self,
+        model: &Model,
+        feature_kinds: u8,
+        expected_schema: &str,
+    ) -> Result<()> {
         let associations = self.rows.iter().map(|row| row.scores.len()).sum::<usize>();
         let valid_token =
             |token: u32| token != BOS && (token as usize) < model.geometry.tokens.len();
-        let expected_schema = if self.copy.is_some() {
-            super::word_copy_types::RESPONSE_COPY_SCHEMA
-        } else {
-            RESPONSE_ENTRY_SCHEMA
-        };
         if self.schema != expected_schema
             || model.completion.is_none()
             || self.rows.len() > RESPONSE_ENTRY_ROWS
@@ -84,7 +84,7 @@ impl ResponseEntryModel {
                 .windows(2)
                 .any(|pair| pair[0].feature >= pair[1].feature)
             || self.rows.iter().any(|row| {
-                row.feature.kind >= (RESPONSE_ENTRY_FEATURES * 2) as u8
+                row.feature.kind >= feature_kinds
                     || row.default_score != 0
                     || row.postings.len() > RESPONSE_ENTRY_POSTINGS
                     || row.postings.iter().collect::<BTreeSet<_>>().len() != row.postings.len()
@@ -125,6 +125,19 @@ impl ResponseEntryModel {
         {
             return Err(Error("invalid learned response-entry artifact".into()));
         }
+        Ok(())
+    }
+
+    pub(super) fn validate(&self, model: &Model) -> Result<()> {
+        self.validate_shape(
+            model,
+            (RESPONSE_ENTRY_FEATURES * 2) as u8,
+            if self.copy.is_some() {
+                super::word_copy_types::RESPONSE_COPY_SCHEMA
+            } else {
+                RESPONSE_ENTRY_SCHEMA
+            },
+        )?;
         let mut baseline = model.clone();
         baseline.response_entry = None;
         baseline.refresh_identity()?;
@@ -449,6 +462,157 @@ impl Model {
             selected_entry_epoch: entry_fit.selected_epoch, selected_continuation_epoch: continuation_fit.as_ref().map_or(0, |fit| fit.selected_epoch), config,
             tokenization_law: "Canonical frozen model.encode(response) plus EOS; an overlong response is skipped whole. Entry action is supervised separately from equal-token Base; continuation frames require actual quantized Enter selection and observation. Final shared-posting entry and free-running response checks are reported.".into(),
         };
+        Ok((model, report))
+    }
+}
+
+impl Model {
+    /// Learn literal-numeric continuation after the frozen model selects NoRead.
+    /// The first token, numeric admission, source choice and copied payloads are
+    /// never teacher-forced. Later tokens use the existing sparse entry learner.
+    pub fn fit_no_read_completion(
+        &self,
+        documents: &[ValueExample],
+        config: ResponseEntryFitConfig,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.validate()?;
+        if self.no_read_completion.is_some()
+            || super::role_read::head(self).is_none()
+            || documents.is_empty()
+            || documents.len() > 1024
+            || documents
+                .iter()
+                .any(|d| d.prompt.len().saturating_add(d.response.len()) > 65536)
+            || !(1..=64).contains(&config.epochs)
+            || !config.learning_rate.is_finite()
+            || !(0.0001..=1.0).contains(&config.learning_rate)
+            || !(1..=RESPONSE_ENTRY_POSITIONS).contains(&config.max_positions)
+        {
+            return Err(Error(
+                "invalid NoRead completion source/configuration/parent".into(),
+            ));
+        }
+        let mut ids = BTreeSet::new();
+        let mut receipts = Vec::new();
+        let mut frames = Vec::new();
+        let mut admitted = Vec::new();
+        let mut skipped = Vec::new();
+        for d in documents {
+            if d.id.trim().is_empty() || !ids.insert(&d.id) {
+                return Err(Error("NoRead completion source IDs conflict".into()));
+            }
+            receipts.push(super::training::receipt(&Document {
+                id: d.id.clone(),
+                text: serde_json::to_string(&(&d.prompt, &d.response))
+                    .map_err(|e| Error(e.to_string()))?,
+            }));
+            let mut targets = self.encode(&d.response)?;
+            targets.push(EOS);
+            if targets.len() < 2
+                || targets.len() > usize::from(RESPONSE_ENTRY_STEPS)
+                || frames.len().saturating_add(targets.len() - 1) > config.max_positions
+            {
+                skipped.push(serde_json::json!({"id":d.id,"reason":"whole_response_bound"}));
+                continue;
+            }
+            let mut session = response_session(self, &d.prompt)?;
+            if session.values.as_ref().is_none_or(|v| {
+                !super::word_copy_runtime::literal_no_read_eligible(
+                    v,
+                    &mut super::word_copy_types::WordCopyWork::default(),
+                )
+            }) {
+                skipped
+                    .push(serde_json::json!({"id":d.id,"reason":"outside_literal_numeric_scope"}));
+                continue;
+            }
+            let prediction = session.predict(self)?;
+            if prediction.token != targets[0]
+                || session.word_copy_decision().is_none_or(|p| {
+                    p.action != WordCopyAction::NoRead || p.token != prediction.token
+                })
+            {
+                skipped.push(serde_json::json!({"id":d.id,"reason":"frozen_parent_did_not_select_target_NoRead"}));
+                continue;
+            }
+            session.observe(self, prediction.token)?;
+            for &target in &targets[1..] {
+                let baseline = session.predict(self)?.token;
+                if session.response_entry.as_ref().is_none_or(|s| !s.active)
+                    || session
+                        .word_copy
+                        .as_ref()
+                        .and_then(|c| c.read_commit)
+                        .is_none_or(|c| c.source.is_some())
+                {
+                    return Err(Error(
+                        "NoRead continuation lost actual committed entry".into(),
+                    ));
+                }
+                let (features, len) = super::word_copy_runtime::prefix_features(
+                    self,
+                    session
+                        .response_entry
+                        .as_ref()
+                        .ok_or_else(|| Error("NoRead entry absent".into()))?,
+                    session
+                        .values
+                        .as_ref()
+                        .ok_or_else(|| Error("NoRead values absent".into()))?,
+                    Control::Full,
+                    &mut super::word_copy_types::WordCopyWork::default(),
+                );
+                frames.push(Frame {
+                    features,
+                    len,
+                    target,
+                    baseline,
+                });
+                session.observe(self, target)?;
+            }
+            admitted.push(d.id.clone());
+        }
+        if frames.is_empty() {
+            return Err(Error(
+                "no actual NoRead continuation training frames".into(),
+            ));
+        }
+        let fit = fit_sparse_frames(
+            &frames,
+            ValueCompletionFitConfig {
+                epochs: config.epochs,
+                learning_rate: config.learning_rate,
+                max_positions: config.max_positions,
+            },
+            RESPONSE_ENTRY_ROWS,
+            RESPONSE_ENTRY_ASSOCIATIONS,
+            0,
+        )?;
+        let report = serde_json::json!({"schema":"uor-r4.no-read-completion-fit/1","parent":self.artifact_cid(),
+            "documents":documents.len(),"admitted":admitted,"skipped":skipped,"positions":frames.len(),
+            "correct_positions":fit.correct,"loss":fit.loss,"selected_epoch":fit.selected_epoch,
+            "rows":fit.rows.len(),"associations":fit.learned_associations,
+            "dropped_rows":fit.dropped_row_events,"dropped_associations":fit.dropped_association_events,
+            "scope":"Literal-numeric continuation only after actual frozen-parent NoRead. Teacher-forced token learning is not free-generation acceptance; all parent parameters preserved."});
+        let mut model = self.clone();
+        model.no_read_completion = Some(ResponseEntryModel {
+            schema: NO_READ_COMPLETION_SCHEMA.into(),
+            baseline_artifact: self.artifact_cid.clone(),
+            rows: fit.rows,
+            global_postings: fit.global_postings,
+            fit_config: [
+                config.epochs as u64,
+                config.learning_rate.to_bits(),
+                config.max_positions as u64,
+                fit.selected_epoch as u64,
+                fit.selected_epoch as u64,
+            ],
+            fit_positions: frames.len(),
+            training: receipts,
+            copy: None,
+        });
+        model.refresh_identity()?;
+        model.validate()?;
         Ok((model, report))
     }
 }

--- a/crates/uor-r4-core/src/native_geometric/response_entry_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/response_entry_types.rs
@@ -1,6 +1,8 @@
 //! Optional learned lexical-token entry and continuation at a response boundary.
 use super::*;
 
+pub(super) const NO_READ_COMPLETION_SCHEMA: &str =
+    "uor-r4.native-literal-no-read-binding-completion/1";
 pub(super) const RESPONSE_ENTRY_SCHEMA: &str = "uor-r4.native-response-entry/1";
 pub(super) const RESPONSE_ENTRY_FEATURES: usize = 16;
 pub(super) const RESPONSE_ENTRY_CANDIDATES: usize = 16;

--- a/crates/uor-r4-core/src/native_geometric/role_read_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/role_read_tests.rs
@@ -165,3 +165,104 @@ fn native_role_read_validates_quantized_rows_and_parent_identity() {
         changed
     );
 }
+
+#[test]
+fn native_no_read_completion_preserves_parent_and_requires_committed_no_read() {
+    let parent = fitted();
+    let docs: Vec<_> = ["alpha", "bravo", "cedar", "delta"]
+        .into_iter()
+        .enumerate()
+        .map(|(i, name)| ValueExample {
+            id: format!("no-read-suffix-{i}"),
+            prompt: format!("13; {name} in city. Where is missing? Answer:"),
+            response: " Unknown.\n".into(),
+        })
+        .collect();
+    let (model, report) = parent
+        .fit_no_read_completion(&docs, ResponseEntryFitConfig::default())
+        .unwrap();
+    assert_eq!(report["admitted"].as_array().unwrap().len(), docs.len());
+    let mut inherited = model.clone();
+    inherited.no_read_completion = None;
+    inherited.refresh_identity().unwrap();
+    assert_eq!(&inherited, parent);
+    let model = Model::from_bytes(&model.to_bytes().unwrap()).unwrap();
+    let mut no_offer = model.clone();
+    let head = no_offer.no_read_completion.as_mut().unwrap();
+    head.rows.clear();
+    head.global_postings.clear();
+    no_offer.refresh_identity().unwrap();
+    no_offer.validate().unwrap();
+    let unchanged = no_offer
+        .generate(&docs[0].prompt, 32, Control::Full)
+        .unwrap();
+    let original = parent.generate(&docs[0].prompt, 32, Control::Full).unwrap();
+    assert_eq!(unchanged.text, original.text);
+    assert_eq!(
+        unchanged.response_entry_trace, original.response_entry_trace,
+        "no learned offer must preserve inherited pending decisions and prefix fallback"
+    );
+    for d in &docs {
+        let g = model.generate(&d.prompt, 32, Control::Full).unwrap();
+        assert_eq!(g.text, d.response);
+        assert_eq!(g.stop, "end_of_document");
+    }
+    for prompt in [
+        fixture::COPY_PROMPT,
+        "holder in alpha. Where is holder? Answer:",
+        "alpha in city. Where is missing? Answer:",
+    ] {
+        assert_eq!(
+            model.generate(prompt, 32, Control::Full).unwrap().text,
+            parent.generate(prompt, 32, Control::Full).unwrap().text
+        );
+    }
+    let mut s = begin(&model, &docs[0].prompt);
+    let mut scope_values = s.values.as_ref().unwrap().clone();
+    assert!(super::word_copy_runtime::literal_no_read_eligible(
+        &scope_values,
+        &mut Default::default()
+    ));
+    scope_values.sources[0].derived = true;
+    assert!(!super::word_copy_runtime::literal_no_read_eligible(
+        &scope_values,
+        &mut Default::default()
+    ));
+    scope_values.sources.clear();
+    assert!(!super::word_copy_runtime::literal_no_read_eligible(
+        &scope_values,
+        &mut Default::default()
+    ));
+    let p = s.predict(&model).unwrap();
+    assert_eq!(
+        s.word_copy_decision().unwrap().action,
+        WordCopyAction::NoRead
+    );
+    let before = s.checkpoint().unwrap();
+    s.observe(&model, p.token).unwrap();
+    let cp = s.checkpoint().unwrap();
+    let mut restored = model.restore_session(&cp).unwrap();
+    assert_eq!(
+        s.predict(&model).unwrap(),
+        restored.predict(&model).unwrap()
+    );
+    let mut mismatch = model.restore_session(&before).unwrap();
+    mismatch.predict(&model).unwrap();
+    mismatch.observe(&model, u32::from(b'?') + 2).unwrap();
+    assert!(mismatch.word_copy.as_ref().unwrap().read_commit.is_none());
+    for change in 0..4 {
+        let mut bad = model.clone();
+        let h = bad.no_read_completion.as_mut().unwrap();
+        match change {
+            0 => h.baseline_artifact = "bad".into(),
+            1 => h.rows[0].scores[0].token = BOS,
+            2 => h.rows[0].scores[0].score = 1_000_001,
+            _ => h.schema = super::response_entry_types::RESPONSE_ENTRY_SCHEMA.into(),
+        }
+        bad.refresh_identity().unwrap();
+        assert!(bad.validate().is_err());
+    }
+    assert!(model
+        .fit_no_read_completion(&docs, ResponseEntryFitConfig::default())
+        .is_err());
+}

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -178,6 +178,7 @@ impl Trainer {
             dependent_read: None,
             typed_routing: None,
             typed_roles: None,
+            no_read_completion: None,
             typed_literals: None,
             source_routing: None,
             learned_routing: None,
@@ -513,6 +514,33 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(head) = &self.no_read_completion {
+            if head.copy.is_some() || super::role_read::head(self).is_none() {
+                return Err(Error(
+                    "NoRead completion requires the committed role reader".into(),
+                ));
+            }
+            head.validate_shape(
+                self,
+                33,
+                super::response_entry_types::NO_READ_COMPLETION_SCHEMA,
+            )?;
+            let mut parent = self.clone();
+            parent.no_read_completion = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != head.baseline_artifact {
+                return Err(Error("NoRead completion parent differs".into()));
+            }
+            parent.validate()?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("NoRead completion identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(block) = &self.typed_literals {
             if !block.literal_answers
                 || self

--- a/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs
@@ -8,6 +8,22 @@ use super::value_types::{ValueFeature, ValueState};
 use super::word_copy_types::*;
 use super::*;
 
+/// The learned continuation is fitted on literal numeric frames only. Keep
+/// relation-only and computed-result responses on their inherited path.
+pub(super) fn literal_no_read_eligible(values: &ValueState, work: &mut WordCopyWork) -> bool {
+    work.selector.metadata_reads = work.selector.metadata_reads.saturating_add(1);
+    if values.sources.is_empty() {
+        return false;
+    }
+    for source in &values.sources {
+        work.selector.metadata_reads = work.selector.metadata_reads.saturating_add(1);
+        if source.derived {
+            return false;
+        }
+    }
+    true
+}
+
 pub(super) fn enabled(control: Control) -> bool {
     control != Control::WordCopyDisabled
 }
@@ -425,6 +441,33 @@ impl WordCopyState {
             && eligible(model, entry, values, control)
         {
             return super::role_read::offer(self, model, entry, values, baseline, control, work);
+        }
+        // A selected and observed NoRead commits a lexical response, not a
+        // word occurrence. Reuse entry features and the sparse token operator;
+        // never apply this continuation to numeric NoOperation alone or copying.
+        if entry.active && self.read_commit.is_some_and(|c| c.source.is_none()) {
+            if let Some(head) = model
+                .no_read_completion
+                .as_ref()
+                .filter(|_| literal_no_read_eligible(values, work))
+            {
+                let inherited_pending = entry.pending;
+                let (features, len) = prefix_features(model, entry, values, control, work);
+                if let Some(candidate) = entry.offer_features::<WORD_COPY_PREFIX_FEATURES>(
+                    model,
+                    values,
+                    baseline,
+                    control,
+                    &mut work.selector,
+                    head,
+                    &features[..len],
+                ) {
+                    return Some(candidate);
+                }
+                // Base means the whole inherited continuation, including its
+                // pending selection and composed prefix scorer, stays intact.
+                entry.pending = inherited_pending;
+            }
         }
         if let Some(commit) = self.read_commit.filter(|c| c.source.is_some()) {
             work.word_record_reads = work.word_record_reads.saturating_add(1);

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -1348,6 +1348,10 @@ fn native_independent_artifact_is_allocation_free() {
         );
         let mut protected = wire.clone();
         protected.as_object_mut().unwrap().remove("typed_literals");
+        protected
+            .as_object_mut()
+            .unwrap()
+            .remove("no_read_completion");
         for key in ["artifact_cid", "uor_model_address"] {
             protected.as_object_mut().unwrap().remove(key);
             parent.as_object_mut().unwrap().remove(key);
@@ -1367,4 +1371,63 @@ fn native_independent_artifact_is_allocation_free() {
         .remove("operand_provenance");
     assert!(Model::from_bytes(&serde_json::to_vec(&wire).unwrap()).is_err());
     println!("actual independent sums and named Copy: all bytes and EOS correct; allocations=0 bytes=0; checkpoint roundtrip and unbound flag rejection PASS");
+}
+
+#[test]
+#[ignore = "requires the explicitly supplied accepted NoRead completion artifact"]
+fn native_no_read_artifact_is_allocation_free() {
+    use uor_r4_core::native_geometric::Model;
+    let bytes = std::fs::read(std::env::var("R4_NO_READ_MODEL").unwrap()).unwrap();
+    let model = Model::from_bytes(&bytes).unwrap();
+    let mut outer: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(outer
+        .as_object_mut()
+        .unwrap()
+        .remove("no_read_completion")
+        .is_some());
+    let mut parent: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(std::env::var("R4_NO_READ_PARENT").unwrap()).unwrap(),
+    )
+    .unwrap();
+    for doc in [&mut outer, &mut parent] {
+        for k in ["artifact_cid", "uor_model_address"] {
+            doc.as_object_mut().unwrap().remove(k);
+        }
+    }
+    assert_eq!(outer, parent, "every parent parameter must be unchanged");
+    let prompt=model.encode("User: leni has 17 coins. varo has -5 coins. tavi has 301 coins.\nUser: Where is the location of leni?\nAssistant:").unwrap();
+    let mut s = model.session(Control::Full).unwrap();
+    let mut out = [EOS; 32];
+    let mut n = 0;
+    ALLOCATIONS.with(|v| v.set(0));
+    BYTES.with(|v| v.set(0));
+    MEASURING.with(|v| v.set(true));
+    s.observe(&model, BOS).unwrap();
+    for t in prompt {
+        s.observe(&model, t).unwrap();
+    }
+    s.begin_response(&model).unwrap();
+    for slot in &mut out {
+        let p = s.predict(&model).unwrap();
+        *slot = p.token;
+        n += 1;
+        s.observe(&model, p.token).unwrap();
+        if p.token == EOS {
+            break;
+        }
+    }
+    MEASURING.with(|v| v.set(false));
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    assert_eq!(out[n - 1], EOS);
+    assert_eq!(model.decode(&out[..n]).unwrap(), b" Unknown.\n");
+    let checkpoint = s.checkpoint().unwrap();
+    assert_eq!(
+        model
+            .restore_session(&checkpoint)
+            .unwrap()
+            .checkpoint()
+            .unwrap(),
+        checkpoint
+    );
+    println!("actual NoRead answer: exact bytes and EOS; allocations=0 bytes=0; complete parent equality and checkpoint roundtrip PASS");
 }

--- a/docs/MODEL_LIFECYCLE.md
+++ b/docs/MODEL_LIFECYCLE.md
@@ -30,7 +30,15 @@ preservation and are not promoted. Literal-only offline frames cannot supply
 a preceding answer. The [protected admission repair](native_geometric_literal_admission_1139.md)
 now adds optional `typed_literals` while preserving its entire accepted parent.
 It restores prior behavior and is retained at bounded numeric/identifier scope;
-answer routing after NoOperation remains incomplete.
+answer routing after NoOperation remains incomplete. The subsequent
+[NoRead continuation](native_geometric_no_read_completion_1139.md) adds optional
+`no_read_completion`, bound to its entire unchanged parent and an explicit
+literal-numeric binding-completion schema. It reuses the word-copy prefix
+features and entry scorer only after selected NoRead commits, with literal
+numeric records and no derived record. Relation-only and computed-result states
+retain inherited continuation. It adds no session-state fields or provider.
+Runtime copying and numeric admission are still learned upstream decisions;
+the new table cannot correct an unsupported source chosen for copying.
 
 ## Historical and retained reference lifecycles
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,6 +1,22 @@
 # Research: what is measured, what is closed, what is open
 
-## Protected literal admission — current bounded checkpoint, 2026-09-06
+## Literal-context NoRead completion — current bounded checkpoint, 2026-09-06
+
+The [committed continuation](native_geometric_no_read_completion_1139.md)
+retains `e7c14c99` at literal-numeric NoRead scope, with the complete `c29ab982`
+parent unchanged. It reuses existing word-binding features and sparse lexical
+scoring after an actually observed NoRead. Exposed answers improve12/16 to14/16;
+new answers improve14/16 to15/16, with all12 numeric cases and3/4 abstentions.
+Complete computations remain16/16 and identifier returns8/8. The remaining
+failure copies `coins` as a location answer; source selection is not repaired.
+
+Two earlier candidates are preserved negatives: a smaller response-progress
+representation shortened four explanatory answers; broader application of the
+binding-conditioned table broke one relation-conflict session. Literal-only
+state eligibility restores the inherited memory and computed-result paths.
+No new angular-distance advantage or general abstention capability is claimed.
+
+## Protected literal admission — previous bounded checkpoint, 2026-09-06
 
 The [admission repair](native_geometric_literal_admission_1139.md) retains
 `c29ab982`, with the entire accepted parent unchanged and a separate bounded

--- a/docs/evidence/native_geometric_no_read_completion_1139.json
+++ b/docs/evidence/native_geometric_no_read_completion_1139.json
@@ -1,0 +1,2339 @@
+{
+  "schema": "uor-r4.literal-no-read-completion-result/1",
+  "decision": "RETAIN_E7C14C99_LITERAL_NUMERIC_NOREAD_COMPLETION",
+  "execution_base": "5256f8d9982c361151743a5b6c516fb0ca2c51cb",
+  "source_files": [
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/mod.rs",
+      "bytes": 19368,
+      "sha256": "ed950ccaf50b094987fa01c61c573109b1b75165f2de0293a30287db7ce94323"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/training.rs",
+      "bytes": 45547,
+      "sha256": "191fd7ab9782dbaae2cc53fbf94759ed80b17caa8b72389e6f0a84187941f42e"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/response_entry_types.rs",
+      "bytes": 2897,
+      "sha256": "bf79f9c3418f773ab45b9679d9a651ea6fa2ad213d5a53445b1fe97e0749f0dd"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/response_entry_runtime.rs",
+      "bytes": 11680,
+      "sha256": "5466a9ba80ac08202e3e5ccfdf27f3e5911a1e530a7ce89bc87fe8db320619f5"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/response_entry_training.rs",
+      "bytes": 26274,
+      "sha256": "f391fbc8d6abc2d254455bac0f09769d3aab9d5a7d7257bf61ad371786cf9274"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/word_copy_runtime.rs",
+      "bytes": 36752,
+      "sha256": "2bb83480428b01f24d116c2463d1b0befd8e0024481d64c2e33b8a90fdb149df"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/role_read_tests.rs",
+      "bytes": 9764,
+      "sha256": "017d9cd966f908736b98a555cd0a09e95d69b78900eb11c962eba657ccaa4042"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/examples/native_geometric_value_probe/typed_routing.rs",
+      "bytes": 33042,
+      "sha256": "2c2468e8846b5e214eac739698a98aa6b1170233471d95eac8d922583323afed"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "bytes": 55121,
+      "sha256": "3779aa6eeba6d0f1e71f38d25f0506643738271446c2d2677a4c1581b98ce487"
+    }
+  ],
+  "source": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-source.json",
+    "bytes": 87060,
+    "sha256": "15801cf49bd3c2f860546da430eed0afa73916fc06d3a6a11d050d207004d508"
+  },
+  "parent": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/literal-admission-angular/model.json",
+    "bytes": 11176068,
+    "sha256": "1b8e9da3f3b29cf2fe3228d35979c8a03192fd6c3b36e9d398d42ad151010e72"
+  },
+  "fits": [
+    {
+      "status": "REJECT_PRESERVATION",
+      "model": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-candidate/model.json",
+        "bytes": 11207204,
+        "sha256": "f3e1470ebc222111007b088f8cf25cf28356df0f5847aa90d1a0571e68ecaeba"
+      },
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "operator_schema": "uor-r4.native-response-entry/1",
+      "fit": {
+        "admitted": [
+          "literal-preserve/typed-value/fit/prose/no_write/0",
+          "literal-preserve/typed-value/fit/prose/no_write/1",
+          "literal-preserve/typed-value/fit/prose/no_write/2",
+          "literal-preserve/typed-value/fit/prose/no_write/3",
+          "literal-fit/0/false/3",
+          "literal-fit/1/false/3",
+          "literal-fit/2/false/3",
+          "literal-fit/3/false/3"
+        ],
+        "associations": 192,
+        "correct_positions": 52,
+        "documents": 103,
+        "dropped_associations": 0,
+        "dropped_rows": 0,
+        "loss": 0.1670632643605214,
+        "parent": "blake3:c29ab9826e3beddae71f1ba5c189c602cfa2686b652da3b7d78e93d927254ad8",
+        "positions": 56,
+        "rows": 130,
+        "schema": "uor-r4.no-read-completion-fit/1",
+        "scope": "Continuation only after actual frozen-parent NoRead. Teacher-forced token learning is not free-generation acceptance; all parent parameters preserved.",
+        "selected_epoch": 24,
+        "skipped": [
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/0/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/1/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/2/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/3/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/4/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/5/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/independent-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          }
+        ]
+      }
+    },
+    {
+      "status": "REJECT_PRESERVATION",
+      "model": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding/model.json",
+        "bytes": 11212845,
+        "sha256": "b0e5cbaac7097e9efae410a39de0134fb742f1032fcafad3ef71489d61d5350d"
+      },
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "operator_schema": "uor-r4.native-no-read-binding-completion/1",
+      "fit": {
+        "admitted": [
+          "literal-preserve/typed-value/fit/prose/no_write/0",
+          "literal-preserve/typed-value/fit/prose/no_write/1",
+          "literal-preserve/typed-value/fit/prose/no_write/2",
+          "literal-preserve/typed-value/fit/prose/no_write/3",
+          "literal-fit/0/false/3",
+          "literal-fit/1/false/3",
+          "literal-fit/2/false/3",
+          "literal-fit/3/false/3"
+        ],
+        "associations": 354,
+        "correct_positions": 56,
+        "documents": 103,
+        "dropped_associations": 0,
+        "dropped_rows": 0,
+        "loss": 0.03872279702854314,
+        "parent": "blake3:c29ab9826e3beddae71f1ba5c189c602cfa2686b652da3b7d78e93d927254ad8",
+        "positions": 56,
+        "rows": 149,
+        "schema": "uor-r4.no-read-completion-fit/1",
+        "scope": "Continuation only after actual frozen-parent NoRead. Teacher-forced token learning is not free-generation acceptance; all parent parameters preserved.",
+        "selected_epoch": 24,
+        "skipped": [
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/0/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/1/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/2/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/3/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/4/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/5/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/independent-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          }
+        ]
+      }
+    },
+    {
+      "status": "RETAIN_BOUNDED_SCOPE",
+      "model": {
+        "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final/model.json",
+        "bytes": 11212853,
+        "sha256": "d8b54a54966dfc4c7d5d1fc0a2bc3de371eb4f5cd5a78508958a8e7873c9916e"
+      },
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "operator_schema": "uor-r4.native-literal-no-read-binding-completion/1",
+      "fit": {
+        "admitted": [
+          "literal-preserve/typed-value/fit/prose/no_write/0",
+          "literal-preserve/typed-value/fit/prose/no_write/1",
+          "literal-preserve/typed-value/fit/prose/no_write/2",
+          "literal-preserve/typed-value/fit/prose/no_write/3",
+          "literal-fit/0/false/3",
+          "literal-fit/1/false/3",
+          "literal-fit/2/false/3",
+          "literal-fit/3/false/3"
+        ],
+        "associations": 354,
+        "correct_positions": 56,
+        "documents": 103,
+        "dropped_associations": 0,
+        "dropped_rows": 0,
+        "loss": 0.03872279702854314,
+        "parent": "blake3:c29ab9826e3beddae71f1ba5c189c602cfa2686b652da3b7d78e93d927254ad8",
+        "positions": 56,
+        "rows": 149,
+        "schema": "uor-r4.no-read-completion-fit/1",
+        "scope": "Literal-numeric continuation only after actual frozen-parent NoRead. Teacher-forced token learning is not free-generation acceptance; all parent parameters preserved.",
+        "selected_epoch": 24,
+        "skipped": [
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/prose/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/copy_current/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/add/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/dependency_before_update/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/typed-value/fit/rust/no_write/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/0/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/1/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/2/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/3/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/4/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/roles-fit/5/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-preserve/prefix/independent-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/0/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/1/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/2/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/false/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-fit/3/true/3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-0/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-1/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-2/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-0",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-1",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-2",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-3",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-4",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-5",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-6",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          },
+          {
+            "id": "literal-admission/word-copy/fit/context-3/name-7",
+            "reason": "frozen_parent_did_not_select_target_NoRead"
+          }
+        ]
+      }
+    }
+  ],
+  "reports": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-exposed.json",
+      "bytes": 446101,
+      "sha256": "c3f6fdda9f52f2f6dad8575b8cc79a24484138d453ea19803990764609928c8f",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 14,
+      "total": 16,
+      "elapsed_ms": 17,
+      "failures": [
+        {
+          "id": "admission-new-literal/0/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "admission-new-literal/1/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-exposed-final.json",
+      "bytes": 446105,
+      "sha256": "2a2f3842bd680ebf428444ca4b1917eb6bee00f0839db413b43c3f6528b3c298",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 14,
+      "total": 16,
+      "elapsed_ms": 20,
+      "failures": [
+        {
+          "id": "admission-new-literal/0/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "admission-new-literal/1/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-fresh.json",
+      "bytes": 445991,
+      "sha256": "aa5d50caca426d516334440b660194a4bbd045b55eefc55d92dd6315d1e80ffa",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 15,
+      "total": 16,
+      "elapsed_ms": 18,
+      "failures": [
+        {
+          "id": "answer-new/0/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-parent-fresh.json",
+      "bytes": 446150,
+      "sha256": "a38e5e34c446e5439f4b5c787f27336295660d24573956732be47a5c1a11e036",
+      "artifact": "blake3:c29ab9826e3beddae71f1ba5c189c602cfa2686b652da3b7d78e93d927254ad8",
+      "exact": 14,
+      "total": 16,
+      "elapsed_ms": 22,
+      "failures": [
+        {
+          "id": "answer-new/0/false/3",
+          "text": " Unknown. The conversation does not give a:. The conversation does not give a:. The conversation does not give a:.2121. The conversation does",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "answer-new/0/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-construction.json",
+      "bytes": 2503650,
+      "sha256": "a2465135ffbcd43921c25cc49a3f949fb3ef9ba981da5c9a1cd5150dac967a20",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 99,
+      "total": 103,
+      "elapsed_ms": 122,
+      "failures": [
+        {
+          "id": "literal-fit/0/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "literal-fit/1/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "literal-fit/2/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        },
+        {
+          "id": "literal-fit/3/true/3",
+          "text": " coins.\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-chain.json",
+      "bytes": 912085,
+      "sha256": "956f7af4daacde739604a70d30f67597116e25e531db7edb247e24df5417a13f",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 16,
+      "total": 16,
+      "elapsed_ms": 63,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-identifiers.json",
+      "bytes": 135414,
+      "sha256": "714ae4ba072dde10a6e6430e2246b55a34ae4b70db9cba4912539afa0469bd95",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 8,
+      "total": 8,
+      "elapsed_ms": 10,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-old-chain-retry.json",
+      "bytes": 912050,
+      "sha256": "8f6ea7962142522f2db302ca6bbeabfb60ac2b3c6864c35e986b51711bc65730",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 16,
+      "total": 16,
+      "elapsed_ms": 61,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-computed-construction.json",
+      "bytes": 3023794,
+      "sha256": "eff36c9c773913125bf07c2122a4d2b2876950aa29038f21e9305b0332b1602e",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 58,
+      "total": 58,
+      "elapsed_ms": 198,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-prior-numeric.json",
+      "bytes": 272236,
+      "sha256": "9057a17c3257ce9d0febf2012d47491af99e028e2a647ac40ccfd7b5d05ca3cd",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 6,
+      "total": 6,
+      "elapsed_ms": 15,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-prior-roles.json",
+      "bytes": 688698,
+      "sha256": "52c9a664f16a369ea3837ad2f4af63d4e092892cd5ff89e47de3a54ee72e6909",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 12,
+      "total": 12,
+      "elapsed_ms": 52,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-prior-exposed.json",
+      "bytes": 688854,
+      "sha256": "42c83e136f4729d0ec2ffb64fe197316e04460e59f55aed27aa19092d309d2e4",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 12,
+      "total": 12,
+      "elapsed_ms": 52,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-prior-aliases.json",
+      "bytes": 688659,
+      "sha256": "2c435385261fe3a8c3b110f501f12c518e838328462292a9c35fead8a804d8a5",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 12,
+      "total": 12,
+      "elapsed_ms": 60,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-long.json",
+      "bytes": 1453184,
+      "sha256": "237003f4a5755621812e4c0c9138c5edddb7dd6b269d58f38c54559807d7e67b",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 28,
+      "total": 28,
+      "elapsed_ms": 79,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-preservation/development.json",
+      "bytes": 2307747,
+      "sha256": "9eae7918dda8e642038972c25ed978bce0e6f8f84b7aeb49ae67ae491c6a6721",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 48,
+      "total": 48,
+      "elapsed_ms": 48,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-preservation/preservation.json",
+      "bytes": 1460320,
+      "sha256": "dc8ca5bc2c43c68d5266d8f34662f53cd82a6f4a5999f0240cff316f70949b35",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 58,
+      "total": 62,
+      "failures": [
+        {
+          "id": "typed-value/development/prose/no_write/100000",
+          "text": " Unknown.\n",
+          "expected": " Unknown. The conversation does not give a city.\n"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100001",
+          "text": " Unknown.\n",
+          "expected": " Unknown. The conversation does not give a city.\n"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100002",
+          "text": " Unknown.\n",
+          "expected": " Unknown. The conversation does not give a city.\n"
+        },
+        {
+          "id": "typed-value/development/prose/no_write/100003",
+          "text": " Unknown.\n",
+          "expected": " Unknown. The conversation does not give a city.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-preservation/prior.json",
+      "bytes": 328002,
+      "sha256": "57ba817e41f39f1bc1ac112c2aecaa429728a4152732b8fd26f7dabe22faea33",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 24,
+      "total": 24,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-preservation/exposed-names.json",
+      "bytes": 1362358,
+      "sha256": "a7d50b7d7a0ff4902e73f0881b24fc88de6d675c81761c054177543d85ffd734",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 28,
+      "total": 28,
+      "elapsed_ms": 27,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-preservation/sessions.json",
+      "bytes": 37116,
+      "sha256": "f1aedf339c1087cbfbb61cd16b3e8a1317f7a9cf56ee420e74d54197ad55bc2c",
+      "artifact": "blake3:760fc57bfa1c51eba6efca1ad89b429a26869bd3049bc12ab9235053d8e66642",
+      "exact": 5,
+      "total": 5,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding-preservation/development.json",
+      "bytes": 2307795,
+      "sha256": "f990a839fdd0e8ad97e8cc5bbf29ff5489bcdf07584bb86f869c54d73ba59748",
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "exact": 48,
+      "total": 48,
+      "elapsed_ms": 49,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding-preservation/preservation.json",
+      "bytes": 1465643,
+      "sha256": "b80b21d67a0563e2dd6a00c1ffa50129cf187198f0470273d919f385f1b0bb12",
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "exact": 62,
+      "total": 62,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding-preservation/prior.json",
+      "bytes": 328014,
+      "sha256": "31e9c48cbf920d047c05b3d93af8f33da05a3c88127d98ac158c3148f83201e3",
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "exact": 24,
+      "total": 24,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding-preservation/exposed-names.json",
+      "bytes": 1362383,
+      "sha256": "5a19efc793019b621f002466a0faa0f9ac0f5fcaf4cebd8cb907b9bd1bbdf199",
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "exact": 28,
+      "total": 28,
+      "elapsed_ms": 28,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-binding-preservation/sessions.json",
+      "bytes": 37197,
+      "sha256": "31fc1e3b655f6602892e1ed1ad05b57766cac40fe396d7e4b3244c4abd59727a",
+      "artifact": "blake3:235fad685bfbeef5d657fc9947c379c46ee304116b716b3ea06d70853bf3ac58",
+      "exact": 4,
+      "total": 5,
+      "failures": [
+        {
+          "id": "Where is ada? Answer:",
+          "text": " Unknown\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+          "expected": " Unknown.\n"
+        }
+      ]
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final-preservation/development.json",
+      "bytes": 2307697,
+      "sha256": "3a5240436b2326712e39b7cb6c0153e8823b275bff61594d373d31740f098add",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 48,
+      "total": 48,
+      "elapsed_ms": 50,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final-preservation/preservation.json",
+      "bytes": 1465614,
+      "sha256": "ff5bf05413c47b7149bdea8cd885191312e9282526e86c49655397e15815d2c3",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 62,
+      "total": 62,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final-preservation/prior.json",
+      "bytes": 327993,
+      "sha256": "4f13db6811373828434c6d0eb662443c3de645e725d03f520344471766e019a5",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 24,
+      "total": 24,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final-preservation/exposed-names.json",
+      "bytes": 1362333,
+      "sha256": "625ef7a1bf591e1773ced2570172513fb5fb18d22875f28dcc5a5d7fffd8d1c8",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 28,
+      "total": 28,
+      "elapsed_ms": 29,
+      "failures": []
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final-preservation/sessions.json",
+      "bytes": 37117,
+      "sha256": "42904207bc16ff5fe90807e82c3010cd565f518be95aec091a7ee58f9dfa94d0",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 5,
+      "total": 5,
+      "failures": []
+    }
+  ],
+  "parent_trace": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-parent-trace.json",
+    "bytes": 55065,
+    "sha256": "744d676c208179a9c6f3e9eb2f29c171172bef9b8e1b37e3aec80b11cecf51fd"
+  },
+  "cost": {
+    "scope": "Same two exposed literal cases, same32-token ceiling, complete input plus generated path; shorter output changes work",
+    "cases": [
+      {
+        "id": "admission-new-literal/0/false/3",
+        "parent_text": " Unknown. The conversation does not give a:. The 95: What color is.. User:: What color is.. User:: User::",
+        "text": " Unknown.\n",
+        "terminated": true
+      },
+      {
+        "id": "admission-new-literal/1/false/3",
+        "parent_text": " Unknown. The conversation does not give a:. The conversation does not give a:. The conversation does not give a:. The conversation does not give a",
+        "text": " Unknown.\n",
+        "terminated": true
+      }
+    ],
+    "work": {
+      "observed_tokens": {
+        "parent": 192,
+        "candidate": 136
+      },
+      "candidate_evaluations": {
+        "parent": 16871,
+        "candidate": 2162
+      },
+      "h4_table_reads": {
+        "parent": 192,
+        "candidate": 136
+      },
+      "memory_composition_comparisons": {
+        "parent": 592402,
+        "candidate": 74064
+      },
+      "word_copy.selector.row_comparisons": {
+        "parent": 19840,
+        "candidate": 3008
+      },
+      "word_copy.selector.score_lookups": {
+        "parent": 21008,
+        "candidate": 3532
+      },
+      "word_copy.selector.metadata_reads": {
+        "parent": 780,
+        "candidate": 648
+      },
+      "word_copy.dictionary_byte_comparisons": {
+        "parent": 17289,
+        "candidate": 4081
+      },
+      "word_copy.routing.table_reads": {
+        "parent": 1092,
+        "candidate": 1092
+      }
+    }
+  },
+  "checks": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-focused-final.stdout.log",
+      "bytes": 236,
+      "sha256": "67fcc1f2d268673189f46cf5da959360de064c8f6eef28750a5d9d4973036a27"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-entry-tests.stdout.log",
+      "bytes": 1782,
+      "sha256": "8a06d8c3e51f4a527143ea73a42e117c3eafdb9d66f2ed6abd22571a88026b80"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-allocation-final.stdout.log",
+      "bytes": 289,
+      "sha256": "35740e0fc52ab8c4b33fd64b56ca34bfd86cc46f9f5c1974b57c89a18cd5ee93"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-numeric-allocation.stdout.log",
+      "bytes": 390,
+      "sha256": "53247a4f50bdcba18de7a397c0a5c976f4d9d85d78a6ee4bac6b528103f49b2f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-kernel.stdout.log",
+      "bytes": 189,
+      "sha256": "d75275b7fba94eb727e44bf134fc0e5a473bd1e8d08e762e06c5afaec60e7b83"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-cli.stdout.log",
+      "bytes": 9318,
+      "sha256": "c3be2ed42255896f398c2e575fd124a45fedb9b4252ba7572683f2dbcecabe2d"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-cli-identifier.stdout.log",
+      "bytes": 11135,
+      "sha256": "2bb5e098337a67fc0a2b1b73165becd00e699d50980aa303fb3687d4d3876141"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-fmt.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-policy.log",
+      "bytes": 73,
+      "sha256": "58dd9c24c33ba5ff6519ed3f5bea924d8fd10d93bcfaba529e2d8b0101be6ae7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-claims.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    }
+  ],
+  "boundaries": {
+    "entire_parent_unchanged": "PASS_ACTUAL_ARTIFACT",
+    "literal_numerics_without_derived_records": "STRUCTURAL_ELIGIBILITY",
+    "no_read_entry": "LEARNED_PARENT_SELECTION_AND_ACTUAL_OBSERVATION_REQUIRED",
+    "new_state_fields": 0,
+    "new_table_bytes": 36763,
+    "rows": 149,
+    "associations": 354,
+    "serving_matmul": false,
+    "serving_provider": false,
+    "angular_advantage": "NOT_ESTABLISHED",
+    "supported_source_selection": "INCOMPLETE_1_OF_4_NEW_ABSTENTIONS_COPIES_COINS",
+    "generated_rust_assertions": "PRIOR24_NOT_RERUN_THIS_CYCLE;8_COMPLETE_IDENTIFIER_OUTPUTS_PRESERVED",
+    "general_language_or_frontier": "NOT_ESTABLISHED",
+    "broad_release_qa": "NOT_RUN"
+  },
+  "resources": {
+    "projection": {
+      "at": "2026-09-07T00:08:10.063Z",
+      "authority": "standing owner authorization for necessary allowances; no external model cost",
+      "before": {
+        "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+        "at": "2026-09-07T00:07:24.258Z",
+        "inherited_precleanup_bytes": 2747199488,
+        "obsolete_target_growth_credit": 671379456,
+        "current_target_bytes": 2486935552,
+        "predecessor_artifact_root_bytes": 145760256,
+        "current_artifact_root_bytes": 1364320256,
+        "predecessor_worktree_bytes": 9875456,
+        "current_worktree_bytes": 8937472,
+        "stopped_successor_worktree_bytes": 460877824,
+        "source_metadata_reserve_bytes": 5242880,
+        "current_sampled_known_storage_bytes": 6557769728,
+        "storage_limit_bytes": 7063207936,
+        "remaining_storage_bytes": 505438208,
+        "stop_margin_bytes": 134217728,
+        "available_growth_before_stop_bytes": 150032384,
+        "model_ledger": {
+          "cumulative_ms": 3168126,
+          "limit_ms": 3210000
+        },
+        "model_remaining_ms": 41874,
+        "model_process_limit": 1,
+        "model_process_rss_target_bytes": 4294967296,
+        "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+      },
+      "model_increment_ms": 360000,
+      "model_cycle_ms": 360000,
+      "engineering_cycle_ms": 1560000,
+      "model_projection_ms": 300000,
+      "engineering_projection_ms": 500000,
+      "growth_projection_bytes": 134217728,
+      "storage_increment_bytes": 0,
+      "model_processes": 1,
+      "rss_bytes": 4294967296,
+      "scope": "Trace actual NoRead/source decisions, reuse existing geometric answer selector and lexical continuation, preserve computed/literal/identifier paths, bounded fresh transfer and protected delivery.",
+      "revisions": [
+        {
+          "at": "2026-09-07T00:23:57.172Z",
+          "old_engineering_cycle_ms": 720000,
+          "new_engineering_cycle_ms": 900000,
+          "remaining_engineering_projection_ms": 180000,
+          "remaining_model_projection_ms": 200000,
+          "reason": "First candidate repairs loops but regresses four explanatory abstentions; reuse existing32-feature word-binding prefix for context-conditioned continuation. Parent weights remain fixed; no fresh cases opened."
+        },
+        {
+          "at": "2026-09-07T00:32:43.478Z",
+          "old_engineering_cycle_ms": 900000,
+          "new_engineering_cycle_ms": 1140000,
+          "remaining_engineering_projection_ms": 180000,
+          "remaining_model_projection_ms": 200000,
+          "reason": "Binding continuation restores62/62 but regresses one relation-conflict session. Restrict new completion to its literal-numeric state scope; verify unchanged memory/derived continuations and new generated answers."
+        },
+        {
+          "at": "2026-09-07T00:39:30.113Z",
+          "old_engineering_cycle_ms": 1140000,
+          "new_engineering_cycle_ms": 1380000,
+          "remaining_engineering_projection_ms": 340000,
+          "remaining_model_projection_ms": 180000,
+          "reason": "Final scoped candidate preserves all initial sets. Rebuild actual CLI against final artifact schema; finish allocation and complete generated comparisons."
+        },
+        {
+          "at": "2026-09-07T00:42:11.724Z",
+          "authority": "standing owner approval of all necessary incremental storage and resource allowances",
+          "before": {
+            "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+            "at": "2026-09-07T00:41:17.071Z",
+            "inherited_precleanup_bytes": 2747199488,
+            "obsolete_target_growth_credit": 671379456,
+            "current_target_bytes": 2584911872,
+            "predecessor_artifact_root_bytes": 145760256,
+            "current_artifact_root_bytes": 1420288000,
+            "predecessor_worktree_bytes": 9875456,
+            "current_worktree_bytes": 8937472,
+            "stopped_successor_worktree_bytes": 460877824,
+            "source_metadata_reserve_bytes": 5242880,
+            "current_sampled_known_storage_bytes": 6711713792,
+            "storage_limit_bytes": 7063207936,
+            "remaining_storage_bytes": 351494144,
+            "stop_margin_bytes": 134217728,
+            "available_growth_before_stop_bytes": -3911680,
+            "model_ledger": {
+              "cumulative_ms": 3343369,
+              "limit_ms": 3570000
+            },
+            "model_remaining_ms": 226631,
+            "model_process_limit": 1,
+            "model_process_rss_target_bytes": 4294967296,
+            "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+          },
+          "scoped_growth_increment_bytes": 167772160,
+          "broad_storage_increment_bytes": 0,
+          "remaining_growth_projection_bytes": 134217728,
+          "remaining_model_projection_ms": 130000,
+          "remaining_engineering_projection_ms": 360000,
+          "reason": "CLI-only dependency feature variants exceeded tighter cumulative growth ceiling. Preserve compiler products and retry established core-example plus CLI feature union; finish remaining evaluation.",
+          "old_engineering_cycle_ms": 1380000,
+          "new_engineering_cycle_ms": 1560000
+        }
+      ],
+      "scoped_storage_increment_bytes": 167772160
+    },
+    "final": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-07T00:49:17.265Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2584907776,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 1428135936,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 6719557632,
+      "storage_limit_bytes": 7063207936,
+      "remaining_storage_bytes": 343650304,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 156016640,
+      "model_ledger": {
+        "cumulative_ms": 3450276,
+        "limit_ms": 3570000
+      },
+      "model_remaining_ms": 119724,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "model_ms": 282150,
+    "engineering_ms": 1364981,
+    "peak_sampled_known_bytes": 6746660864,
+    "peak_sampled_child_rss_bytes": 1109098496,
+    "scoped_storage_extension": {
+      "at": "2026-09-07T00:42:11.724Z",
+      "authority": "standing owner approval of all necessary incremental storage and resource allowances",
+      "before": {
+        "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+        "at": "2026-09-07T00:41:17.071Z",
+        "inherited_precleanup_bytes": 2747199488,
+        "obsolete_target_growth_credit": 671379456,
+        "current_target_bytes": 2584911872,
+        "predecessor_artifact_root_bytes": 145760256,
+        "current_artifact_root_bytes": 1420288000,
+        "predecessor_worktree_bytes": 9875456,
+        "current_worktree_bytes": 8937472,
+        "stopped_successor_worktree_bytes": 460877824,
+        "source_metadata_reserve_bytes": 5242880,
+        "current_sampled_known_storage_bytes": 6711713792,
+        "storage_limit_bytes": 7063207936,
+        "remaining_storage_bytes": 351494144,
+        "stop_margin_bytes": 134217728,
+        "available_growth_before_stop_bytes": -3911680,
+        "model_ledger": {
+          "cumulative_ms": 3343369,
+          "limit_ms": 3570000
+        },
+        "model_remaining_ms": 226631,
+        "model_process_limit": 1,
+        "model_process_rss_target_bytes": 4294967296,
+        "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+      },
+      "scoped_growth_increment_bytes": 167772160,
+      "broad_storage_increment_bytes": 0,
+      "remaining_growth_projection_bytes": 134217728,
+      "remaining_model_projection_ms": 130000,
+      "remaining_engineering_projection_ms": 360000,
+      "reason": "CLI-only dependency feature variants exceeded tighter cumulative growth ceiling. Preserve compiler products and retry established core-example plus CLI feature union; finish remaining evaluation."
+    },
+    "broader_storage_limit_unchanged": true,
+    "deleted_material": [],
+    "external_model_compute": 0
+  },
+  "command_receipts": {
+    "paths": [
+      "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/commands.jsonl",
+      "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/engineering-commands.jsonl"
+    ],
+    "selector": "append-only rows starting answer-entry-; includes all executed failed/stopped attempts",
+    "zero_execution_refusal": "Remaining evaluation refused before child creation at storage guard; allowance extended before retry"
+  },
+  "commands": [
+    {
+      "label": "answer-entry-parent-trace",
+      "elapsed_ms": 7318,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-source",
+      "elapsed_ms": 11,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-fit",
+      "elapsed_ms": 22920,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-exposed",
+      "elapsed_ms": 8014,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-preserve",
+      "elapsed_ms": 7874,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-binding-fit",
+      "elapsed_ms": 22752,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-binding-preserve",
+      "elapsed_ms": 8197,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-focused",
+      "elapsed_ms": 10171,
+      "code": 101,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-scoped-fit",
+      "elapsed_ms": 23762,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-final-preserve",
+      "elapsed_ms": 8272,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-exposed-final",
+      "elapsed_ms": 8087,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-fresh",
+      "elapsed_ms": 8182,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-parent-fresh",
+      "elapsed_ms": 7296,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-construction",
+      "elapsed_ms": 8172,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-chain",
+      "elapsed_ms": 8077,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-identifiers",
+      "elapsed_ms": 8068,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-old-chain",
+      "elapsed_ms": 8070,
+      "code": 1,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-old-chain-retry",
+      "elapsed_ms": 8071,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-computed-construction",
+      "elapsed_ms": 8303,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-prior-numeric",
+      "elapsed_ms": 8071,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-prior-roles",
+      "elapsed_ms": 8067,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-prior-exposed",
+      "elapsed_ms": 8064,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-prior-aliases",
+      "elapsed_ms": 8442,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-focused-final",
+      "elapsed_ms": 11780,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-entry-tests",
+      "elapsed_ms": 4709,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-allocation-final",
+      "elapsed_ms": 8322,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-numeric-allocation",
+      "elapsed_ms": 9310,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-kernel",
+      "elapsed_ms": 9,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-long",
+      "elapsed_ms": 8074,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-cli",
+      "elapsed_ms": 8084,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-cli-identifier",
+      "elapsed_ms": 7601,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": false
+    },
+    {
+      "label": "answer-entry-trace-build",
+      "elapsed_ms": 119337,
+      "code": 101,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-build",
+      "elapsed_ms": 309763,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-final-probe-build",
+      "elapsed_ms": 131045,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-test-build",
+      "elapsed_ms": 21250,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-allocation-build",
+      "elapsed_ms": 6397,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-context-build",
+      "elapsed_ms": 50229,
+      "code": null,
+      "stopped": "wrapper_SIGINT",
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-binding-build",
+      "elapsed_ms": 128979,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-binding-test-build",
+      "elapsed_ms": 20931,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-binding-allocation-build",
+      "elapsed_ms": 6378,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-scoped-test-build",
+      "elapsed_ms": 21191,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-scoped-build",
+      "elapsed_ms": 138820,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-final-test-build",
+      "elapsed_ms": 23463,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-final-allocation-build",
+      "elapsed_ms": 6592,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-final-cli-build",
+      "elapsed_ms": 57116,
+      "code": null,
+      "stopped": "storage_margin",
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-cli-retry",
+      "elapsed_ms": 319693,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-fmt",
+      "elapsed_ms": 3364,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-policy",
+      "elapsed_ms": 146,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    },
+    {
+      "label": "answer-entry-claims",
+      "elapsed_ms": 287,
+      "code": 0,
+      "stopped": null,
+      "engineering_only": true
+    }
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,51 @@
 # Current native geometric AI work
 
-## Protected computed roles and literal admission — #1139 / #1140, 2026-09-06
+## Committed NoRead completion in literal contexts — #1139 / #1140, 2026-09-06
+
+**Retain `e7c14c99` at literal-numeric NoRead-completion scope.** The
+[result](../native_geometric_no_read_completion_1139.md) and
+[evidence](../evidence/native_geometric_no_read_completion_1139.json) bind the
+actual native Rust path. A36,763-byte continuation table reuses existing
+word-binding prefix features and integer token scoring after selected NoRead
+commits. It applies only with retained literal numeric records and no derived
+record. The complete `c29ab982` parent and all learned numeric/source parameters
+remain unchanged; no session-state field or response provider is added.
+
+Exposed complete answers improve12/16 to14/16 and reserved changed-name/value
+answers14/16 to15/16. All12 new numeric answers and3/4 abstentions pass. The
+remaining new failure copies `coins` as a location answer. Complete three-turn
+computations stay16/16, identifier returns8/8, and the earlier independent set
+16/16. Preservation passes48/48 dependent cases,62/62 earlier responses,24/24
+prior transfer,28/28 exposed names,28/28 long-context,5/5 persistent turns,
+6/6 earlier numeric, all three12-case role sets and58/58 computed construction.
+Thirteen focused tests, actual NoRead and three-turn zero allocations, complete
+parent equality, checkpoint and mutation checks pass. Construction is99/103;
+four construction cases still choose an unsupported source.
+
+Two intermediate candidates are retained negatives: `760fc57b` shortened four
+required explanatory responses; `235fad68` restored62/62 but broke a
+relation-conflict session. Their first-use evaluation remained unopened during
+revision. The final state-scope correction restores memory behavior without
+changing the second candidate's learned table. No new angular-distance
+advantage or general abstention capability is established.
+
+**Next: repair joint source/NoRead selection for unsupported retained words.**
+Reuse the existing geometric source router and occurrence binding, training
+supported-word and missing-attribute cases together. Keep numeric admission,
+computed results, copied identifiers and memory preservation. Do not replace
+NoOperation with a universal Unknown or add an observed-question parser.
+General prose, syntax, reasoning, frontier capability and whole-model laptop
+advantage remain unqualified. #1139/#1140 remain open.
+
+The rebuilt actual CLI returns the repaired abstention and the preserved
+identifier with EOS. Model work282.150s brings cumulative use to3450.276/3570s,
+leaving119.724s. The scoped storage-growth allowance increased160MiB after the
+CLI-only build reached its guard; the broad ceiling stays7,063,207,936 bytes.
+All build/model failures, corrections and retries remain charged. Exact costs
+and the revised engineering projections are in the evidence. No deletions or
+external model compute.
+
+## Previous checkpoint: protected computed roles and literal admission — #1139 / #1140, 2026-09-06
 
 **Retain `c29ab982` at bounded literal-admission scope.** The
 [result](../native_geometric_literal_admission_1139.md) and

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -213,10 +213,17 @@ computed-result and identifier-copy cases. The subsequent
 retains `c29ab982`: inherited computed roles are unchanged, exposed complete
 transfer improves12/16 to16/16, new complete transfer12/16 to16/16, and all prior
 preservation is restored. Eight new identifier-return functions pass24 executed
-assertions. Four abstention texts still fail. Next connect numeric NoOperation
-to the correct supported-word or abstention answer path, preserving these
-successes before broader Rust reasoning. General named-role binding remains
-unqualified.
+assertions. The [committed NoRead continuation](../native_geometric_no_read_completion_1139.md)
+then retains `e7c14c99` at literal-numeric scope: exposed answers12/16 to14/16,
+new answers14/16 to15/16, with computed, identifier and memory preservation.
+Two intermediate candidates remain recorded negatives. **Next: revise joint
+source/NoRead selection when a retained word is unsupported by the question.**
+Reuse the existing geometric source router and occurrence binding; include
+supported-word and missing-attribute cases together, with source-order/name
+changes and the current numeric/identifier/memory preservation. Do not map all
+numeric NoOperation to Unknown, add a parser for the observed question template,
+or expand model/context capacity before this selection seam is addressed.
+General named-role binding and broader Rust reasoning remain unqualified.
 No additional cache campaign is active. Follow current-state.md for artifacts
 and cumulative resources; a new issue does not reset the spent amount.
 The full handoff remains unmet.

--- a/docs/native_geometric_no_read_completion_1139.md
+++ b/docs/native_geometric_no_read_completion_1139.md
@@ -1,0 +1,175 @@
+# Committed NoRead continuation — #1139 / #1140, 2026-09-06
+
+## Cause and implementation
+
+The accepted literal-admission artifact `c29ab982` declined arithmetic on four
+unanswered location questions but failed every complete answer. Two outputs
+began ` Unknown.` and continued into unrelated looping text; two selected and
+copied `coins`. Native parent traces confirm actual NoRead/no-source-sentinel16 for the
+first pair and Prepare/source11 followed by exact byte copying for the second. These are different failures: lexical continuation after an
+abstention decision, and selection of an unsupported retained word.
+
+This increment addresses the first failure with the existing response-entry
+learner and integer token scorer. An optional `no_read_completion` artifact
+component uses the existing response-entry table representation and a distinct
+`uor-r4.native-literal-no-read-binding-completion/1` schema. It runs only
+when an actual selected NoRead token has been observed, the response entry is
+active, its committed read has no source, and at least one numeric source is
+retained with no derived numeric records. Numeric NoOperation alone cannot
+activate it. A selected word source continues through the unchanged byte cursor
+and copied-word suffix. The complete inherited model is preserved verbatim.
+
+Offline Rust fitting admits a document only when the frozen assembled parent
+actually selects NoRead and its first token matches the supplied response.
+It rejects relation-only and computed-result contexts outside that literal
+training scope. It then learns remaining canonical lexical/byte tokens and EOS with the existing
+sparse optimizer. Later tokens are teacher-forced during fitting; that score is
+not free-generation acceptance. Whole-response and position bounds skip an
+entire example rather than truncating it. A table with no positive offer preserves the full inherited prefix fallback
+and its pending decision. IDs, raw prompt/response receipts,
+configuration, exact parent CID, tables and resulting identity are bound.
+
+No grammar or universal Unknown rule is added. The learned NoRead action still
+chooses the first token; source selection and all numeric parameters are fixed.
+This does not repair an unsupported source that the reader chooses to copy.
+
+## Representation and cost boundary
+
+No new session state is added. The existing word-copy prefix feature extractor
+retains the query-boundary anchor, last two token identities, response-step
+count, signed relative H4 pose/orientation and eight wrapped fixed-zeta phase
+channels, plus up to16 candidate-relative binding-mask/preceding-word addresses.
+It supplies at most32 sparse features. Known words use exact dictionary primes;
+unknown identities collapse to the dictionary miss code. Binding masks retain
+only their declared recent equality relationships and lose broader sentence
+structure. These are reused construction-learned fields, not a new grammar parser.
+The head retains learned next-token scores and postings, not a stored answer
+buffer. Exact retained words and numeric values remain in their existing state.
+The finite features do not retain arbitrary response history or establish a
+semantic distance. Geometry can distinguish states without guaranteeing the
+correct next token.
+
+At an eligible continuation, the same bounded scorer reads at most16 candidate
+tokens with four postings per matching row. The artifact cap is4096 rows and
+32768 associations; this run's actual sizes and complete whole-path work belong
+in the execution evidence. Existing parent scoring still executes, and its
+cost must remain included. Source-model/provider access and runtime matrix
+multiplication are absent from this operator. Artifact loading, validation,
+encoding and checkpoint serialization remain separately measured host work.
+
+## First candidate: continuation repair with a preservation regression
+
+`760fc57b` used only the16 response-entry features. It repaired both looping
+cases (exposed14/16 versus parent12/16), but shortened four earlier explanatory
+abstentions, reducing preservation from62/62 to58/62. Other measured sets
+remained48/48,24/24,28/28 and5/5. It is not accepted. Its56 teacher-forced
+positions scored52/56; this was insufficient to preserve the full outputs.
+The source, model, fit and complete reports remain retained.
+
+The next revision reuses the existing32-feature word-binding prefix rather
+than adding another selector. This restores access to query/source wording
+that the smaller response-progress representation compressed away. A distinct
+NoRead schema prevents silently interpreting the first candidate under the
+revised feature law.
+
+## Second candidate: restored short/explanatory responses, overbroad application
+
+`235fad68` uses the32 prefix features and fits56/56 positions. It restores62/62
+prior responses, retaining48/48 dependent,24/24 prior transfer and28/28 exposed
+names. It is not accepted: the existing persistent relation-conflict turn emits
+` Unknown` followed by repeated newlines, reducing that session from5/5 to4/5.
+No fresh cases were opened during either revision.
+
+The final correction restricts the new table to its literal-numeric training
+scope. Relation-only contexts and any context with a derived numeric record
+retain the entire inherited continuation. The structural check scans at most16
+records, counts its metadata reads and adds no cached state. Selection within
+the eligible path remains learned. This is not a general abstention model or a
+claim that changing expected wording is equivalent to factual fabrication.
+
+## Final execution
+
+Retain `blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11`
+at literal-numeric NoRead-completion scope. The head is36,763 serialized bytes,
+with149 rows and354 associations. Eight actual selected NoRead examples supply
+56 continuation positions; all56 fit. The other95 of103 supplied construction
+examples do not supply a selected, matching NoRead continuation. No rows or
+associations are dropped. The final learned table/configuration equals
+`235fad68` after excluding the changed operator schema: the final correction
+is its state eligibility, not another parameter search.
+
+| Complete generated scope | Parent `c29ab982` | Final `e7c14c99` |
+|---|---:|---:|
+|16 exposed literal cases |12/16|14/16|
+|16 reserved changed-name/value cases |14/16|15/16|
+|16 complete three-turn computations |16/16|16/16|
+|8 identifier-return cases |8/8|8/8|
+|103 construction responses |95/103|99/103|
+
+All12 reserved numeric answers pass;3/4 reserved abstentions pass. The remaining
+reserved failure and both remaining exposed failures copy `coins` as a location
+answer. All four construction failures likewise select that unsupported word.
+The new set includes two numeric worlds, source-order reversals and a shorter
+location-question form; it is a bounded first-use comparison, not a sealed
+language-capability qualification. Its cases were not evaluated until after
+the final design selection.
+
+Preservation passes48/48 dependent responses/writes,62/62 earlier responses,
+24/24 prior transfer,28/28 exposed names,28/28 long-context,5/5 persistent turns,
+6/6 earlier numeric, three12-case role sets,58/58 computed construction and
+16/16 earlier independent-result transfer. The eight identifier-return outputs
+are preserved; this increment does not claim new algorithm synthesis or new
+execution of the prior24 Rust assertions. The rebuilt actual CLI emits
+` Unknown.\n` for the repaired literal query and `zorin\n}\n` for the numeric-
+distractor identity-function prompt, with EOS in both cases.
+
+Thirteen focused tests pass, including actual fit/parent equality, no-offer
+fallback, literal/derived/empty eligibility, selected-observation causality,
+checkpoint restoration and invalid schema/parent/token/weight rejection. Both
+the actual NoRead response and actual three-turn numeric path measure zero
+allocations and zero allocated bytes. The entire actual parent artifact is
+unchanged. The kernel source check passes. Broader dormant release QA is
+`NOT_RUN`; no new angular-distance advantage is claimed.
+
+For the same two repaired exposed prompts under the same32-token ceiling,
+whole-path observed tokens fall192 to136, candidate evaluations16,871 to2,162,
+and memory-composition comparisons592,402 to74,064. Word-selector row
+comparisons fall19,840 to3,008; score lookups21,008 to3,532; dictionary byte
+comparisons17,289 to4,081. Initial routing table reads remain1,092 in both.
+These reductions follow correct early termination, not a matched per-token
+speed claim. Input processing, inherited scoring, eligibility, dictionary,
+state, selection and emitted-token work remain included in the retained reports.
+
+## Resources and delivery
+
+Model work is282.150s against the360s cycle ceiling and300s projection.
+Cumulative use is3450.276/3570s, leaving119.724s; the pre-recorded cumulative
+extension was+360s under standing owner authorization. All failures/retries
+remain charged. Build/check work exceeded the initial500s projection; the
+recorded engineering ceiling was extended to1560s for the corrections and final
+CLI integration. Engineering totals1364.981/1560s. Peak sampled known storage is6,746,660,864
+bytes and peak sampled child RSS is1,109,098,496 bytes (4GiB target). Details are in the
+[compact evidence](evidence/native_geometric_no_read_completion_1139.json).
+
+The CLI-only feature combination crossed the tighter storage guard and stopped;
+subsequent evaluation was refused before execution. The scoped growth allowance
+then increased160MiB under standing owner authorization, with a128MiB remaining-
+work projection. The broad7,063,207,936-byte storage ceiling stayed unchanged;
+the effective tighter ceiling is6,875,574,272 bytes. No material was deleted and
+no external model compute was used. A wrong source-split argument, an EOS test-
+interface correction, a stopped intermediate schema build and all candidate
+revisions are retained in the command receipts; they are not model-quality
+results.
+
+Artifacts, sources, complete reports and append-only command receipts are under
+`.uor-models/native-typed-value-2026-09-05/`. The accepted artifact is
+`answer-entry-final/model.json`; prior candidates remain in
+`answer-entry-candidate/` and `answer-entry-binding/`. The evidence binds exact
+paths, SHA256 file digests, model CIDs, source code, commands and resource records.
+
+Next revise joint source/NoRead selection for a retained word unsupported by
+the question. Reuse the existing geometric source router and exact occurrence
+binding, with supported-word/missing-attribute pairs and current preservation.
+Keep the accepted numeric, identifier and memory paths intact. General syntax,
+prose, reasoning, frontier capability and whole-model laptop advantage remain
+unqualified; #1139/#1140 remain open.


### PR DESCRIPTION
Literal numeric prompts can correctly decline arithmetic and select NoRead, then loop into unrelated prose. This adds a bounded learned continuation after the selected NoRead token is actually observed. It reuses the existing word-binding prefix features and integer/table token scorer, preserves the complete accepted parent, and applies only to retained literal numeric records with no derived result. No new session-state field or response provider is added.

Retain `e7c14c99` at that scope. Exposed complete answers improve12/16 to14/16; reserved changed-name/value answers improve14/16 to15/16. All12 reserved numerics and3/4 abstentions pass. The remaining failure copies `coins` as a location answer and remains a source-selection problem. The roadmap and current-state point to joint supported-source/NoRead selection next.

Validation:13 focused tests; actual NoRead and three-turn numeric zero allocations/bytes; entire-parent equality, checkpoint and mutation checks; kernel source scan; formatting, architecture-policy and claim-wording checks. The rebuilt CLI emits the correct abstention and preserved identifier with EOS. Preservation passes48/48 dependent,62/62 earlier responses,24/24 prior transfer,28/28 exposed names,28/28 long-context,5/5 persistent turns,6/6 earlier numeric, three12-case role sets,58/58 computed construction,16/16 independent-result transfer,16/16 complete chains and8/8 identifier returns. Construction is99/103. Prior24 generated-Rust assertions were not rerun; the eight complete identifier outputs are preserved.

Two intermediate candidates remain recorded negatives: one shortened four explanatory answers; the broader binding-conditioned candidate broke a relation-conflict session. Restricting the final operator to its training state scope restores preservation with the same learned table. No new angular-distance or general-language capability claim.

Resource receipts include all corrections, failures and retries:282.150s model work;1364.981s engineering. Cumulative model use3450.276/3570s. A standing-authorized160MiB scoped growth extension followed a guarded CLI build stop; the broader storage ceiling stays unchanged. No material deletion or external model compute. Protected CI remains required; compatibility statuses are not behavioral qualification. Broad dormant release QA is NOT_RUN.

Refs #1139, #1140. Full result and compact evidence: `docs/native_geometric_no_read_completion_1139.md` and `docs/evidence/native_geometric_no_read_completion_1139.json`.
