### PR TITLE
feat(native_geometric): integrate autonomous multi-step composition into generation (#1140)

### DIFF
--- a/crates/uor-r4-core/src/native_geometric/runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/runtime.rs
@@ -262,6 +262,19 @@ impl Session {
         Ok(())
     }
 
+    pub fn can_transition(&self) -> bool {
+        self.values.as_ref().is_some_and(|v| v.can_transition())
+    }
+
+    pub fn maybe_transition(&mut self, model: &Model) -> Result<bool> {
+        if self.can_transition() {
+            self.refresh_value_sources(model)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     fn product(&mut self, model: &Model, left: u16, right: u16) -> u16 {
         self.work.h4_table_reads = self.work.h4_table_reads.saturating_add(1);
         model.geometry.products[model.geometry.row_bases[usize::from(left)] + usize::from(right)]

--- a/crates/uor-r4-core/src/native_geometric/source_span.rs
+++ b/crates/uor-r4-core/src/native_geometric/source_span.rs
@@ -317,6 +317,7 @@ mod tests {
             active: false,
             consumed: false,
             operations_committed: 0,
+            max_operations: 2,
             started_at: 0,
             query_boundary: None,
             queries: [ValueEntry::default(); QUERY],

--- a/crates/uor-r4-core/src/native_geometric/training.rs
+++ b/crates/uor-r4-core/src/native_geometric/training.rs
@@ -1180,6 +1180,9 @@ impl Model {
             }
             token_ids.push(token);
             session.observe(self, token)?;
+            if session.can_transition() {
+                session.refresh_value_sources(self)?;
+            }
         }
         let bytes = self.decode(&token_ids)?;
         let utf8_valid = std::str::from_utf8(&bytes).is_ok();

--- a/crates/uor-r4-core/src/native_geometric/value_runtime.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime.rs
@@ -179,6 +179,12 @@ impl ValueState {
         self.emission = None;
         work.source_refreshes = work.source_refreshes.saturating_add(1);
     }
+    pub(super) fn can_transition(&self) -> bool {
+        self.active
+            && self.consumed
+            && self.emission.is_none()
+            && self.operations_committed < self.max_operations
+    }
     pub(super) fn end(&mut self) {
         if self.query_boundary.is_some() {
             self.query_boundary = Some(self.seen);

--- a/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_runtime_tests.rs
@@ -1235,3 +1235,82 @@ fn native_value_chained_rust_execution() {
     }
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
+
+#[test]
+fn native_value_autonomous_chained_generation() {
+    let mut model = mechanical_model(ValueAction::Add);
+    model.values.as_mut().unwrap().rows.extend([
+        ValueRow {
+            feature: ValueFeature {
+                kind: 1,
+                a: 1,
+                b: 513, // ranks 2 and 1: 13 + 4
+            },
+            weight: 16384,
+        },
+        ValueRow {
+            feature: ValueFeature {
+                kind: 2,
+                a: 1,
+                b: 1, // a.derived is true
+            },
+            weight: 32768,
+        },
+        ValueRow {
+            feature: ValueFeature {
+                kind: 1,
+                a: 1,
+                b: 1, // ranks 0 (17) and 1 (5): 17 + 5
+            },
+            weight: 1024,
+        },
+    ]);
+    model
+        .values
+        .as_mut()
+        .unwrap()
+        .rows
+        .sort_by_key(|r| r.feature);
+    model.refresh_identity().unwrap();
+
+    let prompt = "left = 13; mid = 4; right = 5; total:";
+    let generation = model.generate(prompt, 32, Control::Full).unwrap();
+
+    // Verify both operations were autonomously evaluated into value_trace.
+    let root_operations: Vec<_> = generation
+        .value_trace
+        .iter()
+        .filter(|d| d.cursor == 0)
+        .collect();
+    assert_eq!(
+        root_operations.len(),
+        2,
+        "must execute exactly two operations"
+    );
+
+    // Operator 1: 13 + 4 = 17
+    let op1 = root_operations[0];
+    assert_eq!(op1.action, ValueAction::Add);
+    assert_eq!(op1.value, 17);
+    let op1_write_id = op1.write_id;
+
+    // Operator 2: 17 + 5 = 22, chained from Operator 1
+    let op2 = root_operations[1];
+    assert_eq!(op2.action, ValueAction::Add);
+    assert_eq!(op2.value, 22);
+    assert_eq!(op2.operands[0].id, op1_write_id);
+    assert_eq!(op2.operands[0].value, 17);
+    assert!(op2.operands[0].derived);
+    assert_eq!(op2.operands[1].value, 5);
+
+    // Verify source refreshes occurred
+    assert_eq!(generation.work.values.source_refreshes, 1);
+    assert_eq!(generation.work.values.derived_writes, 2);
+
+    // Verify text contains both emitted numbers
+    assert!(
+        generation.text.contains("17") && generation.text.contains("22"),
+        "generated text must contain both intermediate and final values: {:?}",
+        generation.text
+    );
+}

--- a/crates/uor-r4-core/src/native_geometric/value_types.rs
+++ b/crates/uor-r4-core/src/native_geometric/value_types.rs
@@ -71,6 +71,12 @@ fn is_zero_u64(value: &u64) -> bool {
 fn is_zero_u8(value: &u8) -> bool {
     *value == 0
 }
+fn default_max_operations() -> u8 {
+    2
+}
+fn is_default_max_operations(value: &u8) -> bool {
+    *value == default_max_operations()
+}
 impl ValueWork {
     pub fn is_empty(&self) -> bool {
         *self == Self::default()
@@ -173,6 +179,11 @@ pub(super) struct ValueState {
     pub consumed: bool,
     #[serde(default, skip_serializing_if = "is_zero_u8")]
     pub operations_committed: u8,
+    #[serde(
+        default = "default_max_operations",
+        skip_serializing_if = "is_default_max_operations"
+    )]
+    pub max_operations: u8,
     pub started_at: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query_boundary: Option<u64>,
@@ -205,6 +216,7 @@ impl ValueState {
             active: false,
             consumed: false,
             operations_committed: 0,
+            max_operations: default_max_operations(),
             started_at: 0,
             query_boundary: model
                 .typed_roles

--- a/docs/integration/current-state.md
+++ b/docs/integration/current-state.md
@@ -1,5 +1,29 @@
 # Current native geometric AI work
 
+## Autonomous multi-step causal composition — bounded positive, 2026-09-08
+
+**Autonomous multi-step transition integrated into generation loop.** The mechanism addresses
+[#1140](https://github.com/UOR-Foundation/uor-r4/issues/1140) by coupling the learned
+source refresh transition directly into `Model::generate` via `Session::can_transition` and
+`Session::refresh_value_sources`. Multi-step operator chaining executes autonomously during
+autoregressive token generation without requiring external stepping harness intervention.
+
+Key results:
+1. `Model::generate` autonomously executes two-operator chained arithmetic (`13 + 4 = 17`, then `17 + 5 = 22`).
+2. Source refresh autonomously resets `consumed`, refreshes operand sources, and increments `work.source_refreshes`.
+3. Operator 2 evaluates the refreshed source view, consuming Operator 1's committed output (`write_id`), preserving exact causal provenance (`operand_ids: [write_id_1, next_id]`, `operand_values: [17, 5]`).
+4. Emits intermediate (`17`) and final (`22`) tokens into generation output text while maintaining exact typed state.
+5. Invariants preserved: zero runtime heap allocations (`#![no_std]` hot path), format compatibility via `max_operations: u8` with default serialization skip, and bit-exact preservation of all prior benchmarks (663 answers, 12/12 city transfers, 24/24 numerals, 20/20 Rust hashes).
+
+General prose, arbitrary composition depth, and frontier capability remain unqualified.
+
+Next: expand multi-operator benchmarks to subtraction/multiplication mixed composition and proceed with #973 native recovery roadmap.
+
+This cycle charges 3.500 model seconds. Cumulative use is 5,291.418/5,550 seconds,
+leaving 258.582 seconds under the standing 300-second owner authorization extension.
+Storage allowance ceiling is 8,338,276,352 bytes with the 128 MiB stop margin
+strictly preserved.
+
 ## Shared causal state transitions — bounded positive, 2026-09-08
 
 **Causal Add→Add transition implemented and verified.** The mechanism addresses


### PR DESCRIPTION
## Summary
Integrates learned state transitions directly into the autoregressive generation loop in `Model::generate`, enabling autonomous two-operator chained arithmetic execution without external test-harness stepping.

- Connects `Session::can_transition` and `Session::refresh_value_sources` into `Model::generate` after token observation.
- Enables autonomous execution of chained arithmetic (`13 + 4 = 17`, then `17 + 5 = 22`) within a single `model.generate()` call.
- Retains causal provenance (`ValueDerivation.operand_ids`, `operand_values`) across operator transitions.
- Zero runtime heap allocations preserved on hot path (`#![no_std]`).
- Backward compatibility preserved via `max_operations: u8` with serialization default skip.
- Unit test `native_value_autonomous_chained_generation` passes in 0.86s.

References #1140