### PR TITLE
Learn supported-source and NoRead selection with preserved model lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,14 @@ identifier-return functions execute24 assertions. The subsequent
 [committed NoRead completion](docs/native_geometric_no_read_completion_1139.md)
 preserves that model and repairs looping literal-context abstentions: the exposed
 set improves12/16 to14/16 and a new set14/16 to15/16. Identifier returns remain8/8
-and complete three-turn computations16/16. The remaining failure selects a
-retained but unsupported word; joint source/NoRead selection is next.
+and complete three-turn computations16/16. The subsequent
+[joint source/NoRead refinement](docs/native_geometric_source_noread_1139.md)
+repairs unsupported retained-word selection:20/20 new complete answers versus
+14/20 parent and10/20 matched exact-code continuation, with earlier numeric,
+identifier and memory behavior preserved. The existing router is refined in
+place; exact parent reconstruction preserves all downstream training provenance.
+A supported location can still be taken over by numerical admission; joint
+numeric-versus-word selection is the next observed boundary.
 General prose/syntax/reasoning and frontier capability remain unqualified. Follow
 the current-state pointer for artifacts, costs and the next implementation.
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -23,6 +23,8 @@ type ProbeResult<T> = Result<T, Box<dyn Error>>;
 mod relation_memory;
 #[path = "native_geometric_value_probe/role_read.rs"]
 mod role_read;
+#[path = "native_geometric_value_probe/source_noread.rs"]
+mod source_noread;
 #[path = "native_geometric_value_probe/typed_routing.rs"]
 mod typed_routing_probe;
 #[path = "native_geometric_value_probe/wording.rs"]
@@ -973,6 +975,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("source-noread") {
+        return source_noread::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("typed-routing") {
         return typed_routing_probe::run(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/source_noread.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/source_noread.rs
@@ -1,0 +1,178 @@
+//! Bounded continuation of the existing source selector; authored data stays offline.
+use super::*;
+use uor_r4_core::native_geometric::{
+    RelationExample, RoutingMode, SourceRoutingConfig, TypedRoutingExample,
+};
+
+fn contrasts(prefix: &str, worlds: &[(&str, &str, &str, i64, i64)]) -> Vec<ValueExample> {
+    let mut docs = Vec::new();
+    for (world, &(name, other, city, a, b)) in worlds.iter().enumerate() {
+        for reverse in [false, true] {
+            for supported in [false, true] {
+                let first = format!("{name} has {a} coins.");
+                let second = if supported {
+                    format!("{name} lives in {city}.")
+                } else {
+                    format!("{other} has {b} coins.")
+                };
+                let facts = if reverse {
+                    format!("{second} {first}")
+                } else {
+                    format!("{first} {second}")
+                };
+                for wording in 0..2 {
+                    let question = if wording == 0 {
+                        format!("Where is {name}?")
+                    } else {
+                        format!("Where is the location of {name}?")
+                    };
+                    docs.push(ValueExample {
+                        id: format!("{prefix}/{world}/{reverse}/{supported}/{wording}"),
+                        prompt: format!("User: {facts}\nUser: {question}\nAssistant:"),
+                        response: if supported {
+                            format!(" {city}.\n")
+                        } else {
+                            " Unknown.\n".into()
+                        },
+                    });
+                }
+            }
+            // A positive answer equal to the observed false copy prevents treating
+            // the word coins itself as universally unsupported.
+            let facts = if reverse {
+                format!("{other} has stones. {name} has coins.")
+            } else {
+                format!("{name} has coins. {other} has stones.")
+            };
+            docs.push(ValueExample {
+                id: format!("{prefix}/{world}/{reverse}/supported-object"),
+                prompt: format!("User: {facts}\nUser: What does {name} have?\nAssistant:"),
+                response: " coins.\n".into(),
+            });
+        }
+    }
+    docs
+}
+fn responses(
+    model: &Model,
+    docs: &[ValueExample],
+    trace: bool,
+    control: Control,
+) -> ProbeResult<Value> {
+    let mut rows = Vec::new();
+    for d in docs {
+        let generation = model.generate(&d.prompt, 32, control)?;
+        let decision = if trace && control == Control::Full {
+            Some(model.source_routing_trace(&d.prompt)?)
+        } else {
+            None
+        };
+        rows.push(json!({"id":d.id,"prompt":d.prompt,"expected":d.response,"exact":generation.text==d.response && generation.stop=="end_of_document","generation":generation,"source_trace":decision}));
+    }
+    Ok(
+        json!({"artifact":model.artifact_cid(),"exact":rows.iter().filter(|r|r["exact"]==true).count(),"total":rows.len(),"cases":rows}),
+    )
+}
+fn relation_responses(model: &Model, docs: &[RelationExample]) -> ProbeResult<Value> {
+    let mut report = writer_binding::evaluate(model, docs)?;
+    let rows = report["cases"]
+        .as_array_mut()
+        .ok_or("relation report cases absent")?;
+    for row in rows.iter_mut() {
+        row["exact"] =
+            json!(row["exact"] == true && row["generation"]["stop"] == "end_of_document");
+    }
+    let exact = rows.iter().filter(|row| row["exact"] == true).count();
+    report["exact"] = json!(exact);
+    report["exact_scope"] = json!("Complete bytes and EOS; writes counted separately.");
+    Ok(report)
+}
+fn save(out: &Path, name: &str, report: &Value) -> ProbeResult<()> {
+    write_json(&out.join(format!("{name}.json")), report)?;
+    println!(
+        "{}",
+        json!({"split":name,"exact":report["exact"],"total":report["total"]})
+    );
+    Ok(())
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    match args.first().map(String::as_str) {
+        Some("prepare") if args.len()==4 => {
+            let prior:Value=serde_json::from_slice(&fs::read(&args[1])?)?;
+            let literal:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            let mut fit:Vec<ValueExample>=serde_json::from_value(prior["fit"].clone())?;
+            let inherited=fit.len();
+            let literal_fit:Vec<TypedRoutingExample>=serde_json::from_value(literal["fit"].clone())?;
+            fit.extend(literal_fit.into_iter().filter(|d|d.literal_only).map(|d|ValueExample{id:format!("source-joint/{}",d.id),prompt:d.query,response:d.response}));
+            let added=contrasts("source-joint-fit",&[("ada","ben","Rome",8,7),("cyra","dara","Paris",13,4)]);
+            fit.extend(added);
+            let mut development=contrasts("source-joint-open",&[("leni","varo","Dover",17,-5)]);
+            let exposed:Vec<TypedRoutingExample>=serde_json::from_value(literal["exposed_answers"].clone())?;
+            development.extend(exposed.into_iter().filter(|d|d.action.is_none()).map(|d|ValueExample{id:format!("observed-failure/{}",d.id),prompt:d.query,response:d.response}));
+            let first_use=contrasts("source-joint-reserved",&[("selvi","dovra","Norvik",-9,26),("pavren","milso","Kestra",32,-11)]);
+            let encoded=serde_json::to_string(&fit)?;
+            for name in ["selvi","dovra","Norvik","pavren","milso","Kestra"] {if encoded.contains(name){return Err("new source names overlap fit".into());}}
+            write_json(Path::new(&args[3]),&json!({"schema":"uor-r4.source-noread-contrasts/1","scope":"Existing source and literal construction plus paired supported/missing location and positive coins answers. Exact names/order/literal distractors vary. Fresh names/places/numbers opened after design selection; familiar wording is not general-language qualification.","inherited_source_examples":inherited,"fit":fit,"development":development,"first_use":first_use}))?;
+        }
+        Some("fit") if args.len()==6 => {
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs:Vec<ValueExample>=serde_json::from_value(source["fit"].clone())?;
+            let mode=match args[5].as_str(){"angular"=>RoutingMode::Angular,"equality"=>RoutingMode::Equality,_=>return Err("source mode".into())};
+            let config=SourceRoutingConfig{learned_features:args[4].parse()?,passes:4,proposals:12,max_seconds:45,mode,role_context_only:true,..SourceRoutingConfig::default()};
+            let (candidate,report)=model.refine_source_routing(&docs,config)?;
+            let out=Path::new(&args[3]);fs::create_dir(out)?;
+            write_new(&out.join("model.json"),&candidate.to_bytes()?)?;
+            save(out,"fit",&report)?;
+            save(out,"construction",&responses(&candidate,&docs,false,Control::Full)?)?;
+            let open:Vec<ValueExample>=serde_json::from_value(source["development"].clone())?;
+            save(out,"development",&responses(&candidate,&open,true,Control::Full)?)?;
+            println!("{}",report);
+        }
+        Some("evaluate") if args.len()==6 => {
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let source:Value=serde_json::from_slice(&fs::read(&args[2])?)?;
+            let docs:Vec<ValueExample>=serde_json::from_value(source[&args[3]].clone())?;
+            let control=match args[5].as_str(){"full"=>Control::Full,"codes-disabled"=>Control::LearnedRoutingTransformDisabled,_=>return Err("source control".into())};
+            let report=responses(&model,&docs,true,control)?;
+            write_json(Path::new(&args[4]),&report)?;
+            println!("{}",json!({"exact":report["exact"],"total":report["total"]}));
+        }
+        Some("preserve") if args.len()==4 => {
+            let model=Model::from_bytes(&fs::read(&args[1])?)?;
+            let root=Path::new(&args[2]);let out=Path::new(&args[3]);fs::create_dir(out)?;
+            for (file,split,label) in [
+                ("answer-entry-source.json","fit","literal-construction"),
+                ("answer-entry-source.json","first_use","prior-fresh"),
+                ("literal-admission-source.json","first_use","exposed-literals"),
+                ("literal-admission-source.json","transfer","chains"),
+                ("literal-admission-source.json","identifiers","identifiers"),
+                ("independent-reachable-source.json","first_use","prior-chains"),
+                ("independent-reachable-source.json","fit","computed-construction"),
+                ("typed-routing-case-source.json","first_use","numeric"),
+                ("typed-roles-query-source.json","first_use","roles"),
+                ("typed-roles-query-source.json","exposed_first_use","exposed-roles"),
+                ("typed-roles-query-source.json","exposed_alias_first_use","aliases")
+            ] {
+                let source:Value=serde_json::from_slice(&fs::read(root.join(file))?)?;
+                let docs:Vec<TypedRoutingExample>=serde_json::from_value(source[split].clone())?;
+                save(out,label,&model.evaluate_typed_routing(&docs,false)?)?;
+            }
+            let source:Value=serde_json::from_slice(&fs::read(root.join("writer-binding-continuation-source.json"))?)?;
+            for (split,label) in [("development","dependent"),("fresh","names")] {
+                let docs:Vec<RelationExample>=serde_json::from_value(source[split].clone())?;
+                save(out,label,&relation_responses(&model,&docs)?)?;
+            }
+            for split in ["preservation","prior"] {
+                let docs:Vec<ValueExample>=serde_json::from_value(source[split].clone())?;
+                save(out,split,&responses(&model,&docs,false,Control::Full)?)?;
+            }
+            let source:Value=serde_json::from_slice(&fs::read(root.join("relation-admission-source.json"))?)?;
+            let docs:Vec<RelationExample>=serde_json::from_value(source["first_use"].clone())?;
+            save(out,"long",&relation_responses(&model,&docs)?)?;
+            relation_memory::verify_model(model,&out.join("sessions.json"))?;
+        }
+        _=>return Err("source-noread prepare PRIOR LITERAL OUTPUT | fit MODEL SOURCE NEW_DIR FEATURES angular|equality | evaluate MODEL SOURCE SPLIT REPORT full|codes-disabled | preserve MODEL ROOT NEW_DIR".into())
+    }
+    Ok(())
+}

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/writer_binding.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/writer_binding.rs
@@ -60,7 +60,7 @@ fn variant(d: &RelationExample) -> ProbeResult<RelationExample> {
         .replacen(&format!("Now {owner} in"), &format!("{owner} now in"), 1);
     labeled(next)
 }
-fn evaluate(model: &Model, docs: &[RelationExample]) -> ProbeResult<Value> {
+pub(super) fn evaluate(model: &Model, docs: &[RelationExample]) -> ProbeResult<Value> {
     let start = Instant::now();
     let mut rows = Vec::new();
     for d in docs {

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -15,6 +15,8 @@ mod dependent_read_training;
 pub use dependent_read_training::DependentReadExample;
 #[cfg(test)]
 mod dependent_read_tests;
+#[cfg(test)]
+mod source_refinement_tests;
 mod source_routing;
 #[cfg(test)]
 mod source_routing_tests;
@@ -327,6 +329,8 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source_routing: Option<source_routing::SourceRouting>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_routing_refinement: Option<source_routing::SourceRoutingRefinement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     learned_routing: Option<learned_routing::RoutingBlock>,
     schema: String,
     artifact_cid: String,
@@ -368,6 +372,8 @@ struct ModelWire {
     dependent_read: Option<dependent_read::DependentRead>,
     #[serde(default)]
     source_routing: Option<source_routing::SourceRouting>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_routing_refinement: Option<source_routing::SourceRoutingRefinement>,
     #[serde(default)]
     learned_routing: Option<learned_routing::RoutingBlock>,
     schema: String,
@@ -403,6 +409,7 @@ impl TryFrom<ModelWire> for Model {
             relation_writer: wire.relation_writer,
             dependent_read: wire.dependent_read,
             source_routing: wire.source_routing,
+            source_routing_refinement: wire.source_routing_refinement,
             learned_routing: wire.learned_routing,
             schema: wire.schema,
             artifact_cid: wire.artifact_cid,

--- a/crates/uor-r4-core/src/native_geometric/source_refinement_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_refinement_tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+use std::sync::OnceLock;
+
+fn documents() -> Vec<ValueExample> {
+    ["alpha", "bravo", "cedar", "delta"]
+        .into_iter()
+        .enumerate()
+        .flat_map(|(i, name)| {
+            [
+                ValueExample {
+                    id: format!("refine-copy-{i}"),
+                    prompt: format!("holder in {name}. Where is holder? Answer:"),
+                    response: format!(" {name}.\n"),
+                },
+                ValueExample {
+                    id: format!("refine-none-{i}"),
+                    prompt: format!("{name} in city. Where is missing? Answer:"),
+                    response: " Unknown.\n".into(),
+                },
+            ]
+        })
+        .collect()
+}
+fn config(features: usize) -> SourceRoutingConfig {
+    SourceRoutingConfig {
+        learned_features: features,
+        passes: 1,
+        proposals: 2,
+        role_context_only: true,
+        ..SourceRoutingConfig::default()
+    }
+}
+fn pair() -> &'static (Model, Model, serde_json::Value) {
+    static PAIR: OnceLock<(Model, Model, serde_json::Value)> = OnceLock::new();
+    PAIR.get_or_init(|| {
+        let (parent, _) = role_read_tests::fitted()
+            .fit_source_routing(&documents(), config(16))
+            .unwrap();
+        let (refined, report) = parent
+            .refine_source_routing(&documents(), config(32))
+            .unwrap();
+        (parent, refined, report)
+    })
+}
+#[test]
+fn source_refinement_reconstructs_exact_parent_and_reloads() {
+    let (parent, refined, report) = pair();
+    assert_eq!(report["warm_initialization_preserved"], true);
+    assert_eq!(report["warm_features"], 16);
+    assert!(report["added_features"].as_u64().unwrap() > 0);
+    let witness = refined.source_routing_refinement.as_ref().unwrap();
+    assert_eq!(&witness.previous, parent.source_routing.as_ref().unwrap());
+    let mut reconstructed = refined.clone();
+    reconstructed.source_routing_refinement = None;
+    reconstructed.source_routing = Some(witness.previous.clone());
+    reconstructed.refresh_identity().unwrap();
+    assert_eq!(&reconstructed, parent);
+    assert_eq!(refined.response_entry, parent.response_entry);
+    let loaded = Model::from_bytes(&refined.to_bytes().unwrap()).unwrap();
+    let prompt = &documents()[0].prompt;
+    assert_eq!(
+        loaded.generate(prompt, 32, Control::Full).unwrap(),
+        refined.generate(prompt, 32, Control::Full).unwrap()
+    );
+}
+#[test]
+fn source_refinement_rejects_tampered_parent_and_inherited_parameters() {
+    let (_, refined, _) = pair();
+    for field in 0..4 {
+        let mut bad = refined.clone();
+        match field {
+            0 => {
+                bad.source_routing_refinement
+                    .as_mut()
+                    .unwrap()
+                    .parent_artifact = "different".into()
+            }
+            1 => {
+                bad.source_routing_refinement
+                    .as_mut()
+                    .unwrap()
+                    .previous
+                    .biases[0] += 1
+            }
+            2 => bad.prior_scores[0] += 1,
+            _ => bad.source_routing.as_mut().unwrap().codes[0].roots[0] = 120,
+        }
+        bad.refresh_identity().unwrap();
+        assert!(Model::from_bytes(&bad.to_bytes().unwrap()).is_err());
+    }
+}
+#[test]
+fn source_refinement_bounds_and_single_revision_are_explicit() {
+    let (parent, refined, _) = pair();
+    assert!(refined
+        .refine_source_routing(&documents(), config(32))
+        .is_err());
+    assert!(parent
+        .refine_source_routing(&documents(), config(8))
+        .is_err());
+    let mut changed_context = config(32);
+    changed_context.role_context_only = false;
+    assert!(parent
+        .refine_source_routing(&documents(), changed_context)
+        .is_err());
+    assert!(parent.refine_source_routing(&[], config(32)).is_err());
+    assert!(parent.source_routing_trace(&"x".repeat(65537)).is_err());
+}
+#[test]
+fn source_refinement_trace_scores_match_selected_direct_choice() {
+    let (_, refined, _) = pair();
+    let trace = refined
+        .source_routing_trace(&documents()[0].prompt)
+        .unwrap();
+    assert_eq!(trace["direct_source_dispatch"], true);
+    let selected = trace["direct_choice"].as_array().unwrap();
+    let source = selected[0].as_u64().unwrap();
+    let action = selected[1].as_u64().unwrap();
+    let score = selected[2].as_i64().unwrap();
+    let mut first_best = None;
+    for candidate in trace["candidates"].as_array().unwrap() {
+        for scored in candidate["scores"].as_array().unwrap() {
+            let value = scored["score"].as_i64().unwrap();
+            if first_best.is_none_or(|(_, _, prior)| value > prior) {
+                first_best = Some((
+                    candidate["source"].as_u64().unwrap(),
+                    scored["action"].as_u64().unwrap(),
+                    value,
+                ));
+            }
+        }
+    }
+    assert_eq!(first_best, Some((source, action, score)));
+}

--- a/crates/uor-r4-core/src/native_geometric/source_routing.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_routing.rs
@@ -26,6 +26,14 @@ pub(super) struct SourceRouting {
     pub training: Vec<DocumentReceipt>,
     pub config: SourceRoutingConfig,
 }
+/// A single, nonexecuting replacement witness. Descendant components remain
+/// exactly as trained; restoring `previous` reconstructs their frozen parent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SourceRoutingRefinement {
+    pub parent_artifact: String,
+    pub previous: SourceRouting,
+}
 impl SourceRouting {
     pub(super) fn encode(
         &self,

--- a/crates/uor-r4-core/src/native_geometric/source_routing_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_routing_training.rs
@@ -121,6 +121,30 @@ impl Objective {
     }
 }
 
+// A feature-sequence alias is descriptive: it need not make the entire frame
+// impossible if another positive alternative remains distinguishable.
+fn feature_alias_frames(frames: &[Frame], codes: &[SourceCode]) -> usize {
+    frames
+        .iter()
+        .filter(|frame| {
+            let mut seen = BTreeMap::new();
+            frame.alternatives.iter().any(|alternative| {
+                let sequence: Vec<_> = alternative
+                    .features
+                    .iter()
+                    .filter_map(|feature| {
+                        codes
+                            .binary_search_by_key(feature, |code| code.feature)
+                            .ok()
+                    })
+                    .collect();
+                seen.insert((alternative.action, sequence), alternative.correct)
+                    .is_some_and(|prior| prior != alternative.correct)
+            })
+        })
+        .count()
+}
+
 fn objective(model: &Model, block: &SourceRouting, frames: &[Frame]) -> Objective {
     let mut result = Objective {
         correct: 0,
@@ -183,9 +207,29 @@ impl Model {
         docs: &[ValueExample],
         config: SourceRoutingConfig,
     ) -> Result<(Model, serde_json::Value)> {
+        self.fit_source_routing_mode(docs, config, false)
+    }
+
+    /// Refine the existing source/action router in place. Only one refinement
+    /// is supported; the exact frozen parent is retained as a load-time witness.
+    pub fn refine_source_routing(
+        &self,
+        docs: &[ValueExample],
+        config: SourceRoutingConfig,
+    ) -> Result<(Model, serde_json::Value)> {
+        self.fit_source_routing_mode(docs, config, true)
+    }
+
+    fn fit_source_routing_mode(
+        &self,
+        docs: &[ValueExample],
+        config: SourceRoutingConfig,
+        refine: bool,
+    ) -> Result<(Model, serde_json::Value)> {
         config.validate()?;
         self.validate()?;
-        if self.source_routing.is_some()
+        if self.source_routing.is_some() != refine
+            || self.source_routing_refinement.is_some()
             || self.learned_routing.is_some()
             || docs.is_empty()
             || docs.len() > 1024
@@ -194,6 +238,19 @@ impl Model {
                 .any(|d| d.prompt.len() + d.response.len() > 65536)
         {
             return Err(Error("source routing parent/source bound invalid".into()));
+        }
+        let previous = if refine {
+            self.source_routing.as_ref()
+        } else {
+            None
+        };
+        if previous.is_some_and(|old| {
+            old.codes.len() > config.learned_features
+                || old.config.role_context_only != config.role_context_only
+        }) {
+            return Err(Error(
+                "source refinement must retain feature vocabulary/context".into(),
+            ));
         }
         let read = role_read::head(self)
             .ok_or_else(|| Error("source routing needs accepted reader".into()))?;
@@ -204,6 +261,7 @@ impl Model {
         let mut ids = BTreeSet::new();
         let mut skipped = 0;
         let mut persistent = 0;
+        let mut dependent = 0;
         let mut unreachable = Vec::new();
         for doc in docs {
             if doc.id.trim().is_empty() || !ids.insert(&doc.id) {
@@ -233,6 +291,18 @@ impl Model {
                 .ok_or_else(|| Error("missing entry state".into()))?;
             if !super::word_copy_runtime::eligible(self, entry, values, Control::Full) {
                 skipped += 1;
+                continue;
+            }
+            if refine
+                && super::dependent_read::choose(
+                    self,
+                    values,
+                    Control::Full,
+                    &mut WordCopyWork::default(),
+                )
+                .is_some()
+            {
+                dependent += 1;
                 continue;
             }
             if super::relation::read_choice(self, values, &mut ValueWork::default()).is_some() {
@@ -330,7 +400,44 @@ impl Model {
             .map(|(f, n)| (*f, salience.get(f).copied().unwrap_or(0), *n))
             .collect();
         vocabulary.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)).then(a.0.cmp(&b.0)));
-        vocabulary.truncate(config.learned_features);
+        if let Some(old) = previous {
+            let retained: BTreeSet<_> = old.codes.iter().map(|c| c.feature).collect();
+            let mut contrast = BTreeMap::<ValueFeature, usize>::new();
+            for frame in &frames {
+                let mut counts = BTreeMap::<ValueFeature, (usize, usize)>::new();
+                let positives = frame.alternatives.iter().filter(|a| a.correct).count();
+                let negatives = frame.alternatives.len() - positives;
+                for a in &frame.alternatives {
+                    for feature in a.features.iter().copied().collect::<BTreeSet<_>>() {
+                        let count = counts.entry(feature).or_default();
+                        if a.correct {
+                            count.0 += 1;
+                        } else {
+                            count.1 += 1;
+                        }
+                    }
+                }
+                for (feature, (positive, negative)) in counts {
+                    if positive * negatives != negative * positives {
+                        *contrast.entry(feature).or_default() += 1;
+                    }
+                }
+            }
+            vocabulary.retain(|v| !retained.contains(&v.0));
+            vocabulary.sort_by(|a, b| {
+                contrast
+                    .get(&b.0)
+                    .copied()
+                    .unwrap_or(0)
+                    .cmp(&contrast.get(&a.0).copied().unwrap_or(0))
+                    .then(b.2.cmp(&a.2))
+                    .then(a.0.cmp(&b.0))
+            });
+            vocabulary.truncate(config.learned_features - old.codes.len());
+            vocabulary.extend(old.codes.iter().map(|c| (c.feature, 0, 0)));
+        } else {
+            vocabulary.truncate(config.learned_features);
+        }
         vocabulary.sort_by_key(|v| v.0);
         let mut rng = config.seed;
         let mut block = SourceRouting {
@@ -340,7 +447,14 @@ impl Model {
                 .iter()
                 .map(|v| SourceCode {
                     feature: v.0,
-                    roots: [self.geometry.identity; LANES],
+                    roots: previous
+                        .and_then(|old| {
+                            old.codes
+                                .binary_search_by_key(&v.0, |c| c.feature)
+                                .ok()
+                                .map(|index| old.codes[index].roots)
+                        })
+                        .unwrap_or([self.geometry.identity; LANES]),
                 })
                 .collect(),
             landmarks: (0..read.actions.len())
@@ -355,15 +469,55 @@ impl Model {
             training: receipts,
             config: config.clone(),
         };
+        if let Some(old) = previous {
+            block.landmarks.clone_from(&old.landmarks);
+            block.biases.clone_from(&old.biases);
+        }
+        let warm_initialization_preserved = previous.is_none_or(|old| {
+            block.landmarks == old.landmarks
+                && block.biases == old.biases
+                && old.codes.iter().all(|code| {
+                    block
+                        .codes
+                        .binary_search_by_key(&code.feature, |c| c.feature)
+                        .is_ok_and(|index| block.codes[index] == *code)
+                })
+        });
+        let warm_feature_alias_frames =
+            previous.map(|old| feature_alias_frames(&frames, &old.codes));
+        let expanded_feature_alias_frames = feature_alias_frames(&frames, &block.codes);
         let learned = learn(self, &mut block, &mut frames, start);
         let block_bytes = serde_json::to_vec(&block)
             .map_err(|e| Error(e.to_string()))?
             .len();
         let mut model = self.clone();
         model.source_routing = Some(block);
+        if let Some(old) = previous {
+            model.source_routing_refinement =
+                Some(super::source_routing::SourceRoutingRefinement {
+                    parent_artifact: self.artifact_cid.clone(),
+                    previous: old.clone(),
+                });
+        }
         model.refresh_identity()?;
         model.validate()?;
         let mut report = serde_json::json!({"schema":"uor-r4.source-routing-fit/1","parent":self.artifact_cid(),"artifact":model.artifact_cid(),"config":config,"documents":docs.len(),"frames":frames.len(),"skipped_upstream":skipped,"preserved_persistent_dispatch":persistent,"unreachable_targets":unreachable,"feature_universe":frequency.len(),"features":vocabulary.len(),"elapsed_ms":start.elapsed().as_millis(),"block_bytes":block_bytes,"scope":"Source/action labels from supplied construction responses; accepted reader weights select feature vocabulary only. Ordered two-channel H4 composition and action landmarks learned with hard serving decisions. Persistent-reader dispatch and numeric eligibility are unchanged. Construction selection is not generation/transfer."});
+        report["refinement"] = serde_json::json!(refine);
+        report["warm_feature_alias_frames"] = serde_json::json!(warm_feature_alias_frames);
+        report["expanded_feature_alias_frames"] = serde_json::json!(expanded_feature_alias_frames);
+        if refine {
+            report["scope"] = serde_json::json!("One warm in-place source/action refinement on exact assembled-parent sessions; all inherited code features retained, added vocabulary ranked by construction label contrasts and frequency. Descendant parameters and original training parent CIDs remain unchanged, verified by exact parent reconstruction. Feature alias counts are descriptive, not frame solvability or generation acceptance.");
+        }
+        report["warm_initialization_preserved"] = serde_json::json!(warm_initialization_preserved);
+        report["preserved_dependent_dispatch"] = serde_json::json!(dependent);
+        report["warm_features"] = serde_json::json!(previous.map_or(0, |old| old.codes.len()));
+        report["added_features"] =
+            serde_json::json!(vocabulary.len() - previous.map_or(0, |old| old.codes.len()));
+        report["parent_reconstruction"] = serde_json::json!(if refine {
+            "EXACT_FROZEN_PARENT"
+        } else {
+            "INITIAL_FIT"
+        });
         if let (Some(r), Some(l)) = (report.as_object_mut(), learned.as_object()) {
             r.extend(l.clone());
         }
@@ -445,4 +599,103 @@ pub(super) fn learn(
     }
 
     serde_json::json!({"initial_correct":initial.correct,"final_correct":best.correct,"initial_hinge":initial.hinge,"final_hinge":best.hinge,"proposals":proposals,"accepted":accepted,"stopped_at_time_limit":stopped})
+}
+
+impl Model {
+    /// Offline, allocating inspection of the existing first source decision.
+    /// Candidate scores are joint action scores, not calibrated language scores.
+    /// This does not alter the model, session cache, or serving feature law.
+    pub fn source_routing_trace(&self, prompt: &str) -> Result<serde_json::Value> {
+        let block = self
+            .source_routing
+            .as_ref()
+            .ok_or_else(|| Error("source trace requires source router".into()))?;
+        if prompt.len() > 65536 {
+            return Err(Error("source trace prompt exceeds bound".into()));
+        }
+        let mut session = self.session(Control::Full)?;
+        session.observe(self, BOS)?;
+        for token in self.encode(prompt)? {
+            session.observe(self, token)?;
+        }
+        session.begin_response(self)?;
+        let prediction = session.predict(self)?;
+        let values = session
+            .values
+            .as_ref()
+            .ok_or_else(|| Error("source trace retained values absent".into()))?;
+        let words = values
+            .lexemes
+            .as_ref()
+            .ok_or_else(|| Error("source trace retained words absent".into()))?;
+        let read =
+            role_read::head(self).ok_or_else(|| Error("source trace role reader absent".into()))?;
+        let entry = session
+            .response_entry
+            .as_ref()
+            .ok_or_else(|| Error("source trace response entry absent".into()))?;
+        let eligible = super::word_copy_runtime::eligible(self, entry, values, Control::Full);
+        let dependent = super::dependent_read::choose(
+            self,
+            values,
+            Control::Full,
+            &mut WordCopyWork::default(),
+        );
+        let persistent = super::relation::read_choice(self, values, &mut ValueWork::default());
+        let feature_control = if block.config.role_context_only {
+            Control::WordCopyGeometryDisabled
+        } else {
+            Control::Full
+        };
+        let mut work = WordCopyWork::default();
+        let ctx = role_read::context(self, values, feature_control, &mut work);
+        let mut candidates = Vec::new();
+        for index in 0..=words.query_len {
+            let source = if index == words.query_len {
+                NO_SOURCE
+            } else {
+                index as u8
+            };
+            let (features, n) =
+                role_read::features(self, values, &ctx, index, feature_control, &mut work);
+            let state = block.encode(self, &features[..n], Control::Full, &mut work.routing);
+            let mapped: Vec<_> =
+                features[..n]
+                    .iter()
+                    .filter_map(|feature| {
+                        block.codes.binary_search_by_key(feature, |c| c.feature).ok().map(|i| {
+                    serde_json::json!({"feature":feature,"roots":block.codes[i].roots})
+                })
+                    })
+                    .collect();
+            let mut scores = Vec::new();
+            for action in 0..read.actions.len() {
+                if super::source_routing::allowed(self, values, source, action) {
+                    scores.push(serde_json::json!({
+                        "action":action,"copy":read.actions[action].copy,
+                        "prefix":read.actions[action].prefix,
+                        "score":block.score(self, state, action, &mut work.routing)
+                    }));
+                }
+            }
+            let word = (index < words.query_len).then(|| &words.queries[index]);
+            candidates.push(serde_json::json!({
+                "source":source,
+                "word":word.map(|w| String::from_utf8_lossy(&w.bytes[..usize::from(w.len)]).into_owned()),
+                "address":if index < words.query_len {ctx.addresses[index]} else {0},
+                "source_end":word.map(|w| w.end),"source_byte_end":word.map(|w| w.byte_end),
+                "features":&features[..n],"mapped_codes":mapped,"state":state,"scores":scores
+            }));
+        }
+        Ok(serde_json::json!({
+            "schema":"uor-r4.source-routing-trace/1", "artifact":self.artifact_cid(),
+            "prompt":prompt,"prediction_token":prediction.token,
+            "actual_word_copy_decision":session.word_copy_decision(),
+            "direct_source_dispatch":eligible && dependent.is_none() && persistent.is_none(),
+            "word_copy_eligible":eligible,"dependent_choice":dependent,"persistent_choice":persistent,
+            "direct_choice":super::source_routing::choose(self, values, Control::Full, &mut WordCopyWork::default()),
+            "candidates":candidates,
+            "scope":"Allocating offline inspection; counterfactual direct candidates are marked when upstream dispatch bypasses this router."
+        }))
+    }
 }

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -181,6 +181,7 @@ impl Trainer {
             no_read_completion: None,
             typed_literals: None,
             source_routing: None,
+            source_routing_refinement: None,
             learned_routing: None,
             schema: SCHEMA.into(),
             artifact_cid: String::new(),
@@ -514,6 +515,45 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(witness) = &self.source_routing_refinement {
+            let block = self
+                .source_routing
+                .as_ref()
+                .ok_or_else(|| Error("source refinement router absent".into()))?;
+            if self.learned_routing.is_some()
+                || block.parent_artifact != witness.parent_artifact
+                || block.config.role_context_only != witness.previous.config.role_context_only
+                || block.codes.len() < witness.previous.codes.len()
+                || witness.previous.codes.iter().any(|old| {
+                    block
+                        .codes
+                        .binary_search_by_key(&old.feature, |c| c.feature)
+                        .is_err()
+                })
+            {
+                return Err(Error("invalid source refinement composition".into()));
+            }
+            // The witness is load-time provenance, never another executing head.
+            // Restoring the only replaced component must recover the entire
+            // exact training parent, including every descendant's original CID.
+            let mut parent = self.clone();
+            parent.source_routing_refinement = None;
+            parent.source_routing = Some(witness.previous.clone());
+            parent.refresh_identity()?;
+            if parent.artifact_cid != witness.parent_artifact {
+                return Err(Error("source refinement frozen parent differs".into()));
+            }
+            parent.validate()?;
+            block.validate(self)?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("source refinement identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(head) = &self.no_read_completion {
             if head.copy.is_some() || super::role_read::head(self).is_none() {
                 return Err(Error(

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -1347,6 +1347,15 @@ fn native_independent_artifact_is_allocation_free() {
             parent["artifact_cid"]
         );
         let mut protected = wire.clone();
+        // A source-only refinement retains the exact earlier router as its
+        // provenance witness; restore it before checking the literal parent.
+        if let Some(witness) = protected
+            .as_object_mut()
+            .unwrap()
+            .remove("source_routing_refinement")
+        {
+            protected["source_routing"] = witness["previous"].clone();
+        }
         protected.as_object_mut().unwrap().remove("typed_literals");
         protected
             .as_object_mut()
@@ -1430,4 +1439,159 @@ fn native_no_read_artifact_is_allocation_free() {
         checkpoint
     );
     println!("actual NoRead answer: exact bytes and EOS; allocations=0 bytes=0; complete parent equality and checkpoint roundtrip PASS");
+}
+
+/// Exercises the fitted replacement router itself, including the observation
+/// boundary that turns a transient source choice into a committed copy/NoRead.
+#[test]
+#[ignore = "requires R4_SOURCE_NO_READ_MODEL and R4_SOURCE_NO_READ_PARENT artifacts"]
+fn native_source_no_read_artifact_is_allocation_free_and_causal() {
+    use uor_r4_core::native_geometric::Model;
+    let bytes = std::fs::read(std::env::var("R4_SOURCE_NO_READ_MODEL").unwrap()).unwrap();
+    let model = Model::from_bytes(&bytes).unwrap();
+    let mut wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let mut parent: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(std::env::var("R4_SOURCE_NO_READ_PARENT").unwrap()).unwrap(),
+    )
+    .unwrap();
+    let witness = wire
+        .as_object_mut()
+        .unwrap()
+        .remove("source_routing_refinement")
+        .expect("actual replacement-router provenance");
+    assert_eq!(witness["parent_artifact"], parent["artifact_cid"]);
+    assert_eq!(witness["previous"], parent["source_routing"]);
+    wire["source_routing"] = witness["previous"].clone();
+    for document in [&mut wire, &mut parent] {
+        for key in ["artifact_cid", "uor_model_address"] {
+            document.as_object_mut().unwrap().remove(key);
+        }
+    }
+    assert_eq!(
+        wire, parent,
+        "all fields outside the replaced router are unchanged"
+    );
+
+    let cases = [
+        (
+            "User: varo has -5 coins. leni has 17 coins. tavi has 301 coins.\nUser: Where is the location of leni?\nAssistant:",
+            b" Unknown.\n".as_slice(),
+            false,
+        ),
+        (
+            "User: varo has stones. leni has coins.\nUser: What does leni have?\nAssistant:",
+            b" coins.\n".as_slice(),
+            true,
+        ),
+    ];
+    for (prompt, expected, supported) in cases {
+        let tokens = model.encode(prompt).unwrap();
+        let mut session = model.session(Control::Full).unwrap();
+        ALLOCATIONS.with(|v| v.set(0));
+        BYTES.with(|v| v.set(0));
+        MEASURING.with(|v| v.set(true));
+        let ingest = (|| {
+            session.observe(&model, BOS)?;
+            for &token in &tokens {
+                session.observe(&model, token)?;
+            }
+            session.begin_response(&model)
+        })();
+        MEASURING.with(|v| v.set(false));
+        ingest.unwrap();
+        let boundary = session.checkpoint().unwrap();
+        let before: serde_json::Value = serde_json::from_slice(&boundary).unwrap();
+        assert!(before["word_copy"]["read_commit"].is_null());
+        let commits = session.work.word_copy.selector.commits;
+
+        MEASURING.with(|v| v.set(true));
+        let first = session.predict(&model);
+        let selected = session.word_copy_decision();
+        let repeated = session.predict(&model);
+        let repeated_choice = session.word_copy_decision();
+        MEASURING.with(|v| v.set(false));
+        let first = first.unwrap();
+        assert_eq!(first, repeated.unwrap());
+        let selected = selected.expect("joint source or NoRead selection exercised");
+        assert_eq!(Some(selected), repeated_choice);
+        assert_eq!(session.work.word_copy.selector.commits, commits);
+        assert_eq!(selected.action == WordCopyAction::NoRead, !supported);
+        if supported {
+            assert!(matches!(
+                selected.action,
+                WordCopyAction::Read | WordCopyAction::Prepare
+            ));
+        }
+        let transient: serde_json::Value =
+            serde_json::from_slice(&session.checkpoint().unwrap()).unwrap();
+        assert_eq!(
+            transient["word_copy"], before["word_copy"],
+            "prediction cannot commit a source"
+        );
+
+        MEASURING.with(|v| v.set(true));
+        let observed = session.observe(&model, first.token);
+        MEASURING.with(|v| v.set(false));
+        observed.unwrap();
+        assert_eq!(session.work.word_copy.selector.commits, commits + 1);
+        let committed = session.checkpoint().unwrap();
+        let state: serde_json::Value = serde_json::from_slice(&committed).unwrap();
+        let read = &state["word_copy"]["read_commit"];
+        assert!(read.is_object());
+        assert_eq!(read["token"], serde_json::json!(first.token));
+        assert_eq!(read["source_end"], serde_json::json!(selected.source_end));
+        assert_eq!(
+            read["source_byte_end"],
+            serde_json::json!(selected.source_byte_end)
+        );
+        if supported {
+            assert_eq!(read["source"], serde_json::json!(selected.word_index));
+        } else {
+            assert!(read["source"].is_null());
+        }
+        assert_eq!(
+            model
+                .restore_session(&committed)
+                .unwrap()
+                .checkpoint()
+                .unwrap(),
+            committed
+        );
+
+        let mut output = [EOS; 32];
+        output[0] = first.token;
+        let mut length = 1;
+        MEASURING.with(|v| v.set(true));
+        let generated = (|| {
+            while output[length - 1] != EOS && length < output.len() {
+                let token = session.predict(&model)?.token;
+                session.observe(&model, token)?;
+                output[length] = token;
+                length += 1;
+            }
+            session.end_response(&model)
+        })();
+        MEASURING.with(|v| v.set(false));
+        generated.unwrap();
+        assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+        assert_eq!(output[length - 1], EOS, "complete answer must terminate");
+        assert_eq!(model.decode(&output[..length]).unwrap(), expected);
+
+        // Restore an uncommitted boundary and observe a different legal byte.
+        // Checkpoint parsing/serialization are deliberately outside the census.
+        let mut mismatch = model.restore_session(&boundary).unwrap();
+        let predicted = mismatch.predict(&model).unwrap();
+        let mismatch_commits = mismatch.work.word_copy.selector.commits;
+        let other = if predicted.token == u32::from(b'x') + 2 {
+            u32::from(b'y') + 2
+        } else {
+            u32::from(b'x') + 2
+        };
+        mismatch.observe(&model, other).unwrap();
+        assert_eq!(mismatch.work.word_copy.selector.commits, mismatch_commits);
+        let mismatch_state: serde_json::Value =
+            serde_json::from_slice(&mismatch.checkpoint().unwrap()).unwrap();
+        assert!(mismatch_state["word_copy"]["read_commit"].is_null());
+    }
+    println!("actual source/NoRead: unsupported and supported complete answers; allocations=0 bytes=0; transient/matching/mismatched commit, checkpoint restore and full parent lineage PASS");
 }

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,6 +1,27 @@
 # Research: what is measured, what is closed, what is open
 
-## Literal-context NoRead completion — current bounded checkpoint, 2026-09-06
+## Supported-source and NoRead selection — current bounded checkpoint, 2026-09-06
+
+The [source refinement](native_geometric_source_noread_1139.md) retains
+`d59070c2`, replacing the existing router while preserving every downstream
+parameter and the exact `e7c14c99` training parent through a nonexecuting witness.
+Warm continuation with128 features reaches384/384 eligible construction choices
+and20/20 new complete source/abstention answers, versus14/20 parent and10/20
+matched exact-code continuation. All20 new cases use the direct source router.
+Earlier literal answers improve to16/16 on both sets and103/103 construction;
+computed, identifier, durable-memory and long-context preservation passes.
+
+Combined construction is551/603 versus545/603, with no lost correct answer;
+all52 remaining wrong outputs equal the parent. Inherited numeric admission
+still takes over some word/identifier requests, including a supported location
+that emits13 instead of Paris. Four focused tests and actual zero-allocation
+source/NoRead and three-turn computation checks pass. Added routing work and
+shorter corrected outputs are accounted separately. This is bounded evidence
+for the selected angular continuation, not general abstention, syntax, prose,
+reasoning or whole-model laptop advantage. Next: joint numerical/word admission
+feeding the existing selected operators, then broader #1139/#1140 composition.
+
+## Literal-context NoRead completion — previous bounded checkpoint, 2026-09-06
 
 The [committed continuation](native_geometric_no_read_completion_1139.md)
 retains `e7c14c99` at literal-numeric NoRead scope, with the complete `c29ab982`

--- a/docs/evidence/native_geometric_source_noread_1139.json
+++ b/docs/evidence/native_geometric_source_noread_1139.json
@@ -1,0 +1,1549 @@
+{
+  "schema": "uor-r4.native-source-noread-evidence/1",
+  "at": "2026-09-07T01:47:03.729447+00:00",
+  "base_pr": 1159,
+  "base_merged_commit": "be32b4103d8f870f8b1f81057c451a609156172e",
+  "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+  "parent": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+  "control": "blake3:369c97f136fd71b919e0086e6f8d2e6b336dd4b401b9bbea22aa5764932a3f06",
+  "decision": "RETAIN_BOUNDED_SUPPORTED_SOURCE_NO_READ",
+  "artifacts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/answer-entry-final/model.json",
+      "bytes": 11212853,
+      "sha256": "d8b54a54966dfc4c7d5d1fc0a2bc3de371eb4f5cd5a78508958a8e7873c9916e"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-angular128/model.json",
+      "bytes": 11304530,
+      "sha256": "a54a98f77e65b704a4d1afa47a755a440f535bf13e993331410665fbb0c6951c"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality128/model.json",
+      "bytes": 11304514,
+      "sha256": "30c3d3f515eb530b66dcdf7b51b4de26adbb7fddb57148a0ad95eaf0cdfebfaa"
+    }
+  ],
+  "source": [
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/mod.rs",
+      "bytes": 19767,
+      "sha256": "b462bcc21046e47da2f66fa61204e28ffb26852723ca60dd27e763bf96b40431"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/training.rs",
+      "bytes": 47500,
+      "sha256": "3874338d156a9a3240bbeda3615042e3b68820055edffa79e7cc29a55394e440"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/source_routing.rs",
+      "bytes": 6625,
+      "sha256": "47604abbf424c7bad5660e940e8f8655f5af907e833227cac2614da8ae9baac4"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/source_routing_training.rs",
+      "bytes": 29731,
+      "sha256": "20ef2b9a441498ba1d5f572a2e6935bf966735e427c71242356a29fb7efc578d"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/src/native_geometric/source_refinement_tests.rs",
+      "bytes": 4969,
+      "sha256": "4135f723a9bd1fcde296068234fcd8f2227dcd7b7372d4643a7361fb4b240574"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+      "bytes": 71270,
+      "sha256": "d4876e05a0d166ff4590c5ba4311f76046bd78df68091328286198dc4b0c1014"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/examples/native_geometric_value_probe/source_noread.rs",
+      "bytes": 10451,
+      "sha256": "477f1ca80203d9c1b8bbe1d900622a19dc2b1325caa41bd0201e5a61a68c7549"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/examples/native_geometric_value_probe/writer_binding.rs",
+      "bytes": 17298,
+      "sha256": "21db433e5f7bbeb2aa002cb5d839e560e17733b1650be4cf3eef2a0f2fe0856c"
+    },
+    {
+      "path": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4/crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "bytes": 62199,
+      "sha256": "edf29711eb0b6ebcf518cd5784a3baecf154341b9d1a216a1a8ee71eb174edde"
+    }
+  ],
+  "fits": {
+    "angular": {
+      "accepted": [
+        8,
+        0,
+        0
+      ],
+      "added_features": 64,
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "block_bytes": 91543,
+      "config": {
+        "learned_features": 128,
+        "max_seconds": 45,
+        "mode": "angular",
+        "passes": 4,
+        "proposals": 12,
+        "role_context_only": true,
+        "seed": 1139
+      },
+      "documents": 603,
+      "elapsed_ms": 10860,
+      "expanded_feature_alias_frames": 0,
+      "feature_universe": 1921,
+      "features": 128,
+      "final_correct": 384,
+      "final_hinge": 0,
+      "frames": 384,
+      "initial_correct": 378,
+      "initial_hinge": 14,
+      "parent": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "parent_reconstruction": "EXACT_FROZEN_PARENT",
+      "preserved_dependent_dispatch": 0,
+      "preserved_persistent_dispatch": 0,
+      "proposals": 15867,
+      "refinement": true,
+      "schema": "uor-r4.source-routing-fit/1",
+      "scope": "One warm in-place source/action refinement on exact assembled-parent sessions; all inherited code features retained, added vocabulary ranked by construction label contrasts and frequency. Descendant parameters and original training parent CIDs remain unchanged, verified by exact parent reconstruction. Feature alias counts are descriptive, not frame solvability or generation acceptance.",
+      "skipped_upstream": 211,
+      "stopped_at_time_limit": false,
+      "unreachable_targets": [
+        "typed-value/fit/rust/copy_current/0/source_names_swapped",
+        "typed-value/fit/rust/copy_current/1/source_names_swapped",
+        "typed-value/fit/rust/copy_current/4/source_names_swapped",
+        "typed-value/fit/rust/copy_current/5/source_names_swapped",
+        "typed-value/fit/rust/copy_current/8/source_names_swapped",
+        "typed-value/fit/rust/copy_current/9/source_names_swapped",
+        "typed-value/fit/rust/copy_current/12/source_names_swapped",
+        "typed-value/fit/rust/copy_current/13/source_names_swapped"
+      ],
+      "warm_feature_alias_frames": 20,
+      "warm_features": 64,
+      "warm_initialization_preserved": true
+    },
+    "equality": {
+      "accepted": [
+        26,
+        2,
+        2
+      ],
+      "added_features": 64,
+      "artifact": "blake3:369c97f136fd71b919e0086e6f8d2e6b336dd4b401b9bbea22aa5764932a3f06",
+      "block_bytes": 91527,
+      "config": {
+        "learned_features": 128,
+        "max_seconds": 45,
+        "mode": "equality",
+        "passes": 4,
+        "proposals": 12,
+        "role_context_only": true,
+        "seed": 1139
+      },
+      "documents": 603,
+      "elapsed_ms": 10701,
+      "expanded_feature_alias_frames": 0,
+      "feature_universe": 1921,
+      "features": 128,
+      "final_correct": 333,
+      "final_hinge": 151,
+      "frames": 384,
+      "initial_correct": 92,
+      "initial_hinge": 1557,
+      "parent": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "parent_reconstruction": "EXACT_FROZEN_PARENT",
+      "preserved_dependent_dispatch": 0,
+      "preserved_persistent_dispatch": 0,
+      "proposals": 15921,
+      "refinement": true,
+      "schema": "uor-r4.source-routing-fit/1",
+      "scope": "One warm in-place source/action refinement on exact assembled-parent sessions; all inherited code features retained, added vocabulary ranked by construction label contrasts and frequency. Descendant parameters and original training parent CIDs remain unchanged, verified by exact parent reconstruction. Feature alias counts are descriptive, not frame solvability or generation acceptance.",
+      "skipped_upstream": 211,
+      "stopped_at_time_limit": false,
+      "unreachable_targets": [
+        "typed-value/fit/rust/copy_current/0/source_names_swapped",
+        "typed-value/fit/rust/copy_current/1/source_names_swapped",
+        "typed-value/fit/rust/copy_current/4/source_names_swapped",
+        "typed-value/fit/rust/copy_current/5/source_names_swapped",
+        "typed-value/fit/rust/copy_current/8/source_names_swapped",
+        "typed-value/fit/rust/copy_current/9/source_names_swapped",
+        "typed-value/fit/rust/copy_current/12/source_names_swapped",
+        "typed-value/fit/rust/copy_current/13/source_names_swapped"
+      ],
+      "warm_feature_alias_frames": 20,
+      "warm_features": 64,
+      "warm_initialization_preserved": true
+    }
+  },
+  "reports": {
+    "source-noread-angular128/construction.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-angular128/construction.json",
+      "bytes": 13033980,
+      "sha256": "2b3b746e393cedd53a8112e4207962f51d4a45f33cd014c4ea64dfc892513fc6",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 551,
+      "total": 603,
+      "writes_exact": null,
+      "failed_ids": [
+        "typed-value/fit/prose/add/0/source_names_swapped",
+        "typed-value/fit/rust/copy_current/0/source_names_swapped",
+        "typed-value/fit/rust/add/0/source_names_swapped",
+        "typed-value/fit/prose/add/1/source_names_swapped",
+        "typed-value/fit/rust/copy_current/1/source_names_swapped",
+        "typed-value/fit/rust/add/1/source_names_swapped",
+        "typed-value/fit/prose/add/2/source_names_swapped",
+        "typed-value/fit/rust/copy_current/2/source_names_swapped",
+        "typed-value/fit/rust/add/2/source_names_swapped",
+        "typed-value/fit/prose/add/3/source_names_swapped",
+        "typed-value/fit/rust/copy_current/3/source_names_swapped",
+        "typed-value/fit/rust/add/3/source_names_swapped",
+        "typed-value/fit/prose/add/4/source_names_swapped",
+        "typed-value/fit/rust/copy_current/4/source_names_swapped",
+        "typed-value/fit/rust/add/4/source_names_swapped",
+        "typed-value/fit/prose/add/5/source_names_swapped",
+        "typed-value/fit/rust/copy_current/5/source_names_swapped",
+        "typed-value/fit/rust/add/5/source_names_swapped",
+        "typed-value/fit/prose/add/6/source_names_swapped",
+        "typed-value/fit/rust/copy_current/6/source_names_swapped",
+        "typed-value/fit/rust/add/6/source_names_swapped",
+        "typed-value/fit/prose/add/7/source_names_swapped",
+        "typed-value/fit/rust/copy_current/7/source_names_swapped",
+        "typed-value/fit/rust/add/7/source_names_swapped",
+        "typed-value/fit/prose/add/8/source_names_swapped",
+        "typed-value/fit/rust/copy_current/8/source_names_swapped",
+        "typed-value/fit/rust/add/8/source_names_swapped",
+        "typed-value/fit/prose/add/9/source_names_swapped",
+        "typed-value/fit/rust/copy_current/9/source_names_swapped",
+        "typed-value/fit/rust/add/9/source_names_swapped",
+        "typed-value/fit/prose/add/10/source_names_swapped",
+        "typed-value/fit/rust/copy_current/10/source_names_swapped",
+        "typed-value/fit/rust/add/10/source_names_swapped",
+        "typed-value/fit/prose/add/11/source_names_swapped",
+        "typed-value/fit/rust/copy_current/11/source_names_swapped",
+        "typed-value/fit/rust/add/11/source_names_swapped",
+        "typed-value/fit/prose/add/12/source_names_swapped",
+        "typed-value/fit/rust/copy_current/12/source_names_swapped",
+        "typed-value/fit/rust/add/12/source_names_swapped",
+        "typed-value/fit/prose/add/13/source_names_swapped",
+        "typed-value/fit/rust/copy_current/13/source_names_swapped",
+        "typed-value/fit/rust/add/13/source_names_swapped",
+        "typed-value/fit/prose/add/14/source_names_swapped",
+        "typed-value/fit/rust/copy_current/14/source_names_swapped",
+        "typed-value/fit/rust/add/14/source_names_swapped",
+        "typed-value/fit/prose/add/15/source_names_swapped",
+        "typed-value/fit/rust/copy_current/15/source_names_swapped",
+        "typed-value/fit/rust/add/15/source_names_swapped",
+        "role-read/fit/0/5/1",
+        "role-read/fit/2/5/3",
+        "role-read/fit/3/5/2",
+        "source-joint-fit/1/false/true/0"
+      ]
+    },
+    "source-noread-angular128/development.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-angular128/development.json",
+      "bytes": 801081,
+      "sha256": "575fe9699fbe16f575e3a7f01d6715656e196614b3ce8b76f307aba69d6f0db9",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 14,
+      "total": 14,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-equality128/construction.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality128/construction.json",
+      "bytes": 12968214,
+      "sha256": "2cb61747a56007c72ef7f876e65ad9b5ebaf5ec33ed0ac36d197161769a96dc4",
+      "artifact": "blake3:369c97f136fd71b919e0086e6f8d2e6b336dd4b401b9bbea22aa5764932a3f06",
+      "exact": 500,
+      "total": 603,
+      "writes_exact": null,
+      "failed_ids": [
+        "typed-value/fit/prose/add/0/source_names_swapped",
+        "typed-value/fit/rust/copy_current/0/source_names_swapped",
+        "typed-value/fit/rust/add/0/source_names_swapped",
+        "typed-value/fit/prose/add/1/source_names_swapped",
+        "typed-value/fit/rust/copy_current/1/source_names_swapped",
+        "typed-value/fit/rust/add/1/source_names_swapped",
+        "typed-value/fit/prose/add/2/source_names_swapped",
+        "typed-value/fit/rust/copy_current/2/source_names_swapped",
+        "typed-value/fit/rust/add/2/source_names_swapped",
+        "typed-value/fit/prose/add/3/source_names_swapped",
+        "typed-value/fit/rust/copy_current/3/source_names_swapped",
+        "typed-value/fit/rust/add/3/source_names_swapped",
+        "typed-value/fit/prose/add/4/source_names_swapped",
+        "typed-value/fit/rust/copy_current/4/source_names_swapped",
+        "typed-value/fit/rust/add/4/source_names_swapped",
+        "typed-value/fit/prose/add/5/source_names_swapped",
+        "typed-value/fit/rust/copy_current/5/source_names_swapped",
+        "typed-value/fit/rust/add/5/source_names_swapped",
+        "typed-value/fit/prose/add/6/source_names_swapped",
+        "typed-value/fit/rust/copy_current/6/source_names_swapped",
+        "typed-value/fit/rust/add/6/source_names_swapped",
+        "typed-value/fit/prose/add/7/source_names_swapped",
+        "typed-value/fit/rust/copy_current/7/source_names_swapped",
+        "typed-value/fit/rust/add/7/source_names_swapped",
+        "typed-value/fit/prose/add/8/source_names_swapped",
+        "typed-value/fit/rust/copy_current/8/source_names_swapped",
+        "typed-value/fit/rust/add/8/source_names_swapped",
+        "typed-value/fit/prose/add/9/source_names_swapped",
+        "typed-value/fit/rust/copy_current/9/source_names_swapped",
+        "typed-value/fit/rust/add/9/source_names_swapped",
+        "typed-value/fit/prose/add/10/source_names_swapped",
+        "typed-value/fit/rust/copy_current/10/source_names_swapped",
+        "typed-value/fit/rust/add/10/source_names_swapped",
+        "typed-value/fit/prose/add/11/source_names_swapped",
+        "typed-value/fit/rust/copy_current/11/source_names_swapped",
+        "typed-value/fit/rust/add/11/source_names_swapped",
+        "typed-value/fit/prose/add/12/source_names_swapped",
+        "typed-value/fit/rust/copy_current/12/source_names_swapped",
+        "typed-value/fit/rust/add/12/source_names_swapped",
+        "typed-value/fit/prose/add/13/source_names_swapped",
+        "typed-value/fit/rust/copy_current/13/source_names_swapped",
+        "typed-value/fit/rust/add/13/source_names_swapped",
+        "typed-value/fit/prose/add/14/source_names_swapped",
+        "typed-value/fit/rust/copy_current/14/source_names_swapped",
+        "typed-value/fit/rust/add/14/source_names_swapped",
+        "typed-value/fit/prose/add/15/source_names_swapped",
+        "typed-value/fit/rust/copy_current/15/source_names_swapped",
+        "typed-value/fit/rust/add/15/source_names_swapped",
+        "fact/fit/0/1/0",
+        "fact/fit/1/0/0",
+        "fact/fit/1/0/1",
+        "fact/fit/1/1/0",
+        "fact/fit/1/1/1",
+        "fact/fit/1/2/0",
+        "fact/fit/2/1/0",
+        "fact/fit/3/0/0",
+        "fact/fit/3/0/1",
+        "fact/fit/3/1/0",
+        "fact/fit/3/1/1",
+        "fact/fit/3/2/0",
+        "fact/fit/3/2/1",
+        "fact/fit/4/1/0",
+        "fact/fit/5/0/0",
+        "fact/fit/5/0/1",
+        "fact/fit/5/1/0",
+        "fact/fit/5/1/1",
+        "fact/fit/5/2/0",
+        "fact/fit/5/2/1",
+        "fact/fit/6/1/0",
+        "fact/fit/7/0/0",
+        "fact/fit/7/0/1",
+        "fact/fit/7/1/0",
+        "fact/fit/7/1/1",
+        "fact/fit/7/2/0",
+        "fact/fit/7/2/1",
+        "role-read/fit/0/1/0",
+        "role-read/fit/0/1/1",
+        "role-read/fit/0/1/3",
+        "role-read/fit/0/3/1",
+        "role-read/fit/0/5/1",
+        "role-read/fit/1/1/0",
+        "role-read/fit/1/1/1",
+        "role-read/fit/1/1/3",
+        "role-read/fit/1/3/1",
+        "role-read/fit/2/1/0",
+        "role-read/fit/2/1/1",
+        "role-read/fit/2/1/3",
+        "role-read/fit/2/3/1",
+        "role-read/fit/2/5/3",
+        "role-read/fit/3/1/0",
+        "role-read/fit/3/1/1",
+        "role-read/fit/3/1/3",
+        "role-read/fit/3/3/1",
+        "role-read/fit/3/5/2",
+        "source-joint-fit/0/false/true/1",
+        "source-joint-fit/0/false/supported-object",
+        "source-joint-fit/0/true/true/1",
+        "source-joint-fit/0/true/supported-object",
+        "source-joint-fit/1/false/true/0",
+        "source-joint-fit/1/false/true/1",
+        "source-joint-fit/1/false/supported-object",
+        "source-joint-fit/1/true/true/1",
+        "source-joint-fit/1/true/supported-object"
+      ]
+    },
+    "source-noread-equality128/development.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality128/development.json",
+      "bytes": 803194,
+      "sha256": "64a70b6fd12c14994f76bd0e5fc20c4f64f502d802e0b3936b577c36a2f82188",
+      "artifact": "blake3:369c97f136fd71b919e0086e6f8d2e6b336dd4b401b9bbea22aa5764932a3f06",
+      "exact": 9,
+      "total": 14,
+      "writes_exact": null,
+      "failed_ids": [
+        "source-joint-open/0/false/true/1",
+        "source-joint-open/0/false/supported-object",
+        "source-joint-open/0/true/true/0",
+        "source-joint-open/0/true/true/1",
+        "source-joint-open/0/true/supported-object"
+      ]
+    },
+    "source-noread-fresh128.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-fresh128.json",
+      "bytes": 1122022,
+      "sha256": "40b78ecae27c86b61509be5af87d513e3729f5db0a15cd1a1e72a406842f281b",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 20,
+      "total": 20,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-parent-fresh.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-fresh.json",
+      "bytes": 1024684,
+      "sha256": "37341fc72cc245d0baae7bb8aa1e2624c9ea102c72422ccedee4f3ad2a5ac25d",
+      "artifact": "blake3:e7c14c994c57eaad6c9a765c71e7699c0f7f0c88a225aea71e6e84c8b7da0e11",
+      "exact": 14,
+      "total": 20,
+      "writes_exact": null,
+      "failed_ids": [
+        "source-joint-reserved/0/false/false/1",
+        "source-joint-reserved/0/false/true/1",
+        "source-joint-reserved/0/true/true/0",
+        "source-joint-reserved/1/false/false/1",
+        "source-joint-reserved/1/false/true/1",
+        "source-joint-reserved/1/true/true/0"
+      ]
+    },
+    "source-noread-equality-fresh.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality-fresh.json",
+      "bytes": 1123502,
+      "sha256": "e9eadffd39b3dcc34fb891281f5f4950aaa65c0787c9a44fd0b7466b41387cf1",
+      "artifact": "blake3:369c97f136fd71b919e0086e6f8d2e6b336dd4b401b9bbea22aa5764932a3f06",
+      "exact": 10,
+      "total": 20,
+      "writes_exact": null,
+      "failed_ids": [
+        "source-joint-reserved/0/false/true/1",
+        "source-joint-reserved/0/false/supported-object",
+        "source-joint-reserved/0/true/true/0",
+        "source-joint-reserved/0/true/true/1",
+        "source-joint-reserved/0/true/supported-object",
+        "source-joint-reserved/1/false/true/1",
+        "source-joint-reserved/1/false/supported-object",
+        "source-joint-reserved/1/true/true/0",
+        "source-joint-reserved/1/true/true/1",
+        "source-joint-reserved/1/true/supported-object"
+      ]
+    },
+    "source-noread-preserve128/aliases.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/aliases.json",
+      "bytes": 688659,
+      "sha256": "91d965ec649c20df611816eb0ff6d13d42697f6b6aaaba295bd8e4f6f9ff61d2",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 12,
+      "total": 12,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/chains.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/chains.json",
+      "bytes": 912085,
+      "sha256": "15ee38850ce19650d1f3e0b7ab88fe8b371845e8ee6b87f4157e9212231e1d57",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 16,
+      "total": 16,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/computed-construction.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/computed-construction.json",
+      "bytes": 3023794,
+      "sha256": "aa3e4483abe46de188e0d59777b2e7383ae6b1f32cc31e86f40cb47413479172",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 58,
+      "total": 58,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/dependent.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/dependent.json",
+      "bytes": 2307772,
+      "sha256": "da70b7d0616ae9bacfd8e52b25e682b535f0ec8add3ed6d94a67ed2a7d50e590",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 48,
+      "total": 48,
+      "writes_exact": 48,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/exposed-literals.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/exposed-literals.json",
+      "bytes": 446143,
+      "sha256": "3bd520bd2809ec95737fba9039782b577220b1d2adffa94a8caf48281e96872c",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 16,
+      "total": 16,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/exposed-roles.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/exposed-roles.json",
+      "bytes": 688854,
+      "sha256": "2f0d853ec59bbfcb0b5909c7a139b5d7d7c904daec1cfa04a27a732e13b5889a",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 12,
+      "total": 12,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/identifiers.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/identifiers.json",
+      "bytes": 135423,
+      "sha256": "232f9da5328f118b88949026c6ef7562dd88c5d229539afcee692df2719083fa",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 8,
+      "total": 8,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/literal-construction.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/literal-construction.json",
+      "bytes": 2503776,
+      "sha256": "aa0712dd2dd15a831fb0b91a5467251ab1dee4129b4fd5056c96a59e9864e4af",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 103,
+      "total": 103,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/long.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/long.json",
+      "bytes": 1457385,
+      "sha256": "af02e349763c9941d4d46607684ebca1469d846dbed28db0bbf00f0fa56745b2",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 28,
+      "total": 28,
+      "writes_exact": 28,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/names.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/names.json",
+      "bytes": 1362406,
+      "sha256": "ba335220894aca958b448d470d6c928710ddd23a7728eea22e63304863cce463",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 28,
+      "total": 28,
+      "writes_exact": 28,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/numeric.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/numeric.json",
+      "bytes": 272236,
+      "sha256": "e35190b9f4bbc6a301bbca88a7e04e6f69167a2e4467074f5d7011abcb59c86c",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 6,
+      "total": 6,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/preservation.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/preservation.json",
+      "bytes": 1475220,
+      "sha256": "7c63d9ba242fb8b22354f39627aba44af11ff411c474c032c407251f9b4c0c86",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 62,
+      "total": 62,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/prior-chains.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/prior-chains.json",
+      "bytes": 912050,
+      "sha256": "5d75f8c95643edc55f4b679464997c5af6ee5cedb65b7d02086ef497ab182c4b",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 16,
+      "total": 16,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/prior-fresh.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/prior-fresh.json",
+      "bytes": 446012,
+      "sha256": "8e4cd348e36512265ef77d4edb0234758e6269d9cd11d2d479541786d02b4ae0",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 16,
+      "total": 16,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/prior.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/prior.json",
+      "bytes": 330894,
+      "sha256": "57314452e2378647bdaffe4cc010ad0c389ffb792cc7b6c0522f2aaa0fe87568",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 24,
+      "total": 24,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/roles.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/roles.json",
+      "bytes": 688698,
+      "sha256": "0c639475f68ddbcb8ee5572299469782c9cc441ff71cf8e7276cf6bcd7bed34e",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 12,
+      "total": 12,
+      "writes_exact": null,
+      "failed_ids": []
+    },
+    "source-noread-preserve128/sessions.json": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128/sessions.json",
+      "bytes": 37117,
+      "sha256": "6c58654a0589b8e42ca0b35417a688f5e1bcb9a8268a8140a1f6f4bdf78eac13",
+      "artifact": "blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f",
+      "exact": 5,
+      "total": 5,
+      "writes_exact": null,
+      "failed_ids": []
+    }
+  },
+  "construction_comparison": {
+    "parent_exact": 545,
+    "candidate_exact": 551,
+    "total": 603,
+    "lost_correct_ids": [],
+    "remaining_wrong_texts_unchanged": true
+  },
+  "checks": {
+    "focused_units": "4 PASS",
+    "actual_source_no_read_allocation_commit_checkpoint": "PASS; zero allocations/bytes",
+    "actual_three_turn_numeric_allocation_checkpoint": "PASS; zero allocations/bytes",
+    "actual_cli_unknown": " Unknown.\n",
+    "actual_cli_supported": " Norvik.\n",
+    "kernel_source": "PASS",
+    "format": "PASS",
+    "architecture_policy": "PASS",
+    "claim_wording": "PASS",
+    "generated_rust_assertions": "NOT_RUN; eight identifier outputs preserved",
+    "broad_release_qa": "NOT_RUN",
+    "protected_successor_ci": "PENDING at evidence construction"
+  },
+  "resource": {
+    "model_cycle_ms": 155350,
+    "engineering_cycle_ms": 524036,
+    "model_peak_sampled_child_rss_bytes": 1141374976,
+    "peak_sampled_known_storage_bytes": 6837837824,
+    "snapshot": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-07T01:44:18.760Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2586329088,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 1533480960,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 6826323968,
+      "storage_limit_bytes": 7734296576,
+      "remaining_storage_bytes": 907972608,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 720338944,
+      "model_ledger": {
+        "cumulative_ms": 3605626,
+        "limit_ms": 4170000
+      },
+      "model_remaining_ms": 564374,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "projection": {
+      "at": "2026-09-07T01:15:40.045Z",
+      "authority": "2026-09-06 canonical handoff and current owner standing authorization for necessary local resource extensions; no external cost",
+      "before": {
+        "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+        "at": "2026-09-07T01:15:40.044Z",
+        "inherited_precleanup_bytes": 2747199488,
+        "obsolete_target_growth_credit": 671379456,
+        "current_target_bytes": 2584907776,
+        "predecessor_artifact_root_bytes": 145760256,
+        "current_artifact_root_bytes": 1428213760,
+        "predecessor_worktree_bytes": 9875456,
+        "current_worktree_bytes": 8937472,
+        "stopped_successor_worktree_bytes": 460877824,
+        "source_metadata_reserve_bytes": 5242880,
+        "current_sampled_known_storage_bytes": 6719635456,
+        "storage_limit_bytes": 7063207936,
+        "remaining_storage_bytes": 343572480,
+        "stop_margin_bytes": 134217728,
+        "available_growth_before_stop_bytes": 155938816,
+        "model_ledger": {
+          "cumulative_ms": 3450276,
+          "limit_ms": 3570000
+        },
+        "model_remaining_ms": 119724,
+        "model_process_limit": 1,
+        "model_process_rss_target_bytes": 4294967296,
+        "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+      },
+      "scope": "In-place warm source-router refinement with supported/NoRead contrasts; preserve complete e7 parent provenance and unchanged downstream components.",
+      "model_increment_ms": 600000,
+      "model_cycle_ms": 540000,
+      "engineering_cycle_ms": 1500000,
+      "model_projection_ms": 420000,
+      "engineering_projection_ms": 900000,
+      "growth_projection_bytes": 536870912,
+      "storage_increment_bytes": 671088640,
+      "model_processes": 1,
+      "rss_bytes": 4294967296,
+      "build_jobs": 1,
+      "model_work_breakdown_ms": {
+        "rust_preparation_and_trace": 45000,
+        "two_bounded_fits": 120000,
+        "open_generation_and_preservation": 130000,
+        "fresh_parent_candidate_control": 80000,
+        "allocation_cli_checkpoint": 45000
+      },
+      "engineering_breakdown_ms": {
+        "coherent_combined_release_build": 400000,
+        "focused_test_build_and_checks": 200000,
+        "correction_and_final_build_reserve": 300000
+      },
+      "storage_breakdown_bytes": {
+        "cargo_variants_and_test_products": 402653184,
+        "retained_models_reports": 117440512,
+        "source_metadata": 16777216
+      },
+      "limits_scope": "Charge all retries, failed and resumed work. Preserve128MiB stop margin. Same isolated full worktree reused; all branches/user material retained."
+    },
+    "deletions": false,
+    "paid_external_model_compute": false,
+    "sampling_limit": "periodic child RSS and conservative du-accounted storage, not exact transient peaks or APFS unique extents"
+  },
+  "files": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-source.json",
+      "bytes": 130905,
+      "sha256": "8958fd1a4dac20108dfafebb8e2c038551573862a48f9ab5aece153c3aa15ae0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-source-v2.json",
+      "bytes": 131825,
+      "sha256": "3a9e0ac477323432e2c30651ca8a79372bdd0d74317b1549aec8e0d7ce4b1024"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-open.json",
+      "bytes": 550153,
+      "sha256": "593953b0d0ba96f08f17995f4064cc49ca3f792de8f2e08a2018023d3225ebd8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-construction.json",
+      "bytes": 32972872,
+      "sha256": "49cd0d9393072474a1f805af2bf8b0aaa742d9bbfa00dc77098c8c900ad3e5d9"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-live-recovery.json",
+      "bytes": 1237,
+      "sha256": "789c805c2c61e1b34bf3065848e49cf7e2bc49f2b94f8465a39a07587ca32d6a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-design-selection.json",
+      "bytes": 2266,
+      "sha256": "51e66df0df230579c004248ab4513d4ae5c1a8a0c491ee900ad2021c6631734b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-projection.json",
+      "bytes": 2951,
+      "sha256": "045e93941190ea284dc09e55ab22adc4988b98845d30f5d24cda25a8ea9b0a04"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-inherited-storage-authorization.json",
+      "bytes": 1412,
+      "sha256": "3f7efc656bb22211c302aca855f3562af8a74376ebc0d8d37710e4975dd2f879"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-effective-storage-authorization.json",
+      "bytes": 1478,
+      "sha256": "90f4bade3651a6a5cd08613b1211d29d3a3c9a65aaf305bcf394ef088663b17b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-delivery-resource.json",
+      "bytes": 1477,
+      "sha256": "eb486f60257cdafceba8cb06bbbd5a536552f67a573d29a97f8eb2895358693e"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-work-comparison.json",
+      "bytes": 37018,
+      "sha256": "c49d9dad9f32c445440224e71e27683fa47417c5363cd6c7f01744c37b3bf6e5"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-run.mjs",
+      "bytes": 968,
+      "sha256": "9eed5bdc4f53d7252b126b234ed9afcec28e45f4ef81b525784dd6f5106496af"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/run-command.mjs",
+      "bytes": 5975,
+      "sha256": "29422110df63b217dde5439ae720f1315e79be7bc5c576ef3193980d0f8c6884"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/resource-accounting.mjs",
+      "bytes": 4139,
+      "sha256": "c6e9a29c861268bcad4ddbd66e1a08c799cc8e5cb105b064a0f8e3e597335d15"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-allocation-build.log",
+      "bytes": 707,
+      "sha256": "7d4ef1e50362828565b1ea212f5d3db7652fff35e22ab0b8150cb6c1bc683102"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-allocation.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-allocation.stdout.log",
+      "bytes": 361,
+      "sha256": "bddbb1604fd611c306b499d940c5208a03986ef9650ee632db9b356a504f678a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-build.log",
+      "bytes": 1437,
+      "sha256": "77cf1b50280e7c9adfb2771f093c51a090eea86eb1427e222e0960fc01ba3d4b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-claims.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-cli-supported.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-cli-supported.stdout.log",
+      "bytes": 12249,
+      "sha256": "24c66abe75f1c79247db87f1fc332ee17f785e0b5b7e303c0e5fe288476e5b02"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-cli-unknown.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-cli-unknown.stdout.log",
+      "bytes": 9320,
+      "sha256": "26fd7406fd3e07eaec6517c503102e1109fcefd8bfb128a8398bb7f957856620"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-control-correction.log",
+      "bytes": 175,
+      "sha256": "da2260f5b003202beecb562aad6d873d83122c09a44c6d506417c9801d3e60d1"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality-fresh.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality-fresh.stdout.log",
+      "bytes": 24,
+      "sha256": "242d30a6864c73cd0478e118cac7c87ff09ee3132a357d29f99e098fd3a6a02c"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality128.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-equality128.stdout.log",
+      "bytes": 1924,
+      "sha256": "43163d3ae36411a3c931c7c8c978a4da437f6d164a7fc82938610f61e4f31d33"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-final-claims.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-final-format.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-fit128.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-fit128.stdout.log",
+      "bytes": 1920,
+      "sha256": "08b75ff779cfe866253a58d33ceccc439a009d9531ccfe9312206424f101bb5b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-format.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-fresh128.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-fresh128.stdout.log",
+      "bytes": 24,
+      "sha256": "0cfaf191d11438121e8660205b9743e41ab142a9f749149915b25a606cc90e5f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-kernel.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-kernel.stdout.log",
+      "bytes": 189,
+      "sha256": "ef649bbd766e40db8ff1ebeb042eb4710d01fe2d361f1c222c49312d5dcc5908"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-numeric-allocation.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-numeric-allocation.stdout.log",
+      "bytes": 390,
+      "sha256": "f44f432b569d4961f7394280a99adbc9972bdf4408385e4db07db4498c820a16"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-construction.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-construction.stdout.log",
+      "bytes": 26,
+      "sha256": "73281bd0c823fb172f5e91c060431a8ee5e7d4cf60c5bce6c869c35ac2ff7ad0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-fresh.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-fresh.stdout.log",
+      "bytes": 24,
+      "sha256": "a72eeddb7e3e74490abc7292cc45331a6c7daca6a018aa4774d2a1786a25a448"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-open.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-parent-open.stdout.log",
+      "bytes": 23,
+      "sha256": "de1b9f24968fb1edc12edb553cb61f1d2b567fb228cd86b96fc0286ec63a46de"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-policy.log",
+      "bytes": 73,
+      "sha256": "58dd9c24c33ba5ff6519ed3f5bea924d8fd10d93bcfaba529e2d8b0101be6ae7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-prepare-v2.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-prepare-v2.stdout.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-prepare.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-prepare.stdout.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-preserve128.stdout.log",
+      "bytes": 832,
+      "sha256": "7eb0cb3c1f02a54be9c30c94ccb3a1dbbe533eb4c3780cae54b01484a83e00e9"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-probe-correction.log",
+      "bytes": 175,
+      "sha256": "5e3560a9d4dac639db41e67580793d8b770be86e82b70ff30a59426b2454f605"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-test-build.log",
+      "bytes": 282,
+      "sha256": "30360b8655add507a6724e62a2836bc8a105821cefa8888f24837138eb8676fd"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-unit.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/source-noread-unit.stdout.log",
+      "bytes": 577,
+      "sha256": "4b54795a23b1c57e492dfdc8a0f71dbd9d0369140c8a8b48af5e2bf2629a67f0"
+    }
+  ],
+  "commands": [
+    {
+      "label": "source-noread-prepare",
+      "started": "2026-09-07T01:27:52.705Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "prepare",
+        "source-routing-role-comparison/source.json",
+        "answer-entry-source.json",
+        "source-noread-source.json"
+      ],
+      "elapsed_ms": 204,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6720458752
+    },
+    {
+      "label": "source-noread-parent-open",
+      "started": "2026-09-07T01:27:59.773Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "evaluate",
+        "answer-entry-final/model.json",
+        "source-noread-source.json",
+        "development",
+        "source-noread-parent-open.json",
+        "full"
+      ],
+      "elapsed_ms": 8061,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 881360896,
+      "peak_sampled_known_bytes": 6721015808
+    },
+    {
+      "label": "source-noread-prepare-v2",
+      "started": "2026-09-07T01:29:24.957Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "prepare",
+        "source-routing-role-comparison/source.json",
+        "answer-entry-source.json",
+        "source-noread-source-v2.json"
+      ],
+      "elapsed_ms": 186,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6721155072
+    },
+    {
+      "label": "source-noread-fit128",
+      "started": "2026-09-07T01:29:34.531Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "fit",
+        "answer-entry-final/model.json",
+        "source-noread-source-v2.json",
+        "source-noread-angular128",
+        "128",
+        "angular"
+      ],
+      "elapsed_ms": 27145,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 903806976,
+      "peak_sampled_known_bytes": 6746308608
+    },
+    {
+      "label": "source-noread-preserve128",
+      "started": "2026-09-07T01:31:04.995Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "preserve",
+        "source-noread-angular128/model.json",
+        ".",
+        "source-noread-preserve128"
+      ],
+      "elapsed_ms": 9523,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 885686272,
+      "peak_sampled_known_bytes": 6764040192
+    },
+    {
+      "label": "source-noread-parent-construction",
+      "started": "2026-09-07T01:31:48.621Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "evaluate",
+        "answer-entry-final/model.json",
+        "source-noread-source-v2.json",
+        "fit",
+        "source-noread-parent-construction.json",
+        "full"
+      ],
+      "elapsed_ms": 9068,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 878575616,
+      "peak_sampled_known_bytes": 6797021184
+    },
+    {
+      "label": "source-noread-unit",
+      "started": "2026-09-07T01:33:10.111Z",
+      "command": "/tmp/r4-native-geometric-target/debug/deps/uor_r4_core-8d8deefa7a2a5da5",
+      "args": [
+        "source_refinement",
+        "--nocapture"
+      ],
+      "elapsed_ms": 13069,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 30916608,
+      "peak_sampled_known_bytes": 6797438976
+    },
+    {
+      "label": "source-noread-fresh128",
+      "started": "2026-09-07T01:33:30.059Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "evaluate",
+        "source-noread-angular128/model.json",
+        "source-noread-source-v2.json",
+        "first_use",
+        "source-noread-fresh128.json",
+        "full"
+      ],
+      "elapsed_ms": 8520,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 890126336,
+      "peak_sampled_known_bytes": 6798565376
+    },
+    {
+      "label": "source-noread-parent-fresh",
+      "started": "2026-09-07T01:34:03.294Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "evaluate",
+        "answer-entry-final/model.json",
+        "source-noread-source-v2.json",
+        "first_use",
+        "source-noread-parent-fresh.json",
+        "full"
+      ],
+      "elapsed_ms": 7698,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 883703808,
+      "peak_sampled_known_bytes": 6799597568
+    },
+    {
+      "label": "source-noread-equality128",
+      "started": "2026-09-07T01:37:00.055Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "fit",
+        "answer-entry-final/model.json",
+        "source-noread-source-v2.json",
+        "source-noread-equality128",
+        "128",
+        "equality"
+      ],
+      "elapsed_ms": 27026,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 909131776,
+      "peak_sampled_known_bytes": 6825041920
+    },
+    {
+      "label": "source-noread-equality-fresh",
+      "started": "2026-09-07T01:37:40.891Z",
+      "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+      "args": [
+        "source-noread",
+        "evaluate",
+        "source-noread-equality128/model.json",
+        "source-noread-source-v2.json",
+        "first_use",
+        "source-noread-equality-fresh.json",
+        "full"
+      ],
+      "elapsed_ms": 8580,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 888602624,
+      "peak_sampled_known_bytes": 6826172416
+    },
+    {
+      "label": "source-noread-allocation",
+      "started": "2026-09-07T01:38:05.606Z",
+      "command": "env",
+      "args": [
+        "R4_SOURCE_NO_READ_MODEL=source-noread-angular128/model.json",
+        "R4_SOURCE_NO_READ_PARENT=answer-entry-final/model.json",
+        "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+        "native_source_no_read_artifact_is_allocation_free_and_causal",
+        "--ignored",
+        "--nocapture"
+      ],
+      "elapsed_ms": 8973,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 160071680,
+      "peak_sampled_known_bytes": 6826176512
+    },
+    {
+      "label": "source-noread-numeric-allocation",
+      "started": "2026-09-07T01:38:58.807Z",
+      "command": "env",
+      "args": [
+        "R4_INDEPENDENT_MODEL=source-noread-angular128/model.json",
+        "R4_LITERAL_PARENT=independent-warm-angular/model.json",
+        "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+        "native_independent_artifact_is_allocation_free",
+        "--ignored",
+        "--nocapture"
+      ],
+      "elapsed_ms": 9842,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 1141374976,
+      "peak_sampled_known_bytes": 6826180608
+    },
+    {
+      "label": "source-noread-cli-unknown",
+      "started": "2026-09-07T01:39:53.051Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "source-noread-angular128/model.json",
+        "--prompt",
+        "User: varo has -5 coins. leni has 17 coins. tavi has 301 coins.\nUser: Where is the location of leni?\nAssistant:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 8935,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 894697472,
+      "peak_sampled_known_bytes": 6826233856
+    },
+    {
+      "label": "source-noread-cli-supported",
+      "started": "2026-09-07T01:41:51.329Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4",
+      "args": [
+        "geometric",
+        "generate",
+        "--model",
+        "source-noread-angular128/model.json",
+        "--prompt",
+        "User: selvi has -9 coins. selvi lives in Norvik.\nUser: Where is the location of selvi?\nAssistant:",
+        "--max-tokens",
+        "32",
+        "--json"
+      ],
+      "elapsed_ms": 8511,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": 892846080,
+      "peak_sampled_known_bytes": 6826246144
+    },
+    {
+      "label": "source-noread-kernel",
+      "started": "2026-09-07T01:43:18.860Z",
+      "command": "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+      "args": [
+        "native_kernel_source_has_no_forbidden_arithmetic_or_float_types",
+        "--nocapture"
+      ],
+      "elapsed_ms": 9,
+      "engineering_only": false,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6826250240
+    },
+    {
+      "label": "source-noread-format",
+      "started": "2026-09-07T01:21:17.024Z",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt"
+      ],
+      "elapsed_ms": 3476,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6719651840
+    },
+    {
+      "label": "source-noread-build",
+      "started": "2026-09-07T01:21:20.660Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 337350,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6747414528
+    },
+    {
+      "label": "source-noread-probe-correction",
+      "started": "2026-09-07T01:27:30.446Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 13156,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6720331776
+    },
+    {
+      "label": "source-noread-control-correction",
+      "started": "2026-09-07T01:28:54.274Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "build",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--example",
+        "native_geometric_value_probe",
+        "-p",
+        "uor-r4-wasm-router",
+        "--bin",
+        "r4"
+      ],
+      "elapsed_ms": 13355,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6721024000
+    },
+    {
+      "label": "source-noread-test-build",
+      "started": "2026-09-07T01:32:30.107Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "CARGO_PROFILE_DEV_DEBUG=0",
+        "CARGO_PROFILE_TEST_DEBUG=0",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--lib",
+        "source_refinement",
+        "--config",
+        "profile.test.package.uor-r4-core.opt-level=0",
+        "--no-run"
+      ],
+      "elapsed_ms": 22812,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6837837824
+    },
+    {
+      "label": "source-noread-allocation-build",
+      "started": "2026-09-07T01:34:43.730Z",
+      "command": "env",
+      "args": [
+        "CARGO_TARGET_DIR=/tmp/r4-native-geometric-target",
+        "CARGO_INCREMENTAL=0",
+        "CARGO_BUILD_JOBS=1",
+        "/Users/casey.allard/.cargo/bin/cargo",
+        "test",
+        "--release",
+        "--offline",
+        "-p",
+        "uor-r4-core",
+        "--test",
+        "native_geometric_allocations",
+        "--no-run"
+      ],
+      "elapsed_ms": 129955,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6800699392
+    },
+    {
+      "label": "source-noread-final-format",
+      "started": "2026-09-07T01:42:49.025Z",
+      "command": "/Users/casey.allard/.cargo/bin/cargo",
+      "args": [
+        "fmt",
+        "--check"
+      ],
+      "elapsed_ms": 3415,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6826250240
+    },
+    {
+      "label": "source-noread-policy",
+      "started": "2026-09-07T01:43:34.454Z",
+      "command": "/tmp/r4-native-geometric-target/release/r4-policy-check",
+      "args": [
+        "."
+      ],
+      "elapsed_ms": 130,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6826258432
+    },
+    {
+      "label": "source-noread-claims",
+      "started": "2026-09-07T01:43:34.745Z",
+      "command": "python3",
+      "args": [
+        "scripts/check_claim_wording.py"
+      ],
+      "elapsed_ms": 215,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6826262528
+    },
+    {
+      "label": "source-noread-final-claims",
+      "started": "2026-09-07T01:47:02.859Z",
+      "command": "python3",
+      "args": [
+        "scripts/check_claim_wording.py"
+      ],
+      "elapsed_ms": 172,
+      "engineering_only": true,
+      "code": 0,
+      "signal": null,
+      "stopped": null,
+      "peak_process_rss_sample_bytes": null,
+      "peak_sampled_known_bytes": 6826340352
+    }
+  ],
+  "limits": [
+    "Single optional nonexecuting refinement witness; original router restored to validate exact training parent. Only one refinement supported.",
+    "All new twenty cases use direct source dispatch, with known query forms and authored worlds.",
+    "Copy labels accept equal payload occurrences; coins success does not establish owner-specific occurrence binding.",
+    "Combined construction has52 unchanged failures, including inherited numeric admission taking a supported location and older identifier queries.",
+    "No general syntax/prose/reasoning, frontier capability or whole-model laptop speedup."
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,6 +1,51 @@
 # Current native geometric AI work
 
-## Committed NoRead completion in literal contexts — #1139 / #1140, 2026-09-06
+## Supported-source versus NoRead selection — #1139 / #1140, 2026-09-06
+
+**Retain `d59070c2` at bounded joint source/action selection scope.** The
+[result](../native_geometric_source_noread_1139.md) and
+[evidence](../evidence/native_geometric_source_noread_1139.json) bind the executed
+Rust refinement. It replaces the existing router, warm-starting64 inherited
+codes and admitting64 construction features. Eight code updates achieve384/384
+eligible selection targets. A nonexecuting previous-router witness reconstructs
+exact `e7c14c99`; all descendant parameters and original parent CIDs remain
+unchanged. No extra serving head, session state, query parser or provider is added.
+
+Fresh complete generation improves14/20 to20/20 versus10/20 matched exact-code;
+all20 cases use the direct router. Open generation is14/14. Combined construction
+improves545/603 to551/603 with no lost correct case, and all52 remaining wrong
+outputs equal the parent. Both earlier literal sets are16/16 and their103-case
+construction now passes. Both16-case computation sets,8 identifiers,58 computed
+construction,6 numerics,three12-case role sets,48 dependent answers/writes,
+62 prior responses,24 transfers,28 exposed-name answers/writes,28 long-context
+answers/writes and5 persistent turns remain correct.
+
+Four focused tests and actual source/NoRead plus three-turn zero-allocation
+checks pass, including observation-only commit, mutation rejection and checkpoint
+restoration. Actual CLI abstention and supported copying are recorded in the
+result. Prior generated-Rust assertions were not rerun; identifier output bytes
+are preserved. The artifact grows91,677 bytes to11,304,530. Routing work increases;
+correct termination reduces complete-population work. No per-token speedup or
+general syntax/prose/reasoning/frontier capability follows.
+
+**Next: joint numerical-versus-word admission at the existing operator boundary.**
+A supported-location construction case about cyra still emits13 instead of Paris
+through inherited numeric selection; three earlier identifier prompts also emit
+numbers. Preserve computed roles and this source/NoRead repair while learning
+that choice, then resume broader #1139 routed-block/#1140 composition requirements.
+Both issues remain open. No new suffix-head or cache campaign is justified.
+
+PR #1159 merged at `be32b410`; this successor uses its identical source tree.
+The shared model ceiling was extended600s to4170s and storage640MiB under standing
+owner authorization before execution. Point projections420s model/900s engineering,
+cycle ceilings540s/1500s, one model process,4GiB child RSS target and128MiB storage
+margin remain enforced. Model work155.350s and engineering524.036s stay below
+projection. Cumulative model use3605.626/4170s leaves564.374s. Peak sampled known
+storage6,837,837,824 bytes and child RSS1,141,374,976 bytes remain within limits.
+All corrections and retained material are charged; no deletion or external model
+compute occurred.
+
+## Previous checkpoint: committed NoRead completion in literal contexts — #1139 / #1140, 2026-09-06
 
 **Retain `e7c14c99` at literal-numeric NoRead-completion scope.** The
 [result](../native_geometric_no_read_completion_1139.md) and

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -216,13 +216,19 @@ preservation is restored. Eight new identifier-return functions pass24 executed
 assertions. The [committed NoRead continuation](../native_geometric_no_read_completion_1139.md)
 then retains `e7c14c99` at literal-numeric scope: exposed answers12/16 to14/16,
 new answers14/16 to15/16, with computed, identifier and memory preservation.
-Two intermediate candidates remain recorded negatives. **Next: revise joint
-source/NoRead selection when a retained word is unsupported by the question.**
-Reuse the existing geometric source router and occurrence binding; include
-supported-word and missing-attribute cases together, with source-order/name
-changes and the current numeric/identifier/memory preservation. Do not map all
-numeric NoOperation to Unknown, add a parser for the observed question template,
-or expand model/context capacity before this selection seam is addressed.
+Two intermediate candidates remain recorded negatives. The subsequent
+[joint source/NoRead refinement](../native_geometric_source_noread_1139.md)
+retains `d59070c2`:20/20 new complete answers versus14/20 parent and10/20
+exact-code continuation, with all prior preservation. The existing router is
+warm-refined in place and its previous component verifies the full unchanged
+training parent. Combined construction improves545/603 to551/603 with no lost
+correct response. **Next: joint numerical-versus-word admission through existing
+selected operators.** The remaining supported-location case emits13 instead of
+Paris through inherited numeric selection; some older identifier requests also
+emit numbers. Learn that choice while protecting computed roles and the completed
+source/NoRead repair, then resume the broader routed-block and composition goals.
+Do not add another suffix head, observed-question parser, provider or generic
+capacity expansion for this identified decision boundary.
 General named-role binding and broader Rust reasoning remain unqualified.
 No additional cache campaign is active. Follow current-state.md for artifacts
 and cumulative resources; a new issue does not reset the spent amount.

--- a/docs/native_geometric_source_noread_1139.md
+++ b/docs/native_geometric_source_noread_1139.md
@@ -1,0 +1,165 @@
+# Joint supported-source and NoRead refinement — #1139 / #1140
+
+## Decision — 2026-09-06, execution September 7 UTC
+
+Retain `blake3:d59070c29e1cebcb12d25c2fc034083d9631b24ab04da0c57b94a007ad10ea6f`
+at bounded source/action selection scope. It replaces the existing source router
+inside the complete `e7c14c99` model, preserving every downstream parameter and
+its original training-parent binding. PR #1159 merged at `be32b410`; this is its
+successor. The [evidence](evidence/native_geometric_source_noread_1139.json)
+binds source, model, complete reports, commands and cumulative resources.
+
+| Actual complete generation | Parent e7 | Angular refinement | Exact-code continuation |
+| --- | ---: | ---: | ---: |
+| 20 fresh names, places, numbers and fact-order cases | 14/20 | 20/20 | 10/20 |
+| 14 open supported/missing-source cases | NOT_RUN on corrected full set | 14/14 | 9/14 |
+| 603 combined construction responses | 545/603 | 551/603 | 500/603 |
+| 16 earlier exposed literals | 14/16 | 16/16 | NOT_RUN |
+| 16 earlier first-use literals, now preservation | 15/16 | 16/16 | NOT_RUN |
+| 103 earlier literal construction responses | 99/103 | 103/103 | NOT_RUN |
+
+All20 fresh angular responses use the direct source router. They comprise eight
+unsupported-location answers, eight supported-location answers and four valid
+`coins` answers in nonnumeric contexts. Source order changes within each pair.
+Fresh names/places/numbers were saved before fitting and opened only after the
+128-feature design passed open development and preservation. Familiar question
+forms and small authored worlds are not sealed general-language qualification.
+No previously correct combined construction response is lost. All52 remaining
+wrong construction outputs are byte-identical to their parent outputs.
+
+The original failed ordering now produces ` Unknown.\n` and EOS:
+
+```text
+User: varo has -5 coins. leni has 17 coins. tavi has 301 coins.
+User: Where is the location of leni?
+Assistant:
+```
+
+Fresh supported examples replace an incorrect `in.` or looping `Unknown` with
+` Norvik.\n` or ` Kestra.\n`. The exact-code control uses the same parent,
+construction data,128-feature budget, initialization, four passes,12 proposals
+and45-second learner cap. It finishes the schedule, as does angular. This is
+bounded evidence favoring this angular continuation, not a universal advantage
+over equality optimizers or a whole-model laptop-performance claim.
+
+## Cause, implementation and provenance
+
+The original64-feature role-context router gives NoRead only a constant feature.
+Copy candidates receive neighboring dictionary addresses, recency and exact
+occurrence/role equality features. Actual traces show a score10 copy/NoRead tie:
+newest-first candidate order can select unsupported `coins`. Names outside the
+dictionary collapse to its miss address, while exact occurrence bytes remain
+separate. Neither larger raw context nor additional suffix fitting addresses
+this first decision.
+
+`Model::refine_source_routing` warm-starts the existing64 codes, landmarks and
+biases. It admits64 additional features ranked by construction-label contrast
+and frequency, initializes them to group identity, and runs the existing joint
+source/action objective. Ordered two-channel signed H4 table products and
+relative-cosine ranks continue to score exact-source references. The fit accepts
+eight code changes: five old code entries and three added entries change;
+landmarks and biases remain fixed. The feature law, dictionary, source support,
+exact copy operator, numerical operators, entry and completion are unchanged.
+No executing head, persistent session state, query parser or provider is added.
+
+The603 supplied examples combine480 prior source examples,103 literal/identifier
+examples and20 new supported/missing contrasts. Full assembled-parent sessions
+exclude211 upstream decisions and report eight unreachable targets;384 eligible
+source/action frames remain. Angular improves378/384 to384/384, hinge0;
+exact-code improves92/384 to333/384, hinge151. The warm vocabulary has20 frames
+with conflicting alternative feature signatures; expanded vocabulary has0.
+These are descriptive signatures, not a proof that every generated answer is
+solvable. Selector fit is not free-generation acceptance.
+
+A first diagnostic proposed numeric `What does leni have?` as a positive `coins`
+control. Actual tracing showed inherited numeric dispatch returning a number,
+so that control was corrected to nonnumeric facts before fitting. The original
+source and5/10 parent diagnostic remain preserved. Correct `coins` copying does
+not identify an owner's particular occurrence when several payloads are equal:
+the existing response-byte supervision accepts any matching occurrence.
+
+Changing the early router would normally invalidate recursive descendant CIDs.
+The optional `source_routing_refinement` witness retains the previous router and
+full frozen parent CID. Loading restores that one component, reconstructs and
+validates exact e7, then validates the replacement and final identity. Original
+numeric, relation, writer, completion and tokenizer fields remain byte-for-byte
+unchanged. The witness never executes as a second router. This version supports
+one refinement and rejects repeat refinement; subsequent composition needs an
+explicit lifecycle extension, not silent rewriting of old provenance.
+
+The artifact is11,304,530 bytes,91,677 bytes larger than e7. Its executing router
+is91,543 serialized bytes including training receipts. The old router retained
+as provenance contributes to the complete artifact cost. Serving keeps the
+bounded sixteen-word plus NoSource scan,512-feature scratch capacity, two H4
+lanes and up to eight actions; this fit stores128 learned code entries. No
+runtime matrix products, floating projection, dense transformer or LLM repair
+are added. Inherited fixed-zeta, exact Z[phi], orientation, typed paired-H4/UOR
+state retain their prior roles without a new semantic qualification.
+
+## Preservation, verification and full work
+
+Angular preserves48/48 dependent answers and writes,62/62 earlier responses,
+24/24 prior transfers,28/28 exposed-name answers and writes,28/28 long-context
+answers and writes,5/5 persistent turns, both16/16 complete three-turn sets,
+8/8 identifiers,58/58 computed construction,6/6 earlier numeric and three12/12
+role/alias sets. New preservation reports require complete bytes and EOS;
+relation-write accuracy is counted separately. The prior24 generated-Rust
+assertions were not rerun: unchanged identifier bytes are preservation evidence,
+not new algorithm synthesis.
+
+Four focused unit tests pass: warm initialization/parent reconstruction/reload,
+mutation rejection, bounds and diagnostic score/selection agreement. Actual
+source/NoRead and three-turn numeric checks each measure zero allocations/bytes,
+including real observation and generation. Repeated prediction cannot commit;
+matching observation commits the exact source/token, mismatched observation
+does not, and checkpoints restore. The allocation check reconstructs the entire
+frozen parent from the witness. The changed probe and actual CLI compile offline.
+Kernel source, architecture policy, formatting and claim checks are recorded
+with their actual outcomes in the evidence. Broad release QA is NOT_RUN.
+
+On the same20 fresh prompts with a32-token ceiling, parent versus angular work:
+
+| Instrumented work | Parent | Angular |
+| --- | ---: | ---: |
+| Observed input/output tokens | 1,258 | 1,212 |
+| Candidate evaluations | 23,866 | 18,820 |
+| Memory-composition comparisons | 1,821,163 | 809,458 |
+| Source routing code reads | 2,020 | 2,852 |
+| Source routing table reads | 10,728 | 12,392 |
+| Source routing comparisons | 20,828 | 23,596 |
+| Source routing logical bytes | 388,992 | 446,032 |
+| Word-copy dictionary byte comparisons | 43,673 | 21,684 |
+
+Both examine304 source candidates and perform2,876 feature lookups. The larger
+table costs more within routing; corrected termination reduces other work.
+Complete nested counters and the14 cases with matching output bytes/EOS remain
+in `source-noread-work-comparison.json`. These overlapping logical counters are
+not ISA/DRAM measurements or a matched per-token speedup. Loading, validation,
+encoding, fitting, failed controls, generation and retained reports are charged.
+
+## Remaining work and resources
+
+All52 combined construction failures remain. Forty-eight are older swapped-name
+numeric/Rust examples, three earlier identifier questions emit numbers, and one
+new supported-location question about cyra emits13 instead of Paris. The latter
+uses inherited numerical admission, so the direct source router cannot repair
+it. This is the next observed boundary: learn numerical-versus-word operator
+admission jointly while preserving computed roles, then resume the broader
+#1139 routed-block and #1140 composition requirements. Do not add another suffix
+head or reinterpret this success as general syntax, prose, reasoning, frontier
+capability or completion of either issue.
+
+Before execution, standing owner authorization added600 seconds to the shared
+model ceiling (3570 to4170 seconds) and640MiB to storage allowance, preserving
+all prior charges and the128MiB stop margin. The complete point projection was
+420 seconds model,900 seconds engineering and512MiB storage growth, with540/1500
+second cycle ceilings, one model process and4GiB child RSS target. The combined
+build took337.350 seconds. Actual model work155.350s and engineering524.036s remain below their point
+projections. Cumulative model use is3605.626/4170s, leaving564.374s. Peak sampled
+known storage is6,837,837,824 bytes under the effective7,546,662,912-byte ceiling;
+peak sampled model-child RSS is1,141,374,976 bytes. The delivery snapshot records
+6,826,323,968 known bytes and720,338,944 bytes before the tighter stop. Compiler
+variants, the corrected control, both probe rebuilds and every command remain
+charged in the evidence and delivery receipt.
+No material deletion or paid external model compute occurred. All prior models,
+original checkout changes, worktrees and rejected/control material remain.


### PR DESCRIPTION
A location question over reordered numeric facts could copy `coins` even though no location was supplied. Warm-refine the existing signed-H4 source/action router on supported-word and NoRead contrasts, preserving the complete e7c14c99 training parent through a nonexecuting previous-router witness. The existing router slot executes the replacement; all downstream numeric, relation, entry and completion parameters remain unchanged.

The selected d59070c2 model produces20/20 fresh complete answers versus14/20 parent and10/20 matched exact-code continuation. All20 use direct source dispatch. Open cases pass14/14, and combined construction improves545/603 to551/603 with no lost correct output. Earlier literals improve to16/16 on both sets and103/103 construction. Existing computations, identifiers, dependent relations, long context and restored sessions remain correct. The52 remaining construction failures match parent bytes; inherited numeric admission still overrides some supported word/identifier requests.

Validation: combined offline release probe/CLI build; four focused reconstruction/mutation/bounds/trace tests; actual source/NoRead and three-turn numeric checks with zero measured allocations/bytes, causal commit and checkpoint restoration; actual CLI abstention and supported copy with EOS; kernel source, formatting, architecture policy and claim checks. Prior generated-Rust assertions and broader release QA were not rerun. Required hosted native checks and protected queue remain mandatory.

Full measured cost:155.350s model and524.036s engineering against420/900s projections. Cumulative model use3605.626/4170s. Pre-recorded standing-authorized extensions were600 model seconds and640MiB storage. Peak sampled storage6,837,837,824 bytes and model-child RSS1,141,374,976 bytes stayed within limits. No deletion or external model compute. Routing work rises with128 features; improved termination reduces total population work, without a per-token speed claim.

The result/evidence and current-state/plan identify the next numerical-versus-word admission boundary. This is bounded learned source selection, not general language, reasoning or frontier qualification.

References #1139, #1140, #973. Does not close their broader scope.
