### PR TITLE
Retain complete forward relation values with geometric extent

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,12 @@ stop or continue at the same word in different source roles. Construction reache
 14/14, open 6/6 and fresh 9/9 (6/9 with the pair disabled), while preserving all
 663 earlier construction answers and the 24/24 exposed set. Unseen connectors
 and double-space gaps still fail 0/2; general phrase understanding is unqualified.
-The next step is bounded value-extent binding and retained multiword memory.
+The subsequent [retained relation spans](docs/native_geometric_retained_spans_1140.md)
+retain `0b12b604` with the corrected forward-only runtime. Without a new fit,
+complete values survive window eviction, repeated assertions, corrections and
+conflicts: 6/6 construction, 6/6 open and 6/6 previously exposed session turns pass.
+All prior preservation passes. Reverse statements retain their existing single-word
+behavior; role-aware endpoints and broader phrase boundaries remain the next need.
 General prose/syntax/reasoning and frontier capability remain unqualified. Follow
 the current-state pointer for artifacts, costs and the next implementation.
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -25,6 +25,8 @@ mod joint_admission;
 mod literal_binding;
 #[path = "native_geometric_value_probe/relation_memory.rs"]
 mod relation_memory;
+#[path = "native_geometric_value_probe/retained_span.rs"]
+mod retained_span;
 #[path = "native_geometric_value_probe/role_read.rs"]
 mod role_read;
 #[path = "native_geometric_value_probe/source_context.rs"]
@@ -985,6 +987,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("retained-span") {
+        return retained_span::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("span-context") {
         return span_context::run(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs
@@ -1,0 +1,209 @@
+//! Reuse the accepted extent operator in durable relation values, without fitting.
+use super::*;
+use uor_r4_core::native_geometric::Session;
+fn ingest(s: &mut Session, m: &Model, text: &str) -> ProbeResult<()> {
+    for t in m.encode(text)? {
+        s.observe(m, t)?;
+    }
+    Ok(())
+}
+fn emit(s: &mut Session, m: &Model) -> ProbeResult<String> {
+    s.begin_response(m)?;
+    let mut out = Vec::new();
+    for _ in 0..32 {
+        let checkpoint = s.checkpoint()?;
+        let mut restored = m.restore_session(&checkpoint)?;
+        let p = s.predict(m)?;
+        if restored.predict(m)? != p {
+            return Err("retained span checkpoint prediction differs".into());
+        }
+        s.observe(m, p.token)?;
+        if p.token == 1 {
+            return Ok(String::from_utf8(m.decode(&out)?)?);
+        }
+        out.push(p.token);
+    }
+    Err("retained span did not terminate".into())
+}
+fn turns(m: &Model, a: &str, b: &str, first: &str, second: &str, tail: &str) -> ProbeResult<Value> {
+    let mut s = m.session(Control::Full)?;
+    s.observe(m, 0)?;
+    let padding = "quiet sky. ".repeat(96);
+    let trailing = m.encode(&padding)?.len();
+    if trailing <= 512 {
+        return Err("padding does not evict raw window".into());
+    }
+    let mut rows = Vec::new();
+    for (input, owner, expected) in [
+        (
+            format!("{a} in {first} {second}. {b} in Cedar Harbor. "),
+            a,
+            format!(" {first} {second}.\n"),
+        ),
+        (
+            format!("{a} in {first} {second}. "),
+            a,
+            format!(" {first} {second}.\n"),
+        ),
+        (
+            format!("{a} now in {first} {tail}. "),
+            a,
+            format!(" {first} {tail}.\n"),
+        ),
+        (String::new(), b, " Cedar Harbor.\n".into()),
+        (
+            format!("{a} in {first} {second}. "),
+            a,
+            " Unknown.\n".into(),
+        ),
+        (
+            format!("{a} now in {first} {second}. "),
+            a,
+            format!(" {first} {second}.\n"),
+        ),
+    ] {
+        s.end_response(m)?;
+        ingest(&mut s, m, &input)?;
+        ingest(&mut s, m, &padding)?;
+        let query = format!("Where is {owner}? Answer:");
+        ingest(&mut s, m, &query)?;
+        let text = emit(&mut s, m)?;
+        let wire: Value = serde_json::from_slice(&s.checkpoint()?)?;
+        let records = wire["values"]["relations"]["records"]
+            .as_array()
+            .ok_or("records absent")?;
+        let current:Vec<_>=records.iter().filter(|r|r["id"].as_u64().unwrap_or(0)>0).map(|r|json!({"id":r["id"],"previous":r["previous"],"action":r["action"],"conflict":r["conflict"],"owner":r["owner"]["bytes"],"value":r["value"]["bytes"],"span":r["span"]})).collect();
+        let expected_versions = [2_u64, 3, 4, 4, 5, 6][rows.len()];
+        let writes_exact = wire["values"]["relations"]["next_id"] == expected_versions + 1
+            && current.len() as u64 == expected_versions;
+        rows.push(json!({"input":input,"query":query,"expected":expected,"text":text,"exact":text==expected,"trailing_tokens":trailing,"checkpoint_predictions_equal":true,"writes_exact":writes_exact,"expected_versions":expected_versions,"records":current}));
+    }
+    let mut isolated = m.session(Control::Full)?;
+    isolated.observe(m, 0)?;
+    ingest(&mut isolated, m, &format!("Where is {a}? Answer:"))?;
+    let isolated = emit(&mut isolated, m)?;
+    let exact = rows.iter().filter(|r| r["exact"] == true).count();
+    Ok(
+        json!({"artifact":m.artifact_cid(),"exact":exact,"total":rows.len(),"turns":rows,"isolated":isolated,"isolation_pass":isolated==" Unknown.\n","writes_exact":rows.iter().all(|r|r["writes_exact"]==true)}),
+    )
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    if args.len() != 3 && !(args.len() == 4 && args[3] == "replay") {
+        return Err("retained-span PARENT ROOT NEW_DIRECTORY | retained-span MODEL ROOT NEW_DIRECTORY replay".into());
+    }
+    let root = Path::new(&args[1]);
+    let out = Path::new(&args[2]);
+    fs::create_dir(out)?;
+    let replay = args.len() == 4;
+    let loaded = Model::from_bytes(&fs::read(&args[0])?)?;
+    let model;
+    let baseline;
+    if replay {
+        model = loaded;
+        baseline = json!({"exact":0,"scope":"Initial matched parent report retained; not rerun"});
+    } else {
+        let parent = loaded;
+        baseline = turns(&parent, "nalia", "evrin", "Gold", "Meadow", "Cove")?;
+        write_json(&out.join("parent-sessions.json"), &baseline)?;
+        model = parent.with_retained_relation_spans()?;
+        write_new(&out.join("model.json"), &model.to_bytes()?)?;
+        let mut wire: Value = serde_json::from_slice(&model.to_bytes()?)?;
+        let mut old: Value = serde_json::from_slice(&parent.to_bytes()?)?;
+        if wire
+            .as_object_mut()
+            .ok_or("model shape")?
+            .remove("relation_spans")
+            != Some(json!(parent.artifact_cid()))
+        {
+            return Err("parent link differs".into());
+        }
+        for v in [&mut wire, &mut old] {
+            let map = v.as_object_mut().ok_or("model shape")?;
+            map.remove("artifact_cid");
+            map.remove("uor_model_address");
+        }
+        if wire != old {
+            return Err("retained span changed parent parameters".into());
+        }
+    }
+    let model_wire: Value = serde_json::from_slice(&model.to_bytes()?)?;
+    let construction = turns(&model, "nalia", "evrin", "Gold", "Meadow", "Cove")?;
+    write_json(&out.join("construction-sessions.json"), &construction)?;
+    let open = turns(&model, "selvi", "tilva", "Dusk", "Ridge", "Vale")?;
+    write_json(&out.join("development-sessions.json"), &open)?;
+    let preserve = out.join("preservation");
+    fs::create_dir(&preserve)?;
+    source_noread::preserve_model_lean(model.clone(), root, &preserve)?;
+    let old: Value =
+        serde_json::from_slice(&fs::read(root.join("source-order-angular256/source.json"))?)?;
+    let docs: Vec<ValueExample> = serde_json::from_value(old["fit"].clone())?;
+    let retained = source_noread::lean(source_noread::responses(
+        &model,
+        &docs,
+        false,
+        Control::Full,
+    )?);
+    write_json(&out.join("retained-construction.json"), &retained)?;
+    // Earlier extent panels are preservation evidence, never new fitting data.
+    for (file, split, name) in [
+        (
+            "span-context-angular/source.json",
+            "fit",
+            "prior-span-construction",
+        ),
+        (
+            "span-context-angular/source.json",
+            "development",
+            "prior-span-development",
+        ),
+        (
+            "span-context-angular/fresh-source.json",
+            "fresh",
+            "prior-span-fresh",
+        ),
+    ] {
+        let source: Value = serde_json::from_slice(&fs::read(root.join(file))?)?;
+        let docs: Vec<ValueExample> = serde_json::from_value(source[split].clone())?;
+        let report = source_noread::lean(source_noread::responses(
+            &model,
+            &docs,
+            false,
+            Control::Full,
+        )?);
+        write_json(&preserve.join(format!("{name}.json")), &report)?;
+    }
+    let mut preserved = true;
+    for entry in fs::read_dir(&preserve)? {
+        let p = entry?.path();
+        if p.extension().is_some_and(|x| x == "json") {
+            let j: Value = serde_json::from_slice(&fs::read(p)?)?;
+            if j["exact"].is_number() {
+                preserved &= j["exact"] == j["total"];
+            }
+            if j["exact_turns"].is_number() {
+                preserved &=
+                    j["exact_turns"] == j["total_turns"] && j["isolated_no_shared_records"] == true;
+            }
+        }
+    }
+    let selected = construction["exact"] == 6
+        && open["exact"] == 6
+        && construction["isolation_pass"] == true
+        && open["isolation_pass"] == true
+        && construction["writes_exact"] == true
+        && open["writes_exact"] == true
+        && retained["exact"] == 663
+        && preserved;
+    write_json(
+        &out.join("design-selection.json"),
+        &json!({"artifact":model.artifact_cid(),"parent":model_wire["relation_spans"],"selected_before_fresh":selected,"parent_parameters_equal":true,"fit":"NOT_RUN_NO_FIT_REQUIRED","preservation":preserved,"construction":construction["exact"],"development":open["exact"],"retained":retained["exact"],"fresh":if replay {"PREVIOUSLY_EXPOSED_PRESERVATION_REPLAY_FOLLOWS"}else{"NOT_RUN_AT_SELECTION"}}),
+    )?;
+    // A fixed separately authored familiar-template panel, never used for fitting.
+    let fresh = turns(&model, "irden", "marvi", "Silken", "Hollow", "River Bank")?;
+    write_json(&out.join("fresh-sessions.json"), &fresh)?;
+    println!(
+        "{}",
+        json!({"artifact":model.artifact_cid(),"parent":baseline["exact"],"construction":construction["exact"],"development":open["exact"],"retained":retained["exact"],"preservation":preserved,"selected_before_fresh":selected,"fresh":fresh["exact"],"fresh_total":fresh["total"]})
+    );
+    Ok(())
+}

--- a/crates/uor-r4-core/src/native_geometric/dependent_read.rs
+++ b/crates/uor-r4-core/src/native_geometric/dependent_read.rs
@@ -85,7 +85,7 @@ pub(super) fn follow<'a>(
     first: &RelationRecord,
     work: &mut ValueWork,
 ) -> Option<&'a RelationRecord> {
-    if first.conflict {
+    if first.conflict || first.span.is_some() {
         return None;
     }
     for &id in &state.directory {
@@ -110,7 +110,10 @@ pub(super) fn valid(values: &ValueState, ids: [u64; 2], work: &mut ValueWork) ->
     work.relations.record_reads += 2;
     match (state.record(ids[0]), state.record(ids[1])) {
         (Some(first), Some(last)) => {
-            !first.conflict && !last.conflict && first.value.matches(&last.owner, work)
+            !first.conflict
+                && first.span.is_none()
+                && !last.conflict
+                && first.value.matches(&last.owner, work)
         }
         _ => false,
     }

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -52,6 +52,7 @@ mod mixture;
 mod numeral;
 mod relation;
 mod relation_admission;
+mod relation_span;
 #[cfg(test)]
 mod relation_tests;
 mod relation_training;
@@ -338,6 +339,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    relation_spans: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     source_span_context: Option<Vec<word_copy_types::WordCopyAddress>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source_span: Option<source_routing::SourceRouting>,
@@ -392,6 +395,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    relation_spans: Option<String>,
+    #[serde(default)]
     source_span_context: Option<Vec<word_copy_types::WordCopyAddress>>,
     #[serde(default)]
     source_span: Option<source_routing::SourceRouting>,
@@ -445,6 +450,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            relation_spans: wire.relation_spans,
             source_span_context: wire.source_span_context,
             source_span: wire.source_span,
             source_context: wire.source_context,

--- a/crates/uor-r4-core/src/native_geometric/relation.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation.rs
@@ -32,6 +32,9 @@ pub(super) struct RelationRecord {
     pub id: u64,
     pub owner: WordAtom,
     pub value: WordAtom,
+    /// Exact bounded value payload; the original WordAtom remains its anchor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span: Option<super::relation_span::RelationSpan>,
     pub previous: u64,
     /// 1=assert, 2=explicit revision, 3=contradiction. Learned choice.
     pub action: u8,
@@ -46,6 +49,8 @@ pub(super) struct RelationState {
     pub directory: [u64; RELATIONS],
     pub next_id: u64,
     pub last_word_end: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending: Option<super::relation_span::PendingRelation>,
 }
 impl Default for RelationState {
     fn default() -> Self {
@@ -54,12 +59,19 @@ impl Default for RelationState {
             directory: [0; RELATIONS],
             next_id: 1,
             last_word_end: None,
+            pending: None,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelationWork {
+    #[serde(default, skip_serializing_if = "RoutingWork::is_empty")]
+    pub span_routing: RoutingWork,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub span_edge_checks: u64,
+    #[serde(default, skip_serializing_if = "relation_count_zero")]
+    pub span_byte_writes: u64,
     pub word_boundaries: u64,
     pub feature_queries: u64,
     pub row_comparisons: u64,
@@ -415,6 +427,16 @@ impl RelationState {
         action: u8,
         work: &mut ValueWork,
     ) {
+        self.commit_span(owner, value, None, action, work);
+    }
+    pub(super) fn commit_span(
+        &mut self,
+        owner: WordAtom,
+        value: WordAtom,
+        span: Option<super::relation_span::RelationSpan>,
+        action: u8,
+        work: &mut ValueWork,
+    ) {
         let Some(next) = self.next_id.checked_add(1) else {
             return;
         };
@@ -431,7 +453,16 @@ impl RelationState {
         }
         let conflict = action == 3
             || (action == 1
-                && previous.is_some_and(|(_, r)| r.conflict || !r.value.matches(&value, work)));
+                && previous.is_some_and(|(_, r)| {
+                    r.conflict
+                        || !super::relation_span::same_value(
+                            &r.value,
+                            r.span.as_ref(),
+                            &value,
+                            span.as_ref(),
+                            work,
+                        )
+                }));
         let slot = ((self.next_id - 1) & 15) as usize;
         let evicted = self.records[slot].id;
         if evicted != 0 {
@@ -457,6 +488,7 @@ impl RelationState {
             id: self.next_id,
             owner,
             value,
+            span,
             previous: previous.map_or(0, |(_, r)| r.id),
             action,
             conflict,
@@ -477,6 +509,10 @@ impl RelationState {
         }
         self.last_word_end = Some(words.recent[0].byte_end);
         work.relations.word_boundaries = work.relations.word_boundaries.saturating_add(1);
+        if model.relation_spans.is_some() {
+            self.observe_span(model, words, work);
+            return;
+        }
         if let Some((o, v, a)) = write_choice(model, &words.recent[..words.recent_len], work) {
             self.commit(words.recent[o], words.recent[v], a, work);
         } else {
@@ -549,7 +585,13 @@ pub(super) fn read_choice(
         let (f, n) = read_features(model, record, words, &addr, work);
         for (ai, action) in role.actions.iter().enumerate() {
             if action.copy
-                && (usize::from(record.value.len) + 1 + usize::from(action.prefix.is_some())
+                && (usize::from(
+                    record
+                        .span
+                        .as_ref()
+                        .map_or(record.value.len, |span| span.len),
+                ) + 1
+                    + usize::from(action.prefix.is_some())
                     > usize::from(super::response_entry_types::RESPONSE_ENTRY_STEPS))
             {
                 continue;
@@ -584,6 +626,7 @@ impl RelationState {
     pub(super) fn validate(&self, values: &ValueState, model: &Model) -> Result<()> {
         let fail = || Error("invalid relation snapshot identity, directory or version".into());
         let words = values.lexemes.as_ref().ok_or_else(fail)?;
+        self.validate_spans(values, model)?;
         if self.next_id == 0
             || self
                 .last_word_end
@@ -629,7 +672,13 @@ impl RelationState {
                 let conflict = r.action == 3
                     || (r.action == 1
                         && (prior.conflict
-                            || !r.value.matches(&prior.value, &mut ValueWork::default())));
+                            || !super::relation_span::same_value(
+                                &r.value,
+                                r.span.as_ref(),
+                                &prior.value,
+                                prior.span.as_ref(),
+                                &mut ValueWork::default(),
+                            )));
                 if conflict != r.conflict {
                     return Err(fail());
                 }

--- a/crates/uor-r4-core/src/native_geometric/relation_span.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_span.rs
@@ -1,0 +1,484 @@
+//! Deferred relation writes preserve one exact bounded value extent. The first
+//! WordAtom remains the semantic anchor; its bytes and geometry are not rewritten.
+use super::relation::{self, RelationState};
+use super::value_lexemes::{LexemeState, WordAtom};
+use super::value_types::{ValueState, ValueWork};
+use super::word_copy_types::WordCopyWork;
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RelationSpan {
+    /// Complete value bytes, including the unchanged first-word payload.
+    pub bytes: [u8; 28],
+    pub len: u8,
+    pub extra_words: u8,
+    pub terminal: WordAtom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PendingRelation {
+    pub owner: WordAtom,
+    pub value: WordAtom,
+    pub action: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span: Option<RelationSpan>,
+}
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+pub(super) fn payload<'a>(value: &'a WordAtom, span: Option<&'a RelationSpan>) -> Option<&'a [u8]> {
+    match span {
+        Some(span) => span.bytes.get(..usize::from(span.len)),
+        None => value.bytes.get(..usize::from(value.len)),
+    }
+}
+
+pub(super) fn same_value(
+    a: &WordAtom,
+    a_span: Option<&RelationSpan>,
+    b: &WordAtom,
+    b_span: Option<&RelationSpan>,
+    work: &mut ValueWork,
+) -> bool {
+    if a_span.is_none() && b_span.is_none() {
+        return a.matches(b, work);
+    }
+    work.lexical_comparisons = work.lexical_comparisons.saturating_add(1);
+    let Some((a, b)) = payload(a, a_span).zip(payload(b, b_span)) else {
+        return false;
+    };
+    if a.is_empty() || a.len() != b.len() {
+        return false;
+    }
+    for (&a, &b) in a.iter().zip(b) {
+        work.lexical_byte_comparisons = work.lexical_byte_comparisons.saturating_add(1);
+        if a != b {
+            return false;
+        }
+    }
+    true
+}
+
+impl PendingRelation {
+    fn terminal(&self) -> &WordAtom {
+        self.span
+            .as_ref()
+            .map_or(&self.value, |span| &span.terminal)
+    }
+
+    /// Return true only when the actual next source word was consumed.
+    fn extend(&mut self, model: &Model, next: WordAtom, work: &mut ValueWork) -> bool {
+        work.relations.span_edge_checks = work.relations.span_edge_checks.saturating_add(1);
+        let prior = *self.terminal();
+        let Some(separator) = next.leading_gap else {
+            return false;
+        };
+        if next.byte_end.checked_sub(u64::from(next.len)) != prior.byte_end.checked_add(1) {
+            return false;
+        }
+        let length = self.span.as_ref().map_or(self.value.len, |span| span.len);
+        let Some(new_length) = length
+            .checked_add(1)
+            .and_then(|len| len.checked_add(next.len))
+            .filter(|&len| len <= 28)
+        else {
+            return false;
+        };
+        let mut routing = WordCopyWork::default();
+        let advance = super::source_span::learned_advance(
+            model,
+            &self.value,
+            &next,
+            separator,
+            Control::Full,
+            &mut routing,
+        );
+        work.relations.span_routing.add(routing.routing);
+        work.relations.record_reads = work
+            .relations
+            .record_reads
+            .saturating_add(routing.word_record_reads);
+        work.relations.dictionary_comparisons = work
+            .relations
+            .dictionary_comparisons
+            .saturating_add(routing.dictionary_comparisons);
+        work.relations.dictionary_byte_comparisons = work
+            .relations
+            .dictionary_byte_comparisons
+            .saturating_add(routing.dictionary_byte_comparisons);
+        if !advance {
+            return false;
+        }
+        if self.span.is_none() {
+            work.relations.span_byte_writes = work
+                .relations
+                .span_byte_writes
+                .saturating_add(u64::from(self.value.len));
+        }
+        let span = self.span.get_or_insert_with(|| {
+            let mut bytes = [0; 28];
+            bytes[..usize::from(self.value.len)]
+                .copy_from_slice(&self.value.bytes[..usize::from(self.value.len)]);
+            RelationSpan {
+                bytes,
+                len: self.value.len,
+                extra_words: 0,
+                terminal: self.value,
+            }
+        });
+        span.bytes[usize::from(length)] = separator;
+        span.bytes[usize::from(length) + 1..usize::from(new_length)]
+            .copy_from_slice(&next.bytes[..usize::from(next.len)]);
+        span.len = new_length;
+        span.extra_words += 1;
+        span.terminal = next;
+        work.relations.span_byte_writes = work
+            .relations
+            .span_byte_writes
+            .saturating_add(u64::from(next.len) + 1);
+        true
+    }
+}
+
+impl RelationState {
+    /// Explicit response boundaries finalize source-only pending writes once.
+    pub(super) fn finish_span(&mut self, work: &mut ValueWork) {
+        if let Some(pending) = self.pending.take() {
+            self.commit_span(
+                pending.owner,
+                pending.value,
+                pending.span,
+                pending.action,
+                work,
+            );
+        }
+    }
+
+    pub(super) fn observe_span(
+        &mut self,
+        model: &Model,
+        words: &LexemeState,
+        work: &mut ValueWork,
+    ) {
+        if let Some(pending) = &mut self.pending {
+            if pending.extend(model, words.recent[0], work) {
+                return;
+            }
+            self.finish_span(work);
+        }
+        let Some((owner, value, action)) =
+            relation::write_choice(model, &words.recent[..words.recent_len], work)
+        else {
+            work.relations.no_writes = work.relations.no_writes.saturating_add(1);
+            return;
+        };
+        // A reverse write completes at the owner and binds only an earlier
+        // value anchor. It supplies no extent boundary for intervening words.
+        if value != 0 {
+            self.commit_span(words.recent[owner], words.recent[value], None, action, work);
+            return;
+        }
+        let pending = PendingRelation {
+            owner: words.recent[owner],
+            value: words.recent[value],
+            action,
+            span: None,
+        };
+        self.pending = Some(pending);
+    }
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END
+
+fn initial(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+fn component(byte: u8) -> bool {
+    initial(byte) || byte.is_ascii_digit()
+}
+
+impl RelationSpan {
+    fn shape_valid(
+        &self,
+        anchor: &WordAtom,
+        seen: u64,
+        source_bytes: u64,
+        geometry_len: usize,
+    ) -> bool {
+        let len = usize::from(self.len);
+        let anchor_len = usize::from(anchor.len);
+        if self.extra_words == 0
+            || self.extra_words > 15
+            || len > 28
+            || len <= anchor_len
+            || self.bytes[len..].iter().any(|&b| b != 0)
+            || self.bytes.get(..anchor_len) != anchor.bytes.get(..anchor_len)
+            || !self
+                .terminal
+                .snapshot_valid(seen, source_bytes, geometry_len)
+            || self.terminal.end < anchor.end
+            || self.terminal.byte_end.checked_sub(anchor.byte_end)
+                != Some(u64::from(self.len) - u64::from(anchor.len))
+        {
+            return false;
+        }
+        let mut words = 0_u8;
+        let mut offset = 0;
+        let mut final_start = 0;
+        while offset < len {
+            if !initial(self.bytes[offset]) {
+                return false;
+            }
+            final_start = offset;
+            words += 1;
+            while offset < len && component(self.bytes[offset]) {
+                offset += 1;
+            }
+            if offset < len {
+                if !self.bytes[offset].is_ascii() || offset + 1 == len {
+                    return false;
+                }
+                offset += 1;
+            }
+        }
+        words == self.extra_words + 1
+            && len - final_start == usize::from(self.terminal.len)
+            && self.bytes[final_start..len] == self.terminal.bytes[..usize::from(self.terminal.len)]
+            && self.terminal.leading_gap == Some(self.bytes[final_start - 1])
+    }
+
+    fn learned_valid(&self, anchor: &WordAtom, model: &Model) -> bool {
+        let mut offset = usize::from(anchor.len);
+        while offset < usize::from(self.len) {
+            let separator = self.bytes[offset];
+            offset += 1;
+            let start = offset;
+            while offset < usize::from(self.len) && component(self.bytes[offset]) {
+                offset += 1;
+            }
+            let mut next = WordAtom {
+                len: (offset - start) as u8,
+                ..Default::default()
+            };
+            next.bytes[..usize::from(next.len)].copy_from_slice(&self.bytes[start..offset]);
+            if !super::source_span::learned_advance(
+                model,
+                anchor,
+                &next,
+                separator,
+                Control::Full,
+                &mut WordCopyWork::default(),
+            ) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl RelationState {
+    pub(super) fn validate_spans(&self, values: &ValueState, model: &Model) -> Result<()> {
+        let fail = || Error("invalid retained relation span or pending write".into());
+        let words = values.lexemes.as_ref().ok_or_else(fail)?;
+        if words.recent_len > words.recent.len() {
+            return Err(fail());
+        }
+        if model.relation_spans.is_none()
+            && (self.pending.is_some() || self.records.iter().any(|r| r.span.is_some()))
+        {
+            return Err(fail());
+        }
+        let valid_atom = |atom: &WordAtom| {
+            atom.len != 0
+                && atom.snapshot_valid(
+                    values.seen,
+                    words.source_bytes_seen,
+                    model.geometry.inverses.len(),
+                )
+        };
+        let visible_atom = |atom: &WordAtom| {
+            words.recent[..words.recent_len]
+                .iter()
+                .filter(|word| word.byte_end == atom.byte_end)
+                .all(|word| word == atom)
+        };
+        let valid_span = |anchor: &WordAtom, span: &RelationSpan| {
+            if !span.shape_valid(
+                anchor,
+                values.seen,
+                words.source_bytes_seen,
+                model.geometry.inverses.len(),
+            ) || !span.learned_valid(anchor, model)
+                || !visible_atom(&span.terminal)
+            {
+                return false;
+            }
+            let start = anchor.byte_end + 1 - u64::from(anchor.len);
+            words.recent[..words.recent_len]
+                .iter()
+                .filter(|word| word.byte_end >= start && word.byte_end <= span.terminal.byte_end)
+                .all(|word| {
+                    let Some(end) = word
+                        .byte_end
+                        .checked_sub(start)
+                        .and_then(|n| n.checked_add(1))
+                    else {
+                        return false;
+                    };
+                    let Some(begin) = end.checked_sub(u64::from(word.len)) else {
+                        return false;
+                    };
+                    span.bytes.get(begin as usize..end as usize)
+                        == word.bytes.get(..usize::from(word.len))
+                        && (begin == 0
+                            || word
+                                .leading_gap
+                                .is_none_or(|gap| span.bytes[begin as usize - 1] == gap))
+                })
+        };
+        for record in &self.records {
+            if let Some(span) = &record.span {
+                if record.owner.byte_end >= record.value.byte_end
+                    || !valid_atom(&record.value)
+                    || !visible_atom(&record.value)
+                    || !valid_span(&record.value, span)
+                {
+                    return Err(fail());
+                }
+            }
+        }
+        if let Some(pending) = &self.pending {
+            if values.active
+                || pending.owner.byte_end >= pending.value.byte_end
+                || !(1..=3).contains(&pending.action)
+                || !valid_atom(&pending.owner)
+                || !valid_atom(&pending.value)
+                || !visible_atom(&pending.owner)
+                || !visible_atom(&pending.value)
+                || pending
+                    .span
+                    .as_ref()
+                    .is_some_and(|span| !valid_span(&pending.value, span))
+                || words.recent_len == 0
+                || words.recent[0] != *pending.terminal()
+                || self.last_word_end != Some(pending.terminal().byte_end)
+            {
+                return Err(fail());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn atom(text: &str, end: u64) -> WordAtom {
+        let mut word = WordAtom {
+            len: text.len() as u8,
+            end,
+            byte_end: end,
+            ..Default::default()
+        };
+        word.bytes[..text.len()].copy_from_slice(text.as_bytes());
+        word
+    }
+    fn span(text: &str, end: u64) -> RelationSpan {
+        let mut bytes = [0; 28];
+        bytes[..text.len()].copy_from_slice(text.as_bytes());
+        let last = text.rsplit(' ').next().unwrap();
+        let mut terminal = atom(last, end);
+        terminal.leading_gap = Some(b' ');
+        RelationSpan {
+            bytes,
+            len: text.len() as u8,
+            extra_words: 1,
+            terminal,
+        }
+    }
+
+    #[test]
+    fn retained_relation_span_conflict_compares_complete_value_and_revision_clears_it() {
+        let mut state = RelationState::default();
+        let mut work = ValueWork::default();
+        state.commit_span(
+            atom("ada", 2),
+            atom("New", 10),
+            Some(span("New York", 15)),
+            1,
+            &mut work,
+        );
+        state.commit_span(
+            atom("ada", 22),
+            atom("New", 30),
+            Some(span("New Jersey", 37)),
+            1,
+            &mut work,
+        );
+        assert!(state.record(2).unwrap().conflict);
+        assert_eq!(state.record(2).unwrap().previous, 1);
+        state.commit_span(
+            atom("ada", 42),
+            atom("New", 50),
+            Some(span("New York", 55)),
+            2,
+            &mut work,
+        );
+        assert!(!state.record(3).unwrap().conflict);
+        assert_eq!(
+            payload(
+                &state.record(1).unwrap().value,
+                state.record(1).unwrap().span.as_ref()
+            )
+            .unwrap(),
+            b"New York"
+        );
+        assert_eq!(state.record(1).unwrap().value, atom("New", 10));
+    }
+
+    #[test]
+    fn retained_relation_pending_flush_commits_once_and_old_fields_stay_absent() {
+        let mut state = RelationState::default();
+        let mut work = ValueWork::default();
+        let wire = serde_json::to_string(&state).unwrap();
+        assert!(!wire.contains("pending"));
+        assert!(!wire.contains("span"));
+        state.pending = Some(PendingRelation {
+            owner: atom("ada", 2),
+            value: atom("New", 10),
+            action: 1,
+            span: Some(span("New York", 15)),
+        });
+        assert_eq!(state.next_id, 1);
+        let mut restored: RelationState =
+            serde_json::from_slice(&serde_json::to_vec(&state).unwrap()).unwrap();
+        restored.finish_span(&mut work);
+        restored.finish_span(&mut work);
+        assert_eq!(restored.next_id, 2);
+        assert_eq!(work.relations.record_writes, 1);
+        assert_eq!(restored.record(1).unwrap().span.unwrap().len, 8);
+    }
+
+    #[test]
+    fn retained_relation_span_shape_binds_padding_anchor_terminal_and_word_count() {
+        let anchor = atom("New", 10);
+        let good = span("New York", 15);
+        assert!(good.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.bytes[27] = 1;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.bytes[0] = b'O';
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.terminal.byte_end += 1;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.extra_words = 2;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.len = 255;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -218,6 +218,9 @@ impl Session {
         if let Some(state) = &mut self.values {
             state.begin(&mut self.work.values);
             state.observe_relation(model, &mut self.work.values);
+            if let Some(relations) = &mut state.relations {
+                relations.finish_span(&mut self.work.values);
+            }
         }
         if let (Some(entry), Some(values)) = (&mut self.response_entry, &self.values) {
             entry.begin(model, values, self.control, &mut self.work.response_entry);

--- a/crates/uor-r4-core/src/native_geometric/source_span.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_span.rs
@@ -12,7 +12,7 @@ fn extended_length(total: u8, next: u8) -> Option<u8> {
 }
 
 /// Only frozen query occurrences have an adjacent source sequence. Persistent
-/// relation/dependency values deliberately retain their single-word behavior.
+/// extents read their separate committed payload through len/byte below.
 pub(super) fn edge(values: &ValueState, origin: u8, work: &mut WordCopyWork) -> Option<(u8, u8)> {
     let words = values.lexemes.as_ref()?;
     work.selector.metadata_reads = work.selector.metadata_reads.saturating_add(1);
@@ -41,6 +41,26 @@ pub(super) fn features(
     paired: bool,
     work: &mut WordCopyWork,
 ) -> ([ValueFeature; 3], usize) {
+    word_features(
+        model,
+        super::relation::source(values, origin),
+        super::relation::source(values, next),
+        separator,
+        contextual,
+        paired,
+        work,
+    )
+}
+
+fn word_features(
+    model: &Model,
+    original: Option<&super::value_lexemes::WordAtom>,
+    next: Option<&super::value_lexemes::WordAtom>,
+    separator: u8,
+    contextual: bool,
+    paired: bool,
+    work: &mut WordCopyWork,
+) -> ([ValueFeature; 3], usize) {
     let mut features = [
         ValueFeature {
             kind: 0,
@@ -53,11 +73,7 @@ pub(super) fn features(
     if !contextual {
         return (features, 1);
     }
-    if let Some((head, word)) = model
-        .source_span_context
-        .as_ref()
-        .zip(super::relation::source(values, next))
-    {
+    if let Some((head, word)) = model.source_span_context.as_ref().zip(next) {
         work.word_record_reads = work.word_record_reads.saturating_add(1);
         let prime = super::word_copy_runtime::address_in(head, word, work);
         if prime != 0 {
@@ -67,7 +83,7 @@ pub(super) fn features(
                 b: 0,
             };
             if paired {
-                if let Some(original) = super::relation::source(values, origin) {
+                if let Some(original) = original {
                     work.word_record_reads = work.word_record_reads.saturating_add(1);
                     let prior = original.predecessors[0];
                     let cue = super::value_lexemes::WordAtom {
@@ -90,6 +106,59 @@ pub(super) fn features(
     (features, 1)
 }
 
+/// Same learned edge law for ingestion and frozen-query copying.
+pub(super) fn learned_advance(
+    model: &Model,
+    original: &super::value_lexemes::WordAtom,
+    next: &super::value_lexemes::WordAtom,
+    separator: u8,
+    control: Control,
+    work: &mut WordCopyWork,
+) -> bool {
+    let (features, count) = word_features(
+        model,
+        Some(original),
+        Some(next),
+        separator,
+        model.source_span_context.is_some() && control != Control::SourceSpanContextDisabled,
+        control != Control::SourceSpanPairDisabled,
+        work,
+    );
+    advance_features(model, &features[..count], control, work)
+}
+
+fn advance_features(
+    model: &Model,
+    features: &[ValueFeature],
+    control: Control,
+    work: &mut WordCopyWork,
+) -> bool {
+    let Some(block) = model
+        .source_span
+        .as_ref()
+        .filter(|_| control != Control::SourceSpanDisabled)
+    else {
+        return false;
+    };
+    work.routing.emission_queries = work.routing.emission_queries.saturating_add(1);
+    if block
+        .codes
+        .binary_search_by(|c| {
+            work.routing.comparisons = work.routing.comparisons.saturating_add(1);
+            work.routing.logical_bytes_read = work.routing.logical_bytes_read.saturating_add(17);
+            c.feature.cmp(&features[0])
+        })
+        .is_err()
+    {
+        return false;
+    }
+    let state = block.encode(model, features, control, &mut work.routing);
+    let stop = block.score(model, state, 0, &mut work.routing);
+    let advance = block.score(model, state, 1, &mut work.routing);
+    work.routing.comparisons = work.routing.comparisons.saturating_add(1);
+    advance > stop
+}
+
 pub(super) fn extent(
     model: &Model,
     values: &ValueState,
@@ -97,7 +166,7 @@ pub(super) fn extent(
     control: Control,
     work: &mut WordCopyWork,
 ) -> u8 {
-    let Some(block) = model
+    let Some(_) = model
         .source_span
         .as_ref()
         .filter(|_| control != Control::SourceSpanDisabled)
@@ -125,26 +194,7 @@ pub(super) fn extent(
             control != Control::SourceSpanPairDisabled,
             work,
         );
-        let feature = features[0];
-        // Unseen transitions default to the inherited finish behavior.
-        work.routing.emission_queries = work.routing.emission_queries.saturating_add(1);
-        if block
-            .codes
-            .binary_search_by(|c| {
-                work.routing.comparisons = work.routing.comparisons.saturating_add(1);
-                work.routing.logical_bytes_read =
-                    work.routing.logical_bytes_read.saturating_add(17);
-                c.feature.cmp(&feature)
-            })
-            .is_err()
-        {
-            break;
-        }
-        let state = block.encode(model, &features[..count], control, &mut work.routing);
-        let stop = block.score(model, state, 0, &mut work.routing);
-        let advance = block.score(model, state, 1, &mut work.routing);
-        work.routing.comparisons = work.routing.comparisons.saturating_add(1);
-        if advance <= stop {
+        if !advance_features(model, &features[..count], control, work) {
             break;
         }
         let Some(word) = super::relation::source(values, next) else {
@@ -163,12 +213,28 @@ pub(super) fn extent(
     extra
 }
 
+fn retained(values: &ValueState, origin: u8) -> Option<&super::relation_span::RelationSpan> {
+    let index = origin.checked_sub(super::relation::RELATION_SOURCE)?;
+    values
+        .relations
+        .as_ref()?
+        .records
+        .get(usize::from(index))
+        .filter(|r| r.id != 0)?
+        .span
+        .as_ref()
+}
+
 pub(super) fn len(
     values: &ValueState,
     origin: u8,
     extra: u8,
     work: &mut WordCopyWork,
 ) -> Option<u8> {
+    if let Some(span) = retained(values, origin) {
+        work.word_record_reads = work.word_record_reads.saturating_add(1);
+        return (extra == 0).then_some(span.len);
+    }
     let mut total = super::relation::source(values, origin)?.len;
     work.word_record_reads = work.word_record_reads.saturating_add(1);
     let mut current = origin;
@@ -190,6 +256,10 @@ pub(super) fn byte(
     mut cursor: u8,
     work: &mut WordCopyWork,
 ) -> Option<u8> {
+    if let Some(span) = retained(values, origin) {
+        work.word_record_reads = work.word_record_reads.saturating_add(1);
+        return (extra == 0 && cursor < span.len).then(|| span.bytes[usize::from(cursor)]);
+    }
     let mut current = origin;
     for step in 0..=extra {
         let word = super::relation::source(values, current)?;

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -178,6 +178,7 @@ impl Trainer {
             dependent_read: None,
             typed_routing: None,
             joint_admission: None,
+            relation_spans: None,
             source_span_context: None,
             source_span: None,
             source_context: None,
@@ -518,8 +519,45 @@ impl Model {
         self.artifact_cid = format!("blake3:{}", blake3::hash(&self.to_bytes()?).to_hex());
         Ok(())
     }
+    /// Bind retained phrase transport to the complete unchanged learned parent.
+    pub fn with_retained_relation_spans(&self) -> Result<Model> {
+        // Candidate validation below reconstructs and validates this entire parent.
+        if self.relation_spans.is_some()
+            || self.source_span_context.is_none()
+            || relation::head(self).is_none()
+        {
+            return Err(Error(
+                "retained spans require contextual span and relation parent".into(),
+            ));
+        }
+        let mut model = self.clone();
+        model.relation_spans = Some(self.artifact_cid.clone());
+        model.refresh_identity()?;
+        model.validate()?;
+        Ok(model)
+    }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(parent_cid) = &self.relation_spans {
+            if self.source_span_context.is_none() || relation::head(self).is_none() {
+                return Err(Error("retained span parent operators absent".into()));
+            }
+            let mut parent = self.clone();
+            parent.relation_spans = None;
+            parent.refresh_identity()?;
+            if &parent.artifact_cid != parent_cid {
+                return Err(Error("retained span frozen parent differs".into()));
+            }
+            parent.validate()?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("retained span identity differs".into()));
+            }
+            return Ok(());
+        }
         if self.source_span_context.is_some() && self.source_span.is_none() {
             return Err(Error("source span context without operator".into()));
         }

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -295,6 +295,24 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             "native source span",
             include_str!("../src/native_geometric/source_span.rs"),
         ),
+        (
+            "native relation memory",
+            region(
+                include_str!("../src/native_geometric/relation.rs"),
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_END",
+            )
+            .1,
+        ),
+        (
+            "native retained relation extent",
+            region(
+                include_str!("../src/native_geometric/relation_span.rs"),
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_END",
+            )
+            .1,
+        ),
         ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
@@ -2102,4 +2120,64 @@ fn native_source_span_preserves_commit_checkpoints_and_zero_allocation() {
     times[..samples].sort_unstable();
     println!("span uncached warm predict+observe samples={samples} median_ns={} max_ns={} (loading, ingestion and checkpoints excluded)", times[samples/2], times[samples-1]);
     println!("parent restoration, malformed code rejection, source commitment, interrupted copy, every-byte checkpoint and zero allocations PASS");
+}
+
+#[test]
+#[ignore = "requires the retained relation span artifact; charged model work"]
+fn native_retained_relation_span_checkpoint_and_allocation() {
+    use uor_r4_core::native_geometric::{Control, Model};
+    let path = std::env::var("R4_RETAINED_SPAN_MODEL").unwrap();
+    let model = Model::from_bytes(&std::fs::read(path).unwrap()).unwrap();
+    let mut session = model.session(Control::Full).unwrap();
+    session.observe(&model, 0).unwrap();
+    for token in model.encode("ada in New ").unwrap() {
+        session.observe(&model, token).unwrap();
+    }
+    let checkpoint = session.checkpoint().unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&checkpoint).unwrap();
+    assert!(wire["values"]["relations"]["pending"].is_object());
+    assert_eq!(wire["values"]["relations"]["next_id"], 1);
+    session = model.restore_session(&checkpoint).unwrap();
+    let rest = format!("York. {}Where is ada? Answer:", "quiet sky. ".repeat(96));
+    let tokens = model.encode(&rest).unwrap();
+    ALLOCATIONS.with(|v| v.set(0));
+    BYTES.with(|v| v.set(0));
+    MEASURING.with(|v| v.set(true));
+    for token in tokens {
+        session.observe(&model, token).unwrap();
+    }
+    session.begin_response(&model).unwrap();
+    MEASURING.with(|v| v.set(false));
+    let saved = session.checkpoint().unwrap();
+    let mut bad: serde_json::Value = serde_json::from_slice(&saved).unwrap();
+    bad["values"]["relations"]["records"][0]["span"]["len"] = 29.into();
+    assert!(model
+        .restore_session(&serde_json::to_vec(&bad).unwrap())
+        .is_err());
+    let mut out = [1; 32];
+    let mut used = 0;
+    let mut times = [0u128; 32];
+    loop {
+        let mut restored = model
+            .restore_session(&session.checkpoint().unwrap())
+            .unwrap();
+        let predicted = restored.predict(&model).unwrap();
+        MEASURING.with(|v| v.set(true));
+        let start = std::time::Instant::now();
+        let actual = session.predict(&model).unwrap();
+        session.observe(&model, actual.token).unwrap();
+        times[used] = start.elapsed().as_nanos();
+        MEASURING.with(|v| v.set(false));
+        assert_eq!(actual, predicted);
+        out[used] = actual.token;
+        used += 1;
+        if actual.token == 1 || used == 32 {
+            break;
+        }
+    }
+    assert_eq!(out[used - 1], 1);
+    assert_eq!(model.decode(&out[..used]).unwrap(), b" New York.\n");
+    assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    times[..used].sort_unstable();
+    println!("retained span pending/atomic write, malformed extent, eviction, each-step checkpoint and zero allocation PASS; uncached predict+observe samples={used} median_ns={} max_ns={} (includes initial selection; excludes load/encoding/ingestion/checkpoints)",times[used/2],times[used-1]);
 }

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -7,6 +7,21 @@ implemented operations, measured behavior and proposed integration. The native
 model was d59070c2 at the review date; no model experiment was
 rerun for that review.
 
+## Retained relation spans — bounded positive after runtime correction, 2026-09-07
+
+The [result](native_geometric_retained_spans_1140.md) retains `0b12b604` with the
+corrected forward-only runtime. It reuses the accepted geometric extent operator
+without fitting. Complete values survive eviction, repeated assertions,
+same-prefix corrections and conflicts on 6/6 construction and 6/6 open session
+turns; six previously exposed turns replay 6/6. All prior preservation passes.
+The initial runtime's reverse-statement extension regressed long-window answers
+to 26/28 and is preserved separately. Restricting deferred extent to the writer's
+forward value restores 28/28 while keeping reverse single-word behavior. Source
+identities distinguish the two runtimes sharing the same learned artifact.
+This is bounded persistent value transport, not a new angular advantage,
+broad phrase understanding, reasoning or energy result. The current-state
+pointer records remaining resources and the role-aware endpoint successor.
+
 ## Context-sensitive source extent — bounded positive, 2026-09-07
 
 The [result](native_geometric_span_context_1139.md) retains `419ba3a7` over

--- a/docs/evidence/native_geometric_retained_spans_1140.json
+++ b/docs/evidence/native_geometric_retained_spans_1140.json
@@ -1,0 +1,1299 @@
+{
+  "schema": "uor-r4.native-retained-span-evidence/1",
+  "at": "2026-09-07T13:35:55.206Z",
+  "decision": "RETAIN_FORWARD_RELATION_SPANS_WITH_CORRECTED_RUNTIME",
+  "base_commit": "f0556bb7cf5e6da355157443739c00769e297195",
+  "artifact": "blake3:0b12b6044e4a04124fa07a69496d9c5da65fc6a9d6ad95072fc46a9590916762",
+  "parent_artifact": "blake3:419ba3a77f062d551909fe0739bf948094b2387843561eee601d3ed0773f2cc0",
+  "model": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/model.json",
+    "bytes": 11631461,
+    "sha256": "39b2e2435b588695ac8fcf37b4f1a70ebe6e130aab0014557d5530f7874c1e25"
+  },
+  "parent": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/span-context-angular/model.json",
+    "bytes": 11631370,
+    "sha256": "8174f36f722da724c820e5c8f8cdc539dab00e74598b400c5cf58849da4aa02b"
+  },
+  "fit": "NOT_RUN_NO_FIT_REQUIRED",
+  "parent_parameters_equal": true,
+  "source_identity_scope": "Same artifact bytes executed under initial and corrected runtimes. Artifact CID binds parameters and enabled component; pair with source identity for behavior reproduction.",
+  "corrected_sources": [
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+      "bytes": 22336,
+      "sha256": "22030167c78a7def19d63c2496b67c58179d8c723d30099ebef587b9f72e669a"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation.rs",
+      "bytes": 25843,
+      "sha256": "fdc1a7c08af8cb458c2d3ad39ffb823291d95bde4c2429b6d4852380aac72124"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation_span.rs",
+      "bytes": 16751,
+      "sha256": "4a8f3cec44b72da64530f59b8204433d282ab1318f02b552877f3748fddad81e"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/source_span.rs",
+      "bytes": 11576,
+      "sha256": "cb8b630bfc930eea8e4a71915e4e3914390b67b6f406191f5c7049e38a9d0942"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/runtime.rs",
+      "bytes": 34047,
+      "sha256": "69dfd84cbdf791ed4bdc7eee57df85afbea640010ceeb28b9151a41053a2a88f"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+      "bytes": 56699,
+      "sha256": "dac067d86feedf19d4d4153be61b3fcf25a1e39101e0d95081f55f403d5d38da"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/dependent_read.rs",
+      "bytes": 6342,
+      "sha256": "eecf3c3d2eb49e8e859cea8fc34d7139f466873ad196a3057b7262c317c1c541"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+      "bytes": 72682,
+      "sha256": "18dd7d0999126d2943f7f4b30093056c92619d07b56b6f9438a1dfdf64033482"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs",
+      "bytes": 9067,
+      "sha256": "d908690a59471ebb885af65f980c5d9f93aed5beb6f80c2f9c2ed50b9aa25d77"
+    },
+    {
+      "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "bytes": 88576,
+      "sha256": "c06c9f320c9b25c6becdc900df3137a100770326f9c79bc17b8959d3625a5df9"
+    }
+  ],
+  "initial_changed_sources": {
+    "source": "/Users/casey.allard/.codex/worktrees/r4-typed-value/uor-r4",
+    "manifest": [
+      {
+        "path": "crates/uor-r4-core/src/native_geometric/relation_span.rs",
+        "sha256": "7d7514f8acf69b1e03e7b901cbc8016a82047a1ef2ddba09d3905c48daaf65b3"
+      },
+      {
+        "path": "crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs",
+        "sha256": "28e5ce153fa6bb5d4293e483130883aa81f39d5c04976eb337cbe22ae5fc2008"
+      }
+    ],
+    "reason": "Preserve exact initial negative source before forward-only correction",
+    "correction_projection": {
+      "model_ms": 16000,
+      "engineering_ms": 300000,
+      "new_artifact_bytes": 0,
+      "report_bytes": 2097152,
+      "within_existing_cycle_caps": true
+    }
+  },
+  "initial_negative": {
+    "selection": {
+      "artifact": "blake3:0b12b6044e4a04124fa07a69496d9c5da65fc6a9d6ad95072fc46a9590916762",
+      "construction": 6,
+      "development": 6,
+      "fit": "NOT_RUN_NO_FIT_REQUIRED",
+      "fresh": "NOT_RUN_AT_SELECTION",
+      "parent": "blake3:419ba3a77f062d551909fe0739bf948094b2387843561eee601d3ed0773f2cc0",
+      "parent_parameters_equal": true,
+      "preservation": false,
+      "retained": 663,
+      "selected_before_fresh": false
+    },
+    "long": [
+      26,
+      28
+    ],
+    "regressions": [
+      {
+        "id": "relation/first-use-admission/1/0",
+        "prompt": "Xarven holds ravnel. senvar in Yelvik. [padding] Which city is ravnel in? Answer:",
+        "expected": " Xarven.\n",
+        "text": " Xarven holds ravnel.\n"
+      },
+      {
+        "id": "relation/first-use-admission/3/0",
+        "prompt": "Zorlan holds torvek. quorvik in Weldor. [padding] Where is torvek? Answer:",
+        "expected": " Zorlan.\n",
+        "text": " Zorlan holds torvek.\n"
+      }
+    ],
+    "sessions": {
+      "construction": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "nalia in Gold Meadow. evrin in Cedar Harbor. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "nalia in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "nalia now in Gold Cove. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Cove.\n",
+            "expected": " Gold Cove.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is evrin? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "nalia in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "nalia now in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      },
+      "development": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "selvi in Dusk Ridge. tilva in Cedar Harbor. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "selvi in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "selvi now in Dusk Vale. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Vale.\n",
+            "expected": " Dusk Vale.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is tilva? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "selvi in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "selvi now in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      },
+      "fresh": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "irden in Silken Hollow. marvi in Cedar Harbor. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "irden in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "irden now in Silken River Bank. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken River Bank.\n",
+            "expected": " Silken River Bank.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is marvi? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "irden in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "irden now in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      }
+    },
+    "fresh_scope": "Six first-use familiar-template turns executed after failed initial design selection; diagnostic, not acceptance evidence for initial runtime."
+  },
+  "corrected": {
+    "selection": {
+      "artifact": "blake3:0b12b6044e4a04124fa07a69496d9c5da65fc6a9d6ad95072fc46a9590916762",
+      "construction": 6,
+      "development": 6,
+      "fit": "NOT_RUN_NO_FIT_REQUIRED",
+      "fresh": "PREVIOUSLY_EXPOSED_PRESERVATION_REPLAY_FOLLOWS",
+      "parent": "blake3:419ba3a77f062d551909fe0739bf948094b2387843561eee601d3ed0773f2cc0",
+      "parent_parameters_equal": true,
+      "preservation": true,
+      "retained": 663,
+      "selected_before_fresh": true
+    },
+    "sessions": {
+      "construction": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "nalia in Gold Meadow. evrin in Cedar Harbor. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "nalia in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "nalia now in Gold Cove. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Cove.\n",
+            "expected": " Gold Cove.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is evrin? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "nalia in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "nalia now in Gold Meadow. ",
+            "query": "Where is nalia? Answer:",
+            "text": " Gold Meadow.\n",
+            "expected": " Gold Meadow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      },
+      "development": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "selvi in Dusk Ridge. tilva in Cedar Harbor. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "selvi in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "selvi now in Dusk Vale. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Vale.\n",
+            "expected": " Dusk Vale.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is tilva? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "selvi in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "selvi now in Dusk Ridge. ",
+            "query": "Where is selvi? Answer:",
+            "text": " Dusk Ridge.\n",
+            "expected": " Dusk Ridge.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      },
+      "fresh": {
+        "exact": 6,
+        "total": 6,
+        "isolation": true,
+        "exact_version_counts": true,
+        "trailing_tokens_each_turn": 1056,
+        "rows": [
+          {
+            "input": "irden in Silken Hollow. marvi in Cedar Harbor. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 2
+          },
+          {
+            "input": "irden in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 3
+          },
+          {
+            "input": "irden now in Silken River Bank. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken River Bank.\n",
+            "expected": " Silken River Bank.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "",
+            "query": "Where is marvi? Answer:",
+            "text": " Cedar Harbor.\n",
+            "expected": " Cedar Harbor.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 4
+          },
+          {
+            "input": "irden in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Unknown.\n",
+            "expected": " Unknown.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 5
+          },
+          {
+            "input": "irden now in Silken Hollow. ",
+            "query": "Where is irden? Answer:",
+            "text": " Silken Hollow.\n",
+            "expected": " Silken Hollow.\n",
+            "exact": true,
+            "checkpoint_predictions_equal": true,
+            "expected_versions": 6
+          }
+        ]
+      }
+    },
+    "fresh_scope": "Previously exposed preservation replay; no new held-out qualification.",
+    "retained": [
+      663,
+      663
+    ],
+    "preservation": {
+      "aliases.json": {
+        "exact": 12,
+        "total": 12
+      },
+      "chains.json": {
+        "exact": 16,
+        "total": 16
+      },
+      "computed-construction.json": {
+        "exact": 58,
+        "total": 58
+      },
+      "dependent.json": {
+        "exact": 48,
+        "total": 48,
+        "writes_exact": 48
+      },
+      "exposed-literals.json": {
+        "exact": 16,
+        "total": 16
+      },
+      "exposed-roles.json": {
+        "exact": 12,
+        "total": 12
+      },
+      "identifiers.json": {
+        "exact": 8,
+        "total": 8
+      },
+      "literal-construction.json": {
+        "exact": 103,
+        "total": 103
+      },
+      "long.json": {
+        "exact": 28,
+        "total": 28,
+        "writes_exact": 28
+      },
+      "names.json": {
+        "exact": 28,
+        "total": 28,
+        "writes_exact": 28
+      },
+      "numeric.json": {
+        "exact": 6,
+        "total": 6
+      },
+      "preservation.json": {
+        "exact": 62,
+        "total": 62
+      },
+      "prior-chains.json": {
+        "exact": 16,
+        "total": 16
+      },
+      "prior-fresh.json": {
+        "exact": 16,
+        "total": 16
+      },
+      "prior-span-construction.json": {
+        "exact": 14,
+        "total": 14
+      },
+      "prior-span-development.json": {
+        "exact": 6,
+        "total": 6
+      },
+      "prior-span-fresh.json": {
+        "exact": 9,
+        "total": 9
+      },
+      "prior.json": {
+        "exact": 24,
+        "total": 24
+      },
+      "roles.json": {
+        "exact": 12,
+        "total": 12
+      },
+      "sessions.json": {
+        "exact_turns": 5,
+        "total_turns": 5,
+        "isolated_no_shared_records": true
+      }
+    }
+  },
+  "checks": {
+    "compile": "Corrected release example and lib/integration test binaries PASS",
+    "focused_relation_tests": 3,
+    "source_span_tests": 2,
+    "integer_source_guard": "PASS after correction; source tokens only, not transitive library or machine-code audit",
+    "architecture_policy": "PASS; no model behavior",
+    "format": "PASS",
+    "claim_wording": "PASS",
+    "initial_actual_artifact": {
+      "status": "PASS",
+      "runtime": "initial; forward path unchanged by correction",
+      "scope": "pending snapshot restore, malformed span rejection, eviction, per-step prediction replay; zero allocations in measured ingestion/emission",
+      "samples": 12,
+      "median_ns": 417,
+      "max_ns": 127916,
+      "timing_scope": "uncached predict plus observe, including first selection; excludes model load, encoding, ingestion and checkpoint host work"
+    },
+    "corrected_actual_artifact_test": "NOT_RERUN; corrected behavior and checkpoints exercised in final probe",
+    "root_cli": "NOT_RUN_FOR_NEW_ARTIFACT",
+    "studio": "NOT_RUN",
+    "energy": "NOT_MEASURED",
+    "release_qa": "NOT_RUN",
+    "ci": "Expected five protected-queue echo acknowledgements only; delivery receipt verifies actual steps"
+  },
+  "resources": {
+    "projection": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-projection.json",
+      "bytes": 2874,
+      "sha256": "b3799b64aae884b7dd9806c000bb523b6f9121a903b3a1ea13726b07db719d14"
+    },
+    "model_ms": 54294,
+    "engineering_ms": 551248,
+    "model_runs": [
+      {
+        "label": "retained-span-evaluate",
+        "started": "2026-09-07T13:24:51.736Z",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "retained-span",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/span-context-angular/model.json",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular"
+        ],
+        "elapsed_ms": 27032,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": false,
+        "run_growth_limit_bytes": 49885184,
+        "effective_run_storage_ceiling_bytes": 7537082368,
+        "peak_process_rss_sample_bytes": 957579264,
+        "process_rss_samples": 26,
+        "peak_sampled_known_bytes": 7500210176,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:24:51.736Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2006958080,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7487197184,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 247099392,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 59465728,
+          "model_ledger": {
+            "cumulative_ms": 4229305,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 60695,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:25:18.832Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2019971072,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500210176,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234086400,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46452736,
+          "model_ledger": {
+            "cumulative_ms": 4256337,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 33663,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "cumulative_ms": 4256337,
+        "remaining_ms": 33663,
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      },
+      {
+        "label": "retained-span-artifact-check",
+        "started": "2026-09-07T13:26:48.957Z",
+        "command": "/usr/bin/env",
+        "args": [
+          "R4_RETAINED_SPAN_MODEL=/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/model.json",
+          "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+          "native_retained_relation_span_checkpoint_and_allocation",
+          "--ignored",
+          "--exact",
+          "--nocapture"
+        ],
+        "elapsed_ms": 12544,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": false,
+        "run_growth_limit_bytes": 36872192,
+        "effective_run_storage_ceiling_bytes": 7537082368,
+        "peak_process_rss_sample_bytes": 218185728,
+        "process_rss_samples": 12,
+        "peak_sampled_known_bytes": 7500214272,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:26:48.956Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2019971072,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500210176,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234086400,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46452736,
+          "model_ledger": {
+            "cumulative_ms": 4256337,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 33663,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:27:01.553Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2019975168,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500214272,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234082304,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46448640,
+          "model_ledger": {
+            "cumulative_ms": 4268881,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 21119,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "cumulative_ms": 4268881,
+        "remaining_ms": 21119,
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      },
+      {
+        "label": "retained-span-corrected-replay",
+        "started": "2026-09-07T13:33:09.323Z",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "retained-span",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/model.json",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward",
+          "replay"
+        ],
+        "elapsed_ms": 14718,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": false,
+        "run_growth_limit_bytes": 36827136,
+        "effective_run_storage_ceiling_bytes": 7537082368,
+        "peak_process_rss_sample_bytes": 942571520,
+        "process_rss_samples": 14,
+        "peak_sampled_known_bytes": 7501602816,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:33:09.323Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2020016128,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500255232,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234041344,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46407680,
+          "model_ledger": {
+            "cumulative_ms": 4268881,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 21119,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:33:24.093Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2021363712,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7501602816,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 232693760,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 45060096,
+          "model_ledger": {
+            "cumulative_ms": 4283599,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 6401,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "cumulative_ms": 4283599,
+        "remaining_ms": 6401,
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      }
+    ],
+    "engineering_runs": [
+      {
+        "label": "retained-span-build",
+        "started": "2026-09-07T13:15:49.048Z",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo fmt --all\n/Users/casey.allard/.cargo/bin/cargo build --release --offline -p uor-r4-core --example native_geometric_value_probe\n/Users/casey.allard/.cargo/bin/cargo test --release --offline -p uor-r4-core --lib --test native_geometric_allocations --no-run"
+        ],
+        "elapsed_ms": 266875,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": true,
+        "run_growth_limit_bytes": 50323456,
+        "effective_run_storage_ceiling_bytes": 7537086464,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 7507427328,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:15:49.048Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773295104,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2006953984,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7486763008,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 247533568,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 59899904,
+          "model_ledger": {
+            "cumulative_ms": 4229305,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 60695,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:20:15.981Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2006958080,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7487197184,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 247099392,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 59465728,
+          "model_ledger": {
+            "cumulative_ms": 4229305,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 60695,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      },
+      {
+        "label": "retained-span-probe-final",
+        "started": "2026-09-07T13:24:20.001Z",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo fmt --all\n/Users/casey.allard/.cargo/bin/cargo build --release --offline -p uor-r4-core --example native_geometric_value_probe\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f retained_relation --nocapture\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f source_span::tests --nocapture\n/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931 native_kernel_source_has_no_forbidden_arithmetic_or_float_types --exact --nocapture\n/tmp/r4-native-geometric-target/release/r4-policy-check ."
+        ],
+        "elapsed_ms": 18799,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": true,
+        "run_growth_limit_bytes": 49889280,
+        "effective_run_storage_ceiling_bytes": 7537086464,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 7487201280,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:24:20.001Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2006958080,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7487197184,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 247099392,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 59465728,
+          "model_ledger": {
+            "cumulative_ms": 4229305,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 60695,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:24:38.890Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2006962176,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7487201280,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 247095296,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 59461632,
+          "model_ledger": {
+            "cumulative_ms": 4229305,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 60695,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      },
+      {
+        "label": "retained-span-forward-build",
+        "started": "2026-09-07T13:28:31.491Z",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo fmt --all\n/Users/casey.allard/.cargo/bin/cargo build --release --offline -p uor-r4-core --example native_geometric_value_probe\n/Users/casey.allard/.cargo/bin/cargo test --release --offline -p uor-r4-core --lib --test native_geometric_allocations --no-run\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f retained_relation --nocapture\n/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931 native_kernel_source_has_no_forbidden_arithmetic_or_float_types --exact --nocapture"
+        ],
+        "elapsed_ms": 261914,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": true,
+        "run_growth_limit_bytes": 36831232,
+        "effective_run_storage_ceiling_bytes": 7537086464,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 7520636928,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:28:31.491Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2020016128,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500255232,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234041344,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46407680,
+          "model_ledger": {
+            "cumulative_ms": 4268881,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 21119,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:32:53.488Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2020020224,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7500259328,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 234037248,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 46403584,
+          "model_ledger": {
+            "cumulative_ms": 4268881,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 21119,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      },
+      {
+        "label": "retained-span-final-checks",
+        "started": "2026-09-07T13:34:45.147Z",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\n/Users/casey.allard/.cargo/bin/cargo fmt --all --check\npython3 scripts/check_claim_wording.py\n/tmp/r4-native-geometric-target/release/r4-policy-check .\ngit diff --check"
+        ],
+        "elapsed_ms": 3660,
+        "code": 0,
+        "signal": null,
+        "stopped": null,
+        "engineering_only": true,
+        "run_growth_limit_bytes": 35479552,
+        "effective_run_storage_ceiling_bytes": 7537086464,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null,
+        "peak_sampled_known_bytes": 7501611008,
+        "initial_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:34:45.147Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2021367808,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7501606912,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 232689664,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 45056000,
+          "model_ledger": {
+            "cumulative_ms": 4283599,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 6401,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "final_resource_snapshot": {
+          "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+          "at": "2026-09-07T13:34:48.860Z",
+          "inherited_precleanup_bytes": 2747199488,
+          "obsolete_target_growth_credit": 671379456,
+          "current_target_bytes": 2773725184,
+          "predecessor_artifact_root_bytes": 145760256,
+          "current_artifact_root_bytes": 2021371904,
+          "predecessor_worktree_bytes": 9875456,
+          "current_worktree_bytes": 8937472,
+          "stopped_successor_worktree_bytes": 460877824,
+          "source_metadata_reserve_bytes": 5242880,
+          "current_sampled_known_storage_bytes": 7501611008,
+          "storage_limit_bytes": 7734296576,
+          "remaining_storage_bytes": 232685568,
+          "stop_margin_bytes": 134217728,
+          "available_growth_before_stop_bytes": 45051904,
+          "model_ledger": {
+            "cumulative_ms": 4283599,
+            "limit_ms": 4290000
+          },
+          "model_remaining_ms": 6401,
+          "model_process_limit": 1,
+          "model_process_rss_target_bytes": 4294967296,
+          "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+        },
+        "sampling_scope": "Child-process RSS only; zero samples means unavailable. Includes current known retained storage and all inherited accounting; not exact transient peaks."
+      }
+    ],
+    "cumulative": {
+      "cumulative_ms": 4283599,
+      "limit_ms": 4290000
+    },
+    "remaining_ms": 6401,
+    "initial": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-07T13:09:47.639Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2773295104,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 2006941696,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 7486750720,
+      "storage_limit_bytes": 7734296576,
+      "remaining_storage_bytes": 247545856,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 59912192,
+      "model_ledger": {
+        "cumulative_ms": 4229305,
+        "limit_ms": 4290000
+      },
+      "model_remaining_ms": 60695,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "at_evidence": {
+      "schema": "uor-r4.native-typed-value-resource-snapshot/1",
+      "at": "2026-09-07T13:35:55.206Z",
+      "inherited_precleanup_bytes": 2747199488,
+      "obsolete_target_growth_credit": 671379456,
+      "current_target_bytes": 2773725184,
+      "predecessor_artifact_root_bytes": 145760256,
+      "current_artifact_root_bytes": 2021367808,
+      "predecessor_worktree_bytes": 9875456,
+      "current_worktree_bytes": 8937472,
+      "stopped_successor_worktree_bytes": 460877824,
+      "source_metadata_reserve_bytes": 5242880,
+      "current_sampled_known_storage_bytes": 7501606912,
+      "storage_limit_bytes": 7734296576,
+      "remaining_storage_bytes": 232689664,
+      "stop_margin_bytes": 134217728,
+      "available_growth_before_stop_bytes": 45056000,
+      "model_ledger": {
+        "cumulative_ms": 4283599,
+        "limit_ms": 4290000
+      },
+      "model_remaining_ms": 6401,
+      "model_process_limit": 1,
+      "model_process_rss_target_bytes": 4294967296,
+      "scope": "Same inherited conservative accounting. Only the previously audited obsolete target-growth credit is applied. Charge all current target bytes, both artifact roots, both measured new-worktree costs and a 5MiB source/metadata reserve. No broad clone/free-disk credits or reset of historical overages. The earlier typed-value cycle removed only its documented failed compiler outputs. The owner-authorized response-entry cycle removes no material and preserves all newly generated compiler products. Periodic du/RSS samples are not exact peak or unique-extent guarantees."
+    },
+    "final_growth_bytes": 14856192,
+    "peak_sampled_growth_bytes": 33886208,
+    "peak_sampled_model_rss_bytes": 957579264,
+    "limits": "60s model,900s engineering,48MiB growth,4GiB model RSS,one model process,one build job; cumulative ceiling unchanged",
+    "cleanup": "NONE this cycle; all user material, artifacts and negatives preserved",
+    "accounting_scope": "Command wall accounting covers builds/tests/model execution; interactive inspection and documentation wall time is not model execution. Storage and RSS are samples, not exact physical peaks."
+  },
+  "limitations": [
+    "Forward retained values only; reverse writer retains its existing single-word anchor.",
+    "At most 28 bytes and exact one-byte separators; inherited unseen-connector and wider-gap limitations.",
+    "Existing query-span ablations do not disable full-control persistent ingestion. Complete parent is the retained-memory control.",
+    "No general phrase understanding, reasoning, frontier, angular superiority or energy claim."
+  ],
+  "next": "Learn role-aware value endpoints in both source orders with existing geometric continuation and selected owner/value roles; new construction/open data and a complete resource projection required before another campaign.",
+  "retained-span-angular_receipts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/construction-sessions.json",
+      "bytes": 159840,
+      "sha256": "c9c0b9a329e64775a41e71777be6d0c92c0ba05d9d43af4815b4e5ee6cd70329"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/design-selection.json",
+      "bytes": 403,
+      "sha256": "cd3a89e9a407842d0f9cbe144b43601eb252b496725259e240a8395678952a10"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/development-sessions.json",
+      "bytes": 159878,
+      "sha256": "20dbd33e4085ed5691528c6d908bc139ec543e8ecefa73182a770c6e51445e8e"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/fresh-sessions.json",
+      "bytes": 160240,
+      "sha256": "3fe32cb3543c17a6f09fcd724b8e76dc31f2222197eed2eb3d1227c5560f77f0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/parent-sessions.json",
+      "bytes": 30620,
+      "sha256": "32b4f46001e8564cd4e13fe1807cb0e70769d416b7703f2a1382e501e1d6120d"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/retained-construction.json",
+      "bytes": 214913,
+      "sha256": "4453fc45d97d0b1ffcacaf110635dc6721b7cc237dc1c3b98ee8183a0e4d1cfd"
+    }
+  ],
+  "retained-span-forward_receipts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward/construction-sessions.json",
+      "bytes": 159840,
+      "sha256": "c9c0b9a329e64775a41e71777be6d0c92c0ba05d9d43af4815b4e5ee6cd70329"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward/design-selection.json",
+      "bytes": 427,
+      "sha256": "05c1f27b9514f07b425724e6b6163a60a29028129978635a27a6e1f8ca2f1cd9"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward/development-sessions.json",
+      "bytes": 159878,
+      "sha256": "20dbd33e4085ed5691528c6d908bc139ec543e8ecefa73182a770c6e51445e8e"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward/fresh-sessions.json",
+      "bytes": 160240,
+      "sha256": "3fe32cb3543c17a6f09fcd724b8e76dc31f2222197eed2eb3d1227c5560f77f0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-forward/retained-construction.json",
+      "bytes": 214913,
+      "sha256": "4453fc45d97d0b1ffcacaf110635dc6721b7cc237dc1c3b98ee8183a0e4d1cfd"
+    }
+  ]
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,38 @@
 # Current native geometric AI work
 
+## Retained multiword relation values — 2026-09-07
+
+**Retain `0b12b604` with the corrected forward-only runtime.** The
+[result](../native_geometric_retained_spans_1140.md) and
+[evidence](../evidence/native_geometric_retained_spans_1140.json) bind the runtime
+source and artifact separately. All `419ba3a7` parameters remain unchanged; no fit
+was needed. The accepted H4 Continue/Finish operator now accumulates a bounded
+forward value during input and commits its complete bytes as one immutable
+relation version. Later reads survive raw-window eviction. Same-prefix values
+conflict correctly; explicit revision clears the conflict.
+
+Parent construction is 0/6; corrected construction and open sessions are 6/6
+each, and all six previously exposed fresh turns replay correctly. Exact
+write/version counts and isolation pass. All 663 retained construction answers,
+14/14, 6/6 and 9/9 prior span panels, 28/28 long-window answers and all other
+preservation pass. The initial runtime overextended two reverse statements and
+was rejected at 26/28 long-window preservation. That negative is preserved.
+Reverse writes now commit their earlier single-word anchor immediately; no
+unobserved endpoint is inferred. Both runs use the same artifact bytes, with
+different source identities. Initial allocation/checkpoint evidence covers the
+unchanged forward path; final behavior is checked on the corrected runtime.
+
+**Next: learn role-aware value endpoints in both source orders**, including
+connector/spacing distinctions, with the existing geometric operator and typed
+owner/value binding. Reverse multiword values, broad phrase understanding and
+general reasoning remain unqualified. Do not tune on the opened fresh panels.
+The cycle used 54.294 seconds of model work. Cumulative use is
+4,283.599/4,290 seconds, leaving 6.401 seconds with no ceiling increase. A new
+model campaign needs a complete resource projection and sufficient authorized
+allocation. Root CLI and Studio execution of this artifact are `NOT_RUN`;
+this delivery qualifies the native library/probe path. See the evidence for
+engineering/storage totals, source hashes and exact execution boundaries.
+
 ## Context-sensitive source extent — 2026-09-07
 
 **Retain `419ba3a7` at bounded source-span scope.** The

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -274,12 +274,17 @@ now retains `419ba3a7`: construction 14/14, open 6/6, fresh 9/9 versus 6/9 with
 the original-source-cue pair removed. All 663 retained construction and 24/24
 prior answers are preserved. This fixes the observed same-word context collision;
 unseen connectors and double-space gaps remain unqualified (0/2).
-**Next: retain accepted bounded multiword values through relation writes and later
-reads**, carrying exact extent and separators with the selected value across
-raw-window eviction. Use independent construction/open session examples, keep
-the first-source and numeric paths fixed, and preserve session behavior. Broader
-connector recognition remains a separate learning need. Do not train on the opened fresh diagnostic.
-Project the full run against the remaining cumulative allocation before execution.
+The [retained-value continuation](../native_geometric_retained_spans_1140.md)
+retains `0b12b604` with the corrected forward-only runtime, reusing all parent
+parameters without fitting. Complete multiword values survive window eviction,
+conflicts and corrections on all 18 session turns, with all prior preservation.
+The initial reverse-statement overextension is preserved as a runtime negative;
+reverse writes now keep their established single-word scope.
+**Next: learn role-aware value endpoints in both source orders**, using the
+existing owner/value binding and geometric continuation operator. Source-cue
+lookup alone still lacks general connector and spacing behavior. New learning
+needs independently authored construction/open cases, fixed earlier panels as
+preservation, and a complete projection against the remaining cumulative budget.
 Do not restart completed order repairs or grow a
 paging subsystem without a measured access bottleneck. General named-role binding
 and broader Rust reasoning remain unqualified. Follow current-state.md for

--- a/docs/native_geometric_retained_spans_1140.md
+++ b/docs/native_geometric_retained_spans_1140.md
@@ -1,0 +1,132 @@
+# Retained geometric relation spans — #1139 / #1140
+
+## Implementation — 2026-09-07
+
+The [accepted source-span operator](native_geometric_span_context_1139.md)
+selects complete values from current query occurrences, but persistent relation
+records retain only their first word. The writer commits when that first word
+finishes, before later words arrive. Its former equality check also treats
+`New York` and `New Jersey` as the same value because both anchors are `New`.
+
+This continuation reuses the accepted signed-H4 Continue/Finish operator during
+input ingestion. An artifact-bound optional `relation_spans` component names
+the complete `419ba3a7` parent. `Model::with_retained_relation_spans` adds this
+execution capability without fitting or changing any parent parameter. Removing
+that component reconstructs the parent; loading validates that relationship.
+
+A fixed pending relation holds the selected owner, first-word anchor, write
+action and accepted extent. Exact adjacent words extend it only when the same
+learned operator admits them, up to 28 bytes. Consumed continuation words do not
+receive a separate writer decision. A non-continuation or explicit response
+boundary finalizes the value once. Previously committed records remain immutable.
+Only forward writes whose value is the newest completed word can defer and
+extend. A reverse write completing at its owner binds its earlier single-word
+value immediately: the existing writer supplies no intervening phrase endpoint.
+Pending and committed-span snapshots enforce owner-before-value order. This
+scope restriction uses selected roles, without a hardcoded relation word.
+
+The committed record keeps its original `WordAtom` identity, position, geometry
+and predecessor context. A separate optional span retains complete exact bytes,
+word count and terminal-word provenance. Versioning and conflict comparison use
+the complete value. Explicit revision can clear a conflict. A multiword value
+cannot silently join a dependent lookup through its first word alone; a final
+retained value can be emitted whole by the existing causal copy cursor.
+
+Snapshot validation checks activation, payload capacity/padding, anchor prefix,
+terminal metadata, contiguous source positions, word count, learned edges and
+consistency with source words still visible. Pending writes must be inactive and
+consistent with the latest completed word. Evicted source information remains
+declared state; these checks do not authenticate unavailable original text.
+Legacy absent optional fields retain their prior serialization and behavior.
+
+The matched retained-memory control is the complete parent artifact. The existing
+`SourceSpanDisabled`, `SourceSpanContextDisabled` and `SourceSpanPairDisabled`
+controls affect frozen-query continuation; retained ingestion uses the full
+accepted operator and committed payload emission does not rerun those controls.
+They are not whole-model ablations of retained phrase memory.
+
+The serving addition uses bounded integer/table operations and exact byte copies.
+Work counters include span edge checks, copied bytes and geometric routing. This
+is reuse of a previously learned geometric operator, not a new angular-versus-
+equality learning result or a general phrase-boundary qualification.
+
+## Execution contract
+
+The cumulative model ceiling remains **4,290 seconds**, with **60.695 seconds**
+available at entry. The new cycle has a **60-second model cap**, **900-second
+engineering cap**, **48 MiB storage-growth cap**, one local model process, one
+Cargo build job and a 4 GiB model RSS target. Projection: 50 seconds model work,
+650 seconds engineering, 12 MiB artifact, 34 MiB compiler transients and 2 MiB
+lean evidence. All retries and stops remain charged. No external compute or
+cumulative allocation increase is authorized by this cycle.
+
+The combined Rust run compares the parent and new artifact, checks construction
+and open sessions plus existing preservation, records the decision, then opens
+a fixed fresh session panel without another fit. Sessions exercise repeated
+assertions, same-prefix revisions and contradictions, unrelated memory and
+isolation after more than 512 padding tokens. Every generated step is compared
+with checkpoint restoration. A separate actual-artifact check covers a pending
+write, atomic commitment, malformed extent rejection and allocation counts.
+
+## Initial result and correction
+
+The initial runtime returns all 6/6 construction, 6/6 open and 6/6 separately
+authored fresh session answers, versus 0/6 parent construction answers. Exact
+write/version counts and new-session isolation pass. All 663 retained
+construction answers and earlier source-span panels pass. However, long-window
+preservation falls to 26/28: `Xarven holds ravnel` and `Zorlan holds torvek`
+incorrectly retain the complete clause as the value. Their original writer
+already selected the right single-word anchor; replaying intervening words
+introduced the regression. Selection was false before opening the fresh panel.
+The negative reports and exact initial runtime/probe sources are preserved.
+
+The correction above removes that unsupported reverse extension. The learned
+artifact and all parameters remain byte-identical; initial versus corrected
+runtime source identities distinguish the two experiments. The artifact CID
+alone does not identify the runtime that executed it. The corrected replay
+reuses all panels as open preservation evidence; the formerly fresh six turns
+are not a new held-out result, and no fitting takes place.
+
+On the initial runtime, the actual-artifact test passes pending-write restore,
+malformed extent rejection, source eviction, every-step prediction replay and
+zero allocations during measured ingestion/emission. Its 12 uncached
+predict-plus-observe samples have median 417 ns and maximum 127,916 ns, including
+initial selection, excluding loading, encoding, ingestion and checkpoints.
+This forward path is unchanged by the correction, but the result is scoped to
+the initial runtime. Energy and end-to-end latency remain unmeasured.
+
+## Corrected result
+
+Retain `blake3:0b12b6044e4a04124fa07a69496d9c5da65fc6a9d6ad95072fc46a9590916762`
+with the corrected runtime, at bounded forward retained-value scope. Construction
+and open sessions pass 6/6 each; all six previously exposed fresh turns replay
+correctly. Every turn restores checkpoints before each prediction; exact expected
+write/version counts and independent-session isolation pass. These count checks
+do not independently compare every owner/value/action against an expected write
+sequence. Parent construction remains the retained 0/6 matched control.
+
+All 663 earlier construction answers pass. The prior span panels pass 14/14,
+6/6 and 9/9. Long-window preservation returns to 28/28 with 28/28 exact write
+witnesses; dependent reads pass 48/48, earlier sessions 5/5 with isolation, and
+all other numeric, literal, identifier, name, role and chain preservation passes.
+No fit or artifact mutation occurred during the correction.
+
+The corrected release probe and test binaries compile; three focused relation
+state tests and the expanded integer-kernel source guard pass after the change.
+Two existing source-span tests and the architecture policy check also passed in
+the cycle. The final replay takes 14.718 seconds, bringing total model work to
+54.294 seconds and cumulative use to 4,283.599/4,290 seconds. The initial actual-
+artifact test is not rerun after correction; final CLI, Studio, broad release
+QA and end-to-end energy measurements are `NOT_RUN`.
+
+**Next:** learn role-aware value endpoints for both source orders using the
+existing learned geometric operator and selected owner/value roles. The reverse
+writer's single-word boundary, unseen connectors and wider gaps remain explicit
+limitations. Do not fit on the opened fresh panels. A successor must project its
+complete resources against the remaining cumulative allocation.
+
+At evidence capture, metered engineering commands total 551.248 seconds.
+Retained sampled growth is 14,856,192 bytes; peak sampled growth is 33,886,208
+bytes, within 48 MiB. Peak sampled model-process RSS is 957,579,264 bytes.
+The artifact is 11,631,461 bytes. No cleanup or external compute was needed.
+These storage/RSS observations are sampled, not exact physical peaks.


### PR DESCRIPTION
Persistent relation writes currently retain only the first word of a value. This adds an opt-in artifact capability that reuses the accepted H4 Continue/Finish operator to retain complete forward values, commit one immutable version, compare complete values for conflicts, and emit them after raw-window eviction. All parent parameters remain unchanged; no fitting was required. Reverse statements retain their established single-word behavior because the writer does not supply a phrase endpoint.

Corrected behavior passes 6/6 construction and 6/6 open session turns plus 6/6 previously exposed preservation turns, including repeated assertions, same-prefix revisions/conflicts, unrelated memory and isolation. All 663 retained construction answers and earlier preservation pass. The initial runtime regressed two reverse-statement answers to 26/28; its source and reports are preserved, and the corrected runtime restores 28/28. Both runs use the same artifact bytes, so the evidence binds runtime source identities separately.

Validation: corrected release probe/test binaries compile; focused relation and source-span tests, integer source guard, formatting, architecture policy and claim wording pass. The initial actual-artifact pending-write/checkpoint/eviction/allocation test passes on the unchanged forward path; final corrected behavior and checkpoint replay pass in the Rust probe. CLI/Studio and broad release QA are NOT_RUN for this artifact. GitHub required statuses are queue acknowledgements only, not test evidence.

Model work: 54.294 seconds; cumulative 4,283.599/4,290, leaving 6.401 seconds without an increase. Engineering: 551.248 seconds; peak sampled storage growth 33,886,208 bytes inside 48 MiB. No cleanup or external compute. Result, source/artifact identities, exact boundaries and next role-aware endpoint direction are recorded in `docs/native_geometric_retained_spans_1140.md` and its evidence receipt; README, research, roadmap and current-state pointers are updated.

Continues #1139 and #1140; neither broader capability issue is closed by this bounded result.
