### PR TITLE
Retain reverse relation phrases at learned writer endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ retain `0b12b604` with the corrected forward-only runtime. Without a new fit,
 complete values survive window eviction, repeated assertions, corrections and
 conflicts: 6/6 construction, 6/6 open and 6/6 previously exposed session turns pass.
 All prior preservation passes. Reverse statements retain their existing single-word
-behavior; role-aware endpoints and broader phrase boundaries remain the next need.
+behavior. The [reverse endpoint continuation](docs/native_geometric_reverse_spans_1140.md)
+now retains `321e990f`, reusing the selected terminal word to bound the phrase.
+Construction improves 3/6 to 6/6, open and fresh turns pass 6/6 each, and short
+reads pass 3/3 with selected preservation intact. Unfamiliar introductions and
+wider gaps still fail; learned phrase starts are the next direction.
 General prose/syntax/reasoning and frontier capability remain unqualified. Follow
 the current-state pointer for artifacts, costs and the next implementation.
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -27,6 +27,8 @@ mod literal_binding;
 mod relation_memory;
 #[path = "native_geometric_value_probe/retained_span.rs"]
 mod retained_span;
+#[path = "native_geometric_value_probe/reverse_span.rs"]
+mod reverse_span;
 #[path = "native_geometric_value_probe/role_read.rs"]
 mod role_read;
 #[path = "native_geometric_value_probe/source_context.rs"]
@@ -987,6 +989,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("reverse-span") {
+        return reverse_span::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("retained-span") {
         return retained_span::run(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs
@@ -25,7 +25,14 @@ fn emit(s: &mut Session, m: &Model) -> ProbeResult<String> {
     }
     Err("retained span did not terminate".into())
 }
-fn turns(m: &Model, a: &str, b: &str, first: &str, second: &str, tail: &str) -> ProbeResult<Value> {
+pub(super) fn turns(
+    m: &Model,
+    a: &str,
+    b: &str,
+    first: &str,
+    second: &str,
+    tail: &str,
+) -> ProbeResult<Value> {
     let mut s = m.session(Control::Full)?;
     s.observe(m, 0)?;
     let padding = "quiet sky. ".repeat(96);

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs
@@ -1,0 +1,278 @@
+//! Reuse the writer's endpoint and learned edges for reverse phrase retention.
+use super::*;
+use uor_r4_core::native_geometric::Session;
+fn ingest(s: &mut Session, m: &Model, text: &str) -> ProbeResult<()> {
+    for token in m.encode(text)? {
+        s.observe(m, token)?;
+    }
+    Ok(())
+}
+fn emit(s: &mut Session, m: &Model) -> ProbeResult<String> {
+    s.begin_response(m)?;
+    let mut tokens = Vec::new();
+    for _ in 0..32 {
+        let mut restored = m.restore_session(&s.checkpoint()?)?;
+        let p = s.predict(m)?;
+        if restored.predict(m)? != p {
+            return Err("reverse span checkpoint differs".into());
+        }
+        s.observe(m, p.token)?;
+        if p.token == 1 {
+            return Ok(String::from_utf8(m.decode(&tokens)?)?);
+        }
+        tokens.push(p.token);
+    }
+    Err("reverse span did not terminate".into())
+}
+fn panel(m: &Model, names: [&str; 2], values: [&str; 3], prefix: &str) -> ProbeResult<Value> {
+    let [a, b] = names;
+    let [first, changed, other] = values;
+    let mut s = m.session(Control::Full)?;
+    s.observe(m, 0)?;
+    let padding = "quiet sky. ".repeat(96);
+    let trailing = m.encode(&padding)?.len();
+    if trailing <= 512 {
+        return Err("source not evicted".into());
+    }
+    let mut rows = Vec::new();
+    for (input, owner, expected, versions) in [
+        (
+            format!("{prefix}{first} holds {a}. {prefix}{other} holds {b}. "),
+            a,
+            format!(" {first}.\n"),
+            2,
+        ),
+        (
+            format!("{prefix}{first} holds {a}. "),
+            a,
+            format!(" {first}.\n"),
+            3,
+        ),
+        (
+            format!("{a} now in {changed}. "),
+            a,
+            format!(" {changed}.\n"),
+            4,
+        ),
+        (String::new(), b, format!(" {other}.\n"), 4),
+        (
+            format!("{prefix}{first} holds {a}. "),
+            a,
+            " Unknown.\n".into(),
+            5,
+        ),
+        (
+            format!("{a} now in {first}. "),
+            a,
+            format!(" {first}.\n"),
+            6,
+        ),
+    ] {
+        s.end_response(m)?;
+        ingest(&mut s, m, &input)?;
+        ingest(&mut s, m, &padding)?;
+        let query = format!("Where is {owner}? Answer:");
+        ingest(&mut s, m, &query)?;
+        let text = emit(&mut s, m)?;
+        let wire: Value = serde_json::from_slice(&s.checkpoint()?)?;
+        let records = wire["values"]["relations"]["records"]
+            .as_array()
+            .ok_or("records missing")?;
+        let records: Vec<_> = records
+            .iter()
+            .filter(|r| r["id"].as_u64().unwrap_or(0) > 0)
+            .cloned()
+            .collect();
+        let count_ok = wire["values"]["relations"]["next_id"] == versions + 1
+            && records.len() == versions as usize;
+        rows.push(json!({"input":input,"query":query,"expected":expected,"text":text,"exact":text==expected,"version_count_exact":count_ok,"expected_versions":versions,"records":records,"checkpoint_predictions_equal":true}));
+    }
+    let mut isolated = m.session(Control::Full)?;
+    isolated.observe(m, 0)?;
+    ingest(&mut isolated, m, &format!("Where is {a}? Answer:"))?;
+    let isolated = emit(&mut isolated, m)?;
+    Ok(
+        json!({"artifact":m.artifact_cid(),"exact":rows.iter().filter(|r|r["exact"]==true).count(),"total":rows.len(),"version_counts_exact":rows.iter().all(|r|r["version_count_exact"]==true),"isolation":isolated==" Unknown.\n","trailing_tokens":trailing,"turns":rows}),
+    )
+}
+fn accepted(j: &Value) -> bool {
+    j["exact"] == j["total"] && j["version_counts_exact"] == true && j["isolation"] == true
+}
+fn short(m: &Model) -> ProbeResult<Value> {
+    let mut rows = Vec::new();
+    for (input, owner, value) in [
+        ("Orin Grove holds nelra.", "nelra", "Orin Grove"),
+        ("Record: Copper Vale holds serin.", "serin", "Copper Vale"),
+        ("Ash Field holds merla.", "merla", "Ash Field"),
+    ] {
+        let mut s = m.session(Control::Full)?;
+        s.observe(m, 0)?;
+        let prompt = format!("{input} Where is {owner}? Answer:");
+        ingest(&mut s, m, &prompt)?;
+        let text = emit(&mut s, m)?;
+        let expected = format!(" {value}.\n");
+        rows.push(json!({"prompt":prompt,"text":text,"expected":expected,"exact":text==expected}));
+    }
+    Ok(
+        json!({"exact":rows.iter().filter(|r|r["exact"]==true).count(),"total":rows.len(),"cases":rows}),
+    )
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    if args.len() != 3 {
+        return Err("reverse-span PARENT ROOT NEW_DIRECTORY".into());
+    }
+    let root = Path::new(&args[1]);
+    let out = Path::new(&args[2]);
+    fs::create_dir(out)?;
+    let parent = Model::from_bytes(&fs::read(&args[0])?)?;
+    let names = ["nelra", "vesk"];
+    let values = ["Orin Grove", "Amber Grove", "Silver Cape"];
+    let before = panel(&parent, names, values, "")?;
+    write_json(&out.join("parent.json"), &before)?;
+    let model = parent.with_reverse_relation_spans()?;
+    write_new(&out.join("model.json"), &model.to_bytes()?)?;
+    let mut wire: Value = serde_json::from_slice(&model.to_bytes()?)?;
+    let mut original: Value = serde_json::from_slice(&parent.to_bytes()?)?;
+    if wire
+        .as_object_mut()
+        .ok_or("shape")?
+        .remove("relation_reverse_spans")
+        != Some(json!(parent.artifact_cid()))
+    {
+        return Err("reverse parent link differs".into());
+    }
+    for value in [&mut wire, &mut original] {
+        let m = value.as_object_mut().ok_or("shape")?;
+        m.remove("artifact_cid");
+        m.remove("uor_model_address");
+    }
+    if wire != original {
+        return Err("reverse span changed learned parameters".into());
+    }
+    let construction = panel(&model, names, values, "")?;
+    write_json(&out.join("construction.json"), &construction)?;
+    let development = panel(
+        &model,
+        ["serin", "mavra"],
+        ["Copper Vale", "Cobalt Vale", "Ivory Pier"],
+        "Record: ",
+    )?;
+    write_json(&out.join("development.json"), &development)?;
+    let preserve = out.join("preservation");
+    fs::create_dir(&preserve)?;
+    source_noread::preserve_model_lean(model.clone(), root, &preserve)?;
+    for (file, split, name) in [
+        (
+            "source-order-angular256/source.json",
+            "fit",
+            "retained-construction",
+        ),
+        (
+            "span-context-angular/source.json",
+            "fit",
+            "prior-span-construction",
+        ),
+        (
+            "span-context-angular/source.json",
+            "development",
+            "prior-span-development",
+        ),
+        (
+            "span-context-angular/fresh-source.json",
+            "fresh",
+            "prior-span-fresh",
+        ),
+    ] {
+        let source: Value = serde_json::from_slice(&fs::read(root.join(file))?)?;
+        let docs: Vec<ValueExample> = serde_json::from_value(source[split].clone())?;
+        let report = source_noread::lean(source_noread::responses(
+            &model,
+            &docs,
+            false,
+            Control::Full,
+        )?);
+        write_json(&preserve.join(format!("{name}.json")), &report)?;
+    }
+    for (name, a, b, first, second, tail) in [
+        (
+            "forward-construction",
+            "nalia",
+            "evrin",
+            "Gold",
+            "Meadow",
+            "Cove",
+        ),
+        ("forward-open", "selvi", "tilva", "Dusk", "Ridge", "Vale"),
+        (
+            "forward-prior-fresh",
+            "irden",
+            "marvi",
+            "Silken",
+            "Hollow",
+            "River Bank",
+        ),
+    ] {
+        let report = retained_span::turns(&model, a, b, first, second, tail)?;
+        write_json(&preserve.join(format!("{name}.json")), &report)?;
+    }
+    let mut preserved = true;
+    for item in fs::read_dir(&preserve)? {
+        let j: Value = serde_json::from_slice(&fs::read(item?.path())?)?;
+        if j["exact"].is_number() {
+            preserved &= j["exact"] == j["total"];
+        }
+        if j["writes_exact"].is_boolean() {
+            preserved &= j["writes_exact"] == true;
+        }
+        if j["writes_exact"].is_number() {
+            preserved &= j["writes_exact"] == j["total"];
+        }
+        if j["isolation_pass"].is_boolean() {
+            preserved &= j["isolation_pass"] == true;
+        }
+        if j["exact_turns"].is_number() {
+            preserved &=
+                j["exact_turns"] == j["total_turns"] && j["isolated_no_shared_records"] == true;
+        }
+    }
+    let short = short(&model)?;
+    write_json(&out.join("short.json"), &short)?;
+    let selected = accepted(&construction)
+        && accepted(&development)
+        && preserved
+        && short["exact"] == short["total"];
+    write_json(
+        &out.join("selection.json"),
+        &json!({"artifact":model.artifact_cid(),"parent":parent.artifact_cid(),"parent_parameters_equal":true,"fit":"NOT_RUN_NO_FIT_REQUIRED","selected_before_fresh":selected,"preservation":preserved,"construction":construction["exact"],"development":development["exact"],"fresh":"NOT_RUN_AT_SELECTION"}),
+    )?;
+    let fresh = panel(
+        &model,
+        ["belvi", "norvi"],
+        ["Quiet River Bend", "Silver River Bend", "Violet Quay"],
+        "",
+    )?;
+    write_json(&out.join("fresh.json"), &fresh)?;
+    let mut boundaries = Vec::new();
+    for (text, expected) in [
+        ("Records show Orin Grove holds nelra.", " Orin Grove.\n"),
+        ("Orin  Grove holds nelra.", " Orin  Grove.\n"),
+    ] {
+        let mut s = model.session(Control::Full)?;
+        s.observe(&model, 0)?;
+        ingest(&mut s, &model, text)?;
+        ingest(&mut s, &model, &"quiet sky. ".repeat(96))?;
+        ingest(&mut s, &model, "Where is nelra? Answer:")?;
+        let actual = emit(&mut s, &model)?;
+        boundaries
+            .push(json!({"input":text,"expected":expected,"text":actual,"exact":actual==expected}));
+    }
+    write_json(
+        &out.join("boundaries.json"),
+        &json!({"cases":boundaries,"scope":"Post-selection diagnostics only: unseen plain intro and two-space gap; no fitting or tuning"}),
+    )?;
+    println!(
+        "{}",
+        json!({"artifact":model.artifact_cid(),"parent":before["exact"],"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"selected":selected,"fresh":fresh["exact"]})
+    );
+    Ok(())
+}

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -339,6 +339,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    relation_reverse_spans: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     relation_spans: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source_span_context: Option<Vec<word_copy_types::WordCopyAddress>>,
@@ -395,6 +397,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    relation_reverse_spans: Option<String>,
+    #[serde(default)]
     relation_spans: Option<String>,
     #[serde(default)]
     source_span_context: Option<Vec<word_copy_types::WordCopyAddress>>,
@@ -450,6 +454,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            relation_reverse_spans: wire.relation_reverse_spans,
             relation_spans: wire.relation_spans,
             source_span_context: wire.source_span_context,
             source_span: wire.source_span,

--- a/crates/uor-r4-core/src/native_geometric/relation.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation.rs
@@ -556,7 +556,8 @@ pub(super) fn read_features(
 }
 
 /// Return a persistent source/action, or defer to the unchanged recent reader.
-/// Values still present in the recent capture retain the #1137 selection law.
+/// Values still present in the recent capture retain the #1137 selection law,
+/// except reverse payloads whose terminal anchor cannot replay their earlier bytes.
 pub(super) fn read_choice(
     model: &Model,
     values: &ValueState,
@@ -575,11 +576,13 @@ pub(super) fn read_choice(
             continue;
         };
         work.relations.record_reads = work.relations.record_reads.saturating_add(1);
-        if words.queries[..words.query_len].iter().any(|w| {
-            work.relations.source_presence_checks =
-                work.relations.source_presence_checks.saturating_add(1);
-            *w == record.value
-        }) {
+        if record.span.as_ref().is_none_or(|span| span.start.is_none())
+            && words.queries[..words.query_len].iter().any(|w| {
+                work.relations.source_presence_checks =
+                    work.relations.source_presence_checks.saturating_add(1);
+                *w == record.value
+            })
+        {
             continue;
         }
         let (f, n) = read_features(model, record, words, &addr, work);

--- a/crates/uor-r4-core/src/native_geometric/relation_span.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_span.rs
@@ -1,4 +1,4 @@
-//! Deferred relation writes preserve one exact bounded value extent. The first
+//! Relation writes preserve exact bounded value extents. The writer-selected
 //! WordAtom remains the semantic anchor; its bytes and geometry are not rewritten.
 use super::relation::{self, RelationState};
 use super::value_lexemes::{LexemeState, WordAtom};
@@ -9,11 +9,14 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct RelationSpan {
-    /// Complete value bytes, including the unchanged first-word payload.
+    /// Complete value bytes, including the unchanged writer-selected payload.
     pub bytes: [u8; 28],
     pub len: u8,
     pub extra_words: u8,
     pub terminal: WordAtom,
+    /// Reverse writes retain their selected endpoint as the record anchor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start: Option<WordAtom>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,6 +128,7 @@ impl PendingRelation {
                 len: self.value.len,
                 extra_words: 0,
                 terminal: self.value,
+                start: None,
             }
         });
         span.bytes[usize::from(length)] = separator;
@@ -139,6 +143,53 @@ impl PendingRelation {
             .saturating_add(u64::from(next.len) + 1);
         true
     }
+}
+
+/// The writer-selected word is a hard endpoint. Each possible earlier start
+/// supplies one fixed source cue for the entire existing learned edge law.
+fn reverse_extent(
+    model: &Model,
+    words: &LexemeState,
+    owner: usize,
+    endpoint: usize,
+    action: u8,
+    work: &mut ValueWork,
+) -> Option<RelationSpan> {
+    let mut best = None;
+    let terminal = words.recent[endpoint];
+    work.relations.record_reads = work.relations.record_reads.saturating_add(1);
+    for start in endpoint + 1..words.recent_len {
+        let first = words.recent[start];
+        work.relations.record_reads = work.relations.record_reads.saturating_add(1);
+        let length = terminal
+            .byte_end
+            .checked_sub(first.byte_end)
+            .and_then(|n| n.checked_add(u64::from(first.len)));
+        if length.is_none_or(|len| len > 28) {
+            break;
+        }
+        let mut candidate = PendingRelation {
+            owner: words.recent[owner],
+            value: first,
+            action,
+            span: None,
+        };
+        let mut complete = true;
+        for next in (endpoint..start).rev() {
+            work.relations.record_reads = work.relations.record_reads.saturating_add(1);
+            if !candidate.extend(model, words.recent[next], work) {
+                complete = false;
+                break;
+            }
+        }
+        if complete {
+            if let Some(mut span) = candidate.span {
+                span.start = Some(first);
+                best = Some(span);
+            }
+        }
+    }
+    best
 }
 
 impl RelationState {
@@ -173,10 +224,14 @@ impl RelationState {
             work.relations.no_writes = work.relations.no_writes.saturating_add(1);
             return;
         };
-        // A reverse write completes at the owner and binds only an earlier
-        // value anchor. It supplies no extent boundary for intervening words.
+        // Reverse writes may inspect only source words at or before their
+        // selected value endpoint; the following linker and owner are excluded.
         if value != 0 {
-            self.commit_span(words.recent[owner], words.recent[value], None, action, work);
+            let span = model
+                .relation_reverse_spans
+                .as_ref()
+                .and_then(|_| reverse_extent(model, words, owner, value, action, work));
+            self.commit_span(words.recent[owner], words.recent[value], span, action, work);
             return;
         }
         let pending = PendingRelation {
@@ -198,6 +253,10 @@ fn component(byte: u8) -> bool {
 }
 
 impl RelationSpan {
+    fn first<'a>(&'a self, anchor: &'a WordAtom) -> &'a WordAtom {
+        self.start.as_ref().unwrap_or(anchor)
+    }
+
     fn shape_valid(
         &self,
         anchor: &WordAtom,
@@ -206,19 +265,25 @@ impl RelationSpan {
         geometry_len: usize,
     ) -> bool {
         let len = usize::from(self.len);
-        let anchor_len = usize::from(anchor.len);
+        let first = self.first(anchor);
+        let anchor_len = usize::from(first.len);
         if self.extra_words == 0
             || self.extra_words > 15
             || len > 28
             || len <= anchor_len
             || self.bytes[len..].iter().any(|&b| b != 0)
-            || self.bytes.get(..anchor_len) != anchor.bytes.get(..anchor_len)
+            || first.len == 0
+            || !first.snapshot_valid(seen, source_bytes, geometry_len)
+            || self.bytes.get(..anchor_len) != first.bytes.get(..anchor_len)
+            || self
+                .start
+                .is_some_and(|start| start.byte_end >= anchor.byte_end || self.terminal != *anchor)
             || !self
                 .terminal
                 .snapshot_valid(seen, source_bytes, geometry_len)
-            || self.terminal.end < anchor.end
-            || self.terminal.byte_end.checked_sub(anchor.byte_end)
-                != Some(u64::from(self.len) - u64::from(anchor.len))
+            || self.terminal.end < first.end
+            || self.terminal.byte_end.checked_sub(first.byte_end)
+                != Some(u64::from(self.len) - u64::from(first.len))
         {
             return false;
         }
@@ -248,7 +313,8 @@ impl RelationSpan {
     }
 
     fn learned_valid(&self, anchor: &WordAtom, model: &Model) -> bool {
-        let mut offset = usize::from(anchor.len);
+        let first = self.first(anchor);
+        let mut offset = usize::from(first.len);
         while offset < usize::from(self.len) {
             let separator = self.bytes[offset];
             offset += 1;
@@ -263,7 +329,7 @@ impl RelationSpan {
             next.bytes[..usize::from(next.len)].copy_from_slice(&self.bytes[start..offset]);
             if !super::source_span::learned_advance(
                 model,
-                anchor,
+                first,
                 &next,
                 separator,
                 Control::Full,
@@ -310,10 +376,12 @@ impl RelationState {
                 model.geometry.inverses.len(),
             ) || !span.learned_valid(anchor, model)
                 || !visible_atom(&span.terminal)
+                || !visible_atom(span.first(anchor))
             {
                 return false;
             }
-            let start = anchor.byte_end + 1 - u64::from(anchor.len);
+            let first = span.first(anchor);
+            let start = first.byte_end + 1 - u64::from(first.len);
             words.recent[..words.recent_len]
                 .iter()
                 .filter(|word| word.byte_end >= start && word.byte_end <= span.terminal.byte_end)
@@ -338,7 +406,13 @@ impl RelationState {
         };
         for record in &self.records {
             if let Some(span) = &record.span {
-                if record.owner.byte_end >= record.value.byte_end
+                let ordering = if span.start.is_some() {
+                    model.relation_reverse_spans.is_some()
+                        && record.owner.byte_end > record.value.byte_end
+                } else {
+                    record.owner.byte_end < record.value.byte_end
+                };
+                if !ordering
                     || !valid_atom(&record.value)
                     || !visible_atom(&record.value)
                     || !valid_span(&record.value, span)
@@ -358,7 +432,7 @@ impl RelationState {
                 || pending
                     .span
                     .as_ref()
-                    .is_some_and(|span| !valid_span(&pending.value, span))
+                    .is_some_and(|span| span.start.is_some() || !valid_span(&pending.value, span))
                 || words.recent_len == 0
                 || words.recent[0] != *pending.terminal()
                 || self.last_word_end != Some(pending.terminal().byte_end)
@@ -395,6 +469,7 @@ mod tests {
             len: text.len() as u8,
             extra_words: 1,
             terminal,
+            start: None,
         }
     }
 
@@ -480,5 +555,65 @@ mod tests {
         let mut bad = good;
         bad.len = 255;
         assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+    }
+
+    #[test]
+    fn reverse_relation_span_shape_keeps_selected_endpoint_and_exact_start() {
+        let mut good = span("New York", 15);
+        good.start = Some(atom("New", 10));
+        let anchor = good.terminal;
+        assert!(good.shape_valid(&anchor, 100, 100, 1));
+        assert_eq!(payload(&anchor, Some(&good)), Some(b"New York".as_slice()));
+        let wire = serde_json::to_vec(&good).unwrap();
+        assert_eq!(serde_json::from_slice::<RelationSpan>(&wire).unwrap(), good);
+        let mut bad = good;
+        bad.terminal.bytes[0] = b'F';
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.start.as_mut().unwrap().byte_end += 1;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let mut bad = good;
+        bad.start = None;
+        assert!(!bad.shape_valid(&anchor, 100, 100, 1));
+        let forward = span("New York", 15);
+        assert!(!serde_json::to_string(&forward).unwrap().contains("start"));
+        assert!(forward.shape_valid(&atom("New", 10), 100, 100, 1));
+    }
+
+    #[test]
+    fn reverse_relation_span_compares_complete_value_across_anchor_directions() {
+        let mut state = RelationState::default();
+        let mut work = ValueWork::default();
+        let forward = span("New York", 15);
+        state.commit_span(atom("ada", 2), atom("New", 10), Some(forward), 1, &mut work);
+        let mut reverse = forward;
+        reverse.start = Some(atom("New", 10));
+        state.commit_span(
+            atom("ada", 30),
+            reverse.terminal,
+            Some(reverse),
+            1,
+            &mut work,
+        );
+        assert!(!state.record(2).unwrap().conflict);
+        assert_eq!(state.record(2).unwrap().value, reverse.terminal);
+        let mut changed = span("Old York", 45);
+        changed.start = Some(atom("Old", 40));
+        state.commit_span(
+            atom("ada", 60),
+            changed.terminal,
+            Some(changed),
+            1,
+            &mut work,
+        );
+        assert!(state.record(3).unwrap().conflict);
+        assert_eq!(state.record(3).unwrap().previous, 2);
+        assert_eq!(
+            payload(
+                &state.record(2).unwrap().value,
+                state.record(2).unwrap().span.as_ref()
+            ),
+            Some(b"New York".as_slice())
+        );
     }
 }

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -178,6 +178,7 @@ impl Trainer {
             dependent_read: None,
             typed_routing: None,
             joint_admission: None,
+            relation_reverse_spans: None,
             relation_spans: None,
             source_span_context: None,
             source_span: None,
@@ -536,8 +537,41 @@ impl Model {
         model.validate()?;
         Ok(model)
     }
+    /// Bind endpoint-bounded reverse extents to the unchanged retained-span parent.
+    pub fn with_reverse_relation_spans(&self) -> Result<Model> {
+        if self.relation_reverse_spans.is_some() || self.relation_spans.is_none() {
+            return Err(Error(
+                "reverse spans require a retained relation span parent".into(),
+            ));
+        }
+        let mut model = self.clone();
+        model.relation_reverse_spans = Some(self.artifact_cid.clone());
+        model.refresh_identity()?;
+        model.validate()?;
+        Ok(model)
+    }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(parent_cid) = &self.relation_reverse_spans {
+            if self.relation_spans.is_none() {
+                return Err(Error("reverse span retained parent absent".into()));
+            }
+            let mut parent = self.clone();
+            parent.relation_reverse_spans = None;
+            parent.refresh_identity()?;
+            if &parent.artifact_cid != parent_cid {
+                return Err(Error("reverse span frozen parent differs".into()));
+            }
+            parent.validate()?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("reverse span identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(parent_cid) = &self.relation_spans {
             if self.source_span_context.is_none() || relation::head(self).is_none() {
                 return Err(Error("retained span parent operators absent".into()));

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -2181,3 +2181,63 @@ fn native_retained_relation_span_checkpoint_and_allocation() {
     times[..used].sort_unstable();
     println!("retained span pending/atomic write, malformed extent, eviction, each-step checkpoint and zero allocation PASS; uncached predict+observe samples={used} median_ns={} max_ns={} (includes initial selection; excludes load/encoding/ingestion/checkpoints)",times[used/2],times[used-1]);
 }
+
+#[test]
+#[ignore = "requires the reverse relation span artifact; charged model work"]
+fn native_reverse_relation_span_checkpoint_and_allocation() {
+    use uor_r4_core::native_geometric::{Control, Model};
+    let bytes = std::fs::read(std::env::var("R4_REVERSE_SPAN_MODEL").unwrap()).unwrap();
+    let model = Model::from_bytes(&bytes).unwrap();
+    let mut wrong: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    wrong["relation_reverse_spans"] = "wrong-parent".into();
+    assert!(Model::from_bytes(&serde_json::to_vec(&wrong).unwrap()).is_err());
+    let mut samples = Vec::new();
+    for padding in [String::new(), "quiet sky. ".repeat(96)] {
+        let mut s = model.session(Control::Full).unwrap();
+        s.observe(&model, 0).unwrap();
+        let prompt = format!("Orin Grove holds nelra. {padding}Where is nelra? Answer:");
+        let tokens = model.encode(&prompt).unwrap();
+        ALLOCATIONS.with(|v| v.set(0));
+        BYTES.with(|v| v.set(0));
+        MEASURING.with(|v| v.set(true));
+        for token in tokens {
+            s.observe(&model, token).unwrap();
+        }
+        s.begin_response(&model).unwrap();
+        MEASURING.with(|v| v.set(false));
+        let checkpoint = s.checkpoint().unwrap();
+        let wire: serde_json::Value = serde_json::from_slice(&checkpoint).unwrap();
+        let record = &wire["values"]["relations"]["records"][0];
+        assert!(record["span"]["start"].is_object());
+        assert_eq!(record["span"]["terminal"], record["value"]);
+        let mut malformed = wire.clone();
+        malformed["values"]["relations"]["records"][0]["span"]["start"]["byte_end"] = 999999.into();
+        assert!(model
+            .restore_session(&serde_json::to_vec(&malformed).unwrap())
+            .is_err());
+        let mut output = [1; 32];
+        let mut used = 0;
+        loop {
+            let mut restored = model.restore_session(&s.checkpoint().unwrap()).unwrap();
+            let expected = restored.predict(&model).unwrap();
+            MEASURING.with(|v| v.set(true));
+            let start = std::time::Instant::now();
+            let actual = s.predict(&model).unwrap();
+            s.observe(&model, actual.token).unwrap();
+            let elapsed = start.elapsed().as_nanos();
+            MEASURING.with(|v| v.set(false));
+            samples.push(elapsed);
+            assert_eq!(actual, expected);
+            output[used] = actual.token;
+            used += 1;
+            if actual.token == 1 || used == 32 {
+                break;
+            }
+        }
+        assert_eq!(output[used - 1], 1);
+        assert_eq!(model.decode(&output[..used]).unwrap(), b" Orin Grove.\n");
+        assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    }
+    samples.sort_unstable();
+    println!("reverse span parent rejection, preserved terminal anchor, malformed start rejection, short/evicted reads, per-step checkpoints and zero allocations PASS; samples={} median_ns={} max_ns={} (uncached predict+observe includes initial selection; excludes load/encoding/ingestion/checkpoints)",samples.len(),samples[samples.len()/2],samples[samples.len()-1]);
+}

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -7,6 +7,20 @@ implemented operations, measured behavior and proposed integration. The native
 model was d59070c2 at the review date; no model experiment was
 rerun for that review.
 
+## Reverse relation endpoints — bounded positive, 2026-09-07
+
+The [result](native_geometric_reverse_spans_1140.md) retains `321e990f` over
+`0b12b604` without fitting. The learned writer supplies a terminal endpoint;
+the existing geometric continuation operator admits earlier bounded starts.
+Construction improves 3/6 to 6/6, open passes 6/6, short reads 3/3 and fresh
+turns after selection 6/6. All selected prior outputs, writes and sessions pass.
+The exact anchor identity remains distinct from complete payload extent.
+Longest admitted prefix overextends an unfamiliar plain introduction, while a
+two-space gap truncates: diagnostics 0/2, preserved without retuning. This is
+bounded value retention, not general phrase understanding or an energy result.
+The next direction is learned start selection, with separator representation
+tracked separately. Current-state records the remaining cumulative allocation.
+
 ## Retained relation spans — bounded positive after runtime correction, 2026-09-07
 
 The [result](native_geometric_retained_spans_1140.md) retains `0b12b604` with the

--- a/docs/evidence/native_geometric_reverse_spans_1140.json
+++ b/docs/evidence/native_geometric_reverse_spans_1140.json
@@ -1,0 +1,783 @@
+{
+  "schema": "uor-r4.reverse-relation-span-evidence/1",
+  "at": "2026-09-07T14:22:30.839Z",
+  "base_commit": "218e11292385ed2f980bf9a884e5b47ecea5350f",
+  "decision": "RETAIN_BOUNDED_REVERSE_RELATION_SPANS",
+  "selection": {
+    "artifact": "blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563",
+    "construction": 6,
+    "development": 6,
+    "fit": "NOT_RUN_NO_FIT_REQUIRED",
+    "fresh": "NOT_RUN_AT_SELECTION",
+    "parent": "blake3:0b12b6044e4a04124fa07a69496d9c5da65fc6a9d6ad95072fc46a9590916762",
+    "parent_parameters_equal": true,
+    "preservation": true,
+    "selected_before_fresh": true
+  },
+  "model": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/model.json",
+    "bytes": 11631560,
+    "sha256": "e094a0b511bba8747cee49867997e908940a85c9147b0537ecbdc1e297ea56ab"
+  },
+  "parent": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/model.json",
+    "bytes": 11631461,
+    "sha256": "39b2e2435b588695ac8fcf37b4f1a70ebe6e130aab0014557d5530f7874c1e25"
+  },
+  "source": [
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+      "bytes": 22574,
+      "sha256": "7cb6065bca81ba88891e12c46355ee3e6d8583443e524a8405252654b4139907"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation.rs",
+      "bytes": 26028,
+      "sha256": "d770cfd4338c53451487f7f5c235a3ce3c4919b9b4908df40892e02170c77b13"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation_span.rs",
+      "bytes": 21878,
+      "sha256": "d08dc308af81af60009278d206a0a91e4475c34b3616912ef92aad7a4740ccc1"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+      "bytes": 58186,
+      "sha256": "f613a38d35135c8b448005e48686cf2494793b981b325173c2334e45fcc30b9a"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/source_span.rs",
+      "bytes": 11576,
+      "sha256": "cb8b630bfc930eea8e4a71915e4e3914390b67b6f406191f5c7049e38a9d0942"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+      "bytes": 72912,
+      "sha256": "e1827f262c7b052bd34944d106e6f93865aecb41947000b809ec3526c032036d"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs",
+      "bytes": 10425,
+      "sha256": "919a035c70510185e0ed10527883d4d7d51a1a14f01e154d11a669f09e34d593"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe/retained_span.rs",
+      "bytes": 9105,
+      "sha256": "87650389282cce86ed93318ac514ce5b0821477f3a621a32b6575c98363275d6"
+    },
+    {
+      "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "bytes": 91720,
+      "sha256": "fb6fce2d090ae24f61590278425e8c4fe1a2b65d967fe6b7467e6d486d8e7a72"
+    }
+  ],
+  "panels": {
+    "parent": {
+      "exact": 3,
+      "total": 6,
+      "version_counts_exact": true,
+      "isolation": true,
+      "trailing_tokens": 1056,
+      "turns": [
+        {
+          "input": "Orin Grove holds nelra. Silver Cape holds vesk. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Grove.\n",
+          "exact": false,
+          "version_count_exact": true,
+          "expected_versions": 2,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Orin Grove holds nelra. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Grove.\n",
+          "exact": false,
+          "version_count_exact": true,
+          "expected_versions": 3,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "nelra now in Amber Grove. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Amber Grove.\n",
+          "text": " Amber Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "",
+          "query": "Where is vesk? Answer:",
+          "expected": " Silver Cape.\n",
+          "text": " Cape.\n",
+          "exact": false,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Orin Grove holds nelra. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Unknown.\n",
+          "text": " Unknown.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 5,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "nelra now in Orin Grove. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Orin Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 6,
+          "checkpoint_predictions_equal": true
+        }
+      ]
+    },
+    "construction": {
+      "exact": 6,
+      "total": 6,
+      "version_counts_exact": true,
+      "isolation": true,
+      "trailing_tokens": 1056,
+      "turns": [
+        {
+          "input": "Orin Grove holds nelra. Silver Cape holds vesk. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Orin Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 2,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Orin Grove holds nelra. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Orin Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 3,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "nelra now in Amber Grove. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Amber Grove.\n",
+          "text": " Amber Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "",
+          "query": "Where is vesk? Answer:",
+          "expected": " Silver Cape.\n",
+          "text": " Silver Cape.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Orin Grove holds nelra. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Unknown.\n",
+          "text": " Unknown.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 5,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "nelra now in Orin Grove. ",
+          "query": "Where is nelra? Answer:",
+          "expected": " Orin Grove.\n",
+          "text": " Orin Grove.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 6,
+          "checkpoint_predictions_equal": true
+        }
+      ]
+    },
+    "development": {
+      "exact": 6,
+      "total": 6,
+      "version_counts_exact": true,
+      "isolation": true,
+      "trailing_tokens": 1056,
+      "turns": [
+        {
+          "input": "Record: Copper Vale holds serin. Record: Ivory Pier holds mavra. ",
+          "query": "Where is serin? Answer:",
+          "expected": " Copper Vale.\n",
+          "text": " Copper Vale.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 2,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Record: Copper Vale holds serin. ",
+          "query": "Where is serin? Answer:",
+          "expected": " Copper Vale.\n",
+          "text": " Copper Vale.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 3,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "serin now in Cobalt Vale. ",
+          "query": "Where is serin? Answer:",
+          "expected": " Cobalt Vale.\n",
+          "text": " Cobalt Vale.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "",
+          "query": "Where is mavra? Answer:",
+          "expected": " Ivory Pier.\n",
+          "text": " Ivory Pier.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Record: Copper Vale holds serin. ",
+          "query": "Where is serin? Answer:",
+          "expected": " Unknown.\n",
+          "text": " Unknown.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 5,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "serin now in Copper Vale. ",
+          "query": "Where is serin? Answer:",
+          "expected": " Copper Vale.\n",
+          "text": " Copper Vale.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 6,
+          "checkpoint_predictions_equal": true
+        }
+      ]
+    },
+    "fresh": {
+      "exact": 6,
+      "total": 6,
+      "version_counts_exact": true,
+      "isolation": true,
+      "trailing_tokens": 1056,
+      "turns": [
+        {
+          "input": "Quiet River Bend holds belvi. Violet Quay holds norvi. ",
+          "query": "Where is belvi? Answer:",
+          "expected": " Quiet River Bend.\n",
+          "text": " Quiet River Bend.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 2,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Quiet River Bend holds belvi. ",
+          "query": "Where is belvi? Answer:",
+          "expected": " Quiet River Bend.\n",
+          "text": " Quiet River Bend.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 3,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "belvi now in Silver River Bend. ",
+          "query": "Where is belvi? Answer:",
+          "expected": " Silver River Bend.\n",
+          "text": " Silver River Bend.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "",
+          "query": "Where is norvi? Answer:",
+          "expected": " Violet Quay.\n",
+          "text": " Violet Quay.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 4,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "Quiet River Bend holds belvi. ",
+          "query": "Where is belvi? Answer:",
+          "expected": " Unknown.\n",
+          "text": " Unknown.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 5,
+          "checkpoint_predictions_equal": true
+        },
+        {
+          "input": "belvi now in Quiet River Bend. ",
+          "query": "Where is belvi? Answer:",
+          "expected": " Quiet River Bend.\n",
+          "text": " Quiet River Bend.\n",
+          "exact": true,
+          "version_count_exact": true,
+          "expected_versions": 6,
+          "checkpoint_predictions_equal": true
+        }
+      ]
+    }
+  },
+  "short": {
+    "cases": [
+      {
+        "exact": true,
+        "expected": " Orin Grove.\n",
+        "prompt": "Orin Grove holds nelra. Where is nelra? Answer:",
+        "text": " Orin Grove.\n"
+      },
+      {
+        "exact": true,
+        "expected": " Copper Vale.\n",
+        "prompt": "Record: Copper Vale holds serin. Where is serin? Answer:",
+        "text": " Copper Vale.\n"
+      },
+      {
+        "exact": true,
+        "expected": " Ash Field.\n",
+        "prompt": "Ash Field holds merla. Where is merla? Answer:",
+        "text": " Ash Field.\n"
+      }
+    ],
+    "exact": 3,
+    "total": 3
+  },
+  "boundaries": {
+    "cases": [
+      {
+        "exact": false,
+        "expected": " Orin Grove.\n",
+        "input": "Records show Orin Grove holds nelra.",
+        "text": " Records show Orin Grove.\n"
+      },
+      {
+        "exact": false,
+        "expected": " Orin  Grove.\n",
+        "input": "Orin  Grove holds nelra.",
+        "text": " Grove.\n"
+      }
+    ],
+    "scope": "Post-selection diagnostics only: unseen plain intro and two-space gap; no fitting or tuning"
+  },
+  "preservation": {
+    "aliases.json": {
+      "exact": 12,
+      "total": 12
+    },
+    "chains.json": {
+      "exact": 16,
+      "total": 16
+    },
+    "computed-construction.json": {
+      "exact": 58,
+      "total": 58
+    },
+    "dependent.json": {
+      "exact": 48,
+      "total": 48,
+      "writes_exact": 48
+    },
+    "exposed-literals.json": {
+      "exact": 16,
+      "total": 16
+    },
+    "exposed-roles.json": {
+      "exact": 12,
+      "total": 12
+    },
+    "forward-construction.json": {
+      "exact": 6,
+      "total": 6,
+      "writes_exact": true,
+      "isolation_pass": true
+    },
+    "forward-open.json": {
+      "exact": 6,
+      "total": 6,
+      "writes_exact": true,
+      "isolation_pass": true
+    },
+    "forward-prior-fresh.json": {
+      "exact": 6,
+      "total": 6,
+      "writes_exact": true,
+      "isolation_pass": true
+    },
+    "identifiers.json": {
+      "exact": 8,
+      "total": 8
+    },
+    "literal-construction.json": {
+      "exact": 103,
+      "total": 103
+    },
+    "long.json": {
+      "exact": 28,
+      "total": 28,
+      "writes_exact": 28
+    },
+    "names.json": {
+      "exact": 28,
+      "total": 28,
+      "writes_exact": 28
+    },
+    "numeric.json": {
+      "exact": 6,
+      "total": 6
+    },
+    "preservation.json": {
+      "exact": 62,
+      "total": 62
+    },
+    "prior-chains.json": {
+      "exact": 16,
+      "total": 16
+    },
+    "prior-fresh.json": {
+      "exact": 16,
+      "total": 16
+    },
+    "prior-span-construction.json": {
+      "exact": 14,
+      "total": 14
+    },
+    "prior-span-development.json": {
+      "exact": 6,
+      "total": 6
+    },
+    "prior-span-fresh.json": {
+      "exact": 9,
+      "total": 9
+    },
+    "prior.json": {
+      "exact": 24,
+      "total": 24
+    },
+    "retained-construction.json": {
+      "exact": 663,
+      "total": 663
+    },
+    "roles.json": {
+      "exact": 12,
+      "total": 12
+    },
+    "sessions.json": {
+      "exact_turns": 5,
+      "total_turns": 5,
+      "isolated_no_shared_records": true
+    }
+  },
+  "checks": {
+    "release_probe_and_test_binaries": "PASS",
+    "focused_relation_span_tests": 5,
+    "integer_kernel_source_guard": "PASS; scoped source-token scan, not transitive/machine-code proof",
+    "architecture_policy": "PASS; no model behavior claim",
+    "format": "PASS",
+    "claim_wording": "PASS",
+    "actual_artifact": "PASS: short and evicted complete output, terminal identity, parent/start mutation rejection, every-step checkpoints, zero measured allocations",
+    "timing": {
+      "samples": 28,
+      "median_ns": 375,
+      "max_ns": 151916,
+      "scope": "Uncached predict+observe including first selection; excludes loading, encoding, ingestion, checkpoints. Energy unmeasured."
+    },
+    "root_cli": "NOT_RUN_FOR_NEW_ARTIFACT",
+    "studio": "NOT_RUN",
+    "broad_release_qa": "NOT_RUN",
+    "warning": "Existing unused NUMERIC_PROMPT test fixture warning; compilation succeeded"
+  },
+  "resources": {
+    "projection": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-projection.json",
+      "bytes": 3040,
+      "sha256": "587806b5bb4b036e659f606cb9e2e72ec6a9a4181166f766fc1a67b5d0909874"
+    },
+    "cycle_model_ms": 43770,
+    "cycle_engineering_ms": 269887,
+    "previous_cumulative_ceiling_ms": 4290000,
+    "current_cumulative": {
+      "cumulative_ms": 4327369,
+      "limit_ms": 4410000
+    },
+    "remaining_model_ms": 82631,
+    "final_sampled_growth_bytes": 14749696,
+    "peak_sampled_growth_bytes": 17833984,
+    "peak_sampled_model_rss_bytes": 967245824,
+    "cleanup": "NONE",
+    "external_compute": "NONE",
+    "scope": "Cumulative command-wall accounting includes artifact construction, validation, behavior, builds and focused tests; interactive review/docs wall time is not model execution. Storage/RSS are samples, not exact peaks.",
+    "commands": [
+      {
+        "label": "reverse-span-evaluate",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "reverse-span",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/retained-span-angular/model.json",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular"
+        ],
+        "elapsed_ms": 29272,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": false,
+        "peak_sampled_known_bytes": 7516405760,
+        "peak_process_rss_sample_bytes": 967245824,
+        "process_rss_samples": 29
+      },
+      {
+        "label": "reverse-span-artifact-check",
+        "command": "/usr/bin/env",
+        "args": [
+          "R4_REVERSE_SPAN_MODEL=/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/model.json",
+          "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+          "native_reverse_relation_span_checkpoint_and_allocation",
+          "--ignored",
+          "--exact",
+          "--nocapture"
+        ],
+        "elapsed_ms": 14498,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": false,
+        "peak_sampled_known_bytes": 7516409856,
+        "peak_process_rss_sample_bytes": 499810304,
+        "process_rss_samples": 14
+      },
+      {
+        "label": "reverse-span-build",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo fmt --all\n/Users/casey.allard/.cargo/bin/cargo build --release --offline -p uor-r4-core --example native_geometric_value_probe\n/Users/casey.allard/.cargo/bin/cargo test --release --offline -p uor-r4-core --lib --test native_geometric_allocations --no-run\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f relation_span::tests --nocapture\n/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931 native_kernel_source_has_no_forbidden_arithmetic_or_float_types --exact --nocapture\n/tmp/r4-native-geometric-target/release/r4-policy-check ."
+        ],
+        "elapsed_ms": 265816,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": true,
+        "peak_sampled_known_bytes": 7519498240,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null
+      },
+      {
+        "label": "reverse-span-final-checks",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\n/Users/casey.allard/.cargo/bin/cargo fmt --all --check\npython3 scripts/check_claim_wording.py\ngit diff --check"
+        ],
+        "elapsed_ms": 4071,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": true,
+        "peak_sampled_known_bytes": 7516418048,
+        "peak_process_rss_sample_bytes": null,
+        "process_rss_samples": null
+      }
+    ]
+  },
+  "receipts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/parent.json",
+      "bytes": 241739,
+      "sha256": "02a5fe02f2bec7b982b1b8cbc6c3005f739e40f0de7081f7a557f4c4cd01be7f"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/construction.json",
+      "bytes": 412677,
+      "sha256": "7e463859134250573ca898f932194cba825a68e5b12f7bf46bce92bdc5381054"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/development.json",
+      "bytes": 435793,
+      "sha256": "b6d416a456cda46bbed84d88785553600be3f95a3874ae30616ec779534f2e11"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/selection.json",
+      "bytes": 382,
+      "sha256": "e71da81b98afacd73481a2af669661ab41a6eb92c4d57ad8eb10531937c6ed6b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/short.json",
+      "bytes": 559,
+      "sha256": "7e9ed91a4d52b277dc6110bb8f38005a9dbbabd607fa8ad2b4c0cfd0d48166c7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/fresh.json",
+      "bytes": 413304,
+      "sha256": "d01b9f9261248a0218c984a24dcbb3ebbb6e411ec07a4a970f04c3ce30ebcac6"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/boundaries.json",
+      "bytes": 436,
+      "sha256": "0ba3627eaf6a9b18d5c411fdcf523c42a5a0a44e988a58dfaea3aecfa117591a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/aliases.json",
+      "bytes": 15252,
+      "sha256": "cb05a5db673311fb7fe501146990099b22f11c8970670c73a03db38e712caead"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/chains.json",
+      "bytes": 18506,
+      "sha256": "213d6886d3d833ecbad64e1f38be140ceec3ce14f48c337a0826d43aeb1492b7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/computed-construction.json",
+      "bytes": 61339,
+      "sha256": "b050c723ab399a4c40243828c3f31f3e02a67a0a00781eb1acf3fdcad1903f69"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/dependent.json",
+      "bytes": 45899,
+      "sha256": "e736fc71114aabb4223243fe49470414178a36d173289480c7d8fe4c2c82ce0b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/exposed-literals.json",
+      "bytes": 14928,
+      "sha256": "d61ec7ee4d196bb31dcf1869486ff0b801b54b7200c1592d818f35488dfc7103"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/exposed-roles.json",
+      "bytes": 15136,
+      "sha256": "d0f328265018131d347d3b886e2a095a4e79469b11e9a9c15c1478e35e563c00"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/forward-construction.json",
+      "bytes": 159840,
+      "sha256": "5bd31ee1c5b2848225918cbb04445414f2a40aee1d87583995e4c695abf62127"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/forward-open.json",
+      "bytes": 159878,
+      "sha256": "941b8b665dc658d8c2d8d50964aae7b7bdc499a33e6a8af4df0bc63d815c96de"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/forward-prior-fresh.json",
+      "bytes": 160240,
+      "sha256": "e1faf5cff54f3909084d6fe702b3e9281bf91fa442bf1a1d90b4ef638389969e"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/identifiers.json",
+      "bytes": 7264,
+      "sha256": "b4480d726ed3f72b65aa5ac0238314dc651b1374d6cd2d781a9df2e4a9e48c26"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/literal-construction.json",
+      "bytes": 93929,
+      "sha256": "a009360ab354e778e112f6dc69eaba9e24321efb18c656b5de9206fdb715cb37"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/long.json",
+      "bytes": 147372,
+      "sha256": "ddbb22ac91dbe289654b9b9c209046a0bbe23623ec2fad56a782a92c8ae74841"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/names.json",
+      "bytes": 27972,
+      "sha256": "ba2092c77b9c2991d6ee79657fd0804148cc19f062fd72b62987b70a5850eede"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/numeric.json",
+      "bytes": 6094,
+      "sha256": "3c7dd3f5ec0e34caa705d136c33d4dd39b057a437428a5fb897683634c544983"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/preservation.json",
+      "bytes": 21669,
+      "sha256": "4df9c73489cdad2f8d47cb73b0ad77a6d2a4a86f690a23b94f574d5a4beaf823"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior-chains.json",
+      "bytes": 18496,
+      "sha256": "ea909649bbd27b6972f1d1c71e7600ff49d3a3a16dfb51885fef2f4dac97a5b8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior-fresh.json",
+      "bytes": 14552,
+      "sha256": "9d49306056cf56af6491228327a8a487e406cdaa2ee88243b120e6d0bebe25df"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior-span-construction.json",
+      "bytes": 4445,
+      "sha256": "2928a06119d649eab7c44398f97f8dd5723b0b9b75a2efb644e84945d47d4d26"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior-span-development.json",
+      "bytes": 2175,
+      "sha256": "a550e83b503499f196ec49b5470d21e3fa20730bb9e1b5387afe912a6273b538"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior-span-fresh.json",
+      "bytes": 3102,
+      "sha256": "163ff413e14d7b4cd1805fe966e76da1bd8e9b2191d6b2c55bd87f7f6be29acf"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/prior.json",
+      "bytes": 7457,
+      "sha256": "1a93ee60fe60360ab0a3910ffb26e1885b4dd31b4a559e0eed120756c1680005"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/retained-construction.json",
+      "bytes": 214913,
+      "sha256": "c6668466a048d8e439eeea4c0cc9d942d0c00cb544fa7198d19c77970298aaeb"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/roles.json",
+      "bytes": 15264,
+      "sha256": "9f6d3c3feb07a0263bdd506d96acbe459ed2c76d93cb5608c25dfcc12c4ef1e8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/preservation/sessions.json",
+      "bytes": 58938,
+      "sha256": "ac942d00ffdcacfba45bcb977f71fa9865fe651cec2512aea77f4749ec65c937"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-artifact-check.stdout.log",
+      "bytes": 474,
+      "sha256": "1e59f154da05400ed359055441404eb930ad094f069f146561929b6d42c3b158"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-build.log",
+      "bytes": 1993,
+      "sha256": "6c06ca8a34efac8794eed1b1dce6d4e48eaa12643e68b1d7d58b1d8c9262f153"
+    }
+  ],
+  "limitations": [
+    "Familiar-template bounded memory, not broad language/reasoning/frontier capability.",
+    "No new fit or angular-versus-equality advantage experiment; same learned geometry with typed endpoint.",
+    "Longest admitted start overextends unknown plain introductions; wider gaps remain unrepresented.",
+    "Complete parent is the control; query-span ablations do not disable full-control persistent ingestion."
+  ],
+  "next": "Learn phrase-start selection over admitted starts using new construction/open contrasts; preserve opened diagnostics. Exact wider separators remain a separate representation task. Project all work against the cumulative balance."
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,32 @@
 # Current native geometric AI work
 
+## Reverse relation endpoints — 2026-09-07
+
+**Retain `321e990f` at bounded reverse-value scope.** The
+[result](../native_geometric_reverse_spans_1140.md) and
+[evidence](../evidence/native_geometric_reverse_spans_1140.json) record reuse of
+the existing learned writer endpoint and H4 continuation operator. The full
+`0b12b604` parent is fixed; no fit is added. Earlier starts must reach the
+selected final value word exactly. The selected word keeps its identity, with
+the earlier start retained separately; linker/owner words cannot enter the value.
+
+Construction improves 3/6 to 6/6; open turns pass 6/6, short reads 3/3 and fresh
+turns after selection 6/6. All 663 prior construction answers, all 18 earlier
+forward session turns, 28/28 long-window and 48/48 dependent reads, prior
+source-span panels and other selected preservation pass. Actual-artifact
+parent/start rejection, anchor preservation, checkpoints and zero-allocation
+checks pass. Kernel maximum 0.152 ms excludes loading/input/checkpoint host work;
+energy remains unmeasured. Root CLI and Studio are `NOT_RUN` for this artifact.
+
+**Next: learn phrase-start selection instead of longest admitted prefix.**
+The plain-introduction and two-space diagnostics remain 0/2, with no retry on
+those opened cases. Start selection and exact separator representation are
+separate missing pieces. Use new construction/open contrasts and preserve the
+opened diagnostics. The owner-directed cycle explicitly added 120 seconds to
+the cumulative ceiling (4,290 to 4,410); actual model work was 43.770 seconds.
+Cumulative use is 4,327.369/4,410, leaving 82.631 seconds. Project the complete
+successor before execution; no global timer reset or external compute occurred.
+
 ## Retained multiword relation values — 2026-09-07
 
 **Retain `0b12b604` with the corrected forward-only runtime.** The

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -280,11 +280,16 @@ parameters without fitting. Complete multiword values survive window eviction,
 conflicts and corrections on all 18 session turns, with all prior preservation.
 The initial reverse-statement overextension is preserved as a runtime negative;
 reverse writes now keep their established single-word scope.
-**Next: learn role-aware value endpoints in both source orders**, using the
-existing owner/value binding and geometric continuation operator. Source-cue
-lookup alone still lacks general connector and spacing behavior. New learning
-needs independently authored construction/open cases, fixed earlier panels as
-preservation, and a complete projection against the remaining cumulative budget.
+The [reverse endpoint continuation](../native_geometric_reverse_spans_1140.md)
+retains `321e990f` without fitting: existing writer-selected endpoints bound
+reverse spans, yielding construction 3/6 to 6/6, open 6/6, short 3/3 and fresh
+6/6 with selected preservation intact. The earlier start is retained separately
+from the unchanged terminal anchor.
+**Next: learn phrase-start selection over admitted candidates.** Longest passing
+prefix still includes unfamiliar introductory text; wider gaps remain a separate
+exact-separator representation limitation. New construction/open contrasts must
+remain separate from the opened diagnostics. Project the complete work against
+the current cumulative balance before execution.
 Do not restart completed order repairs or grow a
 paging subsystem without a measured access bottleneck. General named-role binding
 and broader Rust reasoning remain unqualified. Follow current-state.md for

--- a/docs/native_geometric_reverse_spans_1140.md
+++ b/docs/native_geometric_reverse_spans_1140.md
@@ -1,0 +1,111 @@
+# Endpoint-bound reverse relation spans — #1139 / #1140
+
+## Implementation — 2026-09-07
+
+[PR #1169's retained-value path](native_geometric_retained_spans_1140.md) keeps
+complete forward values, but reverse statements commit only the writer-selected
+word. Replaying words after that selected value previously included the linker
+and owner and regressed two long-window answers. That negative remains intact.
+
+The source provides a more useful boundary: the learned reverse writer chooses
+a value word before its owner. This continuation treats that selected word as a
+hard terminal endpoint. The existing H4 Continue/Finish operator checks bounded
+contiguous starts before the endpoint, using each candidate's original source
+cue consistently across every edge. The longest admitted start is retained.
+The linker and owner after the endpoint never enter the value. No new fit,
+lexical linker rule, transformer, matrix product or learned expert gate is added.
+This reuses an already learned edge operator with a typed endpoint; it does not
+establish a new learned general phrase-boundary model.
+
+The selected `WordAtom` keeps its bytes, geometry, predecessor context and
+position. A reverse span carries its earlier `start` atom separately, with its
+terminal equal to that selected anchor. Complete payload comparison works across
+forward and reverse anchors, preserving immutable versions and conflicts.
+Reverse payloads remain eligible for persistent reading while their terminal
+anchor is still visible: the recent reader starting at that final word cannot
+recover the earlier bytes. Existing dependent-read first-leg span rejection
+continues to prevent joining a phrase through one constituent word.
+
+`Model::with_reverse_relation_spans()` adds an optional complete-parent CID to
+the artifact. Removing that field reconstructs the entire retained-span parent;
+loading validates both identities. Snapshot checks bind the opt-in, exact start,
+terminal, ordering, payload, learned edges and source words still visible.
+Reverse spans cannot be pending forward writes. Evicted source fields remain
+declared state, not authentication of unavailable original text. The complete
+parent artifact is the control; existing query-span ablations do not disable
+persistent ingestion using the full learned operator.
+
+## Execution contract
+
+The owner's continuation instruction follows the disclosed 6.401-second balance.
+This cycle explicitly adds 120 seconds to the cumulative ceiling, from 4,290 to
+4,410 seconds, without resetting the 4,283.599 seconds already spent. Cycle caps:
+120 seconds model work, 900 seconds engineering, 40 MiB new sampled storage,
+4 GiB model RSS, one model process and one Cargo build job. Projection: 70 seconds
+model work (35 comparison/artifact construction, 15 actual-artifact checks,
+20 correction reserve), 600 seconds engineering; 12 MiB artifact, 26 MiB compiler
+transients and 2 MiB reports. No external compute or broad cleanup is planned.
+Context remains 512 tokens, retained relations 16, value payload 28 bytes and
+response limit 32 tokens. The existing cumulative guard charges all attempts.
+
+One combined Rust probe compares parent and candidate on six construction turns,
+then six open turns and three short reads. It checks complete outputs, exact
+version counts, checkpoint prediction replay and session isolation. Existing
+forward sessions and numeric/source/dependent preservation follow. A decision is
+recorded before six separately authored fresh turns and two boundary diagnostics
+(unseen plain introduction and a two-space gap). No fitting uses those panels.
+The actual-artifact test checks short/evicted reads, terminal-anchor preservation,
+parent and malformed-start rejection, every-step replay and allocation counts.
+
+## Result
+
+Retain `blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563`
+at bounded reverse-value retention scope. The complete `0b12b604` parent and
+all its learned parameters reconstruct exactly; no fit or correction retry was
+needed. Construction improves 3/6 to 6/6, open development passes 6/6 and short
+reads pass 3/3. Six familiar-template fresh turns first executed after selection
+pass 6/6, including three-word values. All panels preserve exact version counts,
+independent-session isolation and per-step checkpoint prediction equality.
+Counts are not an independent expected owner/value/action sequence comparison.
+
+All 663 retained construction answers pass. Prior source-span panels remain
+14/14, 6/6 and 9/9; all 18 earlier forward session turns pass. Long-window answers
+and write witnesses remain 28/28, dependent reads 48/48, and previous persistent
+sessions 5/5 with isolation. Other selected numeric, literal, name, role,
+identifier and chain preservation passes.
+
+Both boundary diagnostics fail. `Records show Orin Grove holds nelra` yields
+`Records show Orin Grove`, because longest admitted start is not a learned
+semantic start boundary. `Orin  Grove holds nelra` yields `Grove`, because the
+exact one-byte separator representation cannot reconstruct two spaces. These
+post-selection diagnostics are retained and were not used for fitting or a retry.
+The earlier reverse linker/owner overextension stays fixed by the hard endpoint.
+
+The release probe and test binaries compile. Five focused relation-span tests,
+the integer source guard and architecture policy pass. The actual artifact
+passes malformed parent/start rejection, terminal-anchor preservation,
+short/evicted reads, every-step checkpoint replay and zero allocations during
+measured ingestion/emission. Twenty-eight uncached predict-plus-observe samples
+have median 375 ns and maximum 151,916 ns, including initial selection but
+excluding load, encoding, ingestion and checkpoints. This is a small kernel
+measurement, not an end-to-end latency or energy result. Root CLI, Studio and
+broad release QA are `NOT_RUN` for this artifact.
+
+Model work is 43.770 seconds (29.272 comparison/construction, 14.498 actual-artifact
+check). Cumulative use is 4,327.369/4,410 seconds, leaving 82.631 seconds. All
+source, parents and negative results remain retained; no cleanup or external
+compute was needed. The evidence receipt records exact resources and identities.
+
+**Next:** learn a phrase-start decision over admitted starts instead of selecting
+the longest passing prefix. Use exact owner/value context and the existing H4
+operator with independently authored construction/open contrasts; keep these
+opened diagnostics as preservation only. Wider separator retention is a separate
+representation limitation. A new run must project all work against the cumulative
+balance. This step does not establish general language, reasoning, angular
+superiority, frontier capability or energy savings.
+
+At evidence capture, metered engineering commands total 269.887 seconds.
+Retained sampled growth is 14,749,696 bytes; peak sampled growth is 17,833,984
+bytes, within the 40 MiB cycle cap. Peak sampled model-process RSS is
+967,245,824 bytes. The new artifact is 11,631,560 bytes. These observations
+are samples rather than exact physical peak measurements.


### PR DESCRIPTION
Reverse relation writes currently retain only the writer-selected final word. This reuses that learned endpoint and the existing H4 Continue/Finish operator to retain earlier contiguous value words, without including the following linker or owner. The selected WordAtom identity is preserved; the earlier phrase start is stored separately. An optional artifact component reconstructs the complete unchanged parent, with no new fit.

Construction improves 3/6 to 6/6; open sessions pass 6/6, short reads 3/3, and six fresh turns after selection pass 6/6. All 663 prior construction answers, 18 forward session turns, 28 long-window answers and 48 dependent reads remain correct, alongside the other selected preservation checks. Unseen plain introductions still overextend and two-space gaps truncate (0/2 boundary diagnostics); these are preserved without retuning. The next direction is learned start selection over admitted candidates.

Validation: release probe and focused test binaries compile; five relation-span tests, integer source guard, architecture policy, formatting and claim wording pass. The actual artifact passes short/evicted reads, preserved terminal identity, malformed parent/start rejection, every-step checkpoint replay and zero measured allocations. Root CLI/Studio and broad release QA are NOT_RUN for this artifact. Required GitHub statuses remain queue acknowledgements, not model-test evidence.

Actual model work is 43.770 seconds; cumulative 4,327.369/4,410 leaves 82.631 seconds after the announced 120-second continuation allocation. Engineering is 269.887 seconds; peak sampled growth is 17,833,984 bytes within 40 MiB. No cleanup or external model compute. README, roadmap, research and current-state pointers link to the complete result and evidence.

Continues #1139 and #1140; no broad capability issue is closed by this bounded result.
