### PR TITLE
Learn H4 phrase-start selection; preserve open transfer negative

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ behavior. The [reverse endpoint continuation](docs/native_geometric_reverse_span
 now retains `321e990f`, reusing the selected terminal word to bound the phrase.
 Construction improves 3/6 to 6/6, open and fresh turns pass 6/6 each, and short
 reads pass 3/3 with selected preservation intact. Unfamiliar introductions and
-wider gaps still fail; learned phrase starts are the next direction.
+wider gaps still fail. The [learned phrase-start candidate](docs/native_geometric_relation_start_1140.md)
+improves new construction 2/8 to 8/8 and open answers 2/8 to 6/8, preserving
+prior outputs, but is not promoted: predecessor-only learned codes still include
+an introductory word in two cases. Fresh evaluation was not executed.
 General prose/syntax/reasoning and frontier capability remain unqualified. Follow
 the current-state pointer for artifacts, costs and the next implementation.
 

--- a/crates/uor-r4-core/examples/native_geometric_value_probe.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe.rs
@@ -25,6 +25,8 @@ mod joint_admission;
 mod literal_binding;
 #[path = "native_geometric_value_probe/relation_memory.rs"]
 mod relation_memory;
+#[path = "native_geometric_value_probe/relation_start.rs"]
+mod relation_start;
 #[path = "native_geometric_value_probe/retained_span.rs"]
 mod retained_span;
 #[path = "native_geometric_value_probe/reverse_span.rs"]
@@ -989,6 +991,9 @@ fn evaluate_binding(
 }
 
 fn main() -> ProbeResult<()> {
+    if std::env::args().nth(1).as_deref() == Some("relation-start") {
+        return relation_start::run(&std::env::args().skip(2).collect::<Vec<_>>());
+    }
     if std::env::args().nth(1).as_deref() == Some("reverse-span") {
         return reverse_span::run(&std::env::args().skip(2).collect::<Vec<_>>());
     }

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/relation_start.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/relation_start.rs
@@ -1,0 +1,170 @@
+//! Fit only the start scorer; endpoint, admission, payload and parent stay fixed.
+use super::*;
+fn examples(tag: &str, worlds: &[(&str, &str, &str, &str)], long: bool) -> Vec<ValueExample> {
+    let mut out = Vec::new();
+    for (i, &(intro, name, full, single)) in worlds.iter().enumerate() {
+        for (j, (prefix, value)) in [(intro, full), ("", full), (intro, single), ("", single)]
+            .into_iter()
+            .enumerate()
+        {
+            let padding = if long {
+                "quiet sky. ".repeat(96)
+            } else {
+                String::new()
+            };
+            out.push(ValueExample {
+                id: format!("{tag}/{i}/{j}"),
+                prompt: format!("{prefix}{value} holds {name}. {padding}Where is {name}? Answer:"),
+                response: format!(" {value}.\n"),
+            });
+        }
+    }
+    out
+}
+fn save(out: &Path, name: &str, m: &Model, docs: &[ValueExample]) -> ProbeResult<Value> {
+    let report = source_noread::lean(source_noread::responses(m, docs, false, Control::Full)?);
+    write_json(&out.join(format!("{name}.json")), &report)?;
+    Ok(report)
+}
+pub(super) fn run(args: &[String]) -> ProbeResult<()> {
+    if args.len() != 3 {
+        return Err("relation-start PARENT ROOT NEW_DIRECTORY".into());
+    }
+    let root = Path::new(&args[1]);
+    let out = Path::new(&args[2]);
+    fs::create_dir(out)?;
+    let fit = examples(
+        "start-fit",
+        &[
+            ("Notes say ", "telra", "Amber Meadow", "Amber"),
+            ("Log tells ", "mevin", "Dawn River Bend", "Dawn"),
+        ],
+        false,
+    );
+    let open = examples(
+        "start-open",
+        &[
+            ("A ledger says ", "tesvi", "Pearl Cove", "Pearl"),
+            ("Report notes ", "vorin", "Cobalt Field", "Cobalt"),
+        ],
+        false,
+    );
+    write_json(
+        &out.join("source.json"),
+        &json!({"fit":fit,"development":open,"scope":"New authored raw prompt/response contrasts. Existing Records show diagnostic and former fresh panels excluded from fitting."}),
+    )?;
+    let parent = Model::from_bytes(&fs::read(&args[0])?)?;
+    let before = save(out, "parent-construction", &parent, &fit)?;
+    let before_open = save(out, "parent-development", &parent, &open)?;
+    let (model, report) = parent.fit_relation_start(&fit)?;
+    write_json(&out.join("fit.json"), &report)?;
+    write_new(&out.join("model.json"), &model.to_bytes()?)?;
+    let mut wire: Value = serde_json::from_slice(&model.to_bytes()?)?;
+    let mut old: Value = serde_json::from_slice(&parent.to_bytes()?)?;
+    let block = wire
+        .as_object_mut()
+        .ok_or("shape")?
+        .remove("relation_start")
+        .ok_or("start block absent")?;
+    if block["parent_artifact"] != parent.artifact_cid() {
+        return Err("wrong start parent".into());
+    }
+    for x in [&mut wire, &mut old] {
+        let x = x.as_object_mut().ok_or("shape")?;
+        x.remove("artifact_cid");
+        x.remove("uor_model_address");
+    }
+    if wire != old {
+        return Err("parent parameters changed".into());
+    }
+    let construction = save(out, "construction", &model, &fit)?;
+    let development = save(out, "development", &model, &open)?;
+    let mut preserved = reverse_span::preserve(&model, root, out)?;
+    for (name, names, values, prefix) in [
+        (
+            "reverse-construction",
+            ["nelra", "vesk"],
+            ["Orin Grove", "Amber Grove", "Silver Cape"],
+            "",
+        ),
+        (
+            "reverse-open",
+            ["serin", "mavra"],
+            ["Copper Vale", "Cobalt Vale", "Ivory Pier"],
+            "Record: ",
+        ),
+        (
+            "reverse-prior-fresh",
+            ["belvi", "norvi"],
+            ["Quiet River Bend", "Silver River Bend", "Violet Quay"],
+            "",
+        ),
+    ] {
+        let j = reverse_span::panel(&model, names, values, prefix)?;
+        preserved &=
+            j["exact"] == j["total"] && j["version_counts_exact"] == true && j["isolation"] == true;
+        write_json(&out.join("preservation").join(format!("{name}.json")), &j)?;
+    }
+    let short = reverse_span::short(&model)?;
+    preserved &= short["exact"] == short["total"];
+    write_json(&out.join("preservation/reverse-short.json"), &short)?;
+    let selected = construction["exact"] == construction["total"]
+        && development["exact"] == development["total"]
+        && preserved;
+    write_json(
+        &out.join("selection.json"),
+        &json!({"artifact":model.artifact_cid(),"parent":parent.artifact_cid(),"parent_parameters_equal":true,"selected_before_fresh":selected,"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"fresh":"NOT_RUN_AT_SELECTION"}),
+    )?;
+    if !selected {
+        println!(
+            "{}",
+            json!({"artifact":model.artifact_cid(),"parent_construction":before["exact"],"parent_open":before_open["exact"],"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"selected":false,"fresh":"NOT_RUN_SELECTION_FAILED"})
+        );
+        return Ok(());
+    }
+    let fresh = examples(
+        "start-fresh",
+        &[
+            ("File notes ", "remvi", "Opal Coast", "Opal"),
+            ("A witness says ", "sarvi", "Lilac Bay", "Lilac"),
+        ],
+        true,
+    );
+    write_json(
+        &out.join("fresh-source.json"),
+        &json!({"fresh":fresh,"scope":"Familiar template, new names/values/intro wording; source evicted before query, first executed after selection."}),
+    )?;
+    let fresh = save(out, "fresh", &model, &fresh)?;
+    let diagnostics = vec![
+        ValueExample {
+            id: "start-boundary/prior-intro".into(),
+            prompt: format!(
+                "Records show Orin Grove holds nelra. {}Where is nelra? Answer:",
+                "quiet sky. ".repeat(96)
+            ),
+            response: " Orin Grove.\n".into(),
+        },
+        ValueExample {
+            id: "start-boundary/prior-gap".into(),
+            prompt: format!(
+                "Orin  Grove holds nelra. {}Where is nelra? Answer:",
+                "quiet sky. ".repeat(96)
+            ),
+            response: " Orin  Grove.\n".into(),
+        },
+        ValueExample {
+            id: "start-boundary/lowercase".into(),
+            prompt: format!(
+                "File notes fine sand holds remvi. {}Where is remvi? Answer:",
+                "quiet sky. ".repeat(96)
+            ),
+            response: " fine sand.\n".into(),
+        },
+    ];
+    save(out, "diagnostics", &model, &diagnostics)?;
+    println!(
+        "{}",
+        json!({"artifact":model.artifact_cid(),"parent_construction":before["exact"],"parent_open":before_open["exact"],"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"selected":selected,"fresh":fresh["exact"],"fresh_total":fresh["total"]})
+    );
+    Ok(())
+}

--- a/crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs
+++ b/crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs
@@ -24,7 +24,12 @@ fn emit(s: &mut Session, m: &Model) -> ProbeResult<String> {
     }
     Err("reverse span did not terminate".into())
 }
-fn panel(m: &Model, names: [&str; 2], values: [&str; 3], prefix: &str) -> ProbeResult<Value> {
+pub(super) fn panel(
+    m: &Model,
+    names: [&str; 2],
+    values: [&str; 3],
+    prefix: &str,
+) -> ProbeResult<Value> {
     let [a, b] = names;
     let [first, changed, other] = values;
     let mut s = m.session(Control::Full)?;
@@ -98,7 +103,7 @@ fn panel(m: &Model, names: [&str; 2], values: [&str; 3], prefix: &str) -> ProbeR
 fn accepted(j: &Value) -> bool {
     j["exact"] == j["total"] && j["version_counts_exact"] == true && j["isolation"] == true
 }
-fn short(m: &Model) -> ProbeResult<Value> {
+pub(super) fn short(m: &Model) -> ProbeResult<Value> {
     let mut rows = Vec::new();
     for (input, owner, value) in [
         ("Orin Grove holds nelra.", "nelra", "Orin Grove"),
@@ -158,6 +163,50 @@ pub(super) fn run(args: &[String]) -> ProbeResult<()> {
         "Record: ",
     )?;
     write_json(&out.join("development.json"), &development)?;
+    let preserved = preserve(&model, root, out)?;
+    let short = short(&model)?;
+    write_json(&out.join("short.json"), &short)?;
+    let selected = accepted(&construction)
+        && accepted(&development)
+        && preserved
+        && short["exact"] == short["total"];
+    write_json(
+        &out.join("selection.json"),
+        &json!({"artifact":model.artifact_cid(),"parent":parent.artifact_cid(),"parent_parameters_equal":true,"fit":"NOT_RUN_NO_FIT_REQUIRED","selected_before_fresh":selected,"preservation":preserved,"construction":construction["exact"],"development":development["exact"],"fresh":"NOT_RUN_AT_SELECTION"}),
+    )?;
+    let fresh = panel(
+        &model,
+        ["belvi", "norvi"],
+        ["Quiet River Bend", "Silver River Bend", "Violet Quay"],
+        "",
+    )?;
+    write_json(&out.join("fresh.json"), &fresh)?;
+    let mut boundaries = Vec::new();
+    for (text, expected) in [
+        ("Records show Orin Grove holds nelra.", " Orin Grove.\n"),
+        ("Orin  Grove holds nelra.", " Orin  Grove.\n"),
+    ] {
+        let mut s = model.session(Control::Full)?;
+        s.observe(&model, 0)?;
+        ingest(&mut s, &model, text)?;
+        ingest(&mut s, &model, &"quiet sky. ".repeat(96))?;
+        ingest(&mut s, &model, "Where is nelra? Answer:")?;
+        let actual = emit(&mut s, &model)?;
+        boundaries
+            .push(json!({"input":text,"expected":expected,"text":actual,"exact":actual==expected}));
+    }
+    write_json(
+        &out.join("boundaries.json"),
+        &json!({"cases":boundaries,"scope":"Post-selection diagnostics only: unseen plain intro and two-space gap; no fitting or tuning"}),
+    )?;
+    println!(
+        "{}",
+        json!({"artifact":model.artifact_cid(),"parent":before["exact"],"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"selected":selected,"fresh":fresh["exact"]})
+    );
+    Ok(())
+}
+
+pub(super) fn preserve(model: &Model, root: &Path, out: &Path) -> ProbeResult<bool> {
     let preserve = out.join("preservation");
     fs::create_dir(&preserve)?;
     source_noread::preserve_model_lean(model.clone(), root, &preserve)?;
@@ -235,44 +284,5 @@ pub(super) fn run(args: &[String]) -> ProbeResult<()> {
                 j["exact_turns"] == j["total_turns"] && j["isolated_no_shared_records"] == true;
         }
     }
-    let short = short(&model)?;
-    write_json(&out.join("short.json"), &short)?;
-    let selected = accepted(&construction)
-        && accepted(&development)
-        && preserved
-        && short["exact"] == short["total"];
-    write_json(
-        &out.join("selection.json"),
-        &json!({"artifact":model.artifact_cid(),"parent":parent.artifact_cid(),"parent_parameters_equal":true,"fit":"NOT_RUN_NO_FIT_REQUIRED","selected_before_fresh":selected,"preservation":preserved,"construction":construction["exact"],"development":development["exact"],"fresh":"NOT_RUN_AT_SELECTION"}),
-    )?;
-    let fresh = panel(
-        &model,
-        ["belvi", "norvi"],
-        ["Quiet River Bend", "Silver River Bend", "Violet Quay"],
-        "",
-    )?;
-    write_json(&out.join("fresh.json"), &fresh)?;
-    let mut boundaries = Vec::new();
-    for (text, expected) in [
-        ("Records show Orin Grove holds nelra.", " Orin Grove.\n"),
-        ("Orin  Grove holds nelra.", " Orin  Grove.\n"),
-    ] {
-        let mut s = model.session(Control::Full)?;
-        s.observe(&model, 0)?;
-        ingest(&mut s, &model, text)?;
-        ingest(&mut s, &model, &"quiet sky. ".repeat(96))?;
-        ingest(&mut s, &model, "Where is nelra? Answer:")?;
-        let actual = emit(&mut s, &model)?;
-        boundaries
-            .push(json!({"input":text,"expected":expected,"text":actual,"exact":actual==expected}));
-    }
-    write_json(
-        &out.join("boundaries.json"),
-        &json!({"cases":boundaries,"scope":"Post-selection diagnostics only: unseen plain intro and two-space gap; no fitting or tuning"}),
-    )?;
-    println!(
-        "{}",
-        json!({"artifact":model.artifact_cid(),"parent":before["exact"],"construction":construction["exact"],"development":development["exact"],"preservation":preserved,"selected":selected,"fresh":fresh["exact"]})
-    );
-    Ok(())
+    Ok(preserved)
 }

--- a/crates/uor-r4-core/src/native_geometric/mod.rs
+++ b/crates/uor-r4-core/src/native_geometric/mod.rs
@@ -53,6 +53,8 @@ mod numeral;
 mod relation;
 mod relation_admission;
 mod relation_span;
+mod relation_start;
+mod relation_start_training;
 #[cfg(test)]
 mod relation_tests;
 mod relation_training;
@@ -339,6 +341,8 @@ pub struct TrainingProgress {
 #[serde(try_from = "ModelWire")]
 pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    relation_start: Option<source_routing::SourceRouting>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     relation_reverse_spans: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     relation_spans: Option<String>,
@@ -397,6 +401,8 @@ pub struct Model {
 #[serde(deny_unknown_fields)]
 struct ModelWire {
     #[serde(default)]
+    relation_start: Option<source_routing::SourceRouting>,
+    #[serde(default)]
     relation_reverse_spans: Option<String>,
     #[serde(default)]
     relation_spans: Option<String>,
@@ -454,6 +460,7 @@ impl TryFrom<ModelWire> for Model {
     type Error = Error;
     fn try_from(wire: ModelWire) -> Result<Self> {
         let model = Self {
+            relation_start: wire.relation_start,
             relation_reverse_spans: wire.relation_reverse_spans,
             relation_spans: wire.relation_spans,
             source_span_context: wire.source_span_context,

--- a/crates/uor-r4-core/src/native_geometric/relation.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation.rs
@@ -576,7 +576,8 @@ pub(super) fn read_choice(
             continue;
         };
         work.relations.record_reads = work.relations.record_reads.saturating_add(1);
-        if record.span.as_ref().is_none_or(|span| span.start.is_none())
+        if !(model.relation_start.is_some() && record.owner.byte_end > record.value.byte_end)
+            && record.span.as_ref().is_none_or(|span| span.start.is_none())
             && words.queries[..words.query_len].iter().any(|w| {
                 work.relations.source_presence_checks =
                     work.relations.source_presence_checks.saturating_add(1);

--- a/crates/uor-r4-core/src/native_geometric/relation_span.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_span.rs
@@ -19,6 +19,18 @@ pub(super) struct RelationSpan {
     pub start: Option<WordAtom>,
 }
 
+#[derive(Clone, Copy, Default)]
+pub(super) struct ReverseCandidate {
+    pub start: usize,
+    pub span: Option<RelationSpan>,
+}
+
+pub(super) struct ReverseCandidates {
+    /// Singleton first, followed by admitted starts in increasing source extent.
+    pub rows: [ReverseCandidate; 16],
+    pub len: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct PendingRelation {
@@ -147,15 +159,19 @@ impl PendingRelation {
 
 /// The writer-selected word is a hard endpoint. Each possible earlier start
 /// supplies one fixed source cue for the entire existing learned edge law.
-fn reverse_extent(
+pub(super) fn reverse_candidates(
     model: &Model,
     words: &LexemeState,
     owner: usize,
     endpoint: usize,
     action: u8,
     work: &mut ValueWork,
-) -> Option<RelationSpan> {
-    let mut best = None;
+) -> ReverseCandidates {
+    let mut admitted = ReverseCandidates {
+        rows: [ReverseCandidate::default(); 16],
+        len: 1,
+    };
+    admitted.rows[0].start = endpoint;
     let terminal = words.recent[endpoint];
     work.relations.record_reads = work.relations.record_reads.saturating_add(1);
     for start in endpoint + 1..words.recent_len {
@@ -185,11 +201,15 @@ fn reverse_extent(
         if complete {
             if let Some(mut span) = candidate.span {
                 span.start = Some(first);
-                best = Some(span);
+                admitted.rows[admitted.len] = ReverseCandidate {
+                    start,
+                    span: Some(span),
+                };
+                admitted.len += 1;
             }
         }
     }
-    best
+    admitted
 }
 
 impl RelationState {
@@ -227,10 +247,10 @@ impl RelationState {
         // Reverse writes may inspect only source words at or before their
         // selected value endpoint; the following linker and owner are excluded.
         if value != 0 {
-            let span = model
-                .relation_reverse_spans
-                .as_ref()
-                .and_then(|_| reverse_extent(model, words, owner, value, action, work));
+            let span = model.relation_reverse_spans.as_ref().and_then(|_| {
+                let admitted = reverse_candidates(model, words, owner, value, action, work);
+                super::relation_start::select(model, words, value, &admitted, work)
+            });
             self.commit_span(words.recent[owner], words.recent[value], span, action, work);
             return;
         }

--- a/crates/uor-r4-core/src/native_geometric/relation_start.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_start.rs
@@ -1,0 +1,244 @@
+//! Learned choice among already admitted reverse starts. ASCII text shape is
+//! metadata for a learned H4 score, not a grammar or a direct capitalization rule.
+use super::relation_span::{RelationSpan, ReverseCandidate, ReverseCandidates};
+use super::value_lexemes::LexemeState;
+use super::value_types::{ValueFeature, ValueWork};
+use super::*;
+
+pub(super) const FEATURE_COUNT: usize = 7;
+
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN
+/// 0 absent; 1 lowercase; 2 initial uppercase then lowercase; 3 uppercase;
+/// 4 other case; 5 contains digit; 6 contains underscore (highest precedence).
+fn shape(bytes: &[u8], work: &mut RoutingWork) -> u64 {
+    if bytes.is_empty() {
+        return 0;
+    }
+    let (mut lower, mut upper, mut title) = (true, true, true);
+    let (mut digit, mut underscore) = (false, false);
+    for (index, &byte) in bytes.iter().enumerate() {
+        work.logical_bytes_read = work.logical_bytes_read.saturating_add(1);
+        lower &= byte.is_ascii_lowercase();
+        upper &= byte.is_ascii_uppercase();
+        title &= if index == 0 {
+            byte.is_ascii_uppercase()
+        } else {
+            byte.is_ascii_lowercase()
+        };
+        digit |= byte.is_ascii_digit();
+        underscore |= byte == b'_';
+    }
+    if underscore {
+        6
+    } else if digit {
+        5
+    } else if lower {
+        1
+    } else if title {
+        2
+    } else if upper {
+        3
+    } else {
+        4
+    }
+}
+
+/// Ordered first/next/predecessor shapes, preceding gap class, two ordered
+/// shape pairs and singleton flag. The next word is inside the admitted span.
+pub(super) fn features(
+    words: &LexemeState,
+    endpoint: usize,
+    candidate: ReverseCandidate,
+    work: &mut ValueWork,
+) -> [ValueFeature; FEATURE_COUNT] {
+    let first = &words.recent[candidate.start];
+    work.relations.record_reads = work.relations.record_reads.saturating_add(1);
+    let first_shape = shape(
+        &first.bytes[..usize::from(first.len)],
+        &mut work.relations.span_routing,
+    );
+    let next_shape = if candidate.start > endpoint {
+        let next = &words.recent[candidate.start - 1];
+        work.relations.record_reads = work.relations.record_reads.saturating_add(1);
+        shape(
+            &next.bytes[..usize::from(next.len)],
+            &mut work.relations.span_routing,
+        )
+    } else {
+        0
+    };
+    let prior = &first.predecessors[0];
+    let prior_shape = shape(
+        &prior.bytes[..usize::from(prior.len)],
+        &mut work.relations.span_routing,
+    );
+    let gap = match first.leading_gap {
+        None => 0,
+        Some(b' ') => 1,
+        Some(b'\n' | b'\r') => 2,
+        Some(_) => 3,
+    };
+    work.relations.feature_writes = work
+        .relations
+        .feature_writes
+        .saturating_add(FEATURE_COUNT as u64);
+    [
+        ValueFeature {
+            kind: 0,
+            a: first_shape,
+            b: 0,
+        },
+        ValueFeature {
+            kind: 1,
+            a: next_shape,
+            b: 0,
+        },
+        ValueFeature {
+            kind: 2,
+            a: prior_shape,
+            b: 0,
+        },
+        ValueFeature {
+            kind: 3,
+            a: gap,
+            b: 0,
+        },
+        ValueFeature {
+            kind: 4,
+            a: first_shape,
+            b: next_shape,
+        },
+        ValueFeature {
+            kind: 5,
+            a: prior_shape,
+            b: first_shape,
+        },
+        ValueFeature {
+            kind: 6,
+            a: u64::from(candidate.start == endpoint),
+            b: 0,
+        },
+    ]
+}
+
+pub(super) fn select(
+    model: &Model,
+    words: &LexemeState,
+    endpoint: usize,
+    candidates: &ReverseCandidates,
+    work: &mut ValueWork,
+) -> Option<RelationSpan> {
+    let Some(block) = &model.relation_start else {
+        return candidates.rows[candidates.len - 1].span;
+    };
+    let mut best = None;
+    let mut score = i64::MIN;
+    work.relations.span_routing.predictions =
+        work.relations.span_routing.predictions.saturating_add(1);
+    // Longer candidates first preserves the parent decision on an exact tie.
+    for &candidate in candidates.rows[..candidates.len].iter().rev() {
+        let features = features(words, endpoint, candidate, work);
+        let state = block.encode(
+            model,
+            &features,
+            Control::Full,
+            &mut work.relations.span_routing,
+        );
+        let current = block.score(model, state, 0, &mut work.relations.span_routing);
+        work.relations.span_routing.sources_examined = work
+            .relations
+            .span_routing
+            .sources_examined
+            .saturating_add(1);
+        work.relations.span_routing.comparisons =
+            work.relations.span_routing.comparisons.saturating_add(1);
+        if current > score {
+            score = current;
+            best = candidate.span;
+        }
+    }
+    best
+}
+// NATIVE_GEOMETRIC_INTEGER_KERNEL_END
+
+#[cfg(test)]
+mod tests {
+    use super::super::value_types::ValueEntry;
+    use super::*;
+
+    fn words(text: &str) -> LexemeState {
+        let mut words = LexemeState::default();
+        for (sequence, &byte) in text.as_bytes().iter().enumerate() {
+            words.feed(
+                byte,
+                ValueEntry {
+                    sequence: sequence as u64,
+                    ..Default::default()
+                },
+                &mut ValueWork::default(),
+            );
+        }
+        words.finish(&mut ValueWork::default());
+        words
+    }
+
+    #[test]
+    fn relation_start_shape_classes_are_lexical_identity_independent() {
+        for (bytes, expected) in [
+            (b"".as_slice(), 0),
+            (b"say", 1),
+            (b"Amber", 2),
+            (b"NASA", 3),
+            (b"aB", 4),
+            (b"Amber2", 5),
+            (b"_Amber2", 6),
+        ] {
+            let mut work = RoutingWork::default();
+            assert_eq!(shape(bytes, &mut work), expected);
+            assert_eq!(work.logical_bytes_read, bytes.len() as u64);
+        }
+        assert_eq!(
+            shape(b"Amber", &mut RoutingWork::default()),
+            shape(b"Dawn", &mut RoutingWork::default())
+        );
+    }
+
+    #[test]
+    fn relation_start_features_respect_candidate_endpoint_and_context() {
+        let mut words = words("Notes say Amber Meadow holds telra.");
+        let candidate = ReverseCandidate {
+            start: 3,
+            span: None,
+        };
+        let base = features(&words, 2, candidate, &mut ValueWork::default());
+        assert_eq!((base[0].a, base[1].a, base[2].a), (2, 2, 1));
+        assert_eq!(base[6].a, 0);
+        let singleton = features(
+            &words,
+            2,
+            ReverseCandidate {
+                start: 2,
+                span: None,
+            },
+            &mut ValueWork::default(),
+        );
+        assert_eq!((singleton[1].a, singleton[6].a), (0, 1));
+        let intro = features(
+            &words,
+            2,
+            ReverseCandidate {
+                start: 5,
+                span: None,
+            },
+            &mut ValueWork::default(),
+        );
+        assert_ne!(intro, base);
+        // Linker and owner lie after the endpoint and cannot alter the features.
+        words.recent[0].bytes[0] = b'T';
+        words.recent[1].bytes[0] = b'H';
+        assert_eq!(
+            features(&words, 2, candidate, &mut ValueWork::default()),
+            base
+        );
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/relation_start_training.rs
+++ b/crates/uor-r4-core/src/native_geometric/relation_start_training.rs
@@ -1,0 +1,226 @@
+//! Offline response labels rank existing reverse starts. Neither target bytes
+//! nor construction vocabulary are consulted by the serving selector.
+use super::relation_span;
+use super::source_routing::{SourceCode, SourceRouting};
+use super::source_routing_training::{Alternative, Frame};
+use super::value_types::ValueWork;
+use super::*;
+use std::collections::BTreeSet;
+use std::time::Instant;
+
+pub(super) fn validate(block: &SourceRouting, model: &Model) -> Result<()> {
+    block.validate_shape(model, 1, 7)?;
+    if block.config.learned_features > 64
+        || block.config.passes > 4
+        || block.config.proposals > 12
+        || block.config.max_seconds > 3
+        || block.config.mode != RoutingMode::Angular
+        || !block.config.role_context_only
+        || block.codes.iter().any(|code| {
+            let f = code.feature;
+            match f.kind {
+                0..=2 => f.a > 6 || f.b != 0,
+                3 => f.a > 3 || f.b != 0,
+                4 | 5 => f.a > 6 || f.b > 6,
+                6 => f.a > 1 || f.b != 0,
+                _ => true,
+            }
+        })
+    {
+        return Err(Error(
+            "invalid learned relation start configuration or feature".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn construction_frame(model: &Model, doc: &ValueExample) -> Result<(Frame, serde_json::Value)> {
+    let expected = doc
+        .response
+        .strip_prefix(' ')
+        .and_then(|text| text.strip_suffix(".\n"))
+        .filter(|text| !text.is_empty() && text.len() <= 28 && text.is_ascii())
+        .ok_or_else(|| Error(format!("invalid complete value response in {}", doc.id)))?;
+    let mut session = model.session(Control::Full)?;
+    session.observe(model, BOS)?;
+    let mut next_id = 1;
+    let mut result = None;
+    for token in model.encode(&doc.prompt)? {
+        session.observe(model, token)?;
+        let values = session
+            .values
+            .as_ref()
+            .ok_or_else(|| Error("relation start values absent".into()))?;
+        let state = values
+            .relations
+            .as_ref()
+            .ok_or_else(|| Error("relation start memory absent".into()))?;
+        if state.next_id == next_id {
+            continue;
+        }
+        if state.next_id != next_id + 1 || result.is_some() {
+            return Err(Error(format!(
+                "relation start requires one write per document: {}",
+                doc.id
+            )));
+        }
+        let record = state
+            .record(next_id)
+            .ok_or_else(|| Error("relation start write missing".into()))?;
+        next_id = state.next_id;
+        if record.owner.byte_end <= record.value.byte_end {
+            return Err(Error(format!(
+                "relation start requires reverse writer endpoint: {}",
+                doc.id
+            )));
+        }
+        let words = values
+            .lexemes
+            .as_ref()
+            .ok_or_else(|| Error("relation start words absent".into()))?;
+        // The completed owner is the actual reverse-write event boundary.
+        // Refuse a tokenizer piece that hides later completed words in that event.
+        if words.recent_len == 0 || words.recent[0] != record.owner {
+            return Err(Error(format!(
+                "reverse write boundary unavailable: {}",
+                doc.id
+            )));
+        }
+        let endpoint = words.recent[..words.recent_len]
+            .iter()
+            .position(|word| *word == record.value)
+            .ok_or_else(|| Error("reverse endpoint not retained".into()))?;
+        let candidates = relation_span::reverse_candidates(
+            model,
+            words,
+            0,
+            endpoint,
+            record.action,
+            &mut ValueWork::default(),
+        );
+        let mut alternatives = Vec::new();
+        let mut trace = Vec::new();
+        // Match runtime tie order exactly: longest admitted first, singleton last.
+        for &candidate in candidates.rows[..candidates.len].iter().rev() {
+            let features =
+                relation_start::features(words, endpoint, candidate, &mut ValueWork::default());
+            let payload = relation_span::payload(&record.value, candidate.span.as_ref())
+                .ok_or_else(|| Error("invalid reverse candidate payload".into()))?;
+            let correct = payload == expected.as_bytes();
+            alternatives.push(Alternative {
+                features: features.to_vec(),
+                codes: Vec::new(),
+                action: 0,
+                correct,
+            });
+            trace.push(serde_json::json!({"payload":String::from_utf8_lossy(payload),"start":candidate.start,"features":features,"correct":correct}));
+        }
+        if !alternatives.iter().any(|a| a.correct) {
+            return Err(Error(format!(
+                "complete value is outside admitted reverse candidates: {}",
+                doc.id
+            )));
+        }
+        result = Some((
+            Frame { alternatives },
+            serde_json::json!({"id":doc.id,"endpoint_byte_end":record.value.byte_end,"candidates":trace}),
+        ));
+    }
+    result.ok_or_else(|| Error(format!("no completed reverse write in {}", doc.id)))
+}
+
+impl Model {
+    pub fn fit_relation_start(&self, docs: &[ValueExample]) -> Result<(Model, serde_json::Value)> {
+        self.validate()?;
+        if self.relation_reverse_spans.is_none()
+            || self.relation_start.is_some()
+            || docs.is_empty()
+            || docs.len() > 64
+        {
+            return Err(Error("invalid relation start parent/data bounds".into()));
+        }
+        let start = Instant::now();
+        let mut frames = Vec::new();
+        let mut vocabulary = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        let mut receipts = Vec::new();
+        let mut traces = Vec::new();
+        for doc in docs {
+            if doc.id.trim().is_empty()
+                || !ids.insert(&doc.id)
+                || doc.prompt.is_empty()
+                || doc.prompt.len() > 2048
+                || doc.response.len() > 32
+            {
+                return Err(Error("invalid relation start document".into()));
+            }
+            let (frame, trace) = construction_frame(self, doc)?;
+            vocabulary.extend(
+                frame
+                    .alternatives
+                    .iter()
+                    .flat_map(|a| a.features.iter().copied()),
+            );
+            frames.push(frame);
+            traces.push(trace);
+            receipts.push(super::training::receipt(&Document {
+                id: doc.id.clone(),
+                text: serde_json::to_string(&(&doc.prompt, &doc.response))
+                    .map_err(|e| Error(e.to_string()))?,
+            }));
+        }
+        if vocabulary.is_empty() || vocabulary.len() > 64 {
+            return Err(Error(
+                "relation start feature vocabulary exceeds bound".into(),
+            ));
+        }
+        let config = SourceRoutingConfig {
+            learned_features: 64,
+            passes: 4,
+            proposals: 12,
+            max_seconds: 3,
+            role_context_only: true,
+            ..Default::default()
+        };
+        let mut rng = config.seed;
+        let mut block = SourceRouting {
+            schema: "uor-r4.geometric-source-routing/1".into(),
+            parent_artifact: self.artifact_cid.clone(),
+            codes: vocabulary
+                .into_iter()
+                .map(|feature| SourceCode {
+                    feature,
+                    roots: [self.geometry.identity; 2],
+                })
+                .collect(),
+            landmarks: vec![std::array::from_fn(|_| {
+                (learned_routing_training::next_random(&mut rng) % 120) as u16
+            })],
+            biases: vec![0],
+            ranks: learned_routing_training::ranks(self),
+            training: receipts,
+            config,
+        };
+        let preparation_ms = start.elapsed().as_millis();
+        let learning_start = Instant::now();
+        let mut report =
+            source_routing_training::learn(self, &mut block, &mut frames, learning_start);
+        let learning_ms = learning_start.elapsed().as_millis();
+        let feature_count = block.codes.len();
+        let mut model = self.clone();
+        model.relation_start = Some(block);
+        model.refresh_identity()?;
+        model.validate()?;
+        report["artifact"] = serde_json::json!(model.artifact_cid());
+        report["parent"] = serde_json::json!(self.artifact_cid());
+        report["frames"] = serde_json::json!(frames.len());
+        report["documents"] = serde_json::json!(docs.len());
+        report["feature_count"] = serde_json::json!(feature_count);
+        report["preparation_ms"] = serde_json::json!(preparation_ms);
+        report["learning_ms"] = serde_json::json!(learning_ms);
+        report["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis());
+        report["construction"] = serde_json::json!(traces);
+        report["scope"] = serde_json::json!("Single-action signed-H4 scoring of unchanged admitted reverse starts plus singleton endpoint, longest-first ties. Seven ordered features: ASCII first/inside-next/predecessor shapes, predecessor gap class, first-next and predecessor-first shape pairs, singleton flag. No exact vocabulary or response labels at inference, no additional admission, no general phrase parsing claim.");
+        Ok((model, report))
+    }
+}

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -178,6 +178,7 @@ impl Trainer {
             dependent_read: None,
             typed_routing: None,
             joint_admission: None,
+            relation_start: None,
             relation_reverse_spans: None,
             relation_spans: None,
             source_span_context: None,
@@ -552,6 +553,27 @@ impl Model {
     }
     pub(super) fn validate(&self) -> Result<()> {
         self.config.validate()?;
+        if let Some(block) = &self.relation_start {
+            if self.relation_reverse_spans.is_none() {
+                return Err(Error("relation start reverse parent absent".into()));
+            }
+            relation_start_training::validate(block, self)?;
+            let mut parent = self.clone();
+            parent.relation_start = None;
+            parent.refresh_identity()?;
+            if parent.artifact_cid != block.parent_artifact {
+                return Err(Error("relation start frozen parent differs".into()));
+            }
+            parent.validate()?;
+            let mut duplicate = self.clone();
+            duplicate.refresh_identity()?;
+            if duplicate.artifact_cid != self.artifact_cid
+                || duplicate.uor_model_address != self.uor_model_address
+            {
+                return Err(Error("relation start identity differs".into()));
+            }
+            return Ok(());
+        }
         if let Some(parent_cid) = &self.relation_reverse_spans {
             if self.relation_spans.is_none() {
                 return Err(Error("reverse span retained parent absent".into()));

--- a/crates/uor-r4-core/tests/native_geometric_allocations.rs
+++ b/crates/uor-r4-core/tests/native_geometric_allocations.rs
@@ -313,6 +313,15 @@ fn native_kernel_source_has_no_forbidden_arithmetic_or_float_types() {
             )
             .1,
         ),
+        (
+            "native learned relation start",
+            region(
+                include_str!("../src/native_geometric/relation_start.rs"),
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_BEGIN",
+                "// NATIVE_GEOMETRIC_INTEGER_KERNEL_END",
+            )
+            .1,
+        ),
         ("native completion seed", seed),
         ("native numeral codec", numeral),
         ("native whole-word codec", lexemes),
@@ -2240,4 +2249,78 @@ fn native_reverse_relation_span_checkpoint_and_allocation() {
     }
     samples.sort_unstable();
     println!("reverse span parent rejection, preserved terminal anchor, malformed start rejection, short/evicted reads, per-step checkpoints and zero allocations PASS; samples={} median_ns={} max_ns={} (uncached predict+observe includes initial selection; excludes load/encoding/ingestion/checkpoints)",samples.len(),samples[samples.len()/2],samples[samples.len()-1]);
+}
+
+#[test]
+#[ignore = "requires learned relation-start artifact; charged model execution"]
+fn native_relation_start_checkpoint_and_allocation() {
+    use uor_r4_core::native_geometric::{Control, Model};
+    let bytes = std::fs::read(std::env::var("R4_RELATION_START_MODEL").unwrap()).unwrap();
+    let model = Model::from_bytes(&bytes).unwrap();
+    let wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let mut bad = wire.clone();
+    bad["relation_start"]["codes"][0]["roots"][0] = 120.into();
+    assert!(Model::from_bytes(&serde_json::to_vec(&bad).unwrap()).is_err());
+    let mut bad = wire;
+    bad["relation_start"]["parent_artifact"] = "wrong-parent".into();
+    assert!(Model::from_bytes(&serde_json::to_vec(&bad).unwrap()).is_err());
+    let mut times = Vec::new();
+    for (fact, owner, expected, long) in [
+        (
+            "Notes say Amber Meadow holds telra.",
+            "telra",
+            " Amber Meadow.\n",
+            false,
+        ),
+        (
+            "Notes say Amber Meadow holds telra.",
+            "telra",
+            " Amber Meadow.\n",
+            true,
+        ),
+        ("Notes say Amber holds telra.", "telra", " Amber.\n", false),
+    ] {
+        let mut s = model.session(Control::Full).unwrap();
+        s.observe(&model, 0).unwrap();
+        let padding = if long {
+            "quiet sky. ".repeat(96)
+        } else {
+            String::new()
+        };
+        let tokens = model
+            .encode(&format!("{fact} {padding}Where is {owner}? Answer:"))
+            .unwrap();
+        ALLOCATIONS.with(|v| v.set(0));
+        BYTES.with(|v| v.set(0));
+        MEASURING.with(|v| v.set(true));
+        for token in tokens {
+            s.observe(&model, token).unwrap();
+        }
+        s.begin_response(&model).unwrap();
+        MEASURING.with(|v| v.set(false));
+        let mut output = [1; 32];
+        let mut used = 0;
+        loop {
+            let mut restored = model.restore_session(&s.checkpoint().unwrap()).unwrap();
+            let predicted = restored.predict(&model).unwrap();
+            MEASURING.with(|v| v.set(true));
+            let start = std::time::Instant::now();
+            let actual = s.predict(&model).unwrap();
+            s.observe(&model, actual.token).unwrap();
+            let elapsed = start.elapsed().as_nanos();
+            MEASURING.with(|v| v.set(false));
+            assert_eq!(actual, predicted);
+            times.push(elapsed);
+            output[used] = actual.token;
+            used += 1;
+            if actual.token == 1 || used == 32 {
+                break;
+            }
+        }
+        assert_eq!(output[used - 1], 1);
+        assert_eq!(model.decode(&output[..used]).unwrap(), expected.as_bytes());
+        assert_eq!((ALLOCATIONS.with(Cell::get), BYTES.with(Cell::get)), (0, 0));
+    }
+    times.sort_unstable();
+    println!("relation-start model/root rejection, short/evicted/singleton outputs, per-step checkpoints and zero allocations PASS; samples={} median_ns={} max_ns={} (uncached predict+observe including initial selection; excludes loading/encoding/ingestion/checkpoints)",times.len(),times[times.len()/2],times[times.len()-1]);
 }

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -7,6 +7,24 @@ implemented operations, measured behavior and proposed integration. The native
 model was d59070c2 at the review date; no model experiment was
 rerun for that review.
 
+## Learned relation starts — construction fit, open transfer negative, 2026-09-07
+
+The [result](native_geometric_relation_start_1140.md) implements shared signed-H4
+ranking over unchanged admitted reverse starts plus the singleton endpoint.
+Candidate `bb6b8ba4` binds the complete `321e990f` parent. Construction
+improves 2/8 to 8/8 and open answers 2/8 to 6/8; all selected prior preservation
+passes. The two failures retain `says` before the intended value. Only
+predecessor-shape codes changed during fitting, so a longer candidate sharing
+that shape wins the exact score tie. The current construction lacks a contrast
+that would reject this shortcut, although ordered pair features are available.
+
+Selection failed; the fresh panel and subsequent diagnostics were not executed.
+Keep `321e990f` active and preserve this candidate as a bounded negative.
+This result does not establish general phrase understanding, an advantage of
+angular scoring over another scorer, energy savings or frontier capability.
+The next change is contrastive construction for the existing operator, with a
+complete resource projection. See current-state for the cumulative balance.
+
 ## Reverse relation endpoints — bounded positive, 2026-09-07
 
 The [result](native_geometric_reverse_spans_1140.md) retains `321e990f` over

--- a/docs/evidence/native_geometric_relation_start_1140.json
+++ b/docs/evidence/native_geometric_relation_start_1140.json
@@ -1,0 +1,978 @@
+{
+  "schema": "uor-r4.learned-relation-start-evidence/1",
+  "at": "2026-09-07T14:49:52.347Z",
+  "base_commit": "3dd7180206b31a91998e9052e02eeed334655c3d",
+  "decision": "PRESERVE_CANDIDATE_TRANSFER_NEGATIVE_KEEP_321E990F",
+  "selection": {
+    "artifact": "blake3:bb6b8ba41f65b0c9d5c7ddf453e765a52b5ea8b169e50141ead05b3b5cefad79",
+    "construction": 8,
+    "development": 6,
+    "fresh": "NOT_RUN_AT_SELECTION",
+    "parent": "blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563",
+    "parent_parameters_equal": true,
+    "preservation": true,
+    "selected_before_fresh": false
+  },
+  "model": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/model.json",
+    "bytes": 11634162,
+    "sha256": "3d6c1c1f535e989885969b19415aa81c855c4f27517836d5eb994609cb530d4d"
+  },
+  "parent": {
+    "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/model.json",
+    "bytes": 11631560,
+    "sha256": "e094a0b511bba8747cee49867997e908940a85c9147b0537ecbdc1e297ea56ab"
+  },
+  "source": [
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/mod.rs",
+      "bytes": 22875,
+      "sha256": "36814ee5686991b1f40ada7e2d49dedef35a3489f2843783e9144e99f4773535"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation.rs",
+      "bytes": 26126,
+      "sha256": "4dd3ecbf7c8f83268d9c25c27cfab006d7287868fa18f3c9b5c60de9aee660f1"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation_span.rs",
+      "bytes": 22568,
+      "sha256": "1b30657e8cd51386ecd07d0a446672e5dac22c84966c2cd9c0ed083e5a2180ea"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation_start.rs",
+      "bytes": 7425,
+      "sha256": "8bea833c5f343c1524474cde277df18dff998f8b0f19ae55574de6e9efa7c957"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/relation_start_training.rs",
+      "bytes": 9428,
+      "sha256": "dcf5ce709e51899da4a088e9188421702a23ce471d7668a17e11c29139b5e56d"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/training.rs",
+      "bytes": 59162,
+      "sha256": "110aae5db74b9b6a9cbfcfad66edf0c32ed6056c9b3bb4416eee0ac58cc902df"
+    },
+    {
+      "path": "crates/uor-r4-core/src/native_geometric/source_routing.rs",
+      "bytes": 7145,
+      "sha256": "21d301a9547dd89b299029101882b8914a9a4879607e72c00b9b66fad062189d"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe.rs",
+      "bytes": 73150,
+      "sha256": "3776952000606c5516e3973aad1312d8209f14cd6e4543fda09a927f74c60a08"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe/reverse_span.rs",
+      "bytes": 10623,
+      "sha256": "e9c341c1bd66065c15f024d089272eed7c8e4904a11d5c9d179a6090db9c4c60"
+    },
+    {
+      "path": "crates/uor-r4-core/examples/native_geometric_value_probe/relation_start.rs",
+      "bytes": 6921,
+      "sha256": "e19eafbf57d753c5de6dd4e8785bac7eddaab2d00be29e112823c3a71e790b66"
+    },
+    {
+      "path": "crates/uor-r4-core/tests/native_geometric_allocations.rs",
+      "bytes": 95198,
+      "sha256": "ca14c16ea25a9f003b1271b81f66be974e911a46772a94b8690a6de756b40894"
+    }
+  ],
+  "fit": {
+    "accepted": [
+      2,
+      0,
+      0
+    ],
+    "artifact": "blake3:bb6b8ba41f65b0c9d5c7ddf453e765a52b5ea8b169e50141ead05b3b5cefad79",
+    "documents": 8,
+    "elapsed_ms": 14764,
+    "feature_count": 20,
+    "final_correct": 8,
+    "final_hinge": 0,
+    "frames": 8,
+    "initial_correct": 4,
+    "initial_hinge": 6,
+    "learning_ms": 0,
+    "parent": "blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563",
+    "preparation_ms": 1,
+    "proposals": 3118,
+    "scope": "Single-action signed-H4 scoring of unchanged admitted reverse starts plus singleton endpoint, longest-first ties. Seven ordered features: ASCII first/inside-next/predecessor shapes, predecessor gap class, first-next and predecessor-first shape pairs, singleton flag. No exact vocabulary or response labels at inference, no additional admission, no general phrase parsing claim.",
+    "stopped_at_time_limit": false
+  },
+  "comparison": {
+    "parent-construction": {
+      "artifact": "blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563",
+      "cases": [
+        {
+          "exact": false,
+          "expected": " Amber Meadow.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Notes say Amber Meadow.\n"
+          },
+          "id": "start-fit/0/0",
+          "prompt": "Notes say Amber Meadow holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Amber Meadow.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber Meadow.\n"
+          },
+          "id": "start-fit/0/1",
+          "prompt": "Amber Meadow holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Amber.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Notes say Amber.\n"
+          },
+          "id": "start-fit/0/2",
+          "prompt": "Notes say Amber holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Amber.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber holds telra.\n"
+          },
+          "id": "start-fit/0/3",
+          "prompt": "Amber holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Dawn River Bend.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Log tells Dawn River Bend.\n"
+          },
+          "id": "start-fit/1/0",
+          "prompt": "Log tells Dawn River Bend holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Dawn River Bend.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn River Bend.\n"
+          },
+          "id": "start-fit/1/1",
+          "prompt": "Dawn River Bend holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Dawn.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Log tells Dawn.\n"
+          },
+          "id": "start-fit/1/2",
+          "prompt": "Log tells Dawn holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Dawn.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn holds mevin.\n"
+          },
+          "id": "start-fit/1/3",
+          "prompt": "Dawn holds mevin. Where is mevin? Answer:"
+        }
+      ],
+      "exact": 2,
+      "report_scope": "Lean preservation receipt: case identities, available complete inputs and expected labels, actual text/termination/actions/writes, verdicts and aggregate counts retained. Captured state, decisions, work and token traces omitted. Session verification remains unchanged.",
+      "total": 8
+    },
+    "parent-development": {
+      "artifact": "blake3:321e990f218899aa2668c2530caed5589c614cc58d1bb1de0b7145a64aee9563",
+      "cases": [
+        {
+          "exact": false,
+          "expected": " Pearl Cove.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " A ledger says Pearl Cove.\n"
+          },
+          "id": "start-open/0/0",
+          "prompt": "A ledger says Pearl Cove holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Pearl Cove.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Pearl Cove.\n"
+          },
+          "id": "start-open/0/1",
+          "prompt": "Pearl Cove holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Pearl.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " A ledger says Pearl.\n"
+          },
+          "id": "start-open/0/2",
+          "prompt": "A ledger says Pearl holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Pearl.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Pearl holds tesvi.\n"
+          },
+          "id": "start-open/0/3",
+          "prompt": "Pearl holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Cobalt Field.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Report notes Cobalt Field.\n"
+          },
+          "id": "start-open/1/0",
+          "prompt": "Report notes Cobalt Field holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Cobalt Field.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt Field.\n"
+          },
+          "id": "start-open/1/1",
+          "prompt": "Cobalt Field holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Cobalt.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Report notes Cobalt.\n"
+          },
+          "id": "start-open/1/2",
+          "prompt": "Report notes Cobalt holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Cobalt.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt holds vorin.\n"
+          },
+          "id": "start-open/1/3",
+          "prompt": "Cobalt holds vorin. Where is vorin? Answer:"
+        }
+      ],
+      "exact": 2,
+      "report_scope": "Lean preservation receipt: case identities, available complete inputs and expected labels, actual text/termination/actions/writes, verdicts and aggregate counts retained. Captured state, decisions, work and token traces omitted. Session verification remains unchanged.",
+      "total": 8
+    },
+    "construction": {
+      "artifact": "blake3:bb6b8ba41f65b0c9d5c7ddf453e765a52b5ea8b169e50141ead05b3b5cefad79",
+      "cases": [
+        {
+          "exact": true,
+          "expected": " Amber Meadow.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber Meadow.\n"
+          },
+          "id": "start-fit/0/0",
+          "prompt": "Notes say Amber Meadow holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Amber Meadow.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber Meadow.\n"
+          },
+          "id": "start-fit/0/1",
+          "prompt": "Amber Meadow holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Amber.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber.\n"
+          },
+          "id": "start-fit/0/2",
+          "prompt": "Notes say Amber holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Amber.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Amber.\n"
+          },
+          "id": "start-fit/0/3",
+          "prompt": "Amber holds telra. Where is telra? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Dawn River Bend.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn River Bend.\n"
+          },
+          "id": "start-fit/1/0",
+          "prompt": "Log tells Dawn River Bend holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Dawn River Bend.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn River Bend.\n"
+          },
+          "id": "start-fit/1/1",
+          "prompt": "Dawn River Bend holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Dawn.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn.\n"
+          },
+          "id": "start-fit/1/2",
+          "prompt": "Log tells Dawn holds mevin. Where is mevin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Dawn.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Dawn.\n"
+          },
+          "id": "start-fit/1/3",
+          "prompt": "Dawn holds mevin. Where is mevin? Answer:"
+        }
+      ],
+      "exact": 8,
+      "report_scope": "Lean preservation receipt: case identities, available complete inputs and expected labels, actual text/termination/actions/writes, verdicts and aggregate counts retained. Captured state, decisions, work and token traces omitted. Session verification remains unchanged.",
+      "total": 8
+    },
+    "development": {
+      "artifact": "blake3:bb6b8ba41f65b0c9d5c7ddf453e765a52b5ea8b169e50141ead05b3b5cefad79",
+      "cases": [
+        {
+          "exact": false,
+          "expected": " Pearl Cove.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " says Pearl Cove.\n"
+          },
+          "id": "start-open/0/0",
+          "prompt": "A ledger says Pearl Cove holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Pearl Cove.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Pearl Cove.\n"
+          },
+          "id": "start-open/0/1",
+          "prompt": "Pearl Cove holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": false,
+          "expected": " Pearl.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " says Pearl.\n"
+          },
+          "id": "start-open/0/2",
+          "prompt": "A ledger says Pearl holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Pearl.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Pearl.\n"
+          },
+          "id": "start-open/0/3",
+          "prompt": "Pearl holds tesvi. Where is tesvi? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Cobalt Field.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt Field.\n"
+          },
+          "id": "start-open/1/0",
+          "prompt": "Report notes Cobalt Field holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Cobalt Field.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt Field.\n"
+          },
+          "id": "start-open/1/1",
+          "prompt": "Cobalt Field holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Cobalt.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt.\n"
+          },
+          "id": "start-open/1/2",
+          "prompt": "Report notes Cobalt holds vorin. Where is vorin? Answer:"
+        },
+        {
+          "exact": true,
+          "expected": " Cobalt.\n",
+          "generation": {
+            "stop": "end_of_document",
+            "text": " Cobalt.\n"
+          },
+          "id": "start-open/1/3",
+          "prompt": "Cobalt holds vorin. Where is vorin? Answer:"
+        }
+      ],
+      "exact": 6,
+      "report_scope": "Lean preservation receipt: case identities, available complete inputs and expected labels, actual text/termination/actions/writes, verdicts and aggregate counts retained. Captured state, decisions, work and token traces omitted. Session verification remains unchanged.",
+      "total": 8
+    }
+  },
+  "preservation": {
+    "aliases.json": {
+      "elapsed_ms": 51,
+      "exact": 12,
+      "remove_intermediate_control": false,
+      "total": 12
+    },
+    "chains.json": {
+      "elapsed_ms": 59,
+      "exact": 16,
+      "remove_intermediate_control": false,
+      "total": 16
+    },
+    "computed-construction.json": {
+      "elapsed_ms": 192,
+      "exact": 58,
+      "remove_intermediate_control": false,
+      "total": 58
+    },
+    "dependent.json": {
+      "elapsed_ms": 59,
+      "exact": 48,
+      "exact_scope": "Complete bytes and EOS; writes counted separately.",
+      "total": 48,
+      "writes_exact": 48
+    },
+    "exposed-literals.json": {
+      "elapsed_ms": 18,
+      "exact": 16,
+      "remove_intermediate_control": false,
+      "total": 16
+    },
+    "exposed-roles.json": {
+      "elapsed_ms": 53,
+      "exact": 12,
+      "remove_intermediate_control": false,
+      "total": 12
+    },
+    "forward-construction.json": {
+      "exact": 6,
+      "isolation_pass": true,
+      "total": 6,
+      "writes_exact": true
+    },
+    "forward-open.json": {
+      "exact": 6,
+      "isolation_pass": true,
+      "total": 6,
+      "writes_exact": true
+    },
+    "forward-prior-fresh.json": {
+      "exact": 6,
+      "isolation_pass": true,
+      "total": 6,
+      "writes_exact": true
+    },
+    "identifiers.json": {
+      "elapsed_ms": 9,
+      "exact": 8,
+      "remove_intermediate_control": false,
+      "total": 8
+    },
+    "literal-construction.json": {
+      "elapsed_ms": 119,
+      "exact": 103,
+      "remove_intermediate_control": false,
+      "total": 103
+    },
+    "long.json": {
+      "elapsed_ms": 72,
+      "exact": 28,
+      "exact_scope": "Complete bytes and EOS; writes counted separately.",
+      "total": 28,
+      "writes_exact": 28
+    },
+    "names.json": {
+      "elapsed_ms": 34,
+      "exact": 28,
+      "exact_scope": "Complete bytes and EOS; writes counted separately.",
+      "total": 28,
+      "writes_exact": 28
+    },
+    "numeric.json": {
+      "elapsed_ms": 13,
+      "exact": 6,
+      "remove_intermediate_control": false,
+      "total": 6
+    },
+    "preservation.json": {
+      "exact": 62,
+      "total": 62
+    },
+    "prior-chains.json": {
+      "elapsed_ms": 57,
+      "exact": 16,
+      "remove_intermediate_control": false,
+      "total": 16
+    },
+    "prior-fresh.json": {
+      "elapsed_ms": 17,
+      "exact": 16,
+      "remove_intermediate_control": false,
+      "total": 16
+    },
+    "prior-span-construction.json": {
+      "exact": 14,
+      "total": 14
+    },
+    "prior-span-development.json": {
+      "exact": 6,
+      "total": 6
+    },
+    "prior-span-fresh.json": {
+      "exact": 9,
+      "total": 9
+    },
+    "prior.json": {
+      "exact": 24,
+      "total": 24
+    },
+    "retained-construction.json": {
+      "exact": 663,
+      "total": 663
+    },
+    "reverse-construction.json": {
+      "exact": 6,
+      "isolation": true,
+      "total": 6,
+      "trailing_tokens": 1056,
+      "version_counts_exact": true
+    },
+    "reverse-open.json": {
+      "exact": 6,
+      "isolation": true,
+      "total": 6,
+      "trailing_tokens": 1056,
+      "version_counts_exact": true
+    },
+    "reverse-prior-fresh.json": {
+      "exact": 6,
+      "isolation": true,
+      "total": 6,
+      "trailing_tokens": 1056,
+      "version_counts_exact": true
+    },
+    "reverse-short.json": {
+      "exact": 3,
+      "total": 3
+    },
+    "roles.json": {
+      "elapsed_ms": 51,
+      "exact": 12,
+      "remove_intermediate_control": false,
+      "total": 12
+    },
+    "sessions.json": {
+      "exact_turns": 5,
+      "isolated_no_shared_records": true,
+      "isolated_response": " Unknown.\n",
+      "preserved_versions": 4,
+      "restore_and_forged_commit_checks": "PASS",
+      "schema": "uor-r4.relation-session-check/1",
+      "total_turns": 5
+    }
+  },
+  "diagnosis": {
+    "identity": 119,
+    "nonidentity_codes": [
+      {
+        "feature": {
+          "kind": 2,
+          "a": 1,
+          "b": 0
+        },
+        "roots": [
+          24,
+          119
+        ]
+      },
+      {
+        "feature": {
+          "kind": 2,
+          "a": 2,
+          "b": 0
+        },
+        "roots": [
+          119,
+          77
+        ]
+      }
+    ],
+    "basis": "Saved parameters plus shared encode/score source. Only predecessor shape changes state. Both says and Pearl follow lowercase words; exact learned-state tie chooses longer start. This is not an additional model run or a general identifiability theorem.",
+    "new_fresh": "NOT_RUN_SELECTION_FAILED",
+    "post_selection_diagnostics": "NOT_RUN_SELECTION_FAILED"
+  },
+  "checks": {
+    "release_probe_and_test_binaries": "PASS",
+    "focused_start_tests": 2,
+    "focused_span_tests": 5,
+    "integer_source_guard": "PASS; scoped source-token scan, not transitive or machine-code proof",
+    "architecture_policy": "PASS; no model behavior evaluated",
+    "actual_artifact": "PASS: invalid H4 root and frozen-parent rejection, opened construction short/evicted/singleton exact outputs, every-step checkpoint prediction equality, zero measured allocations during ingestion and predict/observe",
+    "timing": {
+      "samples": 41,
+      "median_ns": 458,
+      "max_ns": 156959,
+      "scope": "Uncached predict+observe including first selection; excludes loading, encoding, ingestion and checkpoints. Shape scorer runs during ingestion, so this is not its latency measurement. Energy unmeasured."
+    },
+    "root_cli": "NOT_RUN_FOR_CANDIDATE",
+    "studio": "NOT_RUN",
+    "broad_release_qa": "NOT_RUN",
+    "format": "PASS",
+    "claim_wording": "PASS",
+    "warning": "Existing unused NUMERIC_PROMPT fixture warning; successful compilation"
+  },
+  "resources": {
+    "projection": {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-projection.json",
+      "bytes": 2749,
+      "sha256": "3ea1ac50cd298ce7f5da68c602238adad12c4aa1a2bceb879c1d4844ed9eabe2"
+    },
+    "cycle_model_ms": 60167,
+    "cycle_engineering_ms": 276856,
+    "current_cumulative": {
+      "cumulative_ms": 4387536,
+      "limit_ms": 4410000
+    },
+    "remaining_model_ms": 22464,
+    "final_sampled_growth_bytes": 14761984,
+    "peak_sampled_growth_bytes": 20692992,
+    "peak_sampled_model_rss_bytes": 986791936,
+    "commands": [
+      {
+        "label": "relation-start-evaluate",
+        "command": "/tmp/r4-native-geometric-target/release/examples/native_geometric_value_probe",
+        "args": [
+          "relation-start",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/reverse-span-angular/model.json",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05",
+          "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular"
+        ],
+        "elapsed_ms": 44874,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": false,
+        "peak_sampled_known_bytes": 7531196416,
+        "peak_process_rss_sample_bytes": 986791936
+      },
+      {
+        "label": "relation-start-artifact-check",
+        "command": "/usr/bin/env",
+        "args": [
+          "R4_RELATION_START_MODEL=/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/model.json",
+          "/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931",
+          "native_relation_start_checkpoint_and_allocation",
+          "--ignored",
+          "--exact",
+          "--nocapture"
+        ],
+        "elapsed_ms": 15293,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": false,
+        "peak_sampled_known_bytes": 7531204608,
+        "peak_process_rss_sample_bytes": 744570880
+      },
+      {
+        "label": "relation-start-build",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo fmt --all\n/Users/casey.allard/.cargo/bin/cargo build --release --offline -p uor-r4-core --example native_geometric_value_probe\n/Users/casey.allard/.cargo/bin/cargo test --release --offline -p uor-r4-core --lib --test native_geometric_allocations --no-run\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f relation_start --nocapture\n/tmp/r4-native-geometric-target/release/deps/uor_r4_core-ab236c9b0d8b158f relation_span::tests --nocapture\n/tmp/r4-native-geometric-target/release/deps/native_geometric_allocations-6c7ff1216c7e1931 native_kernel_source_has_no_forbidden_arithmetic_or_float_types --exact --nocapture\n/tmp/r4-native-geometric-target/release/r4-policy-check .\n"
+        ],
+        "elapsed_ms": 267395,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": true,
+        "peak_sampled_known_bytes": 7537143808,
+        "peak_process_rss_sample_bytes": null
+      },
+      {
+        "label": "relation-start-artifact-test-build",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\nexport CARGO_TARGET_DIR=/tmp/r4-native-geometric-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1\n/Users/casey.allard/.cargo/bin/cargo test --release --offline -p uor-r4-core --test native_geometric_allocations --no-run\n"
+        ],
+        "elapsed_ms": 5691,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": true,
+        "peak_sampled_known_bytes": 7532236800,
+        "peak_process_rss_sample_bytes": null
+      },
+      {
+        "label": "relation-start-final-checks",
+        "command": "/bin/zsh",
+        "args": [
+          "-c",
+          "set -e\n/Users/casey.allard/.cargo/bin/cargo fmt --all --check\npython3 scripts/check_claim_wording.py\ngit diff --check\n"
+        ],
+        "elapsed_ms": 3770,
+        "exit_code": 0,
+        "stopped": null,
+        "engineering_only": true,
+        "peak_sampled_known_bytes": 7531212800,
+        "peak_process_rss_sample_bytes": null
+      }
+    ],
+    "cleanup": "NONE",
+    "external_compute": "NONE",
+    "ceiling_increase": "NONE",
+    "scope": "Cumulative command-wall accounting includes load/validation, learning, evaluation and artifact checks. Engineering commands charged separately; interactive review/docs wall time is not model execution. Storage/RSS are sampled conservative accounting, not exact peaks."
+  },
+  "receipts": [
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/construction.json",
+      "bytes": 2554,
+      "sha256": "c467600c6bea8ab7a09723a9cfc7961fd9c75ec882f3d4812acd22a4ec9d0cb9"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/development.json",
+      "bytes": 2570,
+      "sha256": "8162a81e8304c169cb81eaee89c6af7a85b184463ab21812523b37cbe5500951"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/fit.json",
+      "bytes": 19770,
+      "sha256": "45e56d971fefbf2675d75d1fa62d7ce5f43acc4de4a352b480bd406aa93e13b4"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/parent-construction.json",
+      "bytes": 2624,
+      "sha256": "b5061d04464d0202266851e9a08d1f70df6eb18accbdab77c7d0a61df2b65ae1"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/parent-development.json",
+      "bytes": 2642,
+      "sha256": "1478a48af081d553450bb886ea2abeb9c88e043c07aca94aa72b88c21d3a7b37"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/selection.json",
+      "bytes": 347,
+      "sha256": "60b2d90a59ee2ca7dfd54402a018e3a6bd7da9ab271c50d57b18c4df2d2f6467"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/source.json",
+      "bytes": 2540,
+      "sha256": "f4f645a387c9101871596dd0b9cc5b70b821018311f1b9713cc817b61133ddcb"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/aliases.json",
+      "bytes": 15252,
+      "sha256": "1d77db60b505da0cdc845160a79782db1edfd63c43cc214c0bc0b1eca65ad39a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/chains.json",
+      "bytes": 18506,
+      "sha256": "7039692bf5616556b398852765181963e75b67ffc2d08cdc6de0791a06b93e96"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/computed-construction.json",
+      "bytes": 61339,
+      "sha256": "f62fa333d63a48bc61f77865721cfabd86d59e8396f054c705301fc84bb6371a"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/dependent.json",
+      "bytes": 45899,
+      "sha256": "1facea7805e443c23c29c761fe71840b151b4c3bb972568db3d6a47b396a6a6b"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/exposed-literals.json",
+      "bytes": 14928,
+      "sha256": "ac6f22235ddb1ee4a1e3e18a5db77d428382a74084546eece85c8ba2b8117c1c"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/exposed-roles.json",
+      "bytes": 15136,
+      "sha256": "410b08305d5072d486516c691aa0b34da0290018ce3ba8e72023a9875b1b64f7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/forward-construction.json",
+      "bytes": 159840,
+      "sha256": "92d898a23ab2f4a1765e8bc5c34ab999ceaaa353c141ddfbc6cceb791b1b6594"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/forward-open.json",
+      "bytes": 159878,
+      "sha256": "a9cc0be0377aaf5ef5ce9c02a09608a0c237351458bce57a1765626466769ed0"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/forward-prior-fresh.json",
+      "bytes": 160240,
+      "sha256": "452324f6026e1f91a7c8f62b9e46fcbd953e92118782a27804c6571cef8f32e8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/identifiers.json",
+      "bytes": 7263,
+      "sha256": "e6f656900e2aaa1dfa8b937d12a68812a3163e350e938737f5d81e34966927f7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/literal-construction.json",
+      "bytes": 93929,
+      "sha256": "2e4b41326beb76ffcd90f5d56428d84c834e26547653e67373afe47151f9ec68"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/long.json",
+      "bytes": 147372,
+      "sha256": "a5608fdc5746d76b096df5eb3883df4cffe62d51400c9c9931f20dfc6dd45542"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/names.json",
+      "bytes": 27972,
+      "sha256": "3e6aa8e657ae2e65b4da933d9452e5d05d1bdc5ce441f0ec800453911d7d9781"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/numeric.json",
+      "bytes": 6094,
+      "sha256": "fcba6046bd4ee2393b6086d2906c6ca8ace224e08ccbed5ca4739b114ae54c85"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/preservation.json",
+      "bytes": 21669,
+      "sha256": "6e9471ca121c5b6e66f1c5afb7b2d4e417a67eb5c0473262027fafef420479b2"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior-chains.json",
+      "bytes": 18496,
+      "sha256": "e44385d6b1b3dd27669500cb68bdc73123bd2331d9b80b8e3037a2bfba166406"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior-fresh.json",
+      "bytes": 14552,
+      "sha256": "f16470b491815d1b2693d5d4c8d183e635637776305b97ae65fcd3e88743ebfd"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior-span-construction.json",
+      "bytes": 4445,
+      "sha256": "6ba29ce8c400c7dd1c47d3175926e32cbc1c928f054716f7ce3fd915aa948e4c"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior-span-development.json",
+      "bytes": 2175,
+      "sha256": "433bd40f62ca7559a285e8f92320c074ca78009ee2fe6ade94790acfaca83e45"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior-span-fresh.json",
+      "bytes": 3102,
+      "sha256": "3bac3372da8ea829bfe867280927bd14c2c579714a20a7853fa51fb29a94fbf8"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/prior.json",
+      "bytes": 7457,
+      "sha256": "28ea1826d6920415e20a9a04f9a2791b6f910fed275ad3bb16afbd3f49c623e4"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/retained-construction.json",
+      "bytes": 214913,
+      "sha256": "2e8a9ed6cde68c734c99386231d2478caddeaa275828aac69503e8adc940aab6"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/reverse-construction.json",
+      "bytes": 412677,
+      "sha256": "751d728d3bf4906419a411b972441954f1aacc7336e98535cbf9adfdc0c7fffe"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/reverse-open.json",
+      "bytes": 435793,
+      "sha256": "7138e0314c7b05d9da97a98c9c1121ca108ccba740349d6ffd0ea0575d951513"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/reverse-prior-fresh.json",
+      "bytes": 413304,
+      "sha256": "4ad67b2e67766a5b019c2089a1ce03ebf4b9d5b114293f31905c39563c99c555"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/reverse-short.json",
+      "bytes": 559,
+      "sha256": "7e9ed91a4d52b277dc6110bb8f38005a9dbbabd607fa8ad2b4c0cfd0d48166c7"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/roles.json",
+      "bytes": 15264,
+      "sha256": "db1f5520a3879f0d2276bb10a9696d3d381f98bb4cb923e099d4820438b990a5"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-angular/preservation/sessions.json",
+      "bytes": 58938,
+      "sha256": "89273d5cdc892cd690f75fc811a73a25cbe7abbca8614ffed6ef1504f98a1999"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-build.log",
+      "bytes": 2339,
+      "sha256": "edc8d3045a7afa5956caeeb32757c30f15b9a9a0af809d292e045af694ebeedc"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-artifact-test-build.log",
+      "bytes": 706,
+      "sha256": "796c8541cfb3cdc3a8fe8eba42ea531cd5b67afaf4f2afe4daa68800be875923"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-artifact-check.stdout.log",
+      "bytes": 435,
+      "sha256": "7fb50d70dea300f988e35a27c95b6d567d8985c9f56d30a3ae7ed873d004f563"
+    },
+    {
+      "path": "/Users/casey.allard/uor-r4/.uor-models/native-typed-value-2026-09-05/relation-start-final-checks.log",
+      "bytes": 83,
+      "sha256": "78d71cb97c00d606a9a909d89a2f4f4e3b4be6b84af390f20c9fc50ec449922f"
+    }
+  ],
+  "limitations": [
+    "Candidate not promoted; retained parent remains 321e990f.",
+    "Construction and open results use authored familiar templates; not general language or reasoning.",
+    "No new angular-versus-equality comparison; no geometric advantage or energy claim.",
+    "Shape feature vocabulary does not supply general semantic parsing; lowercase and wider gaps unqualified.",
+    "Parent is the complete control; query-side ablations do not disable full-control persistent ingestion."
+  ],
+  "next": "New construction contrasts must reject predecessor-only selection using existing ordered candidate features; preserve opened failures and unexecuted fresh panel. A complete repeat does not fit the remaining 22.464-second model allocation or roughly 15MiB growth balance; no silent ceiling increase."
+}

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,37 @@
 # Current native geometric AI work
 
+## Learned relation starts — transfer negative, 2026-09-07
+
+**Keep `321e990f` as the retained model.** The implemented
+[learned start selector](../native_geometric_relation_start_1140.md) produces
+candidate `bb6b8ba4`: construction improves 2/8 to 8/8 and open development
+2/8 to 6/8. All 663 retained construction answers, earlier forward/reverse
+sessions, long-window/dependent reads and selected preservation pass. Complete
+parent parameters are unchanged. Selection requires all eight open answers;
+it failed, so fresh cases and post-selection diagnostics remain `NOT_RUN`.
+The candidate and its exact failures are preserved, not promoted.
+
+The twenty-code, two-lane H4 fit changed only predecessor-shape codes. In
+`A ledger says Pearl Cove holds tesvi`, both `says` and `Pearl` follow
+lowercase words. Their learned states tie and the longer candidate wins,
+producing ` says Pearl Cove.\n`. Construction offered no contrast to reject
+that shortcut. This is a learned representation-use failure, with the correct
+value still admitted; it is not missing value storage or evidence against the
+whole geometric architecture.
+
+**Next: break the predecessor-only shortcut with construction contrasts.**
+Use newly authored multiword introductions and candidate starts sharing the
+same predecessor shape, including lowercase-value contrasts. Reuse the existing
+ordered first/next/predecessor pair features and H4 learner before adding a new
+mechanism. Keep current open failures available for development; do not relabel
+them as fresh. The authored fresh panel remains unexecuted. Wider separators
+remain a separate representation limitation. See the result/evidence for actual
+checks and cumulative resources. The cycle used 60.167 seconds of model work;
+cumulative use is 4,387.536/4,410 seconds, leaving 22.464 seconds with no
+ceiling increase. A complete repeat of this 60-second cycle does not fit that
+balance; project the full next work and sufficient authorized resources before
+execution. No external compute or cleanup occurred.
+
 ## Reverse relation endpoints — 2026-09-07
 
 **Retain `321e990f` at bounded reverse-value scope.** The

--- a/docs/integration/project-track.md
+++ b/docs/integration/project-track.md
@@ -285,11 +285,15 @@ retains `321e990f` without fitting: existing writer-selected endpoints bound
 reverse spans, yielding construction 3/6 to 6/6, open 6/6, short 3/3 and fresh
 6/6 with selected preservation intact. The earlier start is retained separately
 from the unchanged terminal anchor.
-**Next: learn phrase-start selection over admitted candidates.** Longest passing
-prefix still includes unfamiliar introductory text; wider gaps remain a separate
-exact-separator representation limitation. New construction/open contrasts must
-remain separate from the opened diagnostics. Project the complete work against
-the current cumulative balance before execution.
+The [learned start candidate](../native_geometric_relation_start_1140.md) is
+implemented but not promoted: construction 2/8 to 8/8, open 2/8 to 6/8 and
+selected preservation intact. Its fit uses predecessor shape alone, leaving
+an extra introductory word when two candidate starts share that shape.
+**Next: construction contrasts that break this shortcut**, using the existing
+ordered shape-pair features and H4 learner. Include multiword introductions and
+lowercase values; fresh evaluation remains unexecuted. Wider gaps remain a
+separate exact-separator limitation. Project the complete next work against the
+current cumulative balance before execution.
 Do not restart completed order repairs or grow a
 paging subsystem without a measured access bottleneck. General named-role binding
 and broader Rust reasoning remain unqualified. Follow current-state.md for

--- a/docs/native_geometric_relation_start_1140.md
+++ b/docs/native_geometric_relation_start_1140.md
@@ -1,0 +1,138 @@
+# Learned relation-start selection — #1139 / #1140
+
+## Implementation and projection — 2026-09-07
+
+The [reverse-endpoint path](native_geometric_reverse_spans_1140.md) retains
+complete bounded reverse values, but chooses the longest admitted prefix.
+`Records show Orin Grove` therefore includes the introduction even though the
+correct shorter span is already available. This is a selection failure, separate
+from the known inability to preserve a two-space gap.
+
+This continuation learns a signed-H4 score over the same admitted reverse
+candidates, including the singleton endpoint. The writer-selected endpoint,
+edge admission, byte transport, versions and all parent parameters stay fixed.
+Seven ordered features describe the first word, next word inside the span,
+predecessor, preceding gap, two shape pairs and singleton status. Shape classes
+are explicit ASCII categories (absent, lowercase, title case, uppercase, mixed,
+digit-bearing and underscore-bearing). They are inputs to learned codes, not a
+hardcoded phrase decision or semantic interpretation of hash bits. Exact word
+identity is not a new start feature. This is a bounded text-shape hypothesis;
+lowercase values can remain ambiguous with introductory words.
+
+The existing SourceRouting learner selects two-lane H4 codes and a shared
+landmark using raw construction prompt/response examples. Labels identify the
+complete target payload only during offline training. Inference scores admitted
+starts using integer/table operations, with longest-first tie handling preserving
+the parent's decision on ties. No matrix product or expert gate is added.
+An outer artifact component binds the complete `321e990f` parent and training
+receipts. Persistent reverse reads honor the selected endpoint even for a
+singleton while its source remains visible, preventing a second query-side
+extension from overriding the committed value.
+
+The cycle projects 60 seconds model work and 600 seconds engineering, with caps
+of 80 seconds model, 900 seconds engineering, 28 MiB sampled storage growth,
+4 GiB model RSS, one model process and one build job. It uses the existing
+82.631-second balance; the cumulative ceiling remains 4,410 seconds. Context is
+512 tokens, retained records 16, payload 28 bytes and response limit 32 tokens.
+The existing cumulative command guard charges all attempts; no external model
+compute or broad cleanup is planned.
+
+Eight new construction examples contrast `Notes say` / `Log tells`, bare versus
+introduced phrases and multiword versus singleton values. Eight open examples
+use different introduction wording, names and values. The opened `Records show`
+diagnostic and former fresh panels are excluded from fitting. The same combined
+Rust run checks selected earlier preservation, records a decision, then executes
+eight new familiar-template fresh examples after source eviction. Old intro/gap
+and a lowercase-value case remain diagnostics. A focused actual-artifact test
+covers short, evicted and singleton outputs, malformed model rejection,
+checkpoint prediction replay and measured allocation behavior.
+
+## Measured decision — preserve candidate, do not promote
+
+The one fit produced `blake3:bb6b8ba41f65b0c9d5c7ddf453e765a52b5ea8b169e50141ead05b3b5cefad79`.
+Its 20 learned codes fit all eight construction frames; the learner considered
+3,118 proposals and changed two code roots. The complete parent parameters are
+identical after removing the new block and recomputing the outer identity.
+
+| Complete generated answers | Parent | Candidate |
+|---|---:|---:|
+| New construction | 2/8 | 8/8 |
+| Open development | 2/8 | 6/8 |
+| Retained construction preservation | 663/663 | 663/663 |
+| New fresh panel | NOT_RUN | NOT_RUN_SELECTION_FAILED |
+
+All other selected preservation passed, including 18 prior forward turns,
+18 prior reverse turns, three reverse short reads, 28 long-window and 48
+dependent answers, the prior 14/6/9 source-span panels, versions and isolation.
+Parent preservation values above refer to the previously retained evidence;
+this run replayed the candidate preservation and directly compared both models
+on the new construction/open inputs.
+
+The two open failures are `A ledger says Pearl Cove holds tesvi` and its
+single-word `Pearl` variant. Outputs are ` says Pearl Cove.\n` and
+` says Pearl.\n`. Every nonidentity code is a predecessor-shape feature:
+lowercase maps to roots [24,119] and title case to [119,77], with identity 119.
+All first-word, next-word, pair, gap and singleton codes remain identity. Since
+`says` and `Pearl` both follow lowercase words, this artifact assigns them
+the same state and score; longest-first ties retain `says`. This diagnosis
+follows the saved parameters and shared encode/score source, not a second model
+fit. The construction examples permit that shortcut. The available first/next
+and ordered-pair features can distinguish these starts, but this fit did not
+learn to use them.
+
+The selection receipt was written before the early return. No fresh-source
+file, fresh response or post-selection intro/gap/lowercase diagnostic was
+executed. The later artifact check uses opened construction cases, including
+an evicted repetition, so it does not consume the reserved panel. Keep the
+candidate and all receipts; `321e990f` remains the accepted artifact.
+
+## Next implementation
+
+Add independently authored construction contrasts where wrong and correct
+starts have the same predecessor shape, including multiword introductions and
+lowercase values. Reuse the existing ordered shape pairs and H4 learner first.
+Use the opened errors as development evidence, and retain a distinct final
+comparison after selection. Do not solve the examples with vocabulary rules or
+silently promote partial transfer. Wider separator retention is a separate
+representation task; additional paging or expert gates do not address this
+observed selection shortcut.
+
+## Verification and resources
+
+Release probe and test binaries compiled. Two start-feature tests, five existing
+span arithmetic/state tests, the scoped integer source guard and architecture
+policy check passed. The actual `bb6b8ba4` artifact rejected invalid root and
+parent mutations, generated opened short/evicted/singleton answers exactly,
+replayed predictions from every checkpoint and made zero measured allocations
+during ingestion and prediction/observation. This mechanical result does not
+reverse the failed open selection.
+
+The 41 sampled uncached prediction/observation steps had median 458 ns and
+maximum 156,959 ns. This excludes loading, encoding, ingestion and checkpoint
+host work. **The new start scorer runs during ingestion**, so these samples do
+not measure its latency or establish a submillisecond complete model. Energy,
+root CLI execution for this candidate, Studio and broad release QA are unmeasured
+or `NOT_RUN`. The existing unused `NUMERIC_PROMPT` fixture warning remains.
+
+Model command time was 60.167 seconds (44.874 combined evaluation and 15.293
+artifact check), within the 80-second cap. Cumulative use is
+4,387.536/4,410 seconds, leaving 22.464 seconds. The ceiling did not increase.
+Peak sampled model RSS was 986,791,936 bytes; peak sampled cycle storage growth
+was 20,692,992 bytes, within 4 GiB RSS and 28 MiB growth caps. Final sampled
+storage growth before delivery metadata was 14,753,792 bytes. Sampling is not an
+exact peak or unique-extent guarantee. No source, research, model or other
+material was deleted and no external model compute was used.
+
+The [evidence receipt](evidence/native_geometric_relation_start_1140.json)
+contains artifact/source/data hashes, complete comparison outputs, preservation
+counts and actual model/engineering commands. Build/test commands used one job
+and the pinned offline Rust release profile. The fresh panel is preserved in
+probe source and remains unexecuted. The remaining model balance cannot cover
+a complete repeat at the measured cost; do not reset the ledger or silently
+increase storage/model ceilings. The five automated PR/merge statuses are
+transport acknowledgements only; the local commands are the test evidence.
+
+Final local engineering commands total 276.856 seconds, including formatting and
+claim-wording checks, both PASS. The final sampled growth after those logs is
+14,761,984 bytes; the 20,692,992-byte observed peak above remains the larger
+measurement. Artifact size is 11,634,162 bytes.


### PR DESCRIPTION
The retained reverse-value path chooses the longest admitted phrase, so introductory text can enter a copied value. This adds an optional native Rust learner and integer/table H4 scorer that selects among the same admitted starts plus the singleton endpoint, with complete parent binding. Writer endpoints, admission, exact payloads and prior parameters stay fixed. Singleton reads honor the committed reverse endpoint while its source is visible.

The candidate fits construction (2/8 → 8/8) and improves open answers (2/8 → 6/8), preserving all 663 retained construction answers and the selected forward/reverse, long-window, dependent and source-span checks. It is **not promoted**: its learned predecessor-shape shortcut still emits `says Pearl Cove` for the longer introduction. Selection fails before fresh evaluation; `321e990f` remains retained. The artifact, exact negative and next construction contrasts are recorded in the result, evidence, current-state, plan, README and research log.

Validation: pinned offline release probe/test builds; two start-feature and five span-state tests; integer-kernel source guard; architecture policy; actual-artifact root/parent rejection, opened short/evicted/singleton outputs, every-step checkpoint replay and zero measured allocations; formatting and claim-wording checks. No full release suite, new-artifact CLI or Studio execution. PR/merge statuses acknowledge transport only.

Resources: 60.167 seconds model work and 276.856 seconds engineering commands. Cumulative model use is 4,387.536/4,410 seconds, leaving 22.464 seconds. Peak sampled growth 20,692,992 bytes; model RSS 986,791,936 bytes. No ceiling increase, external compute or cleanup. Another complete fit/evaluation does not fit the remaining allocation.

Related: #1139, #1140. This does not close either broader capability issue.
