### PR TITLE
Stop repeating native test builds on every PR and merge queue run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,23 @@ name: ci
 
 # Pre-alpha verification is issue-scoped: developers compile and run the path
 # they changed instead of paying for the full release ladder on every PR.
-# Pull-request and merge-group events run native architecture and product-path checks plus the five
-# historical status names required by the immutable ruleset. The full release
-# workflow remains available when the implemented product reaches that stage.
+# Owner-directed fast iteration: pull requests and merge groups emit only the
+# five historical status acknowledgements required by the ruleset. Native
+# verification is available through explicit native_checks dispatch; broader
+# product/release workflows remain separately selectable.
 on:
   pull_request:
   merge_group:
   workflow_dispatch:
     inputs:
       qa_scope:
-        description: 'Explicit QA scope; use release_qa only when preparing to ship'
+        description: 'Explicit QA scope; native_checks runs the native suite; release_qa is for shipping'
         required: true
         default: none
         type: choice
         options:
           - none
+          - native_checks
           - product_path
           - release_qa
       decision_reason:
@@ -100,12 +102,19 @@ jobs:
         if: steps.scope.outputs.code == 'true'
         run: cargo test --workspace --lib
 
-  # Ruleset transport only. The repository setting still expects these five
-  # historical names. The first job checks the native architecture contract and
-  # changed geometric paths; this is not the deferred full release ladder.
+  # Keep the required status name until the ruleset is changed. This job is
+  # transparent queue transport, not a successful test or policy evaluation.
   required-core-transport:
     name: fmt / clippy / tests / no_std / κ
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge explicitly requested native verification
+        run: echo "Ruleset transport only; no formatting, Clippy, native tests, no_std, kappa or architecture-policy checks ran. Use workflow_dispatch qa_scope=native_checks for the native suite."
+
+  native-checks:
+    name: manual native architecture and runtime checks
+    if: github.event_name == 'workflow_dispatch' && inputs.qa_scope == 'native_checks'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Acknowledge explicitly requested native verification
+      - name: Acknowledge deferred native verification
         run: echo "Ruleset transport only; no formatting, Clippy, native tests, no_std, kappa or architecture-policy checks ran. Use workflow_dispatch qa_scope=native_checks for the native suite."
 
   native-checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Run the retained native formatting, architecture-policy, model, context,
 allocation and CLI checks explicitly when needed:
 
 ```bash
-gh workflow run ci.yml --ref <branch-or-commit> -f qa_scope=native_checks -f decision_reason="<why this verification is needed>"
+gh workflow run ci.yml --ref <branch-or-tag> -f qa_scope=native_checks -f decision_reason="<why this verification is needed>"
 ```
 
 The existing manual `product_path` and `release_qa` scopes remain available;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,15 +145,24 @@ Do not repeat broad workspace, BDD, no_std, fuzz, WASM, conformance or release
 checks unless their boundary is affected. Run the claim-wording check when
 changing claims. Record actual commands and outcomes, including unrun checks.
 
-The protected queue retains five historical required names. In the
-[current workflow](.github/workflows/ci.yml), pull requests and merge groups
-run `fmt / clippy / tests / no_std / κ` as formatting, the
-Rust architecture-policy check and focused native model, context, allocation,
-CLI/service tests. It does not run every check named in that historical label.
-The other four statuses explicitly acknowledge compatibility only; they do not
-run audit, fuzzing, WASM or Gate C. The broader legacy verification jobs remain
-available through manual `release_qa` dispatch. Their retention is not evidence
-that they ran or that they certify the new model. Report actual job steps.
+The protected queue retains five historical required names. By owner direction
+on 2026-09-06, the [current workflow](.github/workflows/ci.yml) emits all five as
+explicit compatibility acknowledgements on pull requests and merge groups.
+The `fmt / clippy / tests / no_std / κ` job performs no checkout, compilation,
+formatting, linting, tests or architecture-policy evaluation. No automatic
+native suite is repeated on the PR and again in the merge queue.
+
+Run the retained native formatting, architecture-policy, model, context,
+allocation and CLI checks explicitly when needed:
+
+```bash
+gh workflow run ci.yml --ref <branch-or-commit> -f qa_scope=native_checks -f decision_reason="<why this verification is needed>"
+```
+
+The existing manual `product_path` and `release_qa` scopes remain available;
+actual workspace Clippy is part of `release_qa`. Local focused compilation and
+behavior checks remain required for changed Rust paths. A successful transport
+acknowledgement is not verification or model evidence; report actual job steps.
 
 The toolchain is pinned in `rust-toolchain.toml`. Use rustup-managed cargo
 (`~/.cargo/bin/cargo`); a Homebrew binary earlier in PATH can ignore the pin.


### PR DESCRIPTION
Routine PRs and merge groups were each compiling and running the native Rust suite under the historical `fmt / clippy / tests / no_std / κ` status, causing two long waits for each small change. At the owner's explicit request, make that status a transparent no-verification acknowledgement, matching the other four required compatibility statuses.

Preserve the exact native formatting, architecture-policy, model, context, allocation and CLI steps under a manually dispatched `qa_scope=native_checks` job. The broader `product_path` and `release_qa` options remain unchanged; actual workspace Clippy remains in manual release QA. Protected PR delivery and the merge queue remain enabled. AGENTS.md documents the behavior and manual command; changed Rust paths still require appropriate focused local verification.

Validation: parsed workflow YAML; checked all five required names and PR/merge-group conditions are unchanged and execute only echo acknowledgements; verified the manual native steps exactly equal the former automatic steps and every other job is unchanged. Claim-wording and diff-whitespace checks pass. No local Rust build or model work. Required acknowledgements are explicitly not test or model-quality evidence.
